### PR TITLE
Correctly generate and check row constraints on polymorphic types

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -1014,11 +1014,11 @@ impl ToDiagnostic<FileId> for TypecheckError {
             TypecheckError::RowConflict(Ident(ident), conflict, _expd, _actual, span_opt) => {
 vec![
                     Diagnostic::error()
-                        .with_message("Incompatible rows declaration in a type")
+                        .with_message("Multiple rows declaration")
                         .with_labels(mk_expr_label(span_opt))
                         .with_notes(vec![
                         format!("The type of the expression was inferred to have the row `{}: {}`", ident, conflict.as_ref().cloned().unwrap()),
-                        String::from("But this type appears inside another bigger row type which already had a declaration for the field `{}`"),
+                        format!("But this type appears inside another row type, which already has a declaration for the field `{}`", ident),
                         String::from("A type cannot have two conflicting declaration for the same row")
                     ])]
 

--- a/src/typecheck.rs
+++ b/src/typecheck.rs
@@ -1176,7 +1176,7 @@ enum ForallInst {
 }
 
 /// Instantiate the type variables which are quantified in head position with either unification
-/// variable or type constants.
+/// variables or type constants.
 ///
 /// For example, if `inst` is `Constant`, `forall a. forall b. a -> (forall c. b -> c)` is
 /// transformed to `cst1 -> (forall c. cst2 -> c)` where `cst1` and `cst2` are fresh type
@@ -1607,7 +1607,7 @@ fn constraint(state: &mut State, x: TypeWrapper, id: Ident) -> Result<(), RowUni
 /// # Preconditions
 ///
 /// Because `constraint_var` should be called on a fresh unification variable `p`, the following is
-/// asusmed:
+/// assumed:
 /// - `get_root(state.table, p) == p`
 /// - `state.constr.get(&p) == None`
 fn constrain_var(state: &mut State, tyw: &TypeWrapper, p: usize) {
@@ -1669,7 +1669,7 @@ fn constrain_var(state: &mut State, tyw: &TypeWrapper, p: usize) {
 ///    Str}` which violates the original constraint on `p`. Thus, when unifying `p` with `u` or a
 ///    row ending with `u`, `u` must inherit all the constraints of `p`.
 ///
-/// If `tyw` is neither a row or a unification variable, `constr_unify` immediately returns `Ok(())`.
+/// If `tyw` is neither a row nor a unification variable, `constr_unify` immediately returns `Ok(())`.
 pub fn constr_unify(
     constr: &mut RowConstr,
     p: usize,


### PR DESCRIPTION
Close #144. The problem was twofold:

1. Row constraints were not correctly generated.
2. Row constraints were not correctly checked. Depending on the shape the types being unified, the unification function did not always check constraints or update them accordingly.

**what it does**
- after instantiating a polymorphic type, the new `constrain_var` function is called. It takes the instantiated type and the freshly created unification variable as argument, visits the type recursively and look for every row type that contains the variable in tail position, of the form `{id1: Type1, .., idn: TypeN | var}`. For each such type, `id1, .., idn` are added to the row constraints of the variable.
- fix the checking of row constraints. Row constraints were enforced when unifying two populated row type of the form `{id1, .., idn | tail}` and `{id1', .., idn' | tail'}`, or when unifying two variables, but not when unifying a variable with a row type.
- add a regression test
