### PR TITLE
Changed typecheckTypes to a more generic abstraction.

### DIFF
--- a/makam-spec/src/init.makam
+++ b/makam-spec/src/init.makam
@@ -13,7 +13,7 @@ changeToDyn A A when not (refl.isunif A).
 
 removeThunks, removeThunks_ : dyn -> dyn -> prop.
 
-removeThunks X Y :- demand.case_otherwise (removeThunks_  X Y) (structural_rec removeThunks X Y).
+removeThunks X Y :- demand.case_otherwise (removeThunks_  X Y) (structural_map removeThunks X Y).
 
 removeThunks_ (dyn (thunk S A B)) (dyn (named S)) .
 removeThunks_ (dyn (recThunk S A B)) (dyn (named S)) .

--- a/makam-spec/src/typecheck.makam
+++ b/makam-spec/src/typecheck.makam
@@ -1,4 +1,5 @@
 %use "ast".
+%use "utils".
 
 typecheck : expr -> typ -> prop.
 typecheckTypes : typ -> prop.
@@ -79,11 +80,12 @@ typecheck (assume Ty L E) Ty :-
 
 typecheck (label _) tlbl.
 
-typecheckTypes (tarrow S T) :- 
-    typecheckTypes S,
-    typecheckTypes T.
-typecheckTypes (fromExpr E) :-
-    typecheck E (tarrow tlbl (tarrow S S)).
-typecheckTypes T :- 
-    not (eq T (tarrow _ _)),
-    not (eq T (fromExpr _)).
+typecheckTypes_ : dyn -> prop.
+
+typecheckTypes A :- typecheckTypes_ (dyn A).
+
+typecheckTypes_ (dyn A) :-
+    case A [
+        (fromExpr E, typecheck E (tarrow tlbl (tarrow S S))),
+        (Other, structural_map0 typecheckTypes_ (dyn Other))
+    ].

--- a/makam-spec/src/utils.makam
+++ b/makam-spec/src/utils.makam
@@ -1,34 +1,60 @@
+typeq : [B] A -> B -> prop.
+typeq (X : A) (Y : A).
+
+map0 : (A -> prop) -> list A -> prop.
+map0 P nil.
+map0 P (cons HD TL) <- P HD, map0 P TL.
+
 (* TODO: For some reason I can't make the stdlib structural work.
 I tried finding the error, but I couldn't, copying this implementation
 solves the problem for now, but eventually it would make sense to do it with th builtin one.
 *)
-
-typeq : [B] A -> B -> prop.
-typeq (X : A) (Y : A).
-
-structural_rec : (dyn -> dyn -> prop) -> dyn -> dyn -> prop.
+structural_map : (dyn -> dyn -> prop) -> dyn -> dyn -> prop.
 
 (* defer if both input and output are uninstantiated metavariables *)
-(structural_rec Rec (dyn (X : A)) (dyn (Y : A))) when refl.isunif X, refl.isunif Y <-
+(structural_map Rec (dyn (X : A)) (dyn (Y : A))) when refl.isunif X, refl.isunif Y <-
   guardmany [ dyn X , dyn Y ] (Rec (dyn X) (dyn Y)).
 
 (* deal with built-in types *)
-structural_rec Rec (dyn (X : string)) (dyn (X : string)).
-structural_rec Rec (dyn (X : int)) (dyn (X : int)).
-structural_rec Rec (dyn (X : A -> B)) (dyn (Y : A -> B)) <-
+structural_map Rec (dyn (X : string)) (dyn (X : string)).
+structural_map Rec (dyn (X : int)) (dyn (X : int)).
+structural_map Rec (dyn (X : A -> B)) (dyn (Y : A -> B)) <-
   (x:A -> Rec (dyn (X x)) (dyn (Y x))).
 
 (* the essence: forward and backward destructuring *)
 
-(structural_rec Rec (dyn (X : A)) (dyn (Y : A)))
+(structural_map Rec (dyn (X : A)) (dyn (Y : A)))
 when not(typeq X (B : C -> D)), not(refl.isunif X) <-
   refl.headargs X Hd Args,
   map Rec Args Args',
   refl.headargs Y Hd Args'.
 
-(structural_rec Rec (dyn (X : A)) (dyn (Y : A)))
+(structural_map Rec (dyn (X : A)) (dyn (Y : A)))
 when not(typeq X (B : C -> D)), refl.isunif X, not(refl.isunif Y) <-
   refl.headargs Y Hd Args',
   map Rec Args Args',
   refl.headargs X Hd Args.
 
+
+structural_map0 : (dyn -> prop) -> dyn -> prop.
+
+(* defer if both input and output are uninstantiated metavariables *)
+(structural_map0 Rec (dyn (X : A))) when refl.isunif X <-
+  guard X (Rec (dyn X)).
+
+(* deal with built-in types *)
+structural_map0 Rec (dyn (X : string)).
+structural_map0 Rec (dyn (X : int)).
+structural_map0 Rec (dyn (X : A -> B)) <-
+  (x:A -> Rec (dyn (X x))).
+
+(* the essence: forward and backward destructuring *)
+
+(structural_map0 Rec (dyn (X : A)))
+when not(typeq X (B : C -> D)), not(refl.isunif X) <-
+  refl.headargs X Hd Args,
+  map0 Rec Args.
+
+case : A -> (list (tuple A prop)) -> prop.
+case Scrutinee ( (Pattern, Body) :: Rest ) <-
+  if eq Scrutinee Pattern then Body else case Scrutinee Rest.


### PR DESCRIPTION
This is a small change, but ideally we should start using this nice generic functions `makam` provides.

It allows us to extend the language without touching the whole code base, compare how badly it looks to add two new (trivial) type constructors on #32 
https://github.com/tweag/nickel/blob/39ce3520fa197a9546ac3df1e64b55c6991b4695/makam-spec/src/typecheck.makam#L99-L114

With the new implementation `typecheckTypes` wouldn't need to change at all.