### PR TITLE
Type inference of let-bound expressions, the come back

### DIFF
--- a/src/typecheck.rs
+++ b/src/typecheck.rs
@@ -38,8 +38,6 @@
 //! Promise(Num, let id = Promise(forall a. a -> a, fun x => x) in seq (id "a") (id 5))
 //! ```
 //!
-//! This restriction is on purpose
-//!
 //! In non-strict mode, all let-bound expressions are given type `Dyn`, unless annotated.
 use crate::error::TypecheckError;
 use crate::identifier::Ident;


### PR DESCRIPTION
Rebasing of #138 on the current master. Close #136. #138 was accidentally merged in #135 on which it depended, instead of master. To avoid polluting the review of #135, this was reverted. Now that #135 has landed, the time has come to merge #138 again.

No review required, this is the same PR as #138 (excepted small adaptations required by the rebasing on the current master), which was approved.

Hopefully, now that we have dpulls, this should not happen again.