### PR TITLE
Initial commit, very simple CircleCI cfg

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,51 @@
+version: 2
+
+jobs:
+  test:
+    docker:
+      - image: rust:1.32 # Same version as nixos-19.03
+    environment:
+      CACHE_VERSION:
+        "2019-09-09"
+    steps:
+      - checkout
+      - run:
+          name: Load cache version
+          command: echo "$CACHE_VERSION" > _cache_v
+      - run:
+          name: Version information
+          command: rustc --version; cargo --version; rustup --version
+      - restore_cache:
+          keys:
+            - v{{ checksum "_cache_v" }}-nickel-deps-cache-{{ arch }}-{{ checksum "Cargo.lock" }}
+      - run:
+          name: Build all targets
+          command: cargo build --all --all-targets
+      - run:
+          name: Remove non dependencies builds
+          command: |
+            rm -rvf target/debug/incremental/nickel-*
+            rm -rvf target/debug/incremental/build-script-build-*
+            rm -rvf target/debug/.fingerprint/nickel-*
+            rm -rvf target/debug/build/nickel*-
+            rm -rvf target/debug/deps/nickel*-
+            rm -rvf target/debug/nickel.d
+            cargo clean -p nickel
+      - save_cache:
+          paths:
+            - /usr/local/cargo/registry
+            - target
+          key: v{{ checksum "_cache_v" }}-nickel-deps-cache-{{ arch }}-{{ checksum "Cargo.lock" }}
+      - run:
+          name: Run all tests
+          command: cargo test --all
+      - run:
+          name: Check formatting
+          command: |
+            rustup component add rustfmt
+            cargo fmt --all -- --check
+workflows:
+  version: 2
+  test:
+    jobs:
+      - test


### PR DESCRIPTION
Checks:
 * builds
 * test
 * formatting

It has a simple cache for the project, the `lalrpop` dependency takes some time to build.

I set it up to `rust 1.32` since is the version on NixOs 19.03, ideally we should have some nicer setup, but for now it should be ok.