### PR TITLE
[WIP] Dependent functions, an experiment.

### DIFF
--- a/makam-spec/src/ast.makam
+++ b/makam-spec/src/ast.makam
@@ -72,6 +72,7 @@ tbool : typ.
 tstr : typ.
 tlbl : typ.
 tarrow : typ -> typ -> typ.
+tdep : typ -> (bindone expr typ) -> typ.
 forall : (bindone typ typ) -> typ.
 fromExpr : expr -> typ.
 open_rec : typ -> (list (tuple string typ)) -> typ.

--- a/makam-spec/src/eval.makam
+++ b/makam-spec/src/eval.makam
@@ -47,6 +47,17 @@ typToExpr (tarrow S T) (lam (bind _ (fun l => lam (bind _
     typToExpr S Cs,
     typToExpr T Ct.
 
+typToExpr (tdep S (bind _ T)) (lam (bind _ (fun l => lam (bind _ (fun t => 
+  ite 
+    (eunop isFun t) 
+    (lam (bind _ (fun x => 
+      app (app (Ct (app (app Cs (contractify (neg l))) x)) l)
+        (app t (app (app Cs (neg l)) x)))))
+    (eunop blame l)))))) :-
+      typToExpr S Cs,
+      (x: expr ->
+       typToExpr (T x) (Ct x)).
+
 (* forall contract
  * We have two versions of the contract, TyTrue and TyFalse, which one is used
  * depends on the polarity relative to the polarity at the point the forall is at.

--- a/makam-spec/src/syntax.makam
+++ b/makam-spec/src/syntax.makam
@@ -101,6 +101,8 @@ idTy -> concrete.name typvar
 
 typ -> (fun idT => fun body => forall (concrete.bindone idT body))
         { "forall" <idTy> "." <typ> }
+      / (fun idT => fun left => fun body => tdep left (concrete.bindone idT body))
+        { <id> ":" <baseTyp> "=>" <typ> }
       / tarrow
         { <baseTyp> "->" <typ> }
       / { <baseTyp> }

--- a/makam-spec/src/testnickel.makam
+++ b/makam-spec/src/testnickel.makam
@@ -365,3 +365,25 @@ testcase nickel :-
     not (raw_interpreter
     "{blop: 3; blop: false}"
     _ _).
+
+(* Dependent type *)
+
+testcase nickel :-
+    isocast
+    "Promise(x:Num => Bool, 3)"
+    (promise (tdep tnum (bind "x" (fun x => tbool))) (eint 3)).
+
+testcase nickel :-
+    isocast
+    "Promise(x: Num => #(Ifte(x, 5, 4)), 3)"
+    (promise (tdep tnum (bind "x" (fun x => fromExpr (ite x (eint 5) (eint 4))))) (eint 3)).
+
+testcase nickel :-
+    raw_interpreter
+    "let (alwaysTrue = fun l => fun t => Ifte(t, t, blame l)) in
+    let (alwaysFalse = fun l => fun t => Ifte(t, blame l, t)) in
+    
+    Assume(x: Bool => #(Ifte( x, alwaysTrue, alwaysFalse)), fun y =>  y) true"
+    (ebool true)
+    (fromExpr (ite (ebool true) (named "alwaysTrue") (named "alwaysFalse"))).
+

--- a/makam-spec/src/typecheck.makam
+++ b/makam-spec/src/typecheck.makam
@@ -13,8 +13,26 @@ typecheck (lam (bind Name B)) (tarrow S T) :-
     (typecheck (named Name) S ->
     typecheck (B (named Name)) T).
 
+typecheck (lam (bind Name B)) Ty :-
+    not (refl.isunif Ty),
+    eq Ty (tdep S (bind _ T)),
+    (* Here we'd like to say that S can only be an enum *)
+    (* Or that T cant contain fromExpr *)
+    (typecheck (named Name) S ->
+    typecheck (B (named Name)) (T (named Name))).
+
+sourceType : typ -> typ -> prop.
+sourceType (tarrow S _) S.
+sourceType (tdep S _) S.
+
+targetType : typ -> expr -> typ -> prop.
+targetType (tarrow _ T) _ T.
+targetType (tdep _ (bind _ T)) A (T A). (* This should normalize *)
+
 typecheck (app A B) T :-
-    typecheck A (tarrow S T),
+    typecheck A Ty,
+    sourceType Ty S,
+    targetType Ty B T,
     typecheck B S.
 
 typecheck (eint _) tnum.
@@ -110,14 +128,22 @@ typecheck A tdyn :-
     structural_map0 typecheck_dyn (dyn A).
 
 typecheckTypes_ : dyn -> prop.
+typecheck_tdep : typ -> (expr -> typ) -> prop.
 
 typecheckTypes A :- typecheckTypes_ (dyn A).
 
 typecheckTypes_ (dyn A) :-
     case A [
         (fromExpr E, typecheck E (tarrow tlbl (tarrow S S))),
+        (tdep S (bind _ T), typecheck_tdep S T), 
         (Other, structural_map0 typecheckTypes_ (dyn Other))
     ].
 typecheckTypes_ (dyn B) :-
     not (typeq B (X: typ)),
     structural_map0 typecheckTypes_ (dyn B).
+
+typecheck_tdep S T :-
+    typecheckTypes S,
+    (x: expr ->
+     typecheck x S ->
+     typecheckTypes (T x)).


### PR DESCRIPTION
This is **not ready**, it's just an experiment, mainly because it's pointless without enums.

The idea is to have a `x:A => B(x)` type, the contract is as discussed on the literature (see #52), in particular, it can blame the contract itself, so three labels.

The type is very straightforward and, for now, without restrictions. Basically it's the expected rule for \Pi, but it never actually evaluates the type. Not sure how useful it is.