### PR TITLE
Add basic list functions in the stdlib

### DIFF
--- a/src/program.rs
+++ b/src/program.rs
@@ -190,6 +190,9 @@ impl Program {
             &mut global_env,
         )
         .map_err(|e| Error::from(e))?;
+        self.load_stdlib("<stdlib/lists.ncl>", crate::stdlib::LISTS, &mut global_env)
+        .map_err(Error::from)?;
+
         Ok(global_env)
     }
 

--- a/src/stdlib.rs
+++ b/src/stdlib.rs
@@ -1,2 +1,3 @@
 //! Load the Nickel standard library in strings at compile-time.
 pub const CONTRACTS: &str = include_str!("../stdlib/contracts.ncl");
+pub const LISTS: &str = include_str!("../stdlib/lists.ncl");

--- a/stdlib/lists.ncl
+++ b/stdlib/lists.ncl
@@ -1,32 +1,37 @@
 {
   lists = {
-    concat = fun l1 l2 => l1 @ l2;
+    concat = Promise(List -> List -> List, fun l1 l2 => l1 @ l2);
 
-    foldl = fun f fst l =>
-      if isZero (length l) then
-        fst
-      else
-        let rest = foldl f fst (tail l) in
-        seq rest (f rest (head l));
+    foldl = Promise(forall a. (a -> Dyn -> a) -> a -> List -> a,
+      fun f fst l =>
+        if isZero (length l) then
+          fst
+        else
+          let rest = foldl f fst (tail l) in
+          seq rest (f rest (head l)));
 
-    fold = fun f l fst =>
-      if isZero (length l) then
-        fst
-      else
-        f (head l) (fold f (tail l) fst);
+    fold = Promise(forall a. (Dyn -> a -> a) -> List -> a -> a,
+      fun f l fst =>
+        if isZero (length l) then
+          fst
+        else
+          f (head l) (fold f (tail l) fst));
 
-    cons = fun x l => [x] @ l;
+    cons = Promise(Dyn -> List -> List, fun x l => [x] @ l);
 
-    filter = fun pred l =>
-      fold (fun x acc => if pred x then acc @ [x] else acc) l [];
+    filter = Promise((Dyn -> Bool) -> List -> List,
+      fun pred l =>
+        fold (fun x acc => if pred x then acc @ [x] else acc) l []);
 
-    flatten = fun l =>
-      fold (fun l acc => acc @ l) l [];
+    flatten = Promise(List -> List, fun l =>
+      fold (fun l acc => acc @ Assume(List, l)) l []);
 
-    all = fun pred l =>
-      fold (fun x acc => if pred x then acc else false) l true;
+    all = Promise((Dyn -> Bool) -> List -> Bool,
+      fun pred l =>
+        fold (fun x acc => if pred x then acc else false) l true);
 
-    any = fun pred l =>
-      fold (fun x acc => if pred x then true else acc) l false;
+    any = Promise((Dyn -> Bool) -> List -> Bool,
+      fun pred l =>
+        fold (fun x acc => if pred x then true else acc) l false);
   }
 }

--- a/stdlib/lists.ncl
+++ b/stdlib/lists.ncl
@@ -1,0 +1,32 @@
+{
+  lists = {
+    concat = fun l1 l2 => l1 @ l2;
+
+    foldl = fun f fst l =>
+      if isZero (length l) then
+        fst
+      else
+        let rest = foldl f fst (tail l) in
+        seq rest (f rest (head l));
+
+    fold = fun f l fst =>
+      if isZero (length l) then
+        fst
+      else
+        f (head l) (fold f (tail l) fst);
+
+    cons = fun x l => [x] @ l;
+
+    filter = fun pred l =>
+      fold (fun x acc => if pred x then acc @ [x] else acc) l [];
+
+    flatten = fun l =>
+      fold (fun l acc => acc @ l) l [];
+
+    all = fun pred l =>
+      fold (fun x acc => if pred x then acc else false) l true;
+
+    any = fun pred l =>
+      fold (fun x acc => if pred x then true else acc) l false;
+  }
+}


### PR DESCRIPTION
Partly address #80. Depends on #153 and #155. Add the functions listed there to the Nickel standard library.

Some code is not ideal (such as `if isZero (length l)`), because there is a bootstrapping problem: it would need a polymorphic equality to become the more idiomatic `if length l == 0` (or pattern matching), but polymorphic equality on list needs `lists.all` first. This is a first working set of helpers: when new features are implemented, we can improve the standard lib accordingly.

**what it does**
 - add a bunch of list functions in `stdlib/lists.ncl` and load them in the global environment (in a `lists` record).
 - typecheck and apply program transformations on the stdlib parts, which was not done before.