### PR TITLE
First experiments on improving the label

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -177,6 +177,7 @@ pub fn eval(t0: Term) -> Result<Term, EvalError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use label::TyPath;
     use operation::{BinaryOp, UnaryOp};
 
     fn app(t0: Term, t1: Term) -> Term {
@@ -217,6 +218,8 @@ mod tests {
             tag: "testing".to_string(),
             l: 0,
             r: 1,
+            polarity: false,
+            path: TyPath::Nil(),
         };
         assert_eq!(
             Err(EvalError::BlameError(label.clone())),

--- a/src/examples/higherOrder.ncl
+++ b/src/examples/higherOrder.ncl
@@ -1,0 +1,2 @@
+let f = Assume((Num -> Num) -> Num, fun g => g 3) in
+f (fun x => true)

--- a/src/grammar.lalrpop
+++ b/src/grammar.lalrpop
@@ -2,7 +2,7 @@ use identifier::Ident;
 use std::str::FromStr;
 use types::Types;
 use term::Term;
-use label::Label;
+use label::{Label, TyPath};
 use operation::{UnaryOp, BinaryOp};
 
 grammar;
@@ -31,9 +31,9 @@ Applicative: Term = {
 Atom: Term = {
     "(" <Term> ")",
     <l:@L> "Promise(" <ty: Types> "," <t: Term> ")" <r:@R> =>
-        Term::Promise(ty, Label{tag: "A promise".to_string(), l: l, r: r}, Box::new(t)),
+        Term::Promise(ty, Label{tag: "A promise".to_string(), l: l, r: r, polarity: true, path: TyPath::Nil()}, Box::new(t)),
     <l:@L> "Assume(" <ty: Types> "," <t: Term> ")" <r:@R> =>
-        Term::Assume(ty, Label{tag: "An assume".to_string(), l: l, r: r}, Box::new(t)), 
+        Term::Assume(ty, Label{tag: "An assume".to_string(), l: l, r: r, polarity: true, path: TyPath::Nil()}, Box::new(t)), 
     Num => Term::Num(<>),
     Bool => Term::Bool(<>),
     Ident => Term::Var(<>),
@@ -58,6 +58,10 @@ UOp: UnaryOp = {
     "isBool" => UnaryOp::IsBool(),
     "isFun" => UnaryOp::IsFun(),
     "blame" => UnaryOp::Blame(),
+    "chngPol" => UnaryOp::ChangePolarity(),
+    "goDom" => UnaryOp::GoDom(),
+    "goCodom" => UnaryOp::GoCodom(),
+    "tag[" <DbgStr> "]" => UnaryOp::Tag(<>),
 };
 
 BOp: BinaryOp = {
@@ -75,3 +79,5 @@ subType : Types = {
     "Bool" => Types::Bool(),
     "(" <Types> ")" => <>,
 };
+
+DbgStr: String = r"[[:alpha:]_][[:word:]-]*" => <>.to_string();

--- a/src/label.rs
+++ b/src/label.rs
@@ -1,6 +1,15 @@
 #[derive(Debug, Clone, PartialEq)]
+pub enum TyPath {
+    Nil(),
+    Domain(Box<TyPath>),
+    Codomain(Box<TyPath>),
+}
+
+#[derive(Debug, Clone, PartialEq)]
 pub struct Label {
     pub tag: String,
     pub l: usize,
     pub r: usize,
+    pub polarity: bool,
+    pub path: TyPath,
 }

--- a/src/operation.rs
+++ b/src/operation.rs
@@ -1,4 +1,5 @@
 use eval::{Closure, EvalError};
+use label::TyPath;
 use stack::Stack;
 use term::Term;
 
@@ -17,6 +18,10 @@ pub enum UnaryOp {
     IsBool(),
     IsFun(),
     Blame(),
+    ChangePolarity(),
+    GoDom(),
+    GoCodom(),
+    Tag(String),
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -129,6 +134,67 @@ fn process_unary_operation(
             } = *clos
             {
                 Err(EvalError::BlameError(l.clone()))
+            } else {
+                Err(EvalError::TypeError(format!(
+                    "Expected Label, got {:?}",
+                    clos.body
+                )))
+            }
+        }
+        UnaryOp::ChangePolarity() => {
+            if let Closure {
+                body: Term::Lbl(ref mut l),
+                env: _,
+            } = *clos
+            {
+                l.polarity = !l.polarity;
+                Ok(())
+            } else {
+                Err(EvalError::TypeError(format!(
+                    "Expected Label, got {:?}",
+                    clos.body
+                )))
+            }
+        }
+        UnaryOp::GoDom() => {
+            if let Closure {
+                body: Term::Lbl(ref mut l),
+                env: _,
+            } = *clos
+            {
+                l.path = TyPath::Domain(Box::new(l.path.clone()));
+                Ok(())
+            } else {
+                Err(EvalError::TypeError(format!(
+                    "Expected Label, got {:?}",
+                    clos.body
+                )))
+            }
+        }
+        UnaryOp::GoCodom() => {
+            if let Closure {
+                body: Term::Lbl(ref mut l),
+                env: _,
+            } = *clos
+            {
+                l.path = TyPath::Codomain(Box::new(l.path.clone()));
+                Ok(())
+            } else {
+                Err(EvalError::TypeError(format!(
+                    "Expected Label, got {:?}",
+                    clos.body
+                )))
+            }
+        }
+        UnaryOp::Tag(s) => {
+            if let Closure {
+                body: Term::Lbl(ref mut l),
+                env: _,
+            } = *clos
+            {
+                l.tag.push_str("\n");
+                l.tag.push_str(&s);
+                Ok(())
             } else {
                 Err(EvalError::TypeError(format!(
                     "Expected Label, got {:?}",


### PR DESCRIPTION
Added a few features to the labels (together with language primitives):
 * *Path* for now this allows us to understand where on a higher order contract blame was raised
 * *polarity* to understand who's to blame
 * *tag* this was already there but now we can append to it during runtime

For now these three are just experimental, and they may show either useless or short on capabilities (think intersection types path), but I'll put them here for comments.

Old output for the `higherOrder.ncl` example:
```
Evaluation didn't finished, found error:
Reached a blame label, some cast went terribly wrong
    Tag: An assume
    Line: 1 Column: 9 
```

New output for the `higherOrder.ncl` example:
```
Evaluation didn't finished, found error:
Reached a blame label, some cast went terribly wrong
    Tag:
An assume
func
func
num
    Line: 1 Columns: 9 to 50
    Polarity: false
    The blame is on the context (negative blame)
    Path: Codomain(Domain(Nil))
```

__Note:__ There's a lot of information repeated on this new fields, it remains to be seen if there's use to having all of them.