### PR TITLE
Note CUE's lazy evaluation

### DIFF
--- a/RATIONALE.md
+++ b/RATIONALE.md
@@ -289,7 +289,7 @@ code and has no principled approach to data validation.
 | Nickel   | Gradual (dynamic + static)    | Yes       | Lazy       | Yes (constrained)                                 |
 | Starlark | Dynamic                       | No        | Strict     | No                                                |
 | Dhall    | Static (requires annotations) | No        | Lazy       | No                                                |
-| CUE      | Static (everything is a type) | No        | ?          | No, but allowed in the separated scripting layer  |
+| CUE      | Static (everything is a type) | No        | Lazy       | No, but allowed in the separated scripting layer  |
 | Jsonnet  | Dynamic                       | Yes       | Lazy       | No                                                |
 
 ## Conclusion


### PR DESCRIPTION
I could be misinterpreting the docs, since it's an off-handed comment in a sidebar, but the "[Logic of CUE][cue]" page alludes to lazy evaluation:

> This highly abstract definition determines almost everything about CUE. For instance, **lazy binding was not a design decision, but a direct consequence of following this definition.** It determines the possible evaluation strategies and what cycles mean, if allowed.

[cue]: https://cuelang.org/docs/concepts/logic/