### PR TITLE
Added a minimal implementation of flat types.

### DIFF
--- a/src/examples/flatType.ncl
+++ b/src/examples/flatType.ncl
@@ -1,0 +1,3 @@
+let alwaysTrue = fun l => fun t => let boolT = Assume(Bool, t) in 
+    if boolT then boolT else blame l in
+Assume(#alwaysTrue, true)

--- a/src/examples/flatType2.ncl
+++ b/src/examples/flatType2.ncl
@@ -1,0 +1,6 @@
+let alwaysTrue = fun l => fun t => let boolT = Assume(Bool, t) in 
+    if boolT then boolT else blame l in
+let alwaysFalse = fun l => fun t => let boolT = Assume(Bool, t) in 
+    if boolT then  blame l else boolT in
+let not = fun b => if b then false else true in
+Assume(#alwaysTrue -> #alwaysFalse, not ) true

--- a/src/grammar.lalrpop
+++ b/src/grammar.lalrpop
@@ -83,6 +83,7 @@ subType : Types = {
     "Dyn" => Types::Dyn(),
     "Num" => Types::Num(),
     "Bool" => Types::Bool(),
+    "#" <SpTerm<RichTerm>> => Types::Flat(<>),
     "(" <Types> ")" => <>,
 };
 

--- a/src/program.rs
+++ b/src/program.rs
@@ -303,7 +303,36 @@ Promise(Bool, 5)
         );
 
         if let Ok(_) = res {
-            panic!("This expression should return an error!.");
+            panic!("This expression should return an error!");
         }
     }
+
+    #[test]
+    fn flat_contract_fail() {
+        let res = eval_string(
+            "let alwaysTrue = fun l => fun t => let boolT = Assume(Bool, t) in 
+    if boolT then boolT else blame l in
+Assume(#alwaysTrue, false)
+",
+        );
+        if let Ok(_) = res {
+            panic!("This expression should return an error!");
+        }
+    }
+
+    #[test]
+    fn flat_higher_order_contract() {
+        let res = eval_string(
+            "let alwaysTrue = fun l => fun t => let boolT = Assume(Bool, t) in 
+    if boolT then boolT else blame l in
+let alwaysFalse = fun l => fun t => let boolT = Assume(Bool, t) in 
+    if boolT then  blame l else boolT in
+let not = fun b => if b then false else true in
+Assume(#alwaysTrue -> #alwaysFalse, not ) true
+",
+        );
+
+        assert_eq!(Ok(Term::Bool(false)), res);
+    }
+
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -6,6 +6,7 @@ pub enum Types {
     Num(),
     Bool(),
     Arrow(Box<Types>, Box<Types>),
+    Flat(RichTerm),
 }
 
 impl Types {
@@ -18,6 +19,7 @@ impl Types {
                 RichTerm::app(RichTerm::var("func".to_string()), s.contract()),
                 t.contract(),
             ),
+            Types::Flat(t) => t.clone(),
         }
     }
 }


### PR DESCRIPTION
This PR allows the user to use normal expressions as contracts and insert them as types in `Assume`s and `Promise`s. The following example would raise blame, since `false` doesn't comply with the contract `alwaysTrue`.

```
let alwaysTrue = fun l => fun t => let boolT = Assume(Bool, t) in 
    if boolT then boolT else blame l in
Assume(#alwaysTrue, false)
```

Things that could be added later on:
 * Check that flat contracts have a certain type (Lbl -> T -> T)
 * It would be nice to have some higher order contracts stuff, with the current implementation we'd need a way to catch a blame (not the best idea). I'd like to do something like the code below:

```
let not = fun c => fun lbl => fun t => if blamed? (c lbl t) then t else blame lbl
```