### PR TITLE
Do not allow hyphen in identifiers

### DIFF
--- a/src/parser/lexer.rs
+++ b/src/parser/lexer.rs
@@ -276,7 +276,7 @@ fn is_ident_start(chr: char, look_ahead: Option<char>) -> bool {
 
 fn is_ident_char(chr: char) -> bool {
     match chr {
-        '0'..='9' | '-' | '_' => true,
+        '0'..='9' | '_' => true,
         chr => is_ident_start(chr, None),
     }
 }

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -128,7 +128,6 @@ fn applications() {
 
 #[test]
 fn variables() {
-    assert!(parse("x1-x-").is_some()); // TODO controversial
     assert!(parse("x1_x_").is_some());
 }
 


### PR DESCRIPTION
Close #164.