### PR TITLE
Refactor: make dynamic extension and dynamic removal operators consistent

### DIFF
--- a/src/grammar.lalrpop
+++ b/src/grammar.lalrpop
@@ -56,6 +56,7 @@ RecordOperand: RichTerm = {
 RecordOperationChain: RichTerm = {
     <t: SpTerm<RecordOperand>> "." <id: Ident> => RichTerm::new(Term::Op1(UnaryOp::StaticAccess(id), t)),
     <t: SpTerm<RecordOperand>> ".$" <t_id: SpTerm<Atom>> => RichTerm::new(Term::Op2(BinaryOp::DynAccess(), t_id, t)),
+    <t: SpTerm<RecordOperand>> "-$" <t_id: SpTerm<Atom>> => RichTerm::new(Term::Op2(BinaryOp::DynRemove(), t_id, t)),
     <r: SpTerm<RecordOperand>> "$[" <id: SpTerm<Term>> "=" <t: SpTerm<Term>> "]" =>
         RichTerm::new(Term::Op2(BinaryOp::DynExtend(t), id, r)),
 };
@@ -201,7 +202,6 @@ BOpIn: BinaryOp<RichTerm> = {
             op => panic!("Unkown operator {}", op)
         }
     },
-    "-$" => BinaryOp::DynRemove(),
 };
 
 BOpPre: BinaryOp<RichTerm> = {

--- a/src/operation.rs
+++ b/src/operation.rs
@@ -720,26 +720,26 @@ fn process_binary_operation(
             }
         }
         BinaryOp::DynRemove() => {
-            if let Term::Record(mut static_map) = *t1 {
-                if let Term::Str(id) = *t2 {
+            if let Term::Str(id) = *t1 {
+                if let Term::Record(mut static_map) = *t2 {
                     match static_map.remove(&Ident(id.clone())) {
                         None => Err(EvalError::FieldMissing(
                             format!("{}", id),
                             String::from("(-$)"),
                             RichTerm {
                                 term: Box::new(Term::Record(static_map)),
-                                pos: pos1,
+                                pos: pos2,
                             },
                             pos_op,
                         )),
                         Some(_) => Ok(Closure {
                             body: Term::Record(static_map).into(),
-                            env: env1,
+                            env: env2,
                         }),
                     }
                 } else {
                     Err(EvalError::TypeError(
-                        String::from("Str"),
+                        String::from("Record"),
                         String::from("-$"),
                         snd_pos,
                         RichTerm {
@@ -750,7 +750,7 @@ fn process_binary_operation(
                 }
             } else {
                 Err(EvalError::TypeError(
-                    String::from("Record"),
+                    String::from("Str"),
                     String::from("-$"),
                     fst_pos,
                     RichTerm {


### PR DESCRIPTION
The dynamic field removal operator `-$` is treated differently from others builtin record operations, in particular from the dual dynamic extension operator, for no apparent reason. This PRs makes their definitions consistent.

**what it does**
- allow dynamic removal field operator in a record operation chain, which is a syntactic category composed of a record followed by an arbitrary number of record operations which do not requires parentheses, such as `rec.field1.field2.$"dynfield"`. Before, every record operator was allowed excepted the dynamic field removal one.
- use the same order of arguments as other dynamic record operators internally (first the field, then the record). This changes nothing from the user's point of view, it's just for code consistency.