### PR TITLE
Small reorganization of the code

### DIFF
--- a/makam-spec/src/ast.makam
+++ b/makam-spec/src/ast.makam
@@ -1,3 +1,8 @@
+(* The AST expressed here is a subset of the whole AST, 
+ * this is what the result of parsing can be as well as
+ * what the typechecker can type. On eval we extend it.
+ *)
+
 expr : type.
 typ : type.
 
@@ -33,14 +38,10 @@ promise : typ -> expr -> expr.
 assume : typ -> expr -> expr -> expr.
 
 (* Blaming *)
-label : string -> expr.
+label : bool -> string -> expr.
 
 (* Variables *)
 named : string -> expr.
-
-(* These are used for lazy evaluation *)
-thunk : string -> expr -> expr -> expr.
-recThunk : string -> (expr -> expr) -> expr -> expr.
 
 (* Types *)
 tdyn : typ.
@@ -50,28 +51,3 @@ tstr : typ.
 tlbl : typ.
 tarrow : typ -> typ -> typ.
 fromExpr : expr -> typ.
-
-(* Get the expression contract of a given type *)
-typToExpr : typ -> expr -> prop.
-typToExpr tdyn (lam (bind _ (fun l => lam (bind _ 
-  (fun t => t))))).
-typToExpr tnum (lam (bind _ (fun l => lam (bind _ 
-  (fun t => ite (eunop isNum t) t (eunop blame l)))))).
-typToExpr tbool (lam (bind _ (fun l => lam (bind _ 
-  (fun t => ite (eunop isBool t) t (eunop blame l)))))).
-typToExpr tstr (lam (bind _ (fun l => lam (bind _ 
-  (fun t => ite (eunop isStr t) t (eunop blame l)))))).
-typToExpr (tarrow S T) (lam (bind _ (fun l => lam (bind _ 
-  (fun t => ite (eunop isFun t) (lam (bind _ (fun x => app (app Ct l) (app t (app (app Cs l) x))))) (eunop blame l)))))) :-
-    typToExpr S Cs,
-    typToExpr T Ct.
-typToExpr (fromExpr E) E.
-
-(* Other *)
-
-find : string -> list (tuple string A) -> A -> prop.
-find S [] _ :- log_error S `Not found in record ${S}`, failure.
-find S ((S, E) :: _) E.
-find S ((S', _) :: TL) E :-
-  not (eq S S'),
-  find S TL E.

--- a/makam-spec/src/eval.makam
+++ b/makam-spec/src/eval.makam
@@ -1,6 +1,40 @@
 %use "ast".
 
+(* We extend the AST to terms related to the execution,
+ * and add some operations on them
+ *)
+
+(* Negation of the label *)
+neg : expr -> expr.
+
+(* Used for lazy evaluation *)
+thunk : string -> expr -> expr -> expr.
+recThunk : string -> (expr -> expr) -> expr -> expr.
+
+(* Get the expression contract of a given type *)
+typToExpr : typ -> expr -> prop.
+typToExpr tdyn (lam (bind _ (fun l => lam (bind _ 
+  (fun t => t))))).
+typToExpr tnum (lam (bind _ (fun l => lam (bind _ 
+  (fun t => ite (eunop isNum t) t (eunop blame l)))))).
+typToExpr tbool (lam (bind _ (fun l => lam (bind _ 
+  (fun t => ite (eunop isBool t) t (eunop blame l)))))).
+typToExpr tstr (lam (bind _ (fun l => lam (bind _ 
+  (fun t => ite (eunop isStr t) t (eunop blame l)))))).
+typToExpr (tarrow S T) (lam (bind _ (fun l => lam (bind _ 
+  (fun t => ite (eunop isFun t) (lam (bind _ (fun x => app (app Ct l) (app t (app (app Cs (neg l)) x))))) (eunop blame l)))))) :-
+    typToExpr S Cs,
+    typToExpr T Ct.
+typToExpr (fromExpr E) E.
+
 eval : expr -> expr -> prop.
+
+(* label *)
+eval (neg L) (label true S) :-
+  eval L (label false S).
+eval (neg L) (label false S) :-
+  eval L (label true S).
+
 
 (* Lazy evaluation *)
 eval (thunk _ E V) V' when refl.isunif V :-
@@ -12,9 +46,9 @@ eval (thunk _ E V) V' when not (refl.isunif V) :-
 eval (recThunk S E V) V' when refl.isunif V :-
   eval (E (recThunk S E R)) V,
   eq V V'.
-
 eval (recThunk _ E V) V' when not (refl.isunif V) :-
   eq V V'.
+
 
 (* Lambda constructs *)
 eval (let (bind Name E) (bind Name T)) V :-  
@@ -22,7 +56,7 @@ eval (let (bind Name E) (bind Name T)) V :-
 
 eval (lam X_Body) (lam X_Body).
 
-eval (app E1 E2) V :-   (* Beta *)
+eval (app E1 E2) V :-
   eval E1 (lam (bind Name Body)),
   eval (Body (thunk Name E2 Shr)) V.
 
@@ -30,7 +64,7 @@ eval (app E1 E2) V :-   (* Beta *)
 eval (eint N) (eint N).
 eval (ebool B) (ebool B).
 eval (estr S) (estr S).
-eval (label S) (label S).
+eval (label P S) (label P S).
 
 (* Operations *)
 eval (ite C T E) V :-
@@ -56,8 +90,11 @@ eval (eunop Op E) V :-
   eval E E',
   eval_unop Op E' V.
 
-eval_unop blame (label S) _ :- 
-  print `Reached a blame with label ${S}`,
+eval_unop blame (label true S) _ :- 
+  print `Reached a positive blame with label ${S}`,
+  failure.
+eval_unop blame (label false S) _ :- 
+  print `Reached a negative blame with label ${S}`,
   failure.
 
 eval_unop isNum (eint _) (ebool true).

--- a/makam-spec/src/syntax.makam
+++ b/makam-spec/src/syntax.makam
@@ -62,7 +62,7 @@ expr_ -> ite
 baseexpr ->
         promise
         { "Promise(" <typ> "," <expr_> ")"}
-      / fun ty => assume ty (label "Assume")
+      / fun ty => assume ty (label true "Assume")
         { "Assume(" <typ> "," <expr_> ")"}
       / ebool true { "true" }
       / ebool false { "false" }
@@ -73,8 +73,6 @@ baseexpr ->
         { <makam.int_literal> }
       / named 
         { <makam.ident> }
-      / label
-        {"Lbl" <makam.string_literal> }
       / { "(" <expr_> ")" }
 
 def -> tuple
@@ -82,6 +80,10 @@ def -> tuple
 
 id -> concrete.name exprvar
         { <makam.ident> }
+
+typ ->  tarrow
+        { <baseTyp> "->" <typ> }
+      / { <baseTyp> }
 
 baseTyp ->  
         tnum 
@@ -95,10 +97,6 @@ baseTyp ->
       / fromExpr
         { <expr_> }
       / { "(" <typ> ")" }
-
-typ ->  tarrow
-        { <baseTyp> "->" <typ> }
-      / { <baseTyp> }
 
 }} ).
 

