### PR TITLE
Do not drop env when evaluating an interpolated string

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -260,21 +260,23 @@ where
                     body: Term::Str(String::new()).into(),
                     env: HashMap::new(),
                 },
-                Some(StrChunk::Literal(s)) => Closure {
-                    body: Term::Op1(
-                        UnaryOp::ChunksConcat(String::new(), chunks),
-                        Term::Str(s).into(),
-                    )
-                    .into(),
-                    env: HashMap::new(),
-                },
-                Some(StrChunk::Expr(e)) => Closure {
-                    body: RichTerm {
-                        term: Box::new(Term::Op1(UnaryOp::ChunksConcat(String::new(), chunks), e)),
-                        pos,
-                    },
-                    env,
-                },
+                Some(chunk) => {
+                    let arg = match chunk {
+                        StrChunk::Literal(s) => Term::Str(s).into(),
+                        StrChunk::Expr(e) => e,
+                    };
+
+                    Closure {
+                        body: RichTerm {
+                            term: Box::new(Term::Op1(
+                                UnaryOp::ChunksConcat(String::new(), chunks),
+                                arg,
+                            )),
+                            pos,
+                        },
+                        env,
+                    }
+                }
             },
             Term::Promise(ty, l, t) | Term::Assume(ty, l, t) => {
                 stack.push_arg(

--- a/src/operation.rs
+++ b/src/operation.rs
@@ -459,12 +459,16 @@ fn process_unary_operation(
         UnaryOp::ChunksConcat(mut acc, mut tail) => {
             if let Term::Str(s) = *t {
                 acc.push_str(&s);
-                if let Some(next) = tail.pop() {
-                    let arg = match next {
-                        StrChunk::Literal(s) => Closure::atomic_closure(Term::Str(s).into()),
-                        StrChunk::Expr(e) => e,
-                    };
-                    let arg_closure = arg.body.closurize(&mut env, arg.env);
+                let mut next_opt = tail.pop();
+
+                // Pop consecutive string literals to find the next expression to evaluate
+                while let Some(StrChunk::Literal(s)) = next_opt {
+                    acc.push_str(&s);
+                    next_opt = tail.pop();
+                }
+
+                if let Some(StrChunk::Expr(e)) = next_opt {
+                    let arg_closure = e.body.closurize(&mut env, e.env);
                     let tail_closure = tail
                         .into_iter()
                         .map(|chunk| match chunk {

--- a/src/program.rs
+++ b/src/program.rs
@@ -1142,6 +1142,10 @@ Assume(#alwaysTrue -> #alwaysFalse, not ) true
             r#""nested ${ {str = {a = "braces"}.a}.str } !""#,
             "nested braces !",
         );
+        assert_eval_str(
+            r#"let x = "world" in "Hello, ${x}! Welcome in ${let y = "universe" in "the ${x}-${y}"}""#,
+            "Hello, world! Welcome in the world-universe",
+        );
 
         match eval_string(r#""bad type ${1 + 1}""#) {
             Err(Error::EvalError(EvalError::TypeError(_, _, _, _))) => (),


### PR DESCRIPTION
Close #170. The environment was unduly dropped when evaluating a list of interpolated chunks that starts with a string literal.

**what it does**
- do not drop environment when creating a `ChunksConcat` term from string chunks
- small refactoring along
- add a regression test