### PR TITLE
elemAt: check for negative index

### DIFF
--- a/src/operation.rs
+++ b/src/operation.rs
@@ -953,8 +953,8 @@ fn process_binary_operation(
                 let n_int = n as usize;
                 if n.fract() != 0.0 {
                     Err(EvalError::Other(format!("elemAt: expected the 2nd agument to be an integer, got the floating-point value {}", n), pos_op))
-                } else if n_int >= ts.len() {
-                    Err(EvalError::Other(format!("elemAt: index out of bounds. Expected a value between 0 and {}, got {})", ts.len(), n_int), pos_op))
+                } else if n < 0.0 || n_int >= ts.len() {
+                    Err(EvalError::Other(format!("elemAt: index out of bounds. Expected a value between 0 and {}, got {}", ts.len(), n), pos_op))
                 } else {
                     Ok(Closure {
                         body: ts.swap_remove(n_int),


### PR DESCRIPTION
Close #188 . 

`elemAt` was not checking if the index was negative, but just that it was integer, and then converted it to a `usize` value. A bound check was then performed on this value.

Prior to Rust 1.45, casting from a `f64` to `usize` was actually UB, and in the case of Nickel, used to turn a negative value into a very large int. Thus, `elemAt list (-1)` was correctly failing but because `-1` was converted to a number larger than the length of `list`.

In Rust 1.45, a value that can't be represented in the target type is wrapped to `0`, and thus `elemAt list (-1)` is not failing anymore but rather returns the first element of `list`. An additional check has been added to reject negative indices.