--- a/makam-spec/src/testnickel.makam
+++ b/makam-spec/src/testnickel.makam
@@ -2,10 +2,11 @@
 
 
 (* This file defines a bunch of tests across many features
-of the Makam implementation of the Nickel language.
-
-They don't follow any particular organization and should be treated
-as a minimal set of expected behaviour. Also as examples. *)
+ * of the Makam implementation of the Nickel language.
+ *
+ * They don't follow any particular organization and should be treated
+ * as a minimal set of expected behaviour. Also as examples.
+ *)
 
 nickel : testsuite. 
 

--- a/makam-spec/src/typecheck.makam
+++ b/makam-spec/src/typecheck.makam
@@ -78,7 +78,7 @@ typecheck (assume Ty L E) Ty :-
     typecheck L tlbl,
     typecheck E _.
 
-typecheck (label _) tlbl.
+typecheck (label _ _) tlbl.
 
 typecheckTypes_ : dyn -> prop.
 


### PR DESCRIPTION
Two main changes:
 * Reorganized the code, now `ast.makam` only has part of the AST (ie the part that can be parsed), the rest (`thunks` and `typToExpr`) are moved to `eval.makam`.
 * Added polarity to the label, and a way to negate it.

There are two main reasons:
 * _Faster execution_ Since `syntax.makam` depends on `ast.makam`, every change to ast meant waiting some time for staging the code on syntax, when the parser didn't actually depended on those changes most of the time.
 * For now the parts that can appear during executions but not parsed (only execution related terms) is small, but it'll grow (think of the wrapper used for polymorphism).