### PR TITLE
Simple Types and their contracts.

### DIFF
--- a/src/examples/fibo.ncl
+++ b/src/examples/fibo.ncl
@@ -1,13 +1,8 @@
-let dyn = fun l => fun t => t in
-let num = fun l => fun t => if isNum t then t else blame l in
-let bool = fun l => fun t => if isBool t then t else blame l in
-let func = fun s => fun t => fun l => fun e => if isFun e then (fun x => t l (e (s l x))) else blame l in
-
 let Y = (fun f => (fun x => f (x x)) (fun x => f (x x))) in
-let dec = Promise(func num num, fun x => x + (-1)) in
-let or = Promise(func bool (func bool bool), fun x => fun y => if x then x else y) in
+let dec = Promise(Num -> Num, fun x => x + (-1)) in
+let or = Promise(Bool -> Bool -> Bool, fun x => fun y => if x then x else y) in
 
-let fibo = Promise(func num num, Y (fun fibo =>
+let fibo = Promise(Num -> Num, Y (fun fibo =>
     (fun x => if or (isZero x) (isZero (dec x)) then 1 else (fibo (dec x)) + (fibo (dec (dec x)))))) in
-let val = Promise(num, 7) in
+let val = Promise(Num, 7) in
 fibo val

--- a/src/examples/std.ncl
+++ b/src/examples/std.ncl
@@ -1,10 +1,5 @@
-let num = fun l => fun t => if isNum t then t else blame l in
-let bool = fun l => fun t => if isBool t then t else blame l in
-let func = fun s => fun t => fun l => fun e => if isFun e then (fun x => t l (e (s l x))) else blame l in
-
-
-let safePlus = fun x => fun y => Promise(num, Promise(num, x) + Promise(num, y)) in
+let safePlus = fun x => fun y => Promise(Num, Promise(Num, x) + Promise(Num, y)) in
 let const = fun x => fun y => if isNum y then y else 2 in
-let safeAppTwice = fun f => fun y => Promise(func num num, f) ( Promise(func bool num, f)  y) in
+let safeAppTwice = fun f => fun y => Promise(Num -> Num, f) ( Promise(Bool -> Num, f)  y) in
 
 safeAppTwice (const 3) true

--- a/src/examples/std2.ncl
+++ b/src/examples/std2.ncl
@@ -1,13 +1,7 @@
-let dyn = fun l => fun t => t in
-let num = fun l => fun t => if isNum t then t else blame l in
-let bool = fun l => fun t => if isBool t then t else blame l in
-let func = fun s => fun t => fun l => fun e => if isFun e then (fun x => t l (e (s l x))) else blame l in
-
-
 let const = fun x => fun y => x in
 let safeAppTwice = fun f => fun y => f (f y) in
-let ma = Promise(func (func num num) (func dyn num), safeAppTwice) 
-         (Promise(func dyn (func dyn dyn), const) Promise(bool, 1)) 
-         Promise(bool, true) 
+let ma = Promise((Dyn -> Num) -> Dyn -> Num, safeAppTwice) 
+         (Promise(Dyn -> Dyn -> Dyn, const) Promise(Bool, 1)) 
+         Promise(Bool, true) 
          in 
-Promise(dyn, ma)
+Promise(Dyn, ma)

--- a/src/grammar.lalrpop
+++ b/src/grammar.lalrpop
@@ -1,5 +1,6 @@
 use identifier::Ident;
 use std::str::FromStr;
+use types::Types;
 use term::Term;
 use label::Label;
 use operation::{UnaryOp, BinaryOp};
@@ -7,8 +8,8 @@ use operation::{UnaryOp, BinaryOp};
 grammar;
 
 pub Term = {
-    "fun" <ps:Pattern+> "=>" <t:Term> =>
-        Term::Fun(ps, Box::new(t)),
+    "fun" <p:Pattern> "=>" <t:Term> =>
+        Term::Fun(p, Box::new(t)),
     "let" <id:Ident> "=" <t1:Term> "in" <t2:Term> =>
         Term::Let(id, Box::new(t1), Box::new(t2)),
     "if" <b:Term> "then" <t:Term> "else" <e:Term> =>
@@ -29,10 +30,10 @@ Applicative: Term = {
 
 Atom: Term = {
     "(" <Term> ")",
-    <l:@L> "Promise(" <c: Term> "," <t: Term> ")" <r:@R> =>
-        Term::Promise(Box::new(c), Label{tag: "A promise".to_string(), l: l, r: r}, Box::new(t)),
-    <l:@L> "Assume(" <c: Term> "," <t: Term> ")" <r:@R> =>
-        Term::Assume(Box::new(c), Label{tag: "An assume".to_string(), l: l, r: r}, Box::new(t)), 
+    <l:@L> "Promise(" <ty: Types> "," <t: Term> ")" <r:@R> =>
+        Term::Promise(ty, Label{tag: "A promise".to_string(), l: l, r: r}, Box::new(t)),
+    <l:@L> "Assume(" <ty: Types> "," <t: Term> ")" <r:@R> =>
+        Term::Assume(ty, Label{tag: "An assume".to_string(), l: l, r: r}, Box::new(t)), 
     Num => Term::Num(<>),
     Bool => Term::Bool(<>),
     Ident => Term::Var(<>),
@@ -63,4 +64,14 @@ BOp: BinaryOp = {
     "+" => BinaryOp::Plus(),
 };
 
+Types: Types = {
+    <s: subType> "->" <t:Types> => Types::Arrow(Box::new(s), Box::new(t)),
+    <subType>,
+};
 
+subType : Types = {
+    "Dyn" => Types::Dyn(),
+    "Num" => Types::Num(),
+    "Bool" => Types::Bool(),
+    "(" <Types> ")" => <>,
+};

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ mod parser;
 mod program;
 mod stack;
 mod term;
+mod types;
 
 use program::Program;
 

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -82,14 +82,7 @@ fn functions() {
     let parser = super::grammar::TermParser::new();
     assert_eq!(
         parser.parse("fun x => x").unwrap(),
-        Fun(vec![Ident("x".into())], Box::new(Var(Ident("x".into())))),
-    );
-    assert_eq!(
-        parser.parse("fun x y => x").unwrap(),
-        Fun(
-            vec![Ident("x".into()), Ident("y".into())],
-            Box::new(Var(Ident("x".into())))
-        ),
+        Fun(Ident("x".into()), Box::new(Var(Ident("x".into())))),
     );
 }
 

--- a/src/term.rs
+++ b/src/term.rs
@@ -1,13 +1,14 @@
 use identifier::Ident;
 use label::Label;
 use operation::{BinaryOp, UnaryOp};
+use types::Types;
 
 #[derive(Debug, PartialEq, Clone)]
 pub enum Term {
     // Values
     Bool(bool),
     Num(f64),
-    Fun(Vec<Ident>, Box<Term>),
+    Fun(Ident, Box<Term>),
     Lbl(Label),
     // Other lambda
     Let(Ident, Box<Term>, Box<Term>),
@@ -17,6 +18,6 @@ pub enum Term {
     Op1(UnaryOp, Box<Term>),
     Op2(BinaryOp, Box<Term>, Box<Term>),
     // Typing
-    Promise(Box<Term>, Label, Box<Term>),
-    Assume(Box<Term>, Label, Box<Term>),
+    Promise(Types, Label, Box<Term>),
+    Assume(Types, Label, Box<Term>),
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,0 +1,27 @@
+use identifier::Ident;
+use term::Term;
+
+#[derive(Clone, PartialEq, Debug)]
+pub enum Types {
+    Dyn(),
+    Num(),
+    Bool(),
+    Arrow(Box<Types>, Box<Types>),
+}
+
+impl Types {
+    pub fn contract(&self) -> Term {
+        match self {
+            Types::Dyn() => Term::Var(Ident("dyn".to_string())),
+            Types::Num() => Term::Var(Ident("num".to_string())),
+            Types::Bool() => Term::Var(Ident("bool".to_string())),
+            Types::Arrow(s, t) => Term::App(
+                Box::new(Term::App(
+                    Box::new(Term::Var(Ident("func".to_string()))),
+                    Box::new(s.contract()),
+                )),
+                Box::new(t.contract()),
+            ),
+        }
+    }
+}


### PR DESCRIPTION
Changed `Promise` and `Assume` to take `Types` instead of contracts.

The translation is just to the name of the expected contract, which is prepended to every program (we should use imports and have an external library of default contracts, or something smarter).

Also changed the `Term::Fun` to take only one term (instead of many), otherwise is kind of difficult to have contracts for multiple parameters (notice that we don't do partial application).