### PR TITLE
Add basic lists support

### DIFF
--- a/src/examples/lists-all-any.ncl
+++ b/src/examples/lists-all-any.ncl
@@ -1,0 +1,28 @@
+let Y = fun f => (fun x => f (x x)) (fun x => f (x x)) in
+let foldr_ =
+    fun self => fun f => fun acc => fun l =>
+        if isZero (length l) then acc
+        else
+            let h = head l in
+            let t = tail l in
+            let next_acc = self f acc t in
+            f next_acc h
+in
+let foldr = Y foldr_ in
+let and = Promise(Bool -> Bool -> Bool,
+    fun x => fun y =>
+        if x then
+            if y then true else false
+        else false)
+in
+let or = Promise(Bool -> Bool -> Bool,
+    fun x => fun y =>
+        if x then
+            true
+        else
+            if y then true else false)
+in
+let all = fun pred => fun l => foldr and true (map pred l) in
+let any = fun pred => fun l => foldr or false (map pred l) in
+let isZ = fun x => isZero x in
+or (any isZ [1, 1, 1, 1]) (all isZ [0, 0, 0, 0])

--- a/src/examples/lists-flatten.ncl
+++ b/src/examples/lists-flatten.ncl
@@ -1,0 +1,14 @@
+let Y = fun f => (fun x => f (x x)) (fun x => f (x x)) in
+let foldl_ =
+    fun self => fun f => fun acc => fun l =>
+        if isZero (length l) then acc
+        else
+            let h = head l in
+            let t = tail l in
+            let next_acc = f acc h in
+            seq next_acc (self f next_acc t)
+in
+let foldl = Y foldl_ in
+let concat = Promise(List -> List -> List, fun x => fun y => x @ y) in
+let flatten = foldl concat [] in
+flatten [[1,2],[3,4],[]]

--- a/src/examples/lists-foldl.ncl
+++ b/src/examples/lists-foldl.ncl
@@ -1,0 +1,12 @@
+let Y = fun f => (fun x => f (x x)) (fun x => f (x x)) in
+let foldl_ =
+    fun self => fun f => fun acc => fun l =>
+        if isZero (length l) then acc
+        else
+            let h = head l in
+            let t = tail l in
+            let next_acc = f acc h in
+            seq next_acc (self f next_acc t)
+in
+let foldl = Y foldl_ in
+foldl (fun x => fun y => x + y) 0 ([1, 2, 3, 4, 5])

--- a/src/grammar.lalrpop
+++ b/src/grammar.lalrpop
@@ -35,7 +35,7 @@ Applicative: RichTerm = {
     <op: BOpPre> <t1: SpTerm<Atom>> <t2: SpTerm<Atom>> => RichTerm::new(Term::Op2(op, t1, t2)),
     <t: SpTerm<Atom>> "." <id: Ident> => RichTerm::new(Term::Op1(UnaryOp::StaticAccess(id), t)),
     <t: SpTerm<Atom>> ".$" <t_id: SpTerm<Atom>> => RichTerm::new(Term::Op2(BinaryOp::DynAccess(), t_id, t)),
-    <r: SpTerm<Atom>> "[" <id: SpTerm<Atom>> "=" <t: SpTerm<Atom>> "]" =>
+    <r: SpTerm<Atom>> "$[" <id: SpTerm<Atom>> "=" <t: SpTerm<Atom>> "]" =>
         RichTerm::new(Term::Op2(BinaryOp::DynExtend(t), id, r)),
     SpTerm<Atom>,
 };
@@ -68,9 +68,15 @@ Atom: RichTerm = {
                 acc
             ))
         }
