### PR TITLE
Updating the nix shell to NixOS 19.03

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,4 +1,4 @@
-{ pkgs ? import (builtins.fetchTarball "channel:nixos-18.09") {} }:
+{ pkgs ? import (builtins.fetchTarball "channel:nixos-19.03") {} }:
 pkgs.mkShell {
   buildInputs = with pkgs; [
     rust.cargo


### PR DESCRIPTION
Updating the channel to `nixos-19.03`.

@zimbatm I'm adding you since you created the file.

Ideally I'd like to have a proper `nixpkgs` file set up, with a unique rustc and dependencies versions, but this works just fine for now.