### PR TITLE
Move pretty printing of data with locations to a dedicated trait

### DIFF
--- a/src/label.rs
+++ b/src/label.rs
@@ -1,8 +1,16 @@
+use crate::position::{ShowWithSource, SourceMapper};
+
 #[derive(Debug, Clone, PartialEq)]
 pub enum TyPath {
     Nil(),
     Domain(Box<TyPath>),
     Codomain(Box<TyPath>),
+}
+
+impl ShowWithSource for TyPath {
+    fn show_append(&self, s: &mut String, _m: &SourceMapper) {
+        s.push_str(&format!("{:?}", self));
+    }
 }
 
 #[derive(Debug, Clone, PartialEq)]


### PR DESCRIPTION
Related to #92. Depends on #96. Moves the pretty printing logic of data with locations, which need a source mapper for converting absolute offsets to human readable locations, in a dedicated trait. This concerns in particular error messages.

Messages are voluntarily left as they were originally. Improving them is another task for another PR.