### PR TITLE
Update the CI to match the flake setting (NixOS-20.09)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,10 +3,11 @@ version: 2
 jobs:
   test:
     docker:
-      - image: rust:1.44
+      # Same version as nixos-20.09
+      - image: rust:1.45
     environment:
       CACHE_VERSION:
-        "2020-06-24"
+        "2020-10-28"
     steps:
       - checkout
       - run:
@@ -45,8 +46,9 @@ jobs:
             rustup component add rustfmt
             cargo fmt --all -- --check
   makam-tests:
-    docker: 
-      - image: circleci/node:10.15.3 # Same version as nixos-19.03
+    docker:
+      # Same version as nixos-20.09
+      - image: circleci/node:12.18.4
     environment:
       CACHE_VERSION:
         "2019-09-27"
@@ -60,7 +62,7 @@ jobs:
           command: |
             node -v
             npm -v
-      - run: 
+      - run:
         # TODO cache makam, I think Circle is doing this automatically
           name: Install Makam
           command: |
@@ -81,7 +83,7 @@ jobs:
           name: Run Tests
           command: |
             cd makam-spec/src
-            ../../node_modules/.bin/makam --run-tests testnickel.makam 
+            ../../node_modules/.bin/makam --run-tests testnickel.makam
       - save_cache:
           paths:
             - makam-spec/src/.makam-cache


### PR DESCRIPTION
Depends on #189. Upgrade the rust and node version of the CI to match the flake's ones, which are taken from NixOS-20.09.

P.S: would be cool to have a Nickel program to generate both the flake and the CI config at some point.