### PR TITLE
Polymorphic equality

### DIFF
--- a/src/grammar.lalrpop
+++ b/src/grammar.lalrpop
@@ -196,7 +196,7 @@ BOpIn: BinaryOp<RichTerm> = {
         match <> {
             "+" => BinaryOp::Plus(),
             "++" => BinaryOp::PlusStr(),
-            "==" => BinaryOp::EqBool(),
+            "==" => BinaryOp::Eq(),
             "@" => BinaryOp::ListConcat(),
             op => panic!("Unkown operator {}", op)
         }

--- a/src/term.rs
+++ b/src/term.rs
@@ -574,13 +574,13 @@ pub enum BinaryOp<CapturedTerm> {
     ///
     /// See `Wrap` in [`UnaryOp`](enum.UnaryOp.html).
     Unwrap(),
-    /// Equality on booleans.
-    EqBool(),
+    /// Polymorphic equality.
+    Eq(),
     /// Extend a record with a dynamic field.
     ///
-    /// Dynamic means that the field name may be an expression and not a statically known string.
-    /// `DynExtend` tries to evaluate this name to a string, and in case of success, add a field
-    /// with this name to the given record with the `CapturedTerm` as content.
+    /// Dynamic means that the field name may be an expression instead of a statically known
+    /// string.  `DynExtend` tries to evaluate this name to a string, and in case of success, add a
+    /// field with this name to the given record with the `CapturedTerm` as content.
     DynExtend(CapturedTerm),
     /// Remove a field from a record. The field name is given as an arbitrary Nickel expression.
     DynRemove(),
@@ -607,7 +607,7 @@ impl<Ty> BinaryOp<Ty> {
             Plus() => Plus(),
             PlusStr() => PlusStr(),
             Unwrap() => Unwrap(),
-            EqBool() => EqBool(),
+            Eq() => Eq(),
             DynRemove() => DynRemove(),
             DynAccess() => DynAccess(),
             HasField() => HasField(),

--- a/src/typecheck.rs
+++ b/src/typecheck.rs
@@ -1417,14 +1417,17 @@ pub fn get_bop_type(
                 ))),
             ))),
         ))),
-        // Bool -> Bool -> Bool
-        BinaryOp::EqBool() => Ok(TypeWrapper::Concrete(AbsType::arrow(
-            Box::new(TypeWrapper::Concrete(AbsType::Bool())),
-            Box::new(TypeWrapper::Concrete(AbsType::arrow(
-                Box::new(TypeWrapper::Concrete(AbsType::Bool())),
-                Box::new(TypeWrapper::Concrete(AbsType::Bool())),
-            ))),
-        ))),
+        BinaryOp::Eq() =>
+        // forall a b. a -> b -> Bool
+        {
+            Ok(TypeWrapper::Concrete(AbsType::arrow(
+                Box::new(TypeWrapper::Ptr(new_var(state.table))),
+                Box::new(TypeWrapper::Concrete(AbsType::arrow(
+                    Box::new(TypeWrapper::Ptr(new_var(state.table))),
+                    Box::new(TypeWrapper::Concrete(AbsType::Bool())),
+                ))),
+            )))
+        }
         // forall a. Str -> { _ : a} -> a
         BinaryOp::DynAccess() => {
             let res = TypeWrapper::Ptr(new_var(state.table));

--- a/stdlib/lists.ncl
+++ b/stdlib/lists.ncl
@@ -4,7 +4,7 @@
 
     foldl = Promise(forall a. (a -> Dyn -> a) -> a -> List -> a,
       fun f fst l =>
-        if isZero (length l) then
+        if length l == 0 then
           fst
         else
           let rest = foldl f fst (tail l) in
@@ -12,7 +12,7 @@
 
     fold = Promise(forall a. (Dyn -> a -> a) -> List -> a -> a,
       fun f l fst =>
-        if isZero (length l) then
+        if length l == 0 then
           fst
         else
           f (head l) (fold f (tail l) fst));


### PR DESCRIPTION
Depend on #156. Required for #157: in order to implement a record contract in pure Nickel, we need to be able to compare field names, which is easier with a proper equality. It's a good idea anyway in a language with untyped chunks.

Replaces the previous equality operator `==`, which worked only on booleans, to work on any values. It only compares constants of the same base type, compares lists and records recursively, and return false if values are of different types or one of them is a function.

**what it does**
 - implement a polymorphic equality operator
 - replace `isZero (length l)` usages by `length l == 0` in the lists standard lib
 - add corresponding tests