### PR TITLE
Allow n-ary foralls

### DIFF
--- a/src/grammar.lalrpop
+++ b/src/grammar.lalrpop
@@ -225,7 +225,11 @@ BOpPre: BinaryOp<RichTerm> = {
 }
 
 Types: Types = {
-    "forall" <id: Ident> "." <ty: Arrows> => Types(AbsType::Forall(id, Box::new(ty))),
+    "forall" <ids: Ident+> "." <ty: Arrows> =>
+        ids.into_iter().rev().fold(
+            ty,
+            |acc, id| Types(AbsType::Forall(id, Box::new(acc)))
+        ),
     <Arrows>
 }
 


### PR DESCRIPTION
Depends on #180. The syntax currently requires to write nested foralls one by one, that is e.g. `forall a. forall b. forall c. a -> b -> c -> a`. This PRs enables the more concise syntax `forall a b c. a -> b -> c -> a`.