### PR TITLE
Promise and Assume can take Types and expressions

### DIFF
--- a/makam-spec/src/ast.makam
+++ b/makam-spec/src/ast.makam
@@ -1,5 +1,6 @@
 expr : type.
 typ : type.
+contract : type.
 
 (* Lambda constructs *)
 let : expr -> bindone expr expr -> expr.
@@ -29,8 +30,8 @@ sub : binop.
 mul : binop.
 
 (* Typing *)
-promise : typ -> expr -> expr.
-assume : typ -> expr -> expr -> expr.
+promise : contract -> expr -> expr.
+assume : contract -> expr -> expr -> expr.
 
 (* Blaming *)
 label : string -> expr.
@@ -43,22 +44,26 @@ tdyn : typ.
 tnum : typ.
 tbool : typ.
 tstr : typ.
+tlbl : typ.
 tarrow : typ -> typ -> typ.
 
-(* Get the contract of a given type *)
-contract : typ -> expr -> prop.
-contract tdyn (lam (bind _ (fun l => lam (bind _ 
+fromExpr : expr -> contract.
+fromTyp : typ -> contract.
+
+(* Get the expression contract of a given type *)
+typToExpr : typ -> expr -> prop.
+typToExpr tdyn (lam (bind _ (fun l => lam (bind _ 
   (fun t => t))))).
-contract tnum (lam (bind _ (fun l => lam (bind _ 
+typToExpr tnum (lam (bind _ (fun l => lam (bind _ 
   (fun t => ite (eunop isNum t) t (eunop blame l)))))).
-contract tbool (lam (bind _ (fun l => lam (bind _ 
+typToExpr tbool (lam (bind _ (fun l => lam (bind _ 
   (fun t => ite (eunop isBool t) t (eunop blame l)))))).
-contract tstr (lam (bind _ (fun l => lam (bind _ 
+typToExpr tstr (lam (bind _ (fun l => lam (bind _ 
   (fun t => ite (eunop isStr t) t (eunop blame l)))))).
-contract (tarrow S T) (lam (bind _ (fun l => lam (bind _ 
+typToExpr (tarrow S T) (lam (bind _ (fun l => lam (bind _ 
   (fun t => ite (eunop isFun t) (lam (bind _ (fun x => app (app Ct l) (app t (app (app Cs l) x))))) (eunop blame l)))))) :-
-    contract S Cs,
-    contract T Ct.
+    typToExpr S Cs,
+    typToExpr T Ct.
 
 (* Other *)
 

--- a/makam-spec/src/eval.makam
+++ b/makam-spec/src/eval.makam
@@ -45,7 +45,7 @@ eval (eunop Op E) V :-
   eval_unop Op E' V.
 
 eval_unop blame (label S) _ :- 
-  log_error S `Reached a blame with label ${S}`,
+  print `Reached a blame with label ${S}`,
   failure.
 
 eval_unop isNum (eint _) (ebool true).
@@ -63,10 +63,11 @@ eval_unop isFun V (ebool false) :- not (eq V (lam _)).
 eval (promise _ T) V :-
   eval T V.
 
-eval (assume Ty L T) V :-
-  contract Ty CTy,
+eval (assume (fromTyp Ty) L T) V :-
+  typToExpr Ty CTy,
   eval (app (app CTy L) T) V.
-
+eval (assume (fromExpr Ctr) L T) V :-
+  eval (app (app Ctr L) T) V.
 
 (* Variables *)
 eval (named X) _ :- log_error X `unknown variable ${X}`, failure.

--- a/makam-spec/src/examples.makam
+++ b/makam-spec/src/examples.makam
@@ -79,3 +79,24 @@ interpreter "
 let (id = fun x => x) in
 Ifte(true, Promise( Num , id 3), Promise( Bool, Assume( Bool -> Bool , id ) true))
 " V T ?
+
+print "Contracts can also be expression" ?
+
+print "Void type (Blame)" ?
+interpreter "
+let (void = fun l => fun t => blame l) in
+Assume(void, 3)
+" V T ?
+
+print "alwaysTrue (Blame)" ?
+interpreter "
+let (alwaysTrue = fun l => fun t => Ifte(t, t, blame l)) in
+Assume(alwaysTrue, false)
+" V T ?
+
+print "Return true" ?
+interpreter "
+let (alwaysTrue = fun l => fun t => Ifte(t, t, blame l)) in
+Assume(alwaysTrue, true)
+" V T ?
+

--- a/makam-spec/src/init.makam
+++ b/makam-spec/src/init.makam
@@ -3,10 +3,23 @@
 %use "eval".
 %use "typecheck".
 
+changeToDyn : typ -> typ -> prop.
+changeToDyn A tdyn when refl.isunif A.
+changeToDyn (tarrow S T) (tarrow CS CT) :-
+  changeToDyn S CS,
+  changeToDyn T CT.
+changeToDyn A A when not (refl.isunif A).
+
+raw_interpreter : string -> expr -> typ -> prop.
+raw_interpreter S V Ty :-
+  either (isocast S (E: expr)) (log_error S `Parse error in Nickel program`),
+  once (ifte (typecheck E Ty') (print "Typechecked!") (and (print `Could not typecheck`) (failure))),
+  eval E V,
+  print "Evaluated".
+
 interpreter : string -> string -> string -> prop.
 interpreter S S' STy :-
-  either (isocast S (E: expr)) (log_error S `Parse error in Nickel program`),
-  either (typecheck E T) (and (log_error E `Could not typecheck`) (failure)),
-  eval E V,
-  isocast T (STy: string),
-  isocast V (S': string).
+  raw_interpreter S V T',
+  once (changeToDyn T' T), (* The printer will fail if any uninstantiated variable is in the Type *)
+  isocast V (S': string),
+  isocast T (STy: string).

--- a/makam-spec/src/syntax.makam
+++ b/makam-spec/src/syntax.makam
@@ -9,6 +9,7 @@ def : syntax (concrete.name expr * expr).
 binop, binopC : syntax binop.
 unop, unopC : syntax unop.
 typ, baseTyp: syntax typ.
+contract : syntax contract.
 
 exprvar : concrete.namespace expr.
 
@@ -61,9 +62,9 @@ expr_ -> ite
 
 baseexpr ->
         promise
-        { "Promise(" <typ> "," <expr_> ")"}
-      / fun ty => assume ty (label "Assume")
-        { "Assume(" <typ> "," <expr_> ")"}
+        { "Promise(" <contract> "," <expr_> ")"}
+      / fun c => assume c (label "Assume")
+        { "Assume(" <contract> "," <expr_> ")"}
       / ebool true { "true" }
       / ebool false { "false" }
       / estr { <makam.string_literal> }
@@ -93,6 +94,9 @@ baseTyp ->
 typ ->  tarrow
         { <baseTyp> "->" <typ> }
       / { <baseTyp> }
+
+contract -> fromExpr { <expr_> }
+          / fromTyp { <typ> }
 
 }} ).
 

--- a/makam-spec/src/typecheck.makam
+++ b/makam-spec/src/typecheck.makam
@@ -46,7 +46,8 @@ typecheck (ite C T E) tdyn :-
     typecheck T _,
     typecheck E _.
 
-typecheck (eunop blame _) _.
+typecheck (eunop blame L) _ :-
+    typecheck L tlbl.
     
 typecheck (eunop isNum _) tbool.
 typecheck (eunop isBool _) tbool.
@@ -64,15 +65,23 @@ typecheck (ebinop A _ B) tdyn :-
     not (eq Aty tnum),
     typecheck B _.
 
-typecheck (promise Ty E) Ty :-
+typecheck (promise (fromTyp Ty) E) Ty :-
     typecheck E Ty.
-typecheck (promise Ty E) _ :-
+typecheck (promise (fromTyp Ty) E) _ :-
     not (typecheck E Ty),
     log_error Ty `Couldnt check Promise(...)`,
     failure.
+typecheck (promise (fromExpr C) _) _ :-
+    log_error C `Still cant check not type Promise(...)`,
+    failure.
 
 (* The type of an Assume construct doesn't depend on the term *)
-typecheck (assume Ty _ E) Ty :- 
+typecheck (assume (fromTyp Ty) L E) Ty :- 
+    typecheck L tlbl,
+    typecheck E _.
+typecheck (assume (fromExpr Ctr) L E) _ :-
+    typecheck L tlbl,
+    typecheck Ctr (tarrow tlbl (tarrow S S)),
     typecheck E _.
 
-typecheck (label _) tdyn.
+typecheck (label _) tlbl.


### PR DESCRIPTION
A few other changes:
 * labels have a type
 * blame expect to receive something of type label
 * When using an expression as a contract a specific type is expected (Label -> a -> a)

NOTE:
using Assume over an expression means (right now) we can give it any type we want, also we need to change free (uninstantiated) variables on types by `Dyn` before printing.