### PR TITLE
Mute unused_parens warnings in the generated parser

### DIFF
--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -2,6 +2,7 @@ use lalrpop_util::lalrpop_mod;
 
 lalrpop_mod!(
     #[allow(clippy::all)]
+    #[allow(unused_parens)]
     pub grammar);
 
 #[cfg(test)]


### PR DESCRIPTION
Code generated by LARLPOP generates many "unnecessary parentheses around block return value" warnings which clutter rust error messages. I could not find a lot of resources about it, except for a [online chat](https://gitter.im/lalrpop/Lobby?at=5e4459a862e9db4bf7947803) where it was advised to just turn the warning off for the parser module, which this PR does.