### PR TITLE
Static typechecking for `forall`, take 2

### DIFF
--- a/src/examples/forall.ncl
+++ b/src/examples/forall.ncl
@@ -1,0 +1,2 @@
+let f = Promise(forall a. (forall b. a -> b ->  a), fun x => fun y => x) in
+f

--- a/src/examples/forall2.ncl
+++ b/src/examples/forall2.ncl
@@ -1,0 +1,2 @@
+let f = Promise(forall a. (forall b. b -> b) -> a -> a, fun f => fun x => f x) in
+Promise(Num, (f Promise(forall b. b -> b, fun x => x)) 3)

--- a/src/examples/forall3.ncl
+++ b/src/examples/forall3.ncl
@@ -1,0 +1,3 @@
+Promise(
+    ((forall a. a -> a) -> Num) -> Num, 
+    fun f => f Promise(forall b. b -> b, fun y => y) ) (fun g => 3)

--- a/src/examples/forall4.ncl
+++ b/src/examples/forall4.ncl
@@ -1,0 +1,3 @@
+let g = Promise(forall a. a -> a, fun y => (fun x => x) y) in
+let f = Promise(forall a. a -> a, fun y => g y) in
+f


### PR DESCRIPTION
Rewrote PR #64 with simpler ideas proposed by @aspiwack. Like before, I don't infer, I only check.

Every time we want to check that something has type `forall a. ...` we introduce a new constant (unique) type, and substitute `a` for that.
Every time we want to use a variable with type `forall a. ...` we substitute the `a` with the same unification variable.

 