### PR TITLE
Fix the typechecking of types with foralls

### DIFF
--- a/src/typecheck.rs
+++ b/src/typecheck.rs
@@ -1002,6 +1002,27 @@ mod tests {
     }
 
     #[test]
+    fn forall_nested() {
+        parse_and_typecheck(
+            "let f = Promise(forall a. a -> a, let g = Assume(forall a. (a -> a), fun x => x) in g) in
+            Promise(Num, if (f true) then (f 2) else 3)",
+        )
+        .unwrap();
+
+        parse_and_typecheck(
+            "let f = Promise(forall a. a -> a, let g = Promise(forall a. (a -> a), fun x => x) in g g) in
+            Promise(Num, if (f true) then (f 2) else 3)",
+        )
+        .unwrap();
+
+        parse_and_typecheck(
+            "let f = Promise(forall a. a -> a, let g = Promise(forall a. (forall b. (b -> (a -> a))), fun y => fun x => x) in g 0) in
+            Promise(Num, if (f true) then (f 2) else 3)",
+        )
+        .unwrap();
+    }
+
+    #[test]
     fn enum_simple() {
         parse_and_typecheck("Promise(< (| bla, |) >, `bla)").unwrap();
         parse_and_typecheck("Promise(< (| bla, |) >, `blo)").unwrap_err();


### PR DESCRIPTION
Close ~~#86~~ #88. The problem was the following:

1. To typecheck an expression against a polymorphic type, all the type variables bound by foralls are instantiated with fresh type constants.
2. This instantiation is done as a special case in the type checking of let, when the content is of the form `Promise(tpoly, foo)`, and the whole expression `Promise(tpoly,foo)` is type-checked against the instantiation
3. But the type-checking of `Promise(tpoly, foo)` against a type `ty` expects `ty` to have the same shape as `tpoly`, which is not the case if `ty` is already an instantiation of `tpoly`. It is instantiated explicitly later when typechecking the body `foo`.

So 3. fails because 2. passes an already instantiated type, hence the mismatch. This PR removes the superfluous instantiation in 2. A corresponding test case is provided, which fails against master, and passes against this PR.