### PR TITLE
Introducing Enums to the language

### DIFF
--- a/makam-spec/src/ast.makam
+++ b/makam-spec/src/ast.makam
@@ -1,3 +1,6 @@
+%use "row".
+%use "utils".
+
 (* The AST expressed here is a subset of the whole AST, 
  * this is what the result of parsing can be as well as
  * what the typechecker can type. On eval we extend it.
@@ -35,9 +38,8 @@ static_access : expr -> string -> expr.
 dyn_access : expr -> expr -> expr.
 
 (* Enumerations *)
-enum_def : string -> (list string) -> expr -> expr.
-enum_var : string -> string -> expr.
-enum_case : expr -> string -> (list (tuple string expr)) -> expr.
+enum_var : string -> expr.
+enum_case : expr -> (list (tuple string expr)) -> option expr -> expr.
 
 (* Operations *)
 ite : expr -> expr -> expr -> expr.
@@ -50,7 +52,7 @@ isBool : unop.
 isStr : unop.
 isRec : unop.
 isFun : unop.
-isEnum : string -> unop.
+isEnumIn : (list string) -> unop.
 
 binop : type.
 ebinop : expr -> binop -> expr -> expr.
@@ -86,4 +88,4 @@ fromExpr : expr -> typ.
 open_rec : typ -> (list (tuple string typ)) -> typ.
 clos_rec : (list (tuple string typ)) -> typ.
 
-tenum : string -> typ.
+tenum : row string -> typ.

--- a/makam-spec/src/eval.makam
+++ b/makam-spec/src/eval.makam
@@ -1,4 +1,5 @@
 %use "ast".
+%use "row".
 %use "utils".
 
 (* We extend the AST to terms related to the execution,
@@ -42,8 +43,14 @@ typToExpr tbool (lam (bind _ (fun l => lam (bind _
   (fun t => ite (eunop isBool t) t (eunop blame l)))))).
 typToExpr tstr (lam (bind _ (fun l => lam (bind _ 
   (fun t => ite (eunop isStr t) t (eunop blame l)))))).
-typToExpr (tenum S) (lam (bind _ (fun l => lam (bind _ 
-  (fun t => ite (eunop (isEnum S) t) t (eunop blame l)))))).
+
+(* TODO Simple implementation
+ * On positive positions this is ok, but if it's an open enum, it
+ * shouldn't fail negatively
+ *)
+typToExpr (tenum R) (lam (bind _ (fun l => lam (bind _ (fun t => 
+  ite (eunop (isEnumIn L) t) t (eunop blame l)))))) :-
+    row.toList R L.
 
 typToExpr (tarrow S T) (lam (bind _ (fun l => lam (bind _ 
   (fun t => ite (eunop isFun t) (lam (bind _ (fun x => app (app Ct l) (app t (app (app Cs (neg l)) x))))) (eunop blame l)))))) :-
@@ -212,23 +219,16 @@ eval (dyn_access E S) V :-
 
 (* Enumerations *)
 
-isEnumOf : (list string) -> string -> prop.
+eval (enum_var S) (enum_var S).
 
-eval (enum_def N L E) V :-
-  not (isEnumOf _ N),
-  (isEnumOf L N ->
-   eval E V).
-
-eval (enum_var N S) (enum_var N S) :-
-  isEnumOf L N,
-  member L S.
-
-eval (enum_case E N L) V :-
-  eval E (enum_var N S),
-  isEnumOf L' N,
-  member L' S,
+eval (enum_case E L _) V :-
+  eval E (enum_var S),
   find L S (R, _),
   eval R V.
+eval (enum_case E L (some D)) V :-
+  eval E (enum_var S),
+  not (find L S _),
+  eval D V.
 
 
 (* Operations *)
@@ -267,16 +267,15 @@ eval_unop isBool (ebool _) (ebool true).
 eval_unop isStr (estr _) (ebool true).
 eval_unop isRec (rec_val _ _) (ebool true). 
 eval_unop isFun (lam _) (ebool true).
-eval_unop (isEnum N) (enum_var N S) (ebool true) :- isEnumOf L N, member L S.
+eval_unop (isEnumIn L) (enum_var S) (ebool true) :- member L S.
 
 eval_unop isNum V (ebool false) :- not (eq V (eint _)).
 eval_unop isBool V (ebool false) :- not (eq V (ebool _)).
 eval_unop isStr V (ebool false) :- not (eq V (estr _)).
 eval_unop isRec V (ebool false) :- not (eq V (rec_val _ _)).
 eval_unop isFun V (ebool false) :- not (eq V (lam _)).
-eval_unop (isEnum N) (enum_var N S) (ebool false) :- not (isEnumOf _ N).
-eval_unop (isEnum N) (enum_var N S) (ebool false) :- isEnumOf L N, not (member L S).
-eval_unop (isEnum S) V (ebool false) :- not (eq V (enum_var S _)).
+eval_unop (isEnumIn L) (enum_var S) (ebool false) :- not (member L S).
+eval_unop (isEnumIn _) V (ebool false) :- not (eq V (enum_var _)).
 
 (* Typing *)
 (* Promises don't perform any computation *)

--- a/makam-spec/src/syntax.makam
+++ b/makam-spec/src/syntax.makam
@@ -1,4 +1,5 @@
 %use "ast".
+%use "row".
 
 %open syntax.
 
@@ -10,11 +11,12 @@ binop, binopC : syntax binop.
 unop, unopC : syntax unop.
 
 typ, typC, baseTyp: syntax typ.
+ctenum : (list string) -> typ.
 
 rec_field : syntax rec_field.
 rec_field_typ : syntax (tuple string typ).
 
-case_def : syntax (tuple string expr).
+switch_def : syntax (tuple string expr).
 
 exprvar : concrete.namespace expr.
 typvar : concrete.namespace typ.
@@ -41,7 +43,7 @@ unop ->
       / isStr { "isStr" }
       / isRec { "isRec" }
       / isFun { "isFun" }
-      / isEnum { "is[" <makam.ident> "]" }
+      / isEnumIn { "is<" <list_sep (token ",") makam.ident> ">" }
 
 }} ).
 
