### PR TITLE
Merge operator without enriched values

### DIFF
--- a/src/examples/merge.ncl
+++ b/src/examples/merge.ncl
@@ -1,0 +1,9 @@
+let r1 = {
+    a=false;
+    b=(if true then (1 + 1) else (2 + 0));
+    c=(((fun x => x) (fun y => y)) 2);} in
+let r2 = {
+    b=(((fun x => x) (fun y => y)) 2);
+    c=(if true then (1 + 1) else (2 + 0));
+    d=true;} in
+(merge r1 r2).b

--- a/src/examples/merge2.ncl
+++ b/src/examples/merge2.ncl
@@ -1,0 +1,2 @@
+let f = fun y => merge ((fun x => {a=y;}) 0) ({b=false;}) in
+(f 1).a

--- a/src/examples/merge3.ncl
+++ b/src/examples/merge3.ncl
@@ -1,0 +1,4 @@
+let rNest1 = {b={c=10;};} in
+let rNest2 = (fun x => {a=x; b={c=x;};}) 10 in
+let r = merge rNest1 rNest2 in
+(r.b).c

--- a/src/grammar.lalrpop
+++ b/src/grammar.lalrpop
@@ -153,6 +153,7 @@ BOpPre: BinaryOp<RichTerm> = {
     "hasField" => BinaryOp::HasField(),
     "map" => BinaryOp::ListMap(),
     "elemAt" => BinaryOp::ListElemAt(),
+    "merge" => BinaryOp::Merge(),
 }
 
 Types: Types = {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 mod eval;
 mod identifier;
 mod label;
+mod merge;
 mod operation;
 mod parser;
 mod program;

--- a/src/merge.rs
+++ b/src/merge.rs
@@ -1,0 +1,244 @@
+//! Evaluation of the merge operator
+use crate::eval::{Closure, Environment, EvalError, IdentKind};
+use crate::identifier::Ident;
+use crate::term::{BinaryOp, RichTerm, Term};
+use simple_counter::*;
+use std::cell::RefCell;
+use std::collections::HashMap;
+use std::rc::Rc;
+
+generate_counter!(FreshVariableCounter, usize);
+
+/// Compute the merge of the two operands once they have been evaluated
+pub fn merge(
+    t1: Term,
+    env1: Environment,
+    t2: Term,
+    env2: Environment,
+) -> Result<Closure, EvalError> {
+    match (t1, t2) {
+        // Merge is idempotent on basic terms
+        (Term::Bool(b1), Term::Bool(b2)) => {
+            if b1 == b2 {
+                Ok(Closure::atomic_closure(Term::Bool(b1).into()))
+            } else {
+                Err(EvalError::TypeError(String::from(
+                    "Trying to merge two distinct booleans",
+                )))
+            }
+        }
+        (Term::Num(n1), Term::Num(n2)) => {
+            if n1 == n2 {
+                Ok(Closure::atomic_closure(Term::Num(n1).into()))
+            } else {
+                Err(EvalError::TypeError(format!(
+                    "Trying to merge two distinct numbers {} and {}",
+                    n1, n2
+                )))
+            }
+        }
+        (Term::Str(s1), Term::Str(s2)) => {
+            if s1 == s2 {
+                Ok(Closure::atomic_closure(Term::Str(s1).into()))
+            } else {
+                Err(EvalError::TypeError(format!(
+                    "Trying to merge two distinct strings \"{}\" and \"{}\"",
+                    s1, s2
+                )))
+            }
+        }
+        (Term::Lbl(l1), Term::Lbl(l2)) => {
+            if l1 == l2 {
+                Ok(Closure::atomic_closure(Term::Lbl(l1).into()))
+            } else {
+                Err(EvalError::TypeError(format!(
+                    "Trying to merge two distinct labels \"{:?}\" and \"{:?}\"",
+                    l1, l2
+                )))
+            }
+        }
+        // Merge put together the fields of records, and recursively merge
+        // fields that are present in both terms
+        (Term::Record(m1), Term::Record(m2)) => {
+            /* Terms inside m1 and m2 may capture variables of resp. env1 and env2.  Morally, we
+             * need to store closures, or a merge of closures, inside the resulting record.  We use
+             * the same trick as in the evaluation of the operator DynExtend, and replace each such
+             * term by a variable bound to an appropriate closure in the environment
+             */
+            let mut m = HashMap::new();
+            let mut env = HashMap::new();
+            let (mut left, mut center, mut right) = hashmap::split(m1, m2);
+
+            for (field, t) in left.drain() {
+                m.insert(field, closurize(&mut env, t, env1.clone()));
+            }
+
+            for (field, t) in right.drain() {
+                m.insert(field, closurize(&mut env, t, env2.clone()));
+            }
+
+            for (field, (t1, t2)) in center.drain() {
+                m.insert(
+                    field,
+                    Term::Op2(
+                        BinaryOp::Merge(),
+                        closurize(&mut env, t1, env1.clone()),
+                        closurize(&mut env, t2, env2.clone()),
+                    )
+                    .into(),
+                );
+            }
+
+            Ok(Closure {
+                body: Term::Record(m).into(),
+                env,
+            })
+        }
+        //The following cases are either errors or not yet implemented
+        (ref t1, ref t2) => Err(EvalError::TypeError(format!(
+            "Could not merge {:?} and {:?}",
+            *t1, *t2
+        ))),
+    }
+}
+
+/// Create a RichTerm that represents the term `t` together with an environment `with_env`.
+/// It generates a fresh variable, binds it to the corresponding closure `(t,with_env)` in env,
+/// and returns this new variable as a term
+fn closurize(env: &mut Environment, t: RichTerm, with_env: Environment) -> RichTerm {
+    //To avoid clashing with fresh variables introduced by DynExtend, we add an 'm' in the prefix
+    let var = format!("_m{}", FreshVariableCounter::next());
+    let c = Closure {
+        body: t,
+        env: with_env,
+    };
+
+    env.insert(
+        Ident(var.clone()),
+        (Rc::new(RefCell::new(c)), IdentKind::Record()),
+    );
+
+    Term::Var(Ident(var)).into()
+}
+
+pub mod hashmap {
+    use std::collections::HashMap;
+
+    /// Split two hashmaps m1 and m2 in three parts (left,center,right), where left holds bindings
+    /// `(key,value)` where key is not in `m2.keys()`, right is the dual (keys of m2 that are not in m1),
+    /// and center holds bindings for keys that are both in m1 and m2
+    pub fn split<K, V1, V2>(
+        m1: HashMap<K, V1>,
+        m2: HashMap<K, V2>,
+    ) -> (HashMap<K, V1>, HashMap<K, (V1, V2)>, HashMap<K, V2>)
+    where
+        K: std::hash::Hash + Eq,
+    {
+        let mut left = HashMap::new();
+        let mut center = HashMap::new();
+        let mut right = m2;
+
+        for (key, value) in m1 {
+            if let Some(v2) = right.remove(&key) {
+                center.insert(key, (value, v2));
+            } else {
+                left.insert(key, value);
+            }
+        }
+
+        (left, center, right)
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        #[test]
+        fn all_left() -> Result<(), String> {
+            let mut m1 = HashMap::new();
+            let m2 = HashMap::<isize, isize>::new();
+
+            m1.insert(1, 1);
+            let (mut left, center, right) = split(m1, m2);
+
+            if left.remove(&1) == Some(1)
+                && left.is_empty()
+                && center.is_empty()
+                && right.is_empty()
+            {
+                Ok(())
+            } else {
+                Err(String::from("Expected all elements to be in the left part"))
+            }
+        }
+
+        #[test]
+        fn all_right() -> Result<(), String> {
+            let m1 = HashMap::<isize, isize>::new();
+            let mut m2 = HashMap::new();
+
+            m2.insert(1, 1);
+            let (left, center, mut right) = split(m1, m2);
+
+            if right.remove(&1) == Some(1)
+                && right.is_empty()
+                && left.is_empty()
+                && center.is_empty()
+            {
+                Ok(())
+            } else {
+                Err(String::from(
+                    "Expected all elements to be in the right part",
+                ))
+            }
+        }
+
+        #[test]
+        fn all_center() -> Result<(), String> {
+            let mut m1 = HashMap::new();
+            let mut m2 = HashMap::new();
+
+            m1.insert(1, 1);
+            m2.insert(1, 2);
+            let (left, mut center, right) = split(m1, m2);
+
+            if center.remove(&1) == Some((1, 2))
+                && center.is_empty()
+                && left.is_empty()
+                && right.is_empty()
+            {
+                Ok(())
+            } else {
+                Err(String::from(
+                    "Expected all elements to be in the center part",
+                ))
+            }
+        }
+
+        #[test]
+        fn mixed() -> Result<(), String> {
+            let mut m1 = HashMap::new();
+            let mut m2 = HashMap::new();
+
+            m1.insert(1, 1);
+            m1.insert(2, 1);
+            m2.insert(1, -1);
+            m2.insert(3, -1);
+            let (mut left, mut center, mut right) = split(m1, m2);
+
+            if left.remove(&2) == Some(1)
+                && center.remove(&1) == Some((1, -1))
+                && right.remove(&3) == Some(-1)
+                && left.is_empty()
+                && center.is_empty()
+                && right.is_empty()
+            {
+                Ok(())
+            } else {
+                Err(String::from(
+                    "Expected all elements to be in the center part",
+                ))
+            }
+        }
+    }
+}

--- a/src/operation.rs
+++ b/src/operation.rs
@@ -2,6 +2,7 @@ use crate::eval::Environment;
 use crate::eval::{CallStack, Closure, EvalError, IdentKind};
 use crate::identifier::Ident;
 use crate::label::TyPath;
+use crate::merge::merge;
 use crate::stack::Stack;
 use crate::term::{BinaryOp, RichTerm, Term, UnaryOp};
 use simple_counter::*;
@@ -609,6 +610,7 @@ fn process_binary_operation(
                 ))),
             }
         }
