### PR TITLE
Small perf improvement on the parser generator

### DIFF
--- a/makam-spec/src/syntax.makam
+++ b/makam-spec/src/syntax.makam
@@ -6,20 +6,16 @@ expr_, baseexpr : syntax expr.
 expr_concrete : syntax (concrete expr).
 id : syntax (concrete.name expr).
 idTy : syntax (concrete.name typ).
-def : syntax (concrete.name expr * expr).
 binop, binopC : syntax binop.
 unop, unopC : syntax unop.
 
 typ, typC, baseTyp: syntax typ.
-typ_concrete : syntax (concrete typ).
 
 rec_field : syntax rec_field.
 rec_field_typ : syntax (tuple string typ).
 
 exprvar : concrete.namespace expr.
 typvar : concrete.namespace typ.
-
-clet : (concrete.name expr * expr) -> expr -> expr.
 
 token_ARROW : syntax unit.
 token_FATARROW : syntax unit.
@@ -57,8 +53,9 @@ expr_ -> ite
         { "Ifte(" <expr_> "," <expr_> "," <expr_> ")" }
       / (fun id => fun body => lam (concrete.bindone id body))
         { "fun" <id> token_FATARROW <expr_> }
-      / clet
-        { "let" <def> "in" <expr_> }
+      / fun id => fun def => fun body => 
+        let (concrete.bindone id def) (concrete.bindone id body)
+        { "let" "(" <id> "=" <expr_> ")" "in" <expr_> }
       / ebinop
         { <baseexpr> <binopC> <baseexpr> }
       / eunop
@@ -95,16 +92,12 @@ rec_field ->
       / dyn_field
         { "$" <expr_> ":" <expr_>}
 
-def -> tuple
-        { "(" <id> "=" <expr_> ")" }
-
 id -> concrete.name exprvar
         { <makam.ident> }
 
 idTy -> concrete.name typvar
         { <makam.ident> }
 
-typ_concrete -> concrete { <typ> }
 
 typ -> (fun idT => fun body => forall (concrete.bindone idT body))
         { "forall" <idTy> "." <typ> }
@@ -137,14 +130,9 @@ rec_field_typ ->
 
 }} ).
 
-`( syntax.def_toplevel_js typ_concrete ).
 `( syntax.def_toplevel_js expr_concrete ).
 
 concrete.pick_namespace_userdef (_: expr) exprvar.
 concrete.pick_namespace_userdef (_: typ) typvar.
 
 concrete.handle_unresolved_name (concrete.name exprvar ID) (named ID).
-
-concrete.resolve_conversion
-    (clet (Name, Def) Body)
-    (let (concrete.bindone Name Def) (concrete.bindone Name Body)).


### PR DESCRIPTION
I was generating two parsers, one for types and one for expressions. This PR stops the generation of the type parser.

It still takes over 5GB of RAM (killing Circle), but it was reaching the point where it was not viable even for my machine.

See issue #54 