### PR TITLE
Simplify typechecking

### DIFF
--- a/makam-spec/src/init.makam
+++ b/makam-spec/src/init.makam
@@ -18,6 +18,7 @@ removeThunks X Y :- demand.case_otherwise (removeThunks_  X Y) (structural_map r
 removeThunks_ (dyn (thunk S A B)) (dyn (named S)) .
 removeThunks_ (dyn (recThunk S A B)) (dyn (named S)) .
 
+(* Parse, typecheck and interpret *)
 raw_interpreter : string -> expr -> typ -> prop.
 raw_interpreter S V Ty :-
   either (isocast S (E: expr)) (log_error S `Parse error in Nickel program`),
@@ -25,6 +26,7 @@ raw_interpreter S V Ty :-
   eval E V,
   print "Evaluated".
 
+(* Parse, typecheck, interpret and pretty print *)
 interpreter : string -> string -> string -> prop.
 interpreter S S' STy :-
   raw_interpreter S V T',
@@ -32,3 +34,9 @@ interpreter S S' STy :-
   removeThunks (dyn V) (dyn V'),
   isocast V' (S': string),
   isocast T (STy: string).
+
+(* Parse and typecheck *)
+p_typecheck : string -> typ -> prop.
+p_typecheck S Ty :-
+  either (isocast S (E: expr)) (log_error S `Parse error in Nickel program`),
+  once (ifte (typecheck E Ty) (print "Typechecked!") (and (print `Could not typecheck`) (failure))).

--- a/makam-spec/src/testnickel.makam
+++ b/makam-spec/src/testnickel.makam
@@ -80,11 +80,12 @@ testcase nickel :-
     " (ebool true) tdyn.
 
 testcase nickel :-
-    not (
-        raw_interpreter "
-        let (id = fun x => x) in
-        Ifte(true, Assume(Bool, id true), Promise(Num, id 3))
-        " _ _ ).
+    raw_interpreter "
+    let (id = fun x => x) in
+    Ifte(true, Assume(Bool, id true), Promise(Num, id 3))
+    "
+    (ebool true)
+    tdyn.
 
 testcase nickel :-
     raw_interpreter "
@@ -138,3 +139,67 @@ testcase nickel :-
     fun y => f y" 
     (lam (bind "y" (fun y => app (recThunk "f" (fun f => lam (bind "x" (fun x => ebinop x add (eint 1)))) V') y))) 
     (tarrow tnum tnum).
+
+
+nickel_typing : testsuite.
+
+testcase nickel_typing :-
+    p_typecheck
+    "true"
+    tbool.
+
+testcase nickel_typing :-
+    p_typecheck
+    "34"
+    tnum.
+
+testcase nickel_typing :-
+    p_typecheck
+    "34"
+    tdyn.
+
+testcase nickel_typing :-
+    p_typecheck
+    "\"hola\""
+    tstr.
+
+testcase nickel_typing :-
+    p_typecheck
+    "fun x => x"
+    (tarrow A A).
+
+testcase nickel_typing :-
+    p_typecheck
+    "fun x => x"
+    (tarrow tdyn tdyn).
+
+testcase nickel_typing :-
+    p_typecheck
+    "fun x => x"
+    tdyn.
+
+testcase nickel_typing :-
+    p_typecheck
+    "let (x = 34) in x + 2"
+    tnum.
+
+testcase nickel_typing :-
+    p_typecheck
+    "(fun x => x) 3"
+    tnum.
+
+testcase nickel_typing :-
+    p_typecheck
+    "Promise(Bool -> Bool, fun x => x) 3"
+    tdyn.
+
+testcase nickel_typing :-
+    p_typecheck
+    "Promise(Num -> Num, fun x => x) 3"
+    tnum.
+
+testcase nickel_typing :-
+    not (p_typecheck
+        "Promise(Num -> Bool, fun x => x) 3"
+        _
+    ).

--- a/makam-spec/src/typecheck.makam
+++ b/makam-spec/src/typecheck.makam
@@ -16,14 +16,6 @@ typecheck (lam (bind Name B)) (tarrow S T) :-
 typecheck (app A B) T :-
     typecheck A (tarrow S T),
     typecheck B S.
-typecheck (app A B) tdyn :-
-    typecheck A (tarrow S _),
-    typecheck B BTy,
-    not (eq S BTy).
-typecheck (app A B) tdyn :-
-    typecheck A ATy,
-    not (eq ATy (tarrow _ _)),
-    typecheck B _.
 
 typecheck (eint _) tnum.
 typecheck (ebool _) tbool.
@@ -33,16 +25,6 @@ typecheck (ite C T E) Ty :-
     typecheck C tbool,
     typecheck T Ty,
     typecheck E Ty.
-typecheck (ite C T E) tdyn :-
-    typecheck C tbool,
-    typecheck T TTy,
-    typecheck E ETy,
-    not (eq TTy ETy).
-typecheck (ite C T E) tdyn :-
-    typecheck C CTy,
-    not (eq Cty tbool),
-    typecheck T _,
-    typecheck E _.
 
 typecheck (eunop blame L) _ :-
     typecheck L tlbl.
@@ -54,14 +36,6 @@ typecheck (eunop isFun _) tbool.
 typecheck (ebinop A _ B) tnum :-
     typecheck A tnum,
     typecheck B tnum.
-typecheck (ebinop A _ B) tdyn :-
-    typecheck A tnum,
-    typecheck B Bty,
-    not (eq Bty tnum).
-typecheck (ebinop A _ B) tdyn :-
-    typecheck A Aty,
-    not (eq Aty tnum),
-    typecheck B _.
 
 typecheck (promise Ty E) Ty :-
     typecheckTypes Ty,
@@ -79,6 +53,18 @@ typecheck (assume Ty L E) Ty :-
     typecheck E _.
 
 typecheck (label _ _) tlbl.
+
+typecheck_dyn : dyn -> prop.
+typecheck_dyn (dyn A) :-
+    typecheck A _.
+typecheck_dyn (dyn A) :-
+    not (typeq A (X: typ)),
+    structural_map0 typecheck_dyn (dyn A).
+
+typecheck A tdyn :-
+    not (eq A (promise _ _)),
+    (* Still traverse *)
+    structural_map0 typecheck_dyn (dyn A).
 
 typecheckTypes_ : dyn -> prop.
 


### PR DESCRIPTION
Since we're dropping Intersection and union for now, it's worth simplifying the typechecking algorithm.

I basically added a new rule that says that anything can have type `Dyn`, except for `Promise(...)`. And, even if we typecheck something with type `Dyn`, we still traverse it looking for `Promise`s.

Side note, this was probably also possible with inter and union, but my main worry was not that close to the implementation.