+        BinaryOp::Merge() => merge(*t1, env1, *t2, env2),
     }
 }
 

--- a/src/term.rs
+++ b/src/term.rs
@@ -190,6 +190,7 @@ pub enum BinaryOp<CapturedTerm> {
     ListConcat(),
     ListMap(),
     ListElemAt(),
+    Merge(),
 }
 
 impl<Ty> BinaryOp<Ty> {
@@ -198,7 +199,6 @@ impl<Ty> BinaryOp<Ty> {
 
         match self {
             DynExtend(t) => DynExtend(f(t)),
-
             Plus() => Plus(),
             PlusStr() => PlusStr(),
             Unwrap() => Unwrap(),
@@ -209,6 +209,7 @@ impl<Ty> BinaryOp<Ty> {
             ListConcat() => ListConcat(),
             ListMap() => ListMap(),
             ListElemAt() => ListElemAt(),
+            Merge() => Merge(),
         }
     }
 }

--- a/src/typecheck.rs
+++ b/src/typecheck.rs
@@ -838,6 +838,13 @@ pub fn get_bop_type(
                 Box::new(TypeWrapper::Concrete(AbsType::Dyn())),
             ))),
         ))),
+        BinaryOp::Merge() => Ok(TypeWrapper::Concrete(AbsType::arrow(
+            Box::new(TypeWrapper::Concrete(AbsType::Dyn())),
+            Box::new(TypeWrapper::Concrete(AbsType::arrow(
+                Box::new(TypeWrapper::Concrete(AbsType::Dyn())),
+                Box::new(TypeWrapper::Concrete(AbsType::Dyn())),
+            ))),
+        ))),
     }
 }
 


