### PR TITLE
Added blame and label as primitives

### DIFF
--- a/src/examples/fibo.ncl
+++ b/src/examples/fibo.ncl
@@ -1,13 +1,13 @@
 let dyn = fun l => fun t => t in
-let num = fun l => fun t => if isNum t then t else l in
-let bool = fun l => fun t => if isBool t then t else  l in
-let func = fun s => fun t => fun l => fun e => if isFun e then (fun x => t l (e (s l x))) else l in
+let num = fun l => fun t => if isNum t then t else blame l in
+let bool = fun l => fun t => if isBool t then t else blame l in
+let func = fun s => fun t => fun l => fun e => if isFun e then (fun x => t l (e (s l x))) else blame l in
 
 let Y = (fun f => (fun x => f (x x)) (fun x => f (x x))) in
-let dec = func num num (blame label[dec]) (fun x => + x (-1)) in
-let or = func bool (func bool bool) (blame label[or]) (fun x => fun y => if x then x else y) in
+let dec = func num num label[dec] (fun x => + x (-1)) in
+let or = func bool (func bool bool) label[or] (fun x => fun y => if x then x else y) in
 
-let fibo = func num num (blame label[fibo]) (Y (fun fibo =>
+let fibo = func num num label[fibo] (Y (fun fibo =>
     (fun x => if or (isZero x) (isZero (dec x)) then 1 else + (fibo (dec x)) (fibo (dec (dec x)))))) in
-let val = num (blame label[num_value]) 4 in
+let val = num label[num_value] 4 in
 fibo val

--- a/src/examples/std.ncl
+++ b/src/examples/std.ncl
@@ -1,10 +1,10 @@
-let num = fun l => fun t => if isNum t then t else blame NotNum in
-let bool = fun l => fun t => if isBool t then t else blame NotBool in
-let func = fun s => fun t => fun l => fun e => if isFun e then (fun x => t l (e (s l x))) else blame NotFun in
+let num = fun l => fun t => if isNum t then t else blame l in
+let bool = fun l => fun t => if isBool t then t else blame l in
+let func = fun s => fun t => fun l => fun e => if isFun e then (fun x => t l (e (s l x))) else blame l in
 
 
-let safePlus = fun x => fun y => num 1 (+ (num 2 x) (num 3 y)) in
+let safePlus = fun x => fun y => num label[plus] (+ (num label[x] x) (num label[y] y)) in
 let const = fun x => fun y => if isNum y then y else 2 in
-let safeAppTwice = fun f => fun y => (func num num 1000 f) ((func bool num 1000 f)  y) in
+let safeAppTwice = fun f => fun y => (func num num label[f] f) ((func bool num label[f] f)  y) in
 
 safeAppTwice (const 3) true

--- a/src/examples/std2.ncl
+++ b/src/examples/std2.ncl
@@ -1,13 +1,13 @@
 let dyn = fun l => fun t => t in
-let num = fun l => fun t => if isNum t then t else l in
-let bool = fun l => fun t => if isBool t then t else  l in
-let func = fun s => fun t => fun l => fun e => if isFun e then (fun x => t l (e (s l x))) else l in
+let num = fun l => fun t => if isNum t then t else blame l in
+let bool = fun l => fun t => if isBool t then t else blame l in
+let func = fun s => fun t => fun l => fun e => if isFun e then (fun x => t l (e (s l x))) else blame l in
 
 
 let const = fun x => fun y => x in
 let safeAppTwice = fun f => fun y => f (f y) in
-let ma = (func (func num num) (func dyn num) (blame label[safeAppTwice]) safeAppTwice) 
-         ((func dyn (func dyn dyn) (blame label[const]) const) (bool (blame label[n1]) 1)) 
-         (bool (blame label[ltrue]) true) 
+let ma = (func (func num num) (func dyn num) label[safeAppTwice] safeAppTwice) 
+         ((func dyn (func dyn dyn) label[const] const) (bool label[n1] 1)) 
+         (bool label[ltrue] true) 
          in 
-dyn (blame label) ma
+dyn label[ma] ma

--- a/src/grammar.lalrpop
+++ b/src/grammar.lalrpop
@@ -16,7 +16,6 @@ pub Term = {
     // TODO make infix
     <op: BOp> <t1:Atom> <t2:Atom> => Term::Op2(op, Box::new(t1), Box::new(t2)),
     <op: UOp> <t: Atom> => Term::Op1(op, Box::new(t)),
-    "blame" <lab:Term> => Term::Blame(Box::new(lab)),
     Applicative,
 };
 
@@ -52,6 +51,7 @@ UOp: UnaryOp = {
     "isNum" => UnaryOp::IsNum(),
     "isBool" => UnaryOp::IsBool(),
     "isFun" => UnaryOp::IsFun(),
+    "blame" => UnaryOp::Blame(),
 };
 
 BOp: BinaryOp = {

--- a/src/term.rs
+++ b/src/term.rs
@@ -8,6 +8,7 @@ pub enum Term {
     Bool(bool),
     Num(f64),
     Fun(Vec<Ident>, Box<Term>),
+    Lbl(Label),
     // Other lambda
     Let(Ident, Box<Term>, Box<Term>),
     App(Box<Term>, Box<Term>),
@@ -15,7 +16,4 @@ pub enum Term {
     // Primitives
     Op1(UnaryOp, Box<Term>),
     Op2(BinaryOp, Box<Term>, Box<Term>),
-    // Blame
-    Blame(Box<Term>),
-    Lbl(Label),
 }


### PR DESCRIPTION
Now they behave like usual operations (Blame gets into a continuation
and evaluates it's term)

Also, as a consequence of this change, the operations processing functions return an `Result<(), EvalError>`, since it may need to return the blame.