### PR TITLE
Fixing a problem with the recursive let.

### DIFF
--- a/makam-spec/src/eval.makam
+++ b/makam-spec/src/eval.makam
@@ -2,11 +2,17 @@
 
 eval : expr -> expr -> prop.
 
+thunk : expr -> expr -> expr.
+
+eval (thunk E V) V' when refl.isunif V :-
+  eval E V,
+  eq V V'.
+eval (thunk E V) V' when not (refl.isunif V) :-
+  eq V V'.
+
 (* Lambda constructs *)
-eval (let (bind Name E) (bind Name T)) V :-
-  ((eval (named Name) R :- eval (E (named Name)) R) ->
-    eval (T (named Name)) V
-  ).
+eval (let (bind Name E) (bind Name T)) V :-  
+  eval (T (thunk (E V') V')) V. 
 
 eval (lam X_Body) (lam X_Body).
 


### PR DESCRIPTION
The version introduced on #21 had the following problem, when evaluating

```
raw_interpreter "
(let (f = 3) in fun x => f) 4 "
V T ?
```

It failed the evaluation step, since it was trying to evaluate `f` outside of the let, and there wasn't any rule to do that.

The fix is ~copied from~ _based on_ https://github.com/astampoulis/makam/pull/54.