### PR TITLE
Type inference of let-bound expressions

### DIFF
--- a/src/typecheck.rs
+++ b/src/typecheck.rs
@@ -38,8 +38,6 @@
 //! Promise(Num, let id = Promise(forall a. a -> a, fun x => x) in seq (id "a") (id 5))
 //! ```
 //!
-//! This restriction is on purpose
-//!
 //! In non-strict mode, all let-bound expressions are given type `Dyn`, unless annotated.
 use crate::identifier::Ident;
 use crate::program::ImportResolver;


### PR DESCRIPTION
Close #136. Infer the type of unannotated let-bound expressions when typechecking in strict mode (i.e. in a statically typed block). We can now write things like:
```
Promise(Num,
  let x = 1 in
  let f = fun x => if isZero x then 1 else x in
  f (x + 2)
)
```
```
Promise(Num, 
  let mod = { 
    f = fun x => if isZero x then 0 else g x
    g = fun x => 1 + (f (x + (-1)))
  } in
  mod.f 5
)
```
which all required let to be annotated before.

**what it does**
 - in strict mode, when typechecking an expression `let x = bound_exp in body` where `bound_exp` has no type annotation (is different from `Promise` or `Assume`), associate `x` to a new unification variable in the typing environment (which `x` will be typechecked against) instead of defaulting to `Dyn`.
 - have the same behavior on the fields of recursive records.

**what it does not**
 - it does not try to generalize type variables as mentioned in #136. For example, this does not work: `Promise(Num, let id = fun x => x in let _ignore = id "a" in id 0)` as `id` is given the type `Str -> Str` because of `_ignore`. It is easily fixed by adding a polymorphic type annotation on `id`: `let id = Promise(forall a. a -> a, fun x => x) in ...`