### PR TITLE
Do not perform useless thunks update

### DIFF
--- a/src/term.rs
+++ b/src/term.rs
@@ -237,6 +237,60 @@ impl Term {
             | Term::Assume(_, _, _) => String::from("<unevaluated>"),
         }
     }
+
+    /// Determine if a term is in evaluated from, called weak head normal form (WHNF).
+    pub fn is_whnf(&self) -> bool {
+        match self {
+            Term::Bool(_)
+            | Term::Num(_)
+            | Term::Str(_)
+            | Term::Fun(_, _)
+            | Term::Lbl(_)
+            | Term::Enum(_)
+            | Term::Record(_)
+            | Term::List(_)
+            | Term::Sym(_) => true,
+            Term::Let(_, _, _)
+            | Term::App(_, _)
+            | Term::Var(_)
+            | Term::Op1(_, _)
+            | Term::Op2(_, _, _)
+            | Term::Promise(_, _, _)
+            | Term::Assume(_, _, _)
+            | Term::Wrapped(_, _)
+            | Term::Contract(_, _)
+            | Term::DefaultValue(_)
+            | Term::ContractWithDefault(_, _, _)
+            | Term::Docstring(_, _) => false,
+        }
+    }
+
+    /// Determine if a term is an enriched value.
+    pub fn is_enriched(&self) -> bool {
+        match self {
+            Term::Contract(_, _)
+            | Term::DefaultValue(_)
+            | Term::ContractWithDefault(_, _, _)
+            | Term::Docstring(_, _) => true,
+            Term::Bool(_)
+            | Term::Num(_)
+            | Term::Str(_)
+            | Term::Fun(_, _)
+            | Term::Lbl(_)
+            | Term::Enum(_)
+            | Term::Record(_)
+            | Term::List(_)
+            | Term::Sym(_)
+            | Term::Wrapped(_, _)
+            | Term::Let(_, _, _)
+            | Term::App(_, _)
+            | Term::Var(_)
+            | Term::Op1(_, _)
+            | Term::Op2(_, _, _)
+            | Term::Promise(_, _, _)
+            | Term::Assume(_, _, _) => false,
+        }
+    }
 }
 
 /// Primitive unary operators.


### PR DESCRIPTION
When evaluating a variable, the corresponding thunk is put on the stack, such that once the content has been evaluated it can be updated accordingly and the evaluated expression can be reused directly the next time. This is the basic mechanism of lazy evaluation.

Some thunks are obviously not worth updating them, such as already evaluated expressions (WHNFs) and enriched values. The logic to avoid these unnecessary updates was already there but was ineffective because of a function that was not implemented. This PR fixes it.