### PR DESCRIPTION
Implement a merge operator, without support for the enriched value yet (it addresses #74 partially).

## Semantics on values
 Merging two values other than records results in an error, unless these values are constants (Num, Bool, etc.) and equal. We do not inspect functions for syntactical equality, and always fail on them.

- `merge 1 2 = error`
- `merge 1 1 = 1`
- `merge (fun x => ...) _ = error`

## Semantics on records
Merging two records `r1 = {a_1: v_1, ..., a_n: v_n}` and `r2 = {b_1: w_1, ..., b_n: w_m}` gives a record which includes content from both r1 and r2. If the same field `a_i = b_j`is defined in both r1 and r2, the content is recursively merged: `merge r1 r2 = { ..., a_i: merge v_i w_j, ...}`. Note that the inner merge are lazy. For example, `merge {a=1} {a=2}` do not fail until the field a is requested. We may want to alterate this behavior later, or add a way to recursively force record fields for data validation purpose.

## Examples
In the following, take `=` with a grain of salt because of lazyness: it should be understood as "is equal to if we force recursively the evaluation of all record fields".
```
merge {a=1} {b=true} = {a=1; b=true}
merge {a=1} {a=true} = error
merge ((fun x => {a={b=x}}) 1) ((fun x => {a={c=x}}) true) false = {a={b=1;c=true}}
```