-    )
-    
-    
+    ),
+    "[" <terms: (SpTerm<Atom> ",")*> <last: SpTerm<Atom>?> "]" => {
+        let mut terms : Vec<RichTerm> = terms.clone().into_iter().map(|x| x.0).collect();
+        if let Some(t) = last {
+            terms.push(t);
+        }
+
+        RichTerm::new(Term::List(terms))
+    }
 };
 
 RecordField: Either<(Ident, RichTerm), (RichTerm, RichTerm)> = {
@@ -103,6 +109,7 @@ UOp: UnaryOp<RichTerm> = {
     "isBool" => UnaryOp::IsBool(),
     "isStr" => UnaryOp::IsStr(),
     "isFun" => UnaryOp::IsFun(),
+    "isList" => UnaryOp::IsList(),
     "blame" => UnaryOp::Blame(),
     "chngPol" => UnaryOp::ChangePolarity(),
     "polarity" => UnaryOp::Pol(),
@@ -119,6 +126,9 @@ UOp: UnaryOp<RichTerm> = {
     "mapRec" <Atom> => UnaryOp::MapRec(<>),
     "seq" => UnaryOp::Seq(),
     "deepSeq" => UnaryOp::DeepSeq(),
+    "head" => UnaryOp::ListHead(),
+    "tail" => UnaryOp::ListTail(),
+    "length" => UnaryOp::ListLength(),
 };
 
 switch_case: (Ident, RichTerm) = {
@@ -134,11 +144,15 @@ BOpIn: BinaryOp<RichTerm> = {
     "++" => BinaryOp::PlusStr(),
     "=b" => BinaryOp::EqBool(),
     "-$" => BinaryOp::DynRemove(),
+    "@" => BinaryOp::ListConcat(),
+
 };
 
 BOpPre: BinaryOp<RichTerm> = {
     "unwrap" => BinaryOp::Unwrap(),
     "hasField" => BinaryOp::HasField(),
+    "map" => BinaryOp::ListMap(),
+    "elemAt" => BinaryOp::ListElemAt(),
 }
 
 Types: Types = {
@@ -156,6 +170,7 @@ subType : Types = {
     "Num" => Types(AbsType::Num()),
     "Bool" => Types(AbsType::Bool()),
     "Str" => Types(AbsType::Str()),
+    "List" => Types(AbsType::List()),
     <Ident> => Types(AbsType::Var(<>)),
     "#" <SpTerm<RichTerm>> => Types(AbsType::Flat(<>)),
     "(" <Types> ")" => <>,

--- a/src/term.rs
+++ b/src/term.rs
@@ -11,17 +11,25 @@ pub enum Term {
     Str(String),
     Fun(Ident, RichTerm),
     Lbl(Label),
+
     // Other lambda
     Let(Ident, RichTerm, RichTerm),
     App(RichTerm, RichTerm),
     Var(Ident),
+
     // Enums
     Enum(Ident),
-    // Record
+
+    // Records
     Record(HashMap<Ident, RichTerm>),
+
+    // Lists
+    List(Vec<RichTerm>),
+
     // Primitives
     Op1(UnaryOp<RichTerm>, RichTerm),
     Op2(BinaryOp<RichTerm>, RichTerm, RichTerm),
+
     // Typing
     Promise(Types, Label, RichTerm),
     Assume(Types, Label, RichTerm),
@@ -72,6 +80,9 @@ impl Term {
                 func(t1);
                 func(t2);
             }
+            List(ref mut terms) => terms.iter_mut().for_each(|t| {
+                func(t);
+            }),
         }
     }
 }
@@ -86,6 +97,7 @@ pub enum UnaryOp<CapturedTerm> {
     IsBool(),
     IsStr(),
     IsFun(),
+    IsList(),
 
     Blame(),
 
@@ -109,6 +121,10 @@ pub enum UnaryOp<CapturedTerm> {
 
     Seq(),
     DeepSeq(),
+
+    ListHead(),
+    ListTail(),
+    ListLength(),
 }
 
 impl<Ty> UnaryOp<Ty> {
@@ -135,6 +151,7 @@ impl<Ty> UnaryOp<Ty> {
             IsBool() => IsBool(),
             IsStr() => IsStr(),
             IsFun() => IsFun(),
+            IsList() => IsList(),
 
             Blame() => Blame(),
 
@@ -152,6 +169,10 @@ impl<Ty> UnaryOp<Ty> {
 
             Seq() => Seq(),
             DeepSeq() => DeepSeq(),
+
+            ListHead() => ListHead(),
+            ListTail() => ListTail(),
+            ListLength() => ListLength(),
         }
     }
 }
@@ -166,6 +187,9 @@ pub enum BinaryOp<CapturedTerm> {
     DynRemove(),
     DynAccess(),
     HasField(),
+    ListConcat(),
+    ListMap(),
+    ListElemAt(),
 }
 
 impl<Ty> BinaryOp<Ty> {
@@ -182,6 +206,9 @@ impl<Ty> BinaryOp<Ty> {
             DynRemove() => DynRemove(),
             DynAccess() => DynAccess(),
             HasField() => HasField(),
+            ListConcat() => ListConcat(),
+            ListMap() => ListMap(),
+            ListElemAt() => ListElemAt(),
         }
     }
 }

--- a/src/transformations.rs
+++ b/src/transformations.rs
@@ -119,6 +119,30 @@ pub mod share_normal_form {
 
                 result.into()
             }
+            &Term::List(ref ts) => {
+                let mut bindings = Vec::with_capacity(ts.len());
+                let mut new_list = Vec::with_capacity(ts.len());
+
+                for t in ts.iter() {
+                    if should_share(&*t.term) {
+                        let fresh_var = Ident(format!("%{}", FreshVariableCounter::next()));
+                        bindings.push((fresh_var.clone(), transform(t)));
+                        new_list.push(Term::Var(fresh_var).into());
+                    } else {
+                        new_list.push(transform(t));
+                    }
+                }
+
+                let result = bindings.into_iter().fold(
+                    RichTerm {
+                        term: Box::new(Term::List(new_list)),
+                        pos,
+                    },
+                    |acc, (id, t)| Term::Let(id, t, acc).into(),
+                );
+
+                result.into()
+            }
         }
     }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -21,6 +21,7 @@ pub enum AbsType<Ty> {
     StaticRecord(Ty /* Row */),
     // DynRecord will only have a default type, this is simpler for now, I don't think we lose much
     DynRecord(Ty /*, Ty  Row */),
+    List(),
 }
 
 impl<Ty> AbsType<Ty> {
@@ -49,6 +50,7 @@ impl<Ty> AbsType<Ty> {
             AbsType::Enum(t) => AbsType::Enum(f(t)),
             AbsType::StaticRecord(t) => AbsType::StaticRecord(f(t)),
             AbsType::DynRecord(t) => AbsType::DynRecord(f(t)),
+            AbsType::List() => AbsType::List(),
         }
     }
 
@@ -77,6 +79,7 @@ impl Types {
             AbsType::Num() => RichTerm::var("num".to_string()),
             AbsType::Bool() => RichTerm::var("bool".to_string()),
             AbsType::Str() => RichTerm::var("string".to_string()),
+            AbsType::List() => RichTerm::var("list".to_string()),
             AbsType::Sym() => panic!("Are you trying to check a Sym at runtime?"),
             AbsType::Arrow(ref s, ref t) => RichTerm::app(
                 RichTerm::app(


### PR DESCRIPTION
Partly addresses #80 (only basic lists, and no list comprehensions). Depends on #89 . Changes the syntax of dynamic record extension from `[ ... ]` to `$[ ... ]`, to reclaim brackets for lists.