### PR TITLE
A few fixes that simplify the operations.

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -139,9 +139,9 @@ pub fn eval(t0: Term) -> Result<Term, EvalError> {
             }
             // Continuate Operation
             _ if 0 < stack.count_conts() => {
-                continuate_operation(
+                clos = continuate_operation(
                     stack.pop_op_cont().expect("Condition already checked"),
-                    &mut clos,
+                    clos,
                     &mut stack,
                 )?;
             }
@@ -178,7 +178,7 @@ pub fn eval(t0: Term) -> Result<Term, EvalError> {
 mod tests {
     use super::*;
     use label::TyPath;
-    use operation::{BinaryOp, UnaryOp};
+    use term::{BinaryOp, UnaryOp};
 
     fn app(t0: Term, t1: Term) -> Term {
         Term::App(Box::new(t0), Box::new(t1))

--- a/src/grammar.lalrpop
+++ b/src/grammar.lalrpop
@@ -1,9 +1,8 @@
 use identifier::Ident;
 use std::str::FromStr;
 use types::Types;
-use term::Term;
 use label::{Label, TyPath};
-use operation::{UnaryOp, BinaryOp};
+use term::{BinaryOp, Term, UnaryOp};
 
 grammar;
 

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -1,7 +1,6 @@
 use identifier::Ident;
-use operation::{BinaryOp, UnaryOp};
-use term::Term;
 use term::Term::*;
+use term::{BinaryOp, Term, UnaryOp};
 
 fn app(t1: Term, t2: Term) -> Term {
     App(Box::new(t1), Box::new(t2))

--- a/src/stack.rs
+++ b/src/stack.rs
@@ -130,9 +130,8 @@ impl Stack {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use operation::UnaryOp;
     use std::rc::Rc;
-    use term::Term;
+    use term::{Term, UnaryOp};
 
     fn some_closure() -> Closure {
         Closure::atomic_closure(Term::Bool(true))

--- a/src/term.rs
+++ b/src/term.rs
@@ -1,6 +1,5 @@
 use identifier::Ident;
 use label::Label;
-use operation::{BinaryOp, UnaryOp};
 use types::Types;
 
 #[derive(Debug, PartialEq, Clone)]
@@ -20,4 +19,23 @@ pub enum Term {
     // Typing
     Promise(Types, Label, Box<Term>),
     Assume(Types, Label, Box<Term>),
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum UnaryOp {
+    Ite(),
+    IsZero(),
+    IsNum(),
+    IsBool(),
+    IsFun(),
+    Blame(),
+    ChangePolarity(),
+    GoDom(),
+    GoCodom(),
+    Tag(String),
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum BinaryOp {
+    Plus(),
 }


### PR DESCRIPTION
 * UnaryOp and BinaryOp now are part of the `term` module
 * `continuate_operation` consumes a Closure and produces a new one

These changes slightly simplify the code.