### PR TITLE
Extend the merge operator to enriched values

### DIFF
--- a/src/examples/flatType3.ncl
+++ b/src/examples/flatType3.ncl
@@ -1,0 +1,27 @@
+let Y = fun f => (fun x => f (x x)) (fun x => f (x x)) in
+let dec = fun x => x + (-1) in
+let or = fun x => fun y => if x then x else y in
+let isEven = Y (fun f =>
+    (fun x =>
+        if (isZero x) then true
+        else (
+            if (isZero (dec x)) then false
+            else (f (dec (dec x)))
+        )
+    )
+) in
+let isDivBy3 = Y (fun f =>
+    (fun x =>
+        if (isZero x) then true
+        else (
+            if or (isZero (dec (dec x))) (isZero (dec x)) then false
+            else (f (dec (dec (dec x))))
+        )
+    )
+) in
+let toCtr = fun f => fun l => fun x => (
+  if (isNum x) then (
+    if (f x) then x else blame l)
+  else blame l
+) in
+Assume(#(toCtr isDivBy3), 2)

--- a/src/examples/mergeContracts.ncl
+++ b/src/examples/mergeContracts.ncl
@@ -1,0 +1,30 @@
+let Y = fun f => (fun x => f (x x)) (fun x => f (x x)) in
+let dec = fun x => x + (-1) in
+let or = fun x => fun y => if x then x else y in
+let isEven_ = Y (fun f =>
+    (fun x =>
+        if (isZero x) then true
+        else (
+            if (isZero (dec x)) then false
+            else (f (dec (dec x)))
+        )
+    )
+) in
+let isDivBy3_ = Y (fun f =>
+    (fun x =>
+        if (isZero x) then true
+        else (
+            if or (isZero (dec (dec x))) (isZero (dec x)) then false
+            else (f (dec (dec (dec x))))
+        )
+    )
+) in
+let toCtr = fun f => fun l => fun x => (
+  if (isNum x) then (
+    if (f x) then x else blame l)
+  else blame l
+) in
+let isEven = toCtr isEven_ in
+let isDivBy3 = toCtr isDivBy3_ in
+let composed = merge Contract(#isEven) Contract(#isDivBy3) in
+merge 12 composed

--- a/src/examples/mergeEnriched.ncl
+++ b/src/examples/mergeEnriched.ncl
@@ -1,0 +1,28 @@
+let or = Promise(Bool -> Bool -> Bool, fun a => fun b =>
+    if a then true else b) in
+let and = Promise(Bool -> Bool -> Bool, fun a => fun b =>
+    if a then (if b then true else false) else false) in
+let oneOrTwo = fun l => fun x =>
+    if and (isNum x)
+           (or (isZero (x + (-1))) (isZero (x + (-2)))) then
+        x
+    else blame l in
+let confDefault = {
+    pathLibc = Docstring("Installation path of the libc",
+               Default("/lib/x86_64-linux-gnu/libc.so"));
+    gcc = Docstring("Gcc command",
+          Default("gcc -Werror -03"));
+    specialFlag = Docstring("Set 1 for default, 2 for optimized",
+                  Default(1));
+} in
+let confValidation = {
+    pathLibc = Contract(Str);
+    gcc = Contract(Str);
+    specialFlag = Contract(#oneOrTwo);
+} in
+let confValAndDef = merge confValidation confDefault in
+let myConf = {
+    gcc = "gcc -02";
+} in
+let result = merge myConf confValAndDef in
+result.specialFlag

--- a/src/term.rs
+++ b/src/term.rs
@@ -220,6 +220,13 @@ impl<Ty> BinaryOp<Ty> {
             Merge() => Merge(),
         }
     }
+
+    pub fn is_strict(&self) -> bool {
+        match self {
+            BinaryOp::Merge() => false,
+            _ => true,
+        }
+    }
 }
 
 #[derive(Debug, PartialEq, Clone)]
@@ -248,6 +255,10 @@ impl RichTerm {
 
     pub fn var(s: String) -> RichTerm {
         Term::Var(Ident(s)).into()
+    }
+
+    pub fn fun(s: String, rt: RichTerm) -> RichTerm {
+        Term::Fun(Ident(s), rt).into()
     }
 
     pub fn let_in(id: &str, e: RichTerm, t: RichTerm) -> RichTerm {


### PR DESCRIPTION
Extend the merge operator (see #75) to handle enriched terms (see #78). This addresses #74. Depend on both #75 and #78. With this PR, here is an example of a working Nickel program one can write:
```
let confDefault = {
    pathLibc = Docstring("Installation path of the libc",
               Default("/lib/x86_64-linux-gnu/libc.so"));
    gcc = Docstring("Gcc command",
          Default("gcc -Werror -O3"));
    specialFlag = Docstring("Set 1 for default, 2 for optimized",
                  Default(1));
} in
let confValidation = {
    pathLibc = Contract(Str);
    gcc = Contract(Str);
    specialFlag = Contract(#oneOrTwo);
} in
let confValAndDef = merge confValidation confDefault in
let myConf = {
    gcc = "gcc -O2"; 
} in
let result = merge myConf confValAndDef in
result.specialFlag
```
This evaluates to `1`. If one adds a binding `specialFlag = 3` in `myConf`, a blame error occurs. Fields `result.gcc` and `result.pathLibc` are also defined and evaluates to the expected values ("gcc -O2" and "/lib/x86_64-linux-gnu/libc.so"`).

`oneOrTwo` is an user-written contract that checks if its argument is either `1` or `2`, and fails otherwise. It is omitted for conciseness (the lack of basic constructs for now making it slightly verbose) but can be currently defined. See src/examples/mergeExtended.ncl for the complete version.

## Semantics: how merge evaluates on enriched terms
Cases are tested in this order, such that the case for `Docstring` takes precedence over the case of `Default`, for example.

- merging a term with a doctring `Docstring(s,t)` with any other term `t'`recursively pushes the merge inside to give `Docstring(s, merge t t')`
- merging two terms with default values (either `Default(..)` or `ContractDefault(..)`) *fails*
- merging a default value with another term evaluates to the other term
- merging a contract with a default value combines the two (there is a dedicated construct `ContractDefault`, see #78 )
- merging two contracts gives a contract that enforces for both of them, which is a contract for the intersection of the two associated types. See src/examples/mergeContracts.ncl for an example where an "even" contract and "divisible by 3" contract are merged to give a "divisible by 6" contract. If one of the two had a default value, this value is combined back with the result.
- merging a contract `Contract(type)` with any other value `t` generates a cast `Assume(type,t)`