### PR TITLE
Fixing recursive lets and making lambdas lazy

### DIFF
--- a/makam-spec/src/ast.makam
+++ b/makam-spec/src/ast.makam
@@ -38,6 +38,10 @@ label : string -> expr.
 (* Variables *)
 named : string -> expr.
 
+(* These are used for lazy evaluation *)
+thunk : string -> expr -> expr -> expr.
+recThunk : string -> (expr -> expr) -> expr -> expr.
+
 (* Types *)
 tdyn : typ.
 tnum : typ.

--- a/makam-spec/src/eval.makam
+++ b/makam-spec/src/eval.makam
@@ -2,24 +2,29 @@
 
 eval : expr -> expr -> prop.
 
-thunk : expr -> expr -> expr.
-
-eval (thunk E V) V' when refl.isunif V :-
+(* Lazy evaluation *)
+eval (thunk _ E V) V' when refl.isunif V :-
   eval E V,
   eq V V'.
-eval (thunk E V) V' when not (refl.isunif V) :-
+eval (thunk _ E V) V' when not (refl.isunif V) :-
+  eq V V'.
+
+eval (recThunk S E V) V' when refl.isunif V :-
+  eval (E (recThunk S E R)) V,
+  eq V V'.
+
+eval (recThunk _ E V) V' when not (refl.isunif V) :-
   eq V V'.
 
 (* Lambda constructs *)
 eval (let (bind Name E) (bind Name T)) V :-  
-  eval (T (thunk (E V') V')) V. 
+  eval (T (recThunk Name E V')) V. 
 
 eval (lam X_Body) (lam X_Body).
 
 eval (app E1 E2) V :-   (* Beta *)
-  eval E1 (lam X_Body),
-  bindone.apply X_Body E2 E',
-  eval E' V.
+  eval E1 (lam (bind Name Body)),
+  eval (Body (thunk Name E2 Shr)) V.
 
 (* Constants *)
 eval (eint N) (eint N).

--- a/makam-spec/src/examples.makam
+++ b/makam-spec/src/examples.makam
@@ -109,18 +109,36 @@ Promise( void -> void, fun x => x)
 print "We also have nice recursive lets" ?
 
 print "Return 3" ?
-raw_interpreter "
+interpreter "
 let (f = fun x => Ifte(x, f false, 3)) in
 f true
 " V T ?
 
-print "No idea what happens with lets in lets" ?
-raw_interpreter "
-let (f = (let (f = 3) in f)) in f + f
+print "Return 4 -- Shadowing works" ?
+interpreter "
+let (f = (let (f = fun x => 3 - x) in f 1)) in f + f
 " V T ?
 
-(*
-The reason is that when evaluating the body of the let definition we introduce a fresh variable that accounts for 
-the recursive definition, and it may try to escape that context where it exists, not unifying with anything
-*)
+print "Return fun -- What happens with dangling thunks?" ?
+interpreter "
+let (f = fun x => x + 1) in
+fun y => f y"
+V T ?
 
+
+print "Lets try side effects!" ?
+
+print "Return 3 -- Lets are lazy" ?
+side_effect : expr.
+eval (side_effect) (eint 1) :- 
+    print "Side Effect!!".
+
+(isocast "
+fun se => let (f = se) in (f + f) + f
+" (E: expr), eval (app E side_effect) Res) ?
+
+print "Return 2 -- functions as well" ?
+
+(isocast "
+fun se => (fun x => x + x) se
+" (E: expr), eval (app E side_effect) Res) ?

--- a/makam-spec/src/init.makam
+++ b/makam-spec/src/init.makam
@@ -2,6 +2,7 @@
 %use "syntax".
 %use "eval".
 %use "typecheck".
+%use "utils".
 
 changeToDyn : typ -> typ -> prop.
 changeToDyn A tdyn when refl.isunif A.
@@ -9,6 +10,13 @@ changeToDyn (tarrow S T) (tarrow CS CT) :-
   changeToDyn S CS,
   changeToDyn T CT.
 changeToDyn A A when not (refl.isunif A).
+
+removeThunks, removeThunks_ : dyn -> dyn -> prop.
+
+removeThunks X Y :- demand.case_otherwise (removeThunks_  X Y) (structural_rec removeThunks X Y).
+
+removeThunks_ (dyn (thunk S A B)) (dyn (named S)) .
+removeThunks_ (dyn (recThunk S A B)) (dyn (named S)) .
 
 raw_interpreter : string -> expr -> typ -> prop.
 raw_interpreter S V Ty :-
@@ -21,5 +29,6 @@ interpreter : string -> string -> string -> prop.
 interpreter S S' STy :-
   raw_interpreter S V T',
   once (changeToDyn T' T), (* The printer will fail if any uninstantiated variable is in the Type *)
-  isocast V (S': string),
+  removeThunks (dyn V) (dyn V'),
+  isocast V' (S': string),
   isocast T (STy: string).

--- a/makam-spec/src/syntax.makam
+++ b/makam-spec/src/syntax.makam
@@ -73,6 +73,8 @@ baseexpr ->
         { <makam.int_literal> }
       / named 
         { <makam.ident> }
+      / label
+        {"Lbl" <makam.string_literal> }
       / { "(" <expr_> ")" }
 
 def -> tuple

--- a/makam-spec/src/typecheck.makam
+++ b/makam-spec/src/typecheck.makam
@@ -3,18 +3,14 @@
 typecheck : expr -> typ -> prop.
 typecheckTypes : typ -> prop.
 
-typecheck (let (bind _ E) (bind _ B)) T :-
-    (x: expr ->
-        typecheck x T' ->
-        (typecheck (E x) T',
-            typecheck (B x) T)
-    ).
+typecheck (let (bind Name E) (bind Name B)) T :-
+    (typecheck (named Name) T' ->
+        (typecheck (E (named Name)) T',
+        typecheck (B (named Name)) T)).
 
-typecheck (lam (bind _ B)) (tarrow S T) :-
-    (x: expr ->
-        typecheck x S ->
-        typecheck (B x) T 
-    ).
+typecheck (lam (bind Name B)) (tarrow S T) :-
+    (typecheck (named Name) S ->
+    typecheck (B (named Name)) T).
 
 typecheck (app A B) T :-
     typecheck A (tarrow S T),

--- a/makam-spec/src/utils.makam
+++ b/makam-spec/src/utils.makam
@@ -1,0 +1,34 @@
+(* TODO: For some reason I can't make the stdlib structural work.
+I tried finding the error, but I couldn't, copying this implementation
+solves the problem for now, but eventually it would make sense to do it with th builtin one.
+*)
+
+typeq : [B] A -> B -> prop.
+typeq (X : A) (Y : A).
+
+structural_rec : (dyn -> dyn -> prop) -> dyn -> dyn -> prop.
+
+(* defer if both input and output are uninstantiated metavariables *)
+(structural_rec Rec (dyn (X : A)) (dyn (Y : A))) when refl.isunif X, refl.isunif Y <-
+  guardmany [ dyn X , dyn Y ] (Rec (dyn X) (dyn Y)).
+
+(* deal with built-in types *)
+structural_rec Rec (dyn (X : string)) (dyn (X : string)).
+structural_rec Rec (dyn (X : int)) (dyn (X : int)).
+structural_rec Rec (dyn (X : A -> B)) (dyn (Y : A -> B)) <-
+  (x:A -> Rec (dyn (X x)) (dyn (Y x))).
+
+(* the essence: forward and backward destructuring *)
+
+(structural_rec Rec (dyn (X : A)) (dyn (Y : A)))
+when not(typeq X (B : C -> D)), not(refl.isunif X) <-
+  refl.headargs X Hd Args,
+  map Rec Args Args',
+  refl.headargs Y Hd Args'.
+
+(structural_rec Rec (dyn (X : A)) (dyn (Y : A)))
+when not(typeq X (B : C -> D)), refl.isunif X, not(refl.isunif Y) <-
+  refl.headargs Y Hd Args',
+  map Rec Args Args',
+  refl.headargs X Hd Args.
+


### PR DESCRIPTION
The version introduced on #21 had the following problem, when evaluating

```
raw_interpreter "
(let (f = 3) in fun x => f) 4 "
V T ?
```

It failed the evaluation step, since it was trying to evaluate f outside of the let, and there wasn't any rule to do that.

Something similar happened with functions.

The fix is ~copied from~ _based on_ https://github.com/astampoulis/makam/pull/54, since it allows us to get a natural implementation of lazy evaluation, I added that as well to the PR.