### PR TITLE
UnaryOps are treated as functions regarding parsing

### DIFF
--- a/src/grammar.lalrpop
+++ b/src/grammar.lalrpop
@@ -25,12 +25,12 @@ RichTerm: RichTerm = {
 
 Operation: RichTerm = {
     <t1: SpTerm< Applicative>> <op: BOp> <t2: SpTerm<Operation>> => RichTerm::new(Term::Op2(op, t1, t2)),
-    <op: UOp> <t: SpTerm<Operation>> => RichTerm::new(Term::Op1(op, t)),
     SpTerm< Applicative>,
 };
 
 Applicative: RichTerm = {
     <t1:SpTerm< Applicative>> <t2: SpTerm<Atom>> => RichTerm::new(Term::App(t1, t2)),
+    <op: UOp> <t: SpTerm<Atom>> => RichTerm::new(Term::Op1(op, t)),
     SpTerm<Atom>,
 };
 

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -97,3 +97,18 @@ fn lets() {
     assert!(parser.parse("let x1 = x2 in x3").is_ok());
     assert!(parser.parse("x (let x1 = x2 in x3) y").is_ok());
 }
+
+#[test]
+fn unary_op() {
+    assert_eq!(
+        parse_without_pos("isZero x"),
+        Op1(UnaryOp::IsZero(), RichTerm::var("x".to_string())).into()
+    );
+    assert_eq!(
+        parse_without_pos("isZero x y"),
+        RichTerm::app(
+            Op1(UnaryOp::IsZero(), RichTerm::var("x".to_string())).into(),
+            RichTerm::var("y".to_string())
+        )
+    );
+}


### PR DESCRIPTION
This means that `isBool isBool true` is parsed as `(isBool isBool) true`, while before it was `isBool (isBool true)`.

As of now I think this makes things clearer and is more useful (specially when #50 adds the `wrap` unaryOp).