@@ -67,10 +69,10 @@ expr_ -> ite
         { <baseexpr> "." <makam.ident> }
       / dyn_access
         { <baseexpr> ".$" <baseexpr> }
-      / enum_def
-        { <makam.ident> "[" <list_sep (token ",") makam.ident> "]" <baseexpr>}
-      / enum_case
-        { "case" <baseexpr> "of" <makam.ident> "{" <list_sep (token ",") case_def> "}"}
+      / fun e => fun defs => enum_case e defs none
+        { "switch" <baseexpr> "{" <list_sep (token ",") switch_def> "}"}
+      / fun e => fun defs => fun default => enum_case e defs (some default)
+        { "switch" <baseexpr> "{" <list_sep (token ",") switch_def> "," "@" "=>" <baseexpr> "}"}
       / app
         { <baseexpr>  <expr_> }
       / { <baseexpr> }
@@ -88,7 +90,7 @@ baseexpr ->
       / concrete.var
         { <id> }
       / enum_var
-        { "[" <makam.ident> "]" <makam.ident> }
+        { "`" <makam.ident> }
       / eint
         { <makam.int_literal> }
       / named 
@@ -101,7 +103,7 @@ rec_field ->
       / dyn_field
         { "$" <expr_> ":" <expr_>}
 
-case_def -> tuple
+switch_def -> tuple
             { <makam.ident> "=>" <baseexpr>}
 
 id -> concrete.name exprvar
@@ -126,8 +128,8 @@ baseTyp ->
         { "Dyn" }
       / tstr
         { "String" }
-      / tenum 
-        { "[" <makam.ident> "]" }
+      / ctenum 
+        { "<" <list_sep (token ",") makam.ident> ">" }
       / concrete.var
         { <idTy> }
       / open_rec
@@ -150,3 +152,6 @@ concrete.pick_namespace_userdef (_: expr) exprvar.
 concrete.pick_namespace_userdef (_: typ) typvar.
 
 concrete.handle_unresolved_name (concrete.name exprvar ID) (named ID).
+
+concrete.resolve_conversion (ctenum L) (tenum R) :-
+    row.fromList L R, row.close R.

--- a/makam-spec/src/testnickel.makam
+++ b/makam-spec/src/testnickel.makam
@@ -264,10 +264,11 @@ testcase nickel :-
     tdyn.
 
 testcase nickel :-
+(* No impredicative polymorphism, no matter how bad you want it *)
     raw_interpreter
     "(Assume(Num -> (forall a. a -> a) -> Num, fun n => fun f => f n) 34) (fun x => x)"
     (eint 34)
-    tnum.
+    tdyn.
 
 testcase nickel :-
     raw_interpreter
@@ -280,7 +281,6 @@ testcase nickel :-
         "let (f = Promise(forall a . a -> a, fun x => x)) in
         Promise(Num, Promise((Bool -> Num) -> Num, fun f => f true) f)"
         _ _ ).
-
 
 testcase nickel :-
     raw_interpreter
@@ -337,7 +337,7 @@ testcase nickel :-
     "let (f = Assume({hello: Bool} -> Bool, fun x => (x).hello)) in
     f {hello: false }"
     (ebool false)
-    tdyn.
+    tbool.
 
 testcase nickel :-
     not (
@@ -414,108 +414,76 @@ testcase nickel :-
 testcase nickel :-
     row.fromList [1,2 ,3] R, row.fromList [1,2] RR, row.close RR, not(eqv RR R).
 
+
 (* Enums *)
 
 testcase nickel :-
-    isocast "[bla]ble" (enum_var "bla" "ble").
-
-
-testcase nickel :-
-    isocast "bla [ ble, blu] 2" (enum_def "bla" ["ble", "blu"] (eint 2)).
-
+    isocast "`ble" (enum_var "ble").
 
 testcase nickel :-
     isocast 
-        "case ([bla]ble) of bla { blu => 2 , ble => 0}"
+        "switch (`ble) { blu => 2 , ble => 0}"
         (enum_case
-            (enum_var "bla" "ble")
-            "bla"
+            (enum_var "ble")
             [("blu", eint 2), ("ble", eint 0)]
+            none
+        ).
+
+testcase nickel :-
+    isocast 
+        "switch (`ble) { blu => 2 , ble => 0 , @ => 4}"
+        (enum_case
+            (enum_var "ble")
+            [("blu", eint 2), ("ble", eint 0)]
+            (some (eint 4))
         ).
 
 testcase nickel :-
     isocast
-        "is[blop] 3"
-        (eunop (isEnum "blop") (eint 3)).
+        "is<blop, blap> 3"
+        (eunop (isEnumIn ["blop", "blap"]) (eint 3)).
 
 testcase nickel :-
     isocast
-        "Assume([bla], 2)"
-        (assume (tenum "bla") _ (eint 2)).
+        "Assume(<bla>, 2)"
+        (assume (tenum R) _ (eint 2)),
+    row.fromList ["bla"] R', row.close R', eqv R R'.
 
 testcase nickel :-
     raw_interpreter
-        "bla [ble, blo, bli]
-        Assume([bla], [bla]ble)"
-        (enum_var "bla" "ble")
+        "Assume(<bla>, `bla)"
+        (enum_var "bla")
         _.
 
 testcase nickel :-
-    not (raw_interpreter
-        "bla [ble]
-        (bla [bli] 2)"
+    not(raw_interpreter
+        "Assume(<bla>, `ble)"
         _ _).
 
 testcase nickel :-
-    not(raw_interpreter
-        "bla [blo, bli]
-        Assume([bla], [bla]ble)"
-        (enum_var "bla" "ble")
-        _).
-
-testcase nickel :-
-    not(raw_interpreter
-        "bla [ ]
-        Assume([bla], [bla]ble)"
-        (enum_var "bla" "ble")
-        _).
-
-testcase nickel :-
     raw_interpreter
-    "bla [ble]
-    (case ([bla]ble) of bla {bli => 0, ble => 1, blo => 34})"
+    "switch (`ble) {bli => 0, ble => 1, blo => 34}"
     (eint 1)
-    _.
-
-testcase nickel :-
-    not(raw_interpreter
-    "bla []
-    (case ([bla]ble) of bla {ble => 1, blo => 34})"
-    (eint 1)
-    _).
-
-testcase nickel :-
-    not(raw_interpreter
-    "bla [ble]
-    (case ([bla]ble) of bla {bli => 1, blo => 34})"
-    (eint 1)
-    _).
-
-testcase nickel :-
-    p_typecheck
-    "bla [ble]
-    [bla]ble"
-    (tenum "bla").
-
-testcase nickel :-
-    p_typecheck
-    "[bla]ble"
-    tdyn.
-
-testcase nickel :-
-    p_typecheck
-    "bla [ble, bli, blo]
-    (case ([bla]ble) of bla {ble => 1, bli => 2, blo => 3})"
     tnum.
 
 testcase nickel :-
-    p_typecheck
-    "bla [ble, bli, blo]
-    (case ([bla]ble) of bla {ble => 1, blo => 3})"
-    tdyn.
+    not(raw_interpreter
+    "switch (`ble) {bli => 1, blo => 34}"
+    _ _).
 
 testcase nickel :-
     p_typecheck
-    "bla [ ]
-     (bla [ ] 0)"
-    tdyn.
+    "`ble"
+    (tenum R),
+    row.fromList ["ble"] R', eqv R R'.
+
+testcase nickel :-
+    p_typecheck 
+    "fun x => switch x {bla => 2, ble => 1}"
+    (tarrow (tenum (extend "bla" (extend "ble" closed))) tnum).
+
+(*
+This is why ocaml has upper/lower bounds
+p_typecheck
+"fun x => (switch x {bla => 2, ble => 1}) + (switch x {bla => 3})" (`bla) ?
+*)

--- a/makam-spec/src/typecheck.makam
+++ b/makam-spec/src/typecheck.makam
@@ -24,21 +24,26 @@ instantiate Ty Ty :-
  *)
 typedName : string -> typ -> expr.
 
-typecheck (typedName _ Ty) Ty' :-
-    instantiate Ty Ty'.
+typecheck (typedName _ Ty) Ty'' :-
+    instantiate Ty Ty',
+    eqv Ty' Ty''.
 
 (* End of hack *)
 
 typecheck (let (bind Name E) (bind Name B)) T :-
-    typecheck (E (typedName Name T')) T',
-    typecheck (B (typedName Name T')) T.
-
+    typecheck (E (typedName Name T')) T'',
+    eqv T' T'',
+    typecheck (B (typedName Name T')) T''',
+    eqv T T'''.
+    
 typecheck (lam (bind Name B)) (tarrow S T) :-
-    typecheck (B (typedName Name S)) T.
+    typecheck (B (typedName Name S)) T',
+    eqv T T'.
 
 typecheck (app A B) T :-
     typecheck A (tarrow S T),
-    typecheck B S.
+    typecheck B S',
+    eqv S S'.
 
 typecheck (eint _) tnum.
 typecheck (ebool _) tbool.
@@ -73,37 +78,33 @@ typecheck (static_access E S) T :-
     typecheck E (open_rec T L).
 typecheck (static_access E S) T :-
     typecheck E (clos_rec L),
-    find L S (T, _).
+    find L S (T', _),
+    eqv T' T.
 
 typecheck (dyn_access E _) T :-
     typecheck E (open_rec T _).
 
 (* Enumerations *)
 
-isEnumOF : (list string) -> string -> prop.
+typecheck (enum_var S) (tenum R) :-
+    row.empty R,
+    row.add S R.
 
-typecheck (enum_def N L E) Ty :-
-    not (isEnumOF _ N),
-    (isEnumOF L N ->
-     typecheck E Ty).
-
-typecheck (enum_var N S) (tenum N) :-
-    isEnumOF L N,
-    member L S.
-
-typecheck (enum_case E N L) Ty :-
-    (* Is every pattern covered? *)
-    keys L LK,
-    isEnumOF LN N,
-    eq_unord LK LN,
-    (* and check the types *)
-    map (pfun (T, E) => typecheck E Ty) L.
-
+typecheck (enum_case E L D) Ty :-
+    row.empty R,
+    map (pfun (Tag, Ex) => row.add Tag R, typecheck Ex Ty) L,
+    ifte (eq D (some DEx))
+        (typecheck DEx Ty)
+        (row.close R),
+    typecheck E (tenum RE),
+    eqv RE R.
 
 typecheck (ite C T E) Ty :-
     typecheck C tbool,
-    typecheck T Ty,
-    typecheck E Ty.
+    typecheck T Ty',
+    typecheck E Ty'',
+    eqv Ty Ty',
+    eqv Ty Ty''.
 
 typecheck (eunop blame L) _ :-
     typecheck L tlbl.
@@ -113,7 +114,7 @@ typecheck (eunop isBool _) tbool.
 typecheck (eunop isStr _) tbool.
 typecheck (eunop isRec _) tbool.
 typecheck (eunop isFun _) tbool.
-typecheck (eunop (isEnum _) _) tbool.
+typecheck (eunop (isEnumIn _) _) tbool.
 
 typecheck (ebinop A _ B) tnum :-
     typecheck A tnum,
@@ -125,9 +126,16 @@ typecheck E Ty :-
     (x: typ ->
         typecheck E (F x)).
 
+(* A forall is only typechecked when explicitely asked for it, via a promise *)
 typecheck (promise Ty E) Ty :-
+    eq Ty (forall _),
     typecheckTypes Ty,
     typecheck E Ty.
+typecheck (promise Ty E) Ty :-
+    not (eq Ty (forall _)),
+    typecheckTypes Ty,
+    typecheck E Ty',
+    eqv Ty' Ty.
 typecheck (promise Ty E) _ :-
     typecheckTypes Ty,
     not (typecheck E Ty),
@@ -166,3 +174,13 @@ typecheckTypes_ (dyn A) :-
 typecheckTypes_ (dyn B) :-
     not (typeq B (X: typ)),
     structural_map0 typecheckTypes_ (dyn B).
+
+(* This disables the builtin eqv relation for typs *)
+without_eqv_refl (_: typ).
+
+(* This unifies their definitions by expanding them *)
+eqv (T: typ) S when or (not(refl.isunif T)) (not(refl.isunif S)):-
+    structural_map (pfun (dyn A) (dyn B) => eqv A B) (dyn T) (dyn S).
+
+eqv (T: typ) S when refl.isunif T, refl.isunif S :-
+    eq S T.

--- a/makam-spec/src/utils.makam
+++ b/makam-spec/src/utils.makam
@@ -24,7 +24,7 @@ structural_map Rec (dyn (X : A -> B)) (dyn (Y : A -> B)) <-
 (* the essence: forward and backward destructuring *)
 
 (structural_map Rec (dyn (X : A)) (dyn (Y : A)))
-when not(typeq X (B : C -> D)), not(refl.isunif X) <-
+when not(typeq X (B : C -> D)), not(refl.isunif X), refl.isunif Y <-
   refl.headargs X Hd Args,
   map Rec Args Args',
   refl.headargs Y Hd Args'.
@@ -35,6 +35,11 @@ when not(typeq X (B : C -> D)), refl.isunif X, not(refl.isunif Y) <-
   map Rec Args Args',
   refl.headargs X Hd Args.
 
+(structural_map Rec (dyn (X : A)) (dyn (Y : A)))
+when not(typeq X (B : C -> D)), not(refl.isunif X), not(refl.isunif Y) <-
+  refl.headargs X Hd Args,
+  refl.headargs Y Hd Args',
+  map Rec Args Args'.
 
 structural_map0 : (dyn -> prop) -> dyn -> prop.
 
@@ -68,8 +73,9 @@ find ((K, V) :: TL) K' (V', (K, V) :: TL') :-
   find TL K' (V', TL').
 
 member : (list A) -> A -> prop.
-member L X :-
-  find (eq X) L _.
+member (X :: _) X.
+member (X :: TL) Y :-
+  not (eq X Y), member TL Y.
 
 keys : (list (tuple A B)) -> (list A) -> prop.
 keys L K :-


### PR DESCRIPTION
This PR builds up enums without dependency on the language, which means they're quite boring.

There are three new expressions and one new type:
 * `enum_def` defines a new enum, and takes a third parameter that is the rest of the program. The current syntax is `enumName [a1, a2, a3] restOfProgram`
 * `enum_var` is one of the constants of an enum, is written `[enumName]a1`, and it has type `enumName`
 * `enum_case` is a case over an enum, is written `case x of enumName {a1 => t1, a2 => t2, a3 => t3}`. For it to typecheck, every pattern must be covered. There's no default case, but should be easy.
 * `tenum "enumName"` is the type of a given enum. Is written `[enumName]`.

As a few remarks, for the program to typecheck to something, there can't two different enums with the same name within the same AST subtree. If there are, it typechecks to `Dyn`. During evaluation, if two enum definitions are  one under the other on the AST and are evaluated, the evaluation fails.

The syntax is a POC, but I actually like it. Probably changing `[]` for something else, because of lists. Maybe `<>`?