### PR TITLE
Refactoring: implement From trait for identifiers

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -712,7 +712,7 @@ mod tests {
                     "x",
                     "lib",
                     Term::Op1(
-                        UnaryOp::StaticAccess(Ident(String::from("f"))),
+                        UnaryOp::StaticAccess(Ident::from("f")),
                         RichTerm::var(String::from("x"))
                     )
                     .into(),
@@ -733,7 +733,7 @@ mod tests {
                     "x",
                     "cycle",
                     Term::Op1(
-                        UnaryOp::StaticAccess(Ident(String::from("b"))),
+                        UnaryOp::StaticAccess(Ident::from("b")),
                         RichTerm::var(String::from("x"))
                     )
                     .into(),
@@ -819,15 +819,12 @@ mod tests {
             body: Term::Num(1.0).into(),
             env: HashMap::new(),
         }));
-        global_env.insert(
-            Ident(String::from("g")),
-            (Rc::clone(&thunk), IdentKind::Let()),
-        );
+        global_env.insert(Ident::from("g"), (Rc::clone(&thunk), IdentKind::Let()));
 
         let t = RichTerm::let_in(
             "x",
             Term::Num(2.0).into(),
-            Term::Var(Ident(String::from("x"))).into(),
+            Term::Var(Ident::from("x")).into(),
         );
         assert_eq!(
             eval(t, global_env.clone(), &mut resolver),
@@ -837,7 +834,7 @@ mod tests {
         let t = RichTerm::let_in(
             "x",
             Term::Num(2.0).into(),
-            Term::Var(Ident(String::from("g"))).into(),
+            Term::Var(Ident::from("g")).into(),
         );
         assert_eq!(
             eval(t, global_env.clone(), &mut resolver),
@@ -848,7 +845,7 @@ mod tests {
         let t = RichTerm::let_in(
             "g",
             Term::Num(2.0).into(),
-            Term::Var(Ident(String::from("g"))).into(),
+            Term::Var(Ident::from("g")).into(),
         );
         assert_eq!(
             eval(t, global_env.clone(), &mut resolver),

--- a/src/identifier.rs
+++ b/src/identifier.rs
@@ -10,3 +10,12 @@ impl fmt::Display for Ident {
         write!(f, "{}", ident)
     }
 }
+
+impl<F> From<F> for Ident
+where
+    String: From<F>,
+{
+    fn from(val: F) -> Self {
+        Ident(String::from(val))
+    }
+}

--- a/src/program.rs
+++ b/src/program.rs
@@ -478,7 +478,7 @@ mod tests {
         //Check that the record does not contain extra keys
         if let Ok(Term::Record(ref mut m)) = term {
             for (i, t) in res {
-                m.remove(&Ident(String::from(i)))
+                m.remove(&Ident::from(i))
                     .unwrap_or_else(|| panic!(format!("Could not find field {} in result", i)));
 
                 let proj = format!("({}).{}", s, i);


### PR DESCRIPTION
Depend on #156 (not really, but as this PR was detached from #159, it is easier to keep a linear ordering). Implement a `From<T>` for `Ìdent`, for any `T` such that `String` implements a `From<T>`. Makes building identifiers easier and less verbose. Refactor existing `Ident(String::from(s))` to `Ident::from(s)`.