### PR TITLE
Add support for a global environment

### DIFF
--- a/src/program.rs
+++ b/src/program.rs
@@ -137,7 +137,7 @@ impl Program {
             .map_err(|e| Error::from(e))?;
         let t = transformations::transform(t, self).map_err(|err| Error::ImportError(err))?;
         println!("Typechecked: {:?}", type_check(t.as_ref(), self));
-        eval::eval(t, self).map_err(|e| e.into())
+        eval::eval(t, HashMap::new(), self).map_err(|e| e.into())
     }
 
     /// Parse a source file. Do not try to get it from the cache, and do not populate the cache at


### PR DESCRIPTION
Add support for a global environment, to contain builtin symbols.

**what it does**: add a global environment parameter to the evaluation function, which is queried if a variable is not found in the local environment. This implies that the local environment can shadow the global one.

**what it does not**: migrate existin builtins in this new environment. This is left to a subsequent PR.

## Why

Currently, builtin contracts are just pasted at the beginning of a program before execution, with the following downsides:

- It's harcoded as a string in the interpreter
- It must also be pasted at the beginning of each import, since an import is evaluated in an empty environment.
- It messes with locations for error reporting, forcing the parser to perform a translation.
- It pollutes all the (local) environments: each time an application is evaluated, the environment is copied in the closure of the argument on the stack. This means copying every such global entry, every time an environment saved (terms are not actually copied, just the references, but it's still useless work).

Other builtin functions are parsed as special keywords, which is not nice either:
 - It inflates the lexing and parsing code, which must know about these specific tokens.
 - It prevents the user from using these names, which includes common ones such as `map` and `length`.

This PR is a first step to migrate builtin contracts and helpers to dedicated files, which would then be loaded in a global environment.