### PR TITLE
[Refactor]Do not use one catch-all token for binops in the lexer

### DIFF
--- a/src/grammar.lalrpop
+++ b/src/grammar.lalrpop
@@ -204,15 +204,10 @@ switch_default: RichTerm = {
 }
 
 BOpIn: BinaryOp<RichTerm> = {
-    "operator" => {
-        match <> {
-            "+" => BinaryOp::Plus(),
-            "++" => BinaryOp::PlusStr(),
-            "==" => BinaryOp::Eq(),
-            "@" => BinaryOp::ListConcat(),
-            op => panic!("Unkown operator {}", op)
-        }
-    },
+    "+" => BinaryOp::Plus(),
+    "++" => BinaryOp::PlusStr(),
+    "==" => BinaryOp::Eq(),
+    "@" => BinaryOp::ListConcat(),
 };
 
 BOpPre: BinaryOp<RichTerm> = {
@@ -296,7 +291,6 @@ extern {
 
     enum Token<'input> {
         "identifier" => Token::Normal(NormalToken::Identifier(<&'input str>)),
-        "operator" => Token::Normal(NormalToken::BinaryOp(<&'input str>)),
         "str literal" => Token::Str(StringToken::Literal(<&'input str>)),
         "escaped char" => Token::Str(StringToken::EscapedChar(<char>)),
         "num literal" => Token::Normal(NormalToken::NumLiteral(<f64>)),
@@ -322,6 +316,12 @@ extern {
         "$[" => Token::Normal(NormalToken::DollarBracket),
         "${" => Token::Str(StringToken::DollarBrace),
         "-$" => Token::Normal(NormalToken::MinusDollar),
+
+        "+" => Token::Normal(NormalToken::Plus),
+        "++" => Token::Normal(NormalToken::DoublePlus),
+        "==" => Token::Normal(NormalToken::DoubleEq),
+        "@" => Token::Normal(NormalToken::At),
+
         "$=" => Token::Normal(NormalToken::DollarEquals),
         "fun" => Token::Normal(NormalToken::Fun),
         "import" => Token::Normal(NormalToken::Import),

--- a/src/parser/lexer.rs
+++ b/src/parser/lexer.rs
@@ -42,8 +42,6 @@ pub enum NormalToken<'input> {
     Identifier(&'input str),
     #[regex("-?[0-9]*\\.?[0-9]+", |lex| lex.slice().parse())]
     NumLiteral(f64),
-    #[regex("[+@=\\-<>\\.|#]+")]
-    BinaryOp(&'input str),
 
     #[token("Dyn")]
     Dyn,
@@ -100,6 +98,15 @@ pub enum NormalToken<'input> {
     DoubleQuote,
     #[token("-$")]
     MinusDollar,
+
+    #[token("+")]
+    Plus,
+    #[token("++")]
+    DoublePlus,
+    #[token("==")]
+    DoubleEq,
+    #[token("@")]
+    At,
 
     #[token("fun")]
     Fun,


### PR DESCRIPTION
Preparation for #191. The lexer was using one parametrized token for all infix binary operators (anything composed of one or more operator characters was matched). This makes sense in languages that allow user-defined operators, but otherwise, it just makes everything harder. This PRs removes this catch-all token and replace it by specific tokens for every binary operator.