### PR TITLE
Multi-line indented strings

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -261,15 +261,15 @@ where
                     env: HashMap::new(),
                 },
                 Some(chunk) => {
-                    let arg = match chunk {
-                        StrChunk::Literal(s) => Term::Str(s).into(),
-                        StrChunk::Expr(e) => e,
+                    let (arg, indent) = match chunk {
+                        StrChunk::Literal(s) => (Term::Str(s).into(), 0),
+                        StrChunk::Expr(e, indent) => (e, indent),
                     };
 
                     Closure {
                         body: RichTerm {
                             term: Box::new(Term::Op1(
-                                UnaryOp::ChunksConcat(String::new(), chunks),
+                                UnaryOp::ChunksConcat(indent, String::new(), chunks),
                                 arg,
                             )),
                             pos,
@@ -712,7 +712,7 @@ mod tests {
     fn interpolation_simple() {
         let mut chunks = vec![
             StrChunk::Literal(String::from("Hello")),
-            StrChunk::Expr(
+            StrChunk::expr(
                 mk_term::op2(
                     BinaryOp::PlusStr(),
                     mk_term::string(", "),
@@ -721,7 +721,7 @@ mod tests {
                 .into(),
             ),
             StrChunk::Literal(String::from(" How")),
-            StrChunk::Expr(mk_term::if_then_else(
+            StrChunk::expr(mk_term::if_then_else(
                 Term::Bool(true),
                 mk_term::string(" are"),
                 mk_term::string(" is"),
@@ -741,7 +741,7 @@ mod tests {
     fn interpolation_nested() {
         let mut inner_chunks = vec![
             StrChunk::Literal(String::from(" How")),
-            StrChunk::Expr(
+            StrChunk::expr(
                 Term::Op2(
                     BinaryOp::PlusStr(),
                     mk_term::string(" ar"),
@@ -749,7 +749,7 @@ mod tests {
                 )
                 .into(),
             ),
-            StrChunk::Expr(mk_term::if_then_else(
+            StrChunk::expr(mk_term::if_then_else(
                 Term::Bool(true),
                 mk_term::string(" you"),
                 mk_term::string(" me"),
@@ -759,7 +759,7 @@ mod tests {
 
         let mut chunks = vec![
             StrChunk::Literal(String::from("Hello, World!")),
-            StrChunk::Expr(Term::StrChunks(inner_chunks).into()),
+            StrChunk::expr(Term::StrChunks(inner_chunks).into()),
             StrChunk::Literal(String::from("?")),
         ];
         chunks.reverse();

--- a/src/grammar.lalrpop
+++ b/src/grammar.lalrpop
@@ -181,7 +181,7 @@ ChunkLiteral : String =
         })
     };
 
-ChunkExpr: StrChunk<RichTerm> = DollarBrace <t: SpTerm<RichTerm>> "}" => StrChunk::Expr(t);
+ChunkExpr: StrChunk<RichTerm> = DollarBrace <t: SpTerm<RichTerm>> "}" => StrChunk::Expr(t, 0);
 
 DollarBrace = { "${", "${ bis" };
 

--- a/src/grammar.lalrpop
+++ b/src/grammar.lalrpop
@@ -183,17 +183,19 @@ ChunkLiteral : String =
 
 ChunkExpr: StrChunk<RichTerm> = DollarBrace <t: SpTerm<RichTerm>> "}" => StrChunk::Expr(t, 0);
 
-DollarBrace = { "${", "${ bis" };
+DollarBrace = { "${", "multstr ${" };
 
 Str: String = "\"" <s: ChunkLiteral> "\"" => s;
 
 ChunkLiteralPart: Either<&'input str, char> = {
     "str literal" => Either::Left(<>),
     "multstr literal" => Either::Left(<>),
+    "multstr $" => Either::Left(<>),
+    "multstr \\" => Either::Left(<>),
+    "multstr \\${" => Either::Left(<>),
     "false end" => Either::Left(<>),
     "str esc char" => Either::Right(<>),
-    "multstr esc char" => Either::Right(<>),
-};
+    };
 
 UOp: UnaryOp<RichTerm> = {
     "isZero" => UnaryOp::IsZero(),
@@ -416,8 +418,10 @@ extern {
         "identifier" => Token::Normal(NormalToken::Identifier(<&'input str>)),
         "str literal" => Token::Str(StringToken::Literal(<&'input str>)),
         "multstr literal" => Token::MultiStr(MultiStringToken::Literal(<&'input str>)),
+        "multstr $" => Token::MultiStr(MultiStringToken::Dollar(<&'input str>)),
+        "multstr \\${" => Token::MultiStr(MultiStringToken::BackslashDollarBrace(<&'input str>)),
+        "multstr \\" => Token::MultiStr(MultiStringToken::Backslash(<&'input str>)),
         "str esc char" => Token::Str(StringToken::EscapedChar(<char>)),
-        "multstr esc char" => Token::MultiStr(MultiStringToken::EscapedChar(<char>)),
         "false end" => Token::MultiStr(MultiStringToken::FalseEnd(<&'input str>)),
         "num literal" => Token::Normal(NormalToken::NumLiteral(<f64>)),
 
@@ -441,10 +445,10 @@ extern {
         ".$" => Token::Normal(NormalToken::DotDollar),
         "$[" => Token::Normal(NormalToken::DollarBracket),
         "${" => Token::Str(StringToken::DollarBrace),
-        // `${` and `${ bis` are morally the same token used in the same places,
+        // `${` and `multstr ${` are morally the same token used in the same places,
         // but they correspond to two different modes, so we need to have two
         // distinct token
-        "${ bis" => Token::MultiStr(MultiStringToken::DollarBrace),
+        "multstr ${" => Token::MultiStr(MultiStringToken::DollarBrace),
         "-$" => Token::Normal(NormalToken::MinusDollar),
 
         "+" => Token::Normal(NormalToken::Plus),

--- a/src/grammar.lalrpop
+++ b/src/grammar.lalrpop
@@ -3,8 +3,8 @@ use crate::term::{BinaryOp, RichTerm, Term, UnaryOp, StrChunk};
 use crate::term::make as mk_term;
 use crate::mk_app;
 use crate::types::{Types, AbsType};
-use super::utils::{mk_span, mk_label};
-use super::lexer::{Token, NormalToken, StringToken, LexicalError};
+use super::utils::{StringKind, mk_span, mk_label, strip_indent};
+use super::lexer::{Token, NormalToken, StringToken, IndStringToken, LexicalError};
 use std::collections::HashMap;
 use either::*;
 use codespan::FileId;
@@ -131,9 +131,11 @@ Bool: bool = {
     "false" => false,
 };
 
-StrChunks : RichTerm =
-  "\"" <fst: ChunkLiteral?> <chunks: (ChunkExpr+ChunkLiteral)*> <lasts:
-    ChunkExpr*> "\"" => {
+StrChunks : RichTerm = {
+  <start: StringStart> <fst: ChunkLiteral?> <chunks: (ChunkExpr+ChunkLiteral)*> <lasts:
+    ChunkExpr*> <end: StringEnd> => {
+        assert_eq!(start, end);
+
         let chunks: Vec<StrChunk<RichTerm>> = fst.into_iter()
             .map(StrChunk::Literal)
             .chain(chunks.into_iter()
@@ -143,13 +145,31 @@ StrChunks : RichTerm =
                 })
                 .flatten())
             .chain(lasts.into_iter())
-            .rev()
             .collect();
 
-        RichTerm::from(Term::StrChunks(chunks))
-    };
+        let mut chunks = if start == StringKind::Multiline {
+            strip_indent(chunks)
+        }
+        else {
+            chunks
+        };
+        chunks.reverse();
 
-ChunkLiteral: String =
+        RichTerm::new(Term::StrChunks(chunks))
+    },
+};
+
+StringStart : StringKind = {
+    "\"" => StringKind::Standard,
+    "m#\"" => StringKind::Multiline,
+};
+
+StringEnd : StringKind = {
+    "\"" => StringKind::Standard,
+    "\"#m" => StringKind::Multiline,
+};
+
+ChunkLiteral : String =
     <parts: ChunkLiteralPart+> => {
         parts.into_iter().fold(String::new(), |mut acc, part| {
             match part {
@@ -161,13 +181,18 @@ ChunkLiteral: String =
         })
     };
 
-ChunkExpr: StrChunk<RichTerm> = "${" <t: SpTerm<RichTerm>> "}" => StrChunk::Expr(t);
+ChunkExpr: StrChunk<RichTerm> = DollarBrace <t: SpTerm<RichTerm>> "}" => StrChunk::Expr(t);
+
+DollarBrace = { "${", "${ bis" };
 
 Str: String = "\"" <s: ChunkLiteral> "\"" => s;
 
 ChunkLiteralPart: Either<&'input str, char> = {
     "str literal" => Either::Left(<>),
-    "escaped char" => Either::Right(<>),
+    "indstr literal" => Either::Left(<>),
+    "false end" => Either::Left(<>),
+    "str esc char" => Either::Right(<>),
+    "indstr esc char" => Either::Right(<>),
 };
 
 UOp: UnaryOp<RichTerm> = {
@@ -390,7 +415,10 @@ extern {
     enum Token<'input> {
         "identifier" => Token::Normal(NormalToken::Identifier(<&'input str>)),
         "str literal" => Token::Str(StringToken::Literal(<&'input str>)),
-        "escaped char" => Token::Str(StringToken::EscapedChar(<char>)),
+        "indstr literal" => Token::IndStr(IndStringToken::Literal(<&'input str>)),
+        "str esc char" => Token::Str(StringToken::EscapedChar(<char>)),
+        "indstr esc char" => Token::IndStr(IndStringToken::EscapedChar(<char>)),
+        "false end" => Token::IndStr(IndStringToken::FalseEnd(<&'input str>)),
         "num literal" => Token::Normal(NormalToken::NumLiteral(<f64>)),
 
         "if" => Token::Normal(NormalToken::If),
@@ -413,6 +441,10 @@ extern {
         ".$" => Token::Normal(NormalToken::DotDollar),
         "$[" => Token::Normal(NormalToken::DollarBracket),
         "${" => Token::Str(StringToken::DollarBrace),
+        // `${` and `${ bis` are morally the same token used in the same places,
+        // but they correspond to two different modes, so we need to have two
+        // distinct token
+        "${ bis" => Token::IndStr(IndStringToken::DollarBrace),
         "-$" => Token::Normal(NormalToken::MinusDollar),
 
         "+" => Token::Normal(NormalToken::Plus),
@@ -437,6 +469,8 @@ extern {
         "`" => Token::Normal(NormalToken::Backtick),
         "_" => Token::Normal(NormalToken::Underscore),
         "\"" => Token::Normal(NormalToken::DoubleQuote),
+        "\"#m" => Token::IndStr(IndStringToken::End),
+        "m#\"" => Token::Normal(NormalToken::StartMultiline),
 
         "Num" => Token::Normal(NormalToken::Num),
         "Dyn" => Token::Normal(NormalToken::Dyn),

--- a/src/grammar.lalrpop
+++ b/src/grammar.lalrpop
@@ -4,7 +4,7 @@ use crate::term::make as mk_term;
 use crate::mk_app;
 use crate::types::{Types, AbsType};
 use super::utils::{StringKind, mk_span, mk_label, strip_indent};
-use super::lexer::{Token, NormalToken, StringToken, IndStringToken, LexicalError};
+use super::lexer::{Token, NormalToken, StringToken, MultiStringToken, LexicalError};
 use std::collections::HashMap;
 use either::*;
 use codespan::FileId;
@@ -189,10 +189,10 @@ Str: String = "\"" <s: ChunkLiteral> "\"" => s;
 
 ChunkLiteralPart: Either<&'input str, char> = {
     "str literal" => Either::Left(<>),
-    "indstr literal" => Either::Left(<>),
+    "multstr literal" => Either::Left(<>),
     "false end" => Either::Left(<>),
     "str esc char" => Either::Right(<>),
-    "indstr esc char" => Either::Right(<>),
+    "multstr esc char" => Either::Right(<>),
 };
 
 UOp: UnaryOp<RichTerm> = {
@@ -415,10 +415,10 @@ extern {
     enum Token<'input> {
         "identifier" => Token::Normal(NormalToken::Identifier(<&'input str>)),
         "str literal" => Token::Str(StringToken::Literal(<&'input str>)),
-        "indstr literal" => Token::IndStr(IndStringToken::Literal(<&'input str>)),
+        "multstr literal" => Token::MultiStr(MultiStringToken::Literal(<&'input str>)),
         "str esc char" => Token::Str(StringToken::EscapedChar(<char>)),
-        "indstr esc char" => Token::IndStr(IndStringToken::EscapedChar(<char>)),
-        "false end" => Token::IndStr(IndStringToken::FalseEnd(<&'input str>)),
+        "multstr esc char" => Token::MultiStr(MultiStringToken::EscapedChar(<char>)),
+        "false end" => Token::MultiStr(MultiStringToken::FalseEnd(<&'input str>)),
         "num literal" => Token::Normal(NormalToken::NumLiteral(<f64>)),
 
         "if" => Token::Normal(NormalToken::If),
@@ -444,7 +444,7 @@ extern {
         // `${` and `${ bis` are morally the same token used in the same places,
         // but they correspond to two different modes, so we need to have two
         // distinct token
-        "${ bis" => Token::IndStr(IndStringToken::DollarBrace),
+        "${ bis" => Token::MultiStr(MultiStringToken::DollarBrace),
         "-$" => Token::Normal(NormalToken::MinusDollar),
 
         "+" => Token::Normal(NormalToken::Plus),
@@ -469,8 +469,8 @@ extern {
         "`" => Token::Normal(NormalToken::Backtick),
         "_" => Token::Normal(NormalToken::Underscore),
         "\"" => Token::Normal(NormalToken::DoubleQuote),
-        "\"#m" => Token::IndStr(IndStringToken::End),
-        "m#\"" => Token::Normal(NormalToken::StartMultiline),
+        "\"#m" => Token::MultiStr(MultiStringToken::End),
+        "m#\"" => Token::Normal(NormalToken::MultiStringStart(<usize>)),
 
         "Num" => Token::Normal(NormalToken::Num),
         "Dyn" => Token::Normal(NormalToken::Dyn),

--- a/src/grammar.lalrpop
+++ b/src/grammar.lalrpop
@@ -155,7 +155,7 @@ StrChunks : RichTerm = {
         };
         chunks.reverse();
 
-        RichTerm::new(Term::StrChunks(chunks))
+        RichTerm::from(Term::StrChunks(chunks))
     },
 };
 

--- a/src/grammar.lalrpop
+++ b/src/grammar.lalrpop
@@ -189,6 +189,7 @@ Str: String = "\"" <s: ChunkLiteral> "\"" => s;
 
 ChunkLiteralPart: Either<&'input str, char> = {
     "str literal" => Either::Left(<>),
+    "str $" => Either::Left(<>),
     "multstr literal" => Either::Left(<>),
     "multstr $" => Either::Left(<>),
     "multstr \\" => Either::Left(<>),
@@ -417,11 +418,12 @@ extern {
     enum Token<'input> {
         "identifier" => Token::Normal(NormalToken::Identifier(<&'input str>)),
         "str literal" => Token::Str(StringToken::Literal(<&'input str>)),
+        "str $" => Token::Str(StringToken::Dollar(<&'input str>)),
+        "str esc char" => Token::Str(StringToken::EscapedChar(<char>)),
         "multstr literal" => Token::MultiStr(MultiStringToken::Literal(<&'input str>)),
         "multstr $" => Token::MultiStr(MultiStringToken::Dollar(<&'input str>)),
         "multstr \\${" => Token::MultiStr(MultiStringToken::BackslashDollarBrace(<&'input str>)),
         "multstr \\" => Token::MultiStr(MultiStringToken::Backslash(<&'input str>)),
-        "str esc char" => Token::Str(StringToken::EscapedChar(<char>)),
         "false end" => Token::MultiStr(MultiStringToken::FalseEnd(<&'input str>)),
         "num literal" => Token::Normal(NormalToken::NumLiteral(<f64>)),
 

--- a/src/parser/lexer.rs
+++ b/src/parser/lexer.rs
@@ -266,7 +266,7 @@ pub enum MultiStringToken<'input> {
     // look-aheads in the lexer (which Logos doesn't support for performance reason), we just use a
     // separate token. This has lowest matching priority according to Logo's rules, so it is
     // matched only if `CandidateEnd` cannot be
-    #[regex("\"(#|(#[^m]))?")]
+    #[regex("\"(#+|(#+[^m]))?")]
     FalseEnd(&'input str),
     // A candidate end. A multiline string starting delimiter `MultiStringStart` can have a variable
     // number of `#` character, so the lexer matchs candidate end delimiter, compare the number of

--- a/src/parser/lexer.rs
+++ b/src/parser/lexer.rs
@@ -138,6 +138,8 @@ pub enum NormalToken<'input> {
     Backtick,
     #[token("_")]
     Underscore,
+    #[token("m#\"")]
+    StartMultiline,
 
     #[token("tag")]
     Tag,
@@ -251,16 +253,43 @@ pub enum StringToken<'input> {
     EscapedChar(char),
 }
 
+/// The tokens in indented multiline string mode.
+#[derive(Logos, Debug, PartialEq, Clone)]
+pub enum IndStringToken<'input> {
+    #[error]
+    Error,
+
+    #[regex("[^\"$\\\\]+")]
+    Literal(&'input str),
+
+    // This has lowest matching priority according to Logo's rules, so it is matched only if `End`
+    // cannot be
+    #[regex("\"(#|(#[^m]))?")]
+    FalseEnd(&'input str),
+    #[token("\"#m")]
+    End,
+    #[token("${")]
+    DollarBrace,
+    #[regex("\\\\.", |lex| lex.slice().chars().nth(1))]
+    EscapedChar(char),
+}
+
 /// The tokens of the modal lexer.
 #[derive(Debug, PartialEq, Clone)]
 pub enum Token<'input> {
     Normal(NormalToken<'input>),
     Str(StringToken<'input>),
+    IndStr(IndStringToken<'input>),
 }
 
+type NormalLexer<'input> = logos::Lexer<'input, NormalToken<'input>>;
+type StrLexer<'input> = logos::Lexer<'input, StringToken<'input>>;
+type IndStrLexer<'input> = logos::Lexer<'input, IndStringToken<'input>>;
+
 pub enum ModalLexer<'input> {
-    Normal(logos::Lexer<'input, NormalToken<'input>>),
-    Str(logos::Lexer<'input, StringToken<'input>>),
+    Normal(NormalLexer<'input>),
+    Str(StrLexer<'input>),
+    IndStr(IndStrLexer<'input>),
 }
 
 // Wrap the `next()` function of the underlying lexer.
@@ -271,6 +300,7 @@ impl<'input> Iterator for ModalLexer<'input> {
         match self {
             ModalLexer::Normal(lexer) => lexer.next().map(Token::Normal),
             ModalLexer::Str(lexer) => lexer.next().map(Token::Str),
+            ModalLexer::IndStr(lexer) => lexer.next().map(Token::IndStr),
         }
     }
 }
@@ -281,6 +311,7 @@ impl<'input> ModalLexer<'input> {
         match self {
             ModalLexer::Normal(lexer) => lexer.span(),
             ModalLexer::Str(lexer) => lexer.span(),
+            ModalLexer::IndStr(lexer) => lexer.span(),
         }
     }
 }
@@ -295,6 +326,13 @@ pub enum LexicalError {
     Generic(usize, usize),
 }
 
+#[derive(Clone, PartialEq, Eq, Debug, Copy)]
+pub enum ModeElt {
+    Str,
+    IndStr,
+    Normal(usize),
+}
+
 pub struct Lexer<'input> {
     // We are forced to use an `Option` in order to be able to switch mode without cloning the
     // underlying lexer. Logos offers a `morph()` function for a in-place conversion between
@@ -304,7 +342,6 @@ pub struct Lexer<'input> {
     // excepted in an non observable intermediate state during mode switching.
     /// The modal lexer.
     pub lexer: Option<ModalLexer<'input>>,
-    /// The current brace counter used to determine if a closing brace is the end of an
     /// interpolated expression.
     ///
     /// This is always `0` in string mode.
@@ -314,34 +351,52 @@ pub struct Lexer<'input> {
     /// As interpolated strings can be nested, we can start to lex a new string while we were
     /// already inside an interpolated expression. In this case, once this string ends, we must
     /// restore the original brace counter, which is what this stack is used for.
-    pub brace_stack: Vec<usize>,
+    pub stack: Vec<ModeElt>,
 }
 
 impl<'input> Lexer<'input> {
     pub fn new(s: &'input str) -> Self {
         Lexer {
             lexer: Some(ModalLexer::Normal(NormalToken::lexer(s))),
-            brace_stack: Vec::new(),
+            stack: Vec::new(),
             brace_count: 0,
         }
     }
 
-    fn enter_str(&mut self) {
+    fn enter_strlike<F>(&mut self, morph: F)
+    where
+        F: FnOnce(NormalLexer<'input>) -> ModalLexer<'input>,
+    {
         match self.lexer.take() {
+            // Cannot transition from a string mode to another one, so the current mode must be
+            //  `Normal`
             Some(ModalLexer::Normal(lexer)) => {
-                self.brace_stack.push(self.brace_count);
+                self.stack.push(ModeElt::Normal(self.brace_count));
                 self.brace_count = 0;
-                self.lexer.replace(ModalLexer::Str(lexer.morph()));
+                self.lexer.replace(morph(lexer));
             }
-            _ => panic!("lexer::enter_str"),
+            _ => panic!("lexer::enter_strlike"),
         }
+    }
+
+    fn enter_str(&mut self) {
+        self.enter_strlike(|lexer| ModalLexer::Str(lexer.morph()));
+    }
+
+    fn enter_indstr(&mut self) {
+        self.enter_strlike(|lexer| ModalLexer::IndStr(lexer.morph()));
     }
 
     fn enter_normal(&mut self) {
         match self.lexer.take() {
+            //brace_count must be zero, and we do not push it on the stack
             Some(ModalLexer::Str(lexer)) => {
-                //brace_count must be zero, and we do not push it on the stack
                 self.lexer.replace(ModalLexer::Normal(lexer.morph()));
+                self.stack.push(ModeElt::Str);
+            }
+            Some(ModalLexer::IndStr(lexer)) => {
+                self.lexer.replace(ModalLexer::Normal(lexer.morph()));
+                self.stack.push(ModeElt::IndStr);
             }
             _ => panic!("lexer::enter_normal"),
         }
@@ -350,9 +405,27 @@ impl<'input> Lexer<'input> {
     fn leave_str(&mut self) {
         match self.lexer.take() {
             Some(ModalLexer::Str(lexer)) => {
-                // We can only enter string mode from normal mode, so the brace stack should not be
-                // empty
-                self.brace_count = self.brace_stack.pop().unwrap();
+                // We can only enter string mode from normal mode
+                self.brace_count = match self.stack.pop() {
+                    Some(ModeElt::Normal(count)) => count,
+                    mode => panic!("lexer::leave_str (popped mode {:?})", mode),
+                };
+
+                self.lexer.replace(ModalLexer::Normal(lexer.morph()));
+            }
+            _ => panic!("lexer::leave_str"),
+        }
+    }
+
+    fn leave_indstr(&mut self) {
+        match self.lexer.take() {
+            Some(ModalLexer::IndStr(lexer)) => {
+                // We can only enter string mode from normal mode
+                self.brace_count = match self.stack.pop() {
+                    Some(ModeElt::Normal(count)) => count,
+                    mode => panic!("lexer::leave_str (popped mode {:?})", mode),
+                };
+
                 self.lexer.replace(ModalLexer::Normal(lexer.morph()));
             }
             _ => panic!("lexer::leave_str"),
@@ -363,7 +436,11 @@ impl<'input> Lexer<'input> {
         match self.lexer.take() {
             Some(ModalLexer::Normal(lexer)) => {
                 // brace_count must be 0
-                self.lexer.replace(ModalLexer::Str(lexer.morph()));
+                match self.stack.pop() {
+                    Some(ModeElt::Str) => self.lexer.replace(ModalLexer::Str(lexer.morph())),
+                    Some(ModeElt::IndStr) => self.lexer.replace(ModalLexer::IndStr(lexer.morph())),
+                    mode => panic!("lexer::leave_normal (popped mode {:?})", mode),
+                };
             }
             _ => panic!("lexer::leave_normal"),
         }
@@ -382,10 +459,11 @@ impl<'input> Iterator for Lexer<'input> {
 
         match token.as_ref() {
             Some(Normal(NormalToken::DoubleQuote)) => self.enter_str(),
+            Some(Normal(NormalToken::StartMultiline)) => self.enter_indstr(),
             Some(Normal(NormalToken::LBrace)) => self.brace_count += 1,
             Some(Normal(NormalToken::RBrace)) => {
                 if self.brace_count == 0 {
-                    if self.brace_stack.is_empty() {
+                    if self.stack.is_empty() {
                         return Some(Err(LexicalError::UnmatchedCloseBrace(span.start)));
                     }
 
@@ -400,17 +478,27 @@ impl<'input> Iterator for Lexer<'input> {
                 // `DoubleQuote`, namely the the normal one.
                 token = Some(Normal(NormalToken::DoubleQuote));
             }
-            Some(Str(StringToken::DollarBrace)) => self.enter_normal(),
+            Some(Str(StringToken::DollarBrace)) | Some(IndStr(IndStringToken::DollarBrace)) => {
+                self.enter_normal()
+            }
             // Convert escape sequences to the corresponding character.
-            Some(Str(StringToken::EscapedChar(c))) => {
+            Some(Str(StringToken::EscapedChar(c)))
+            | Some(IndStr(IndStringToken::EscapedChar(c))) => {
                 if let Some(esc) = escape_char(*c) {
-                    token = Some(Str(StringToken::EscapedChar(esc)));
+                    if let Some(Str(_)) = &token {
+                        token = Some(Str(StringToken::EscapedChar(esc)));
+                    } else {
+                        token = Some(IndStr(IndStringToken::EscapedChar(esc)));
+                    }
                 } else {
                     return Some(Err(LexicalError::InvalidEscapeSequence(span.start + 1)));
                 }
             }
+            Some(IndStr(IndStringToken::End)) => self.leave_indstr(),
             // Early report errors for now. This could change in the future
-            Some(Str(StringToken::Error)) | Some(Normal(NormalToken::Error)) => {
+            Some(Normal(NormalToken::Error))
+            | Some(Str(StringToken::Error))
+            | Some(IndStr(IndStringToken::Error)) => {
                 return Some(Err(LexicalError::Generic(span.start, span.end)))
             }
             _ => (),

--- a/src/parser/lexer.rs
+++ b/src/parser/lexer.rs
@@ -247,6 +247,9 @@ pub enum StringToken<'input> {
 
     #[token("\"")]
     DoubleQuote,
+    // Has lower matching priority than `DollarBrace` according to Logos' rules.
+    #[token("$")]
+    Dollar(&'input str),
     #[token("${")]
     DollarBrace,
     #[regex("\\\\.", |lex| lex.slice().chars().nth(1))]

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -276,4 +276,8 @@ fn str_escape() {
         parse_without_pos(r#""\$\${ }\$""#),
         mk_single_chunk("$${ }$"),
     );
+    assert_eq!(
+        parse_without_pos(r#""$a$b$c\${d\$""#),
+        mk_single_chunk("$a$b$c${d$"),
+    );
 }

--- a/src/parser/utils.rs
+++ b/src/parser/utils.rs
@@ -37,8 +37,8 @@ pub fn mk_label(types: Types, src_id: FileId, l: usize, r: usize) -> Label {
 ///
 /// The result is determined by computing the minimum indentation level among all lines, where the
 /// indentation level of a line is the number of consecutive whitespace characters, which are
-/// either a space or a, counted from the beginning of the line. If a line is empty or consist only
-/// of whitespace characters, it is ignored.
+/// either a space or a tab, counted from the beginning of the line. If a line is empty or consist
+/// only of whitespace characters, it is ignored.
 pub fn min_indent(chunks: &Vec<StrChunk<RichTerm>>) -> usize {
     let mut min: usize = std::usize::MAX;
     let mut current = 0;
@@ -83,6 +83,51 @@ pub fn min_indent(chunks: &Vec<StrChunk<RichTerm>>) -> usize {
 /// [`min_indent`](./fn.min_indent.html), and strip an equal number of whitespace characters (` `
 /// or `\t`) from the beginning of each line. If the last line is empty or consist only of
 /// whitespace characters, it is filtered out.
+///
+/// The indentation of interpolated expressions in a multi-line string follow the rules:
+/// - if an interpolated expression is alone on a line with whitespaces, its indentation -- minus
+///   the common minimal indentation -- is stored and when the expression will be evaluated, each new
+///   line will be prepended with this indentation level.
+/// - if there are other non whitespace characters or interpolated expressions on the line, then it
+///   is just replaced by its content. The common indentation is still stripped before the start of
+///   this expression, but newlines inside it won't be affected..
+///
+/// Examples:
+///
+/// ```
+/// let x = "I\nam\nindented" in
+/// m#"
+///   baseline
+///     ${x}
+///   end
+/// "#m
+/// ```
+/// gives
+/// ```
+///"baseline
+///  I
+///  am
+///  indented
+/// end"
+/// ```.
+///
+/// while
+/// ```
+/// let x = "I\nam\nnot" in
+/// m#"
+///   baseline
+///     ${x} sth
+///   end
+/// "#m
+/// ```
+/// gives
+/// ```
+///"baseline
+///  I
+///am
+///not sth
+/// end"
+/// ```.
 pub fn strip_indent(mut chunks: Vec<StrChunk<RichTerm>>) -> Vec<StrChunk<RichTerm>> {
     if chunks.is_empty() {
         return chunks;
@@ -91,8 +136,30 @@ pub fn strip_indent(mut chunks: Vec<StrChunk<RichTerm>>) -> Vec<StrChunk<RichTer
     let min = min_indent(&chunks);
     let mut current = 0;
     let mut start_line = true;
-
     let chunks_len = chunks.len();
+
+    // When processing a line with an indented interpolated expression, as in:
+    //
+    // ```
+    // m#"
+    //  some
+    //    ${x} ${y}
+    //    ${x}
+    //  string
+    // "#m
+    // ```
+    //
+    // We don't know at the time we process the expression `${x}` if it wil have to be re-indented,
+    // as it depends on the rest of the line being only whitespace or not, according to the
+    // indentation rule. Here, the first occurrence should not, while the second one should. We can
+    // only know this once we process the next chunks, here when arriving at `${y}`. To handle
+    // this, we set all indentation levels as if expressions were alone on their line during the
+    // main loop, but also store the index of such chunks which indentation level must be revisited
+    // once the information becomes available. Then, their indentation level is erased in a last
+    // pass.
+    let mut unindent: Vec<usize> = Vec::new();
+    let mut expr_on_line: Option<usize> = None;
+
     for (index, chunk) in chunks.iter_mut().enumerate() {
         match chunk {
             StrChunk::Literal(ref mut s) => {
@@ -107,6 +174,7 @@ pub fn strip_indent(mut chunks: Vec<StrChunk<RichTerm>>) -> Vec<StrChunk<RichTer
                         '\n' => {
                             current = 0;
                             start_line = true;
+                            expr_on_line = None;
                             buffer.push(c);
                         }
                         c if start_line => {
@@ -145,11 +213,24 @@ pub fn strip_indent(mut chunks: Vec<StrChunk<RichTerm>>) -> Vec<StrChunk<RichTer
 
                 std::mem::replace(s, buffer);
             }
-            StrChunk::Expr(_, ref mut indent) if start_line => {
-                debug_assert!(current >= min);
-                *indent = current - min;
+            StrChunk::Expr(_, ref mut indent) => {
+                if start_line {
+                    debug_assert!(current >= min);
+                    debug_assert!(expr_on_line.is_none());
+                    *indent = current - min;
+                    start_line = false;
+                    expr_on_line = Some(index);
+                } else if let Some(expr_index) = expr_on_line.take() {
+                    unindent.push(expr_index);
+                }
             }
-            StrChunk::Expr(_, _) => (),
+        }
+    }
+
+    for index in unindent.into_iter() {
+        match chunks.get_mut(index) {
+            Some(StrChunk::Expr(_, ref mut indent)) => *indent = 0,
+            _ => panic!(),
         }
     }
 

--- a/src/parser/utils.rs
+++ b/src/parser/utils.rs
@@ -92,7 +92,8 @@ pub fn strip_indent(mut chunks: Vec<StrChunk<RichTerm>>) -> Vec<StrChunk<RichTer
     let mut current = 0;
     let mut start_line = true;
 
-    for chunk in &mut chunks {
+    let chunks_len = chunks.len();
+    for (index, chunk) in chunks.iter_mut().enumerate() {
         match chunk {
             StrChunk::Literal(ref mut s) => {
                 let mut buffer = String::new();
@@ -113,13 +114,32 @@ pub fn strip_indent(mut chunks: Vec<StrChunk<RichTerm>>) -> Vec<StrChunk<RichTer
                     }
                 }
 
-                if let Some(last_index) = buffer.rfind('\n') {
-                    if last_index == buffer.len() - 1
-                        || buffer.as_bytes()[(last_index + 1)..]
-                            .iter()
-                            .all(|c| *c == b' ' || *c == b'\t')
-                    {
-                        buffer.truncate(last_index);
+                // Strip the first line, if it is only whitespace characters
+                if index == 0 {
+                    println!("First chunk");
+                    if let Some(first_index) = buffer.find('\n') {
+                        println!("Found newline char: {}", first_index);
+                        println!("substring tested: {}", &buffer[0..(first_index + 1)]);
+                        if first_index == 0
+                           || buffer.as_bytes()[..first_index]
+                                .iter()
+                                .all(|c| *c == b' ' || *c == b'\t')
+                        {
+                            buffer = String::from(&buffer[(first_index + 1)..]);
+                        }
+                    }
+                }
+
+                // Strip the last line, if it is only whitespace characters.
+                if index == chunks_len-1 {
+                    if let Some(last_index) = buffer.rfind('\n') {
+                        if last_index == buffer.len() - 1
+                            || buffer.as_bytes()[(last_index + 1)..]
+                                .iter()
+                                .all(|c| *c == b' ' || *c == b'\t')
+                        {
+                            buffer.truncate(last_index);
+                        }
                     }
                 }
 

--- a/src/program.rs
+++ b/src/program.rs
@@ -1436,6 +1436,7 @@ Assume(#alwaysTrue -> #alwaysFalse, not ) true
 
     #[test]
     fn multiline_string_indent() {
+        // /!\ Trailing spaces on the first line are on purpose, don't remove ! /!\
         assert_peq!(
             r##"  
                 m#"
@@ -1445,8 +1446,10 @@ Assume(#alwaysTrue -> #alwaysFalse, not ) true
                    text
                 "#m
             "##,
-            "\"this\n    is an\n    indented\ntext\"");
+            "\"this\n    is an\n    indented\ntext\""
+        );
 
+        // /!\ Trailing spaces on the first line are on purpose, don't remove ! /!\
         assert_peq!(
             r##"  
                 m#"
@@ -1455,9 +1458,10 @@ Assume(#alwaysTrue -> #alwaysFalse, not ) true
                        indented
                    text"#m
             "##,
-            "\"this\n    is an\n    indented\ntext\"");
+            "\"this\n    is an\n    indented\ntext\""
+        );
 
-        // /!\ Trailing spaces on the empty line are on purpose, don't remove ! /!\
+        // /!\ Trailing spaces on the middle line are on purpose, don't remove ! /!\
         assert_peq!(
             r##"  
                 m#"
@@ -1466,7 +1470,8 @@ Assume(#alwaysTrue -> #alwaysFalse, not ) true
                     empty line indent
                 "#m
             "##,
-            "\"ignore\n\n empty line indent\"");
+            "\"ignore\n\n empty line indent\""
+        );
 
         assert_peq!(
             r##"  
@@ -1476,8 +1481,8 @@ Assume(#alwaysTrue -> #alwaysFalse, not ) true
                     first line indent
                 "#m
             "##,
-            "\"\nignore\n first line indent\"");
-
+            "\"\nignore\n first line indent\""
+        );
     }
 
     #[test]
@@ -1506,6 +1511,46 @@ Assume(#alwaysTrue -> #alwaysFalse, not ) true
                    ${"${m##"te"##m}xt"}
                 "#m
             "###,
-            "\"this\n    is an\n    indented\ntext\"");
+            "\"this\n    is an\n    indented\ntext\""
+        );
+
+        assert_peq!(
+            r##"
+                let x = "I\n need\n  indent!" in
+                m#"
+                  base
+                    ${x}
+                  ${x}
+                "#m
+            "##,
+            r#""base
+  I
+   need
+    indent!
+I
+ need
+  indent!""#
+        );
+
+        assert_peq!(
+            r##"
+                let x = "ignore\nmy\nindent" in
+                let y = "me\ntoo" in
+                m#"
+                  strip
+                    ${x} ${y}
+                    ${"not\nme"}
+                "#m
+            "##,
+            r#""strip
+  strip
+  ignore
+my
+indent me
+too
+  not
+  me
+            ""#
+        );
     }
 }

--- a/src/program.rs
+++ b/src/program.rs
@@ -1543,14 +1543,12 @@ I
                 "#m
             "##,
             r#""strip
-  strip
   ignore
 my
 indent me
 too
   not
-  me
-            ""#
+  me""#
         );
     }
 }

--- a/src/program.rs
+++ b/src/program.rs
@@ -1179,7 +1179,6 @@ Assume(#alwaysTrue -> #alwaysFalse, not ) true
     /// instead of the callsite.
     macro_rules! assert_peq {
         ($t1:expr, $t2:expr) => {
-            println!("asserting {:?}", eval_string($t1));
             assert_eq!(
                 eval_string(&format!("({}) == ({})", $t1, $t2)),
                 Ok(Term::Bool(true)),

--- a/src/typecheck.rs
+++ b/src/typecheck.rs
@@ -458,9 +458,10 @@ fn type_check_(
                 .try_for_each(|chunk| -> Result<(), TypecheckError> {
                     match chunk {
                         StrChunk::Literal(_) => Ok(()),
-                        StrChunk::Expr(t, _) =>
-                            type_check_(state, envs.clone(), strict, t, mk_typewrapper::dynamic()),
-                   }
+                        StrChunk::Expr(t, _) => {
+                            type_check_(state, envs.clone(), strict, t, mk_typewrapper::dynamic())
+                        }
+                    }
                 })
         }
         Term::Fun(x, t) => {

--- a/src/typecheck.rs
+++ b/src/typecheck.rs
@@ -458,10 +458,9 @@ fn type_check_(
                 .try_for_each(|chunk| -> Result<(), TypecheckError> {
                     match chunk {
                         StrChunk::Literal(_) => Ok(()),
-                        StrChunk::Expr(t) => {
-                            type_check_(state, envs.clone(), strict, t, mk_typewrapper::dynamic())
-                        }
-                    }
+                        StrChunk::Expr(t, _) =>
+                            type_check_(state, envs.clone(), strict, t, mk_typewrapper::dynamic()),
+                   }
                 })
         }
         Term::Fun(x, t) => {
@@ -1402,7 +1401,7 @@ pub fn get_uop_type(
         // List -> Num
         UnaryOp::ListLength() => mk_tyw_arrow!(AbsType::List(), AbsType::Num()),
         // This should not happen, as ChunksConcat() is only produced during evaluation.
-        UnaryOp::ChunksConcat(_, _) => panic!("cannot type ChunksConcat()"),
+        UnaryOp::ChunksConcat(_, _, _) => panic!("cannot type ChunksConcat()"),
         // forall rows. { rows } -> List
         UnaryOp::FieldsOf() => mk_tyw_arrow!(
             mk_tyw_record!(; TypeWrapper::Ptr(new_var(state.table))),


### PR DESCRIPTION
Close #82. Implement multi-line indented string *à la Nix*, with a few differences.

## Delimiters
As suggested in https://github.com/tweag/nickel/issues/82#issuecomment-646607817, this PR introduces asymmetric and variable-length delimiter, so that it is easier to not clash with external language syntax. It is inspired from Rust's [raw strings](https://doc.rust-lang.org/stable/rust-by-example/std/str.html), using the opening delimiters `m#"` (`m` stands for multiline) and closing `"#m`. As in Rust, one can use an arbitrary number of `#` in the opening delimiter, and the closing delimiter then have to match this number, which allows to write strings containing `m#"` or `"#m` without escaping:

```
let stringception = m##"
  let inner = m#"
    what, Nickel code
    inside Nickel String ?
  "#m in
  inner ++ " Wow !"
"##m
//Result: "let inner = m#\"what, Nickel code\ninside Nickel String ? Wow !\"#m in\ninner ++ \" Wow !\""
```

The choice of the precise Rust-like delimiters is quite arbitrary, as there doesn't seem to be a consensus among languages for raw string delimiters ([C++](https://en.cppreference.com/w/cpp/language/string_literal), [Java](https://openjdk.java.net/jeps/355), [C#](https://docs.microsoft.com/fr-fr/dotnet/csharp/language-reference/tokens/verbatim), [OCaml](https://caml.inria.fr/pub/docs/manual-ocaml/lex.html#sss:stringliterals), [Python](https://docs.python.org/3/reference/lexical_analysis.html#string-and-bytes-literals)) but it can be amended.

## Indentation

### General
Multiline strings strip leading indentation in the same way as Nix in the absence of interpolation:
- the minimal indentation among all lines is computed in a first pass. as the number of space or tabulation between each start of line and the first non-whitespace character
- an "empty" (containing only whitespace characters, or not character at all) is not taken into account for this calculation
- this indentation is stripped from the beginning of every line
- the first line and the last line are ignored if they are "empty"

### Interpolation
As requested in #82 (see the original issues https://github.com/NixOS/nix/issues/543 in Nix and https://github.com/dhall-lang/dhall-lang/issues/200 in Dhall), Nickel adds a specific case for the indentation of an interpolated expression which result itself contains newline characters.
The motivating case is the following: 
```
let inner = m#"
  BEGIN
    some code
  END
"#m in
let outer = m#"
  SOME
    INDENT
      ${inner}
    ENDINDENT
  ENDSOME
"#m
```
In this case, Nix does the following:
```
SOME
  INDENT
    BEGIN
  some code
END
  ENDINDENT
ENDSOME
```
One would arguably expect and want `${inner}` to act like a **block**, rather than just a string literal to insert, that is to have:
```
SOME
  INDENT
    BEGIN
      some code
    END
  ENDINDENT
ENDSOME
```
This is the behavior implemented in this PR. The indentation level of the interpolated expression is attached, and when it is evaluated, an indentation is inserted at each beginning of line. Note that this happens only if an interpolated expression is alone on its line (with the usual gotcha that whitespaces are allowed). That is, in the following case:
```
let inner = "a\nb" in
m#"
begin
  ${inner} ${inner}
end
"#m
```
`${inner}` is not reindented, because it is not alone on its line, giving:
```
m#"
begin
  a
b a
b
end
```
The rationale is that it becomes tedious to define a reasonable behavior with a simple implementation for the general case, and it does not really make sense to have two  interpolated expressions with new lines inside on the same line. In this case, one probably doesn't expect a "block" behavior. We thus restrict this re-indentation to the specific case above. Note that the previous example is easily transformed to trigger a re-indentation if needed:
```
let inner = "a\nb" in
m#"
begin
  ${inner ++ " " ++ inner}
end
"#m
```
```
begin
  a
  b a
  b
end
```

## Shortcomings / coming next
- as opposed to Nix, multi-line strings use the same `\`-based escape mechanism as standard strings. There is no hidden reasons, I just couldn't come up with a good re-escape sequence (`''` in Nix, because these are the delimiters of multi-line strings). Any ideas ?
- as opposed to Nix, but as in Dhall, tabulations are also counted as whitespace characters. I think this is desirable in general, as Nickel could very much needs to represent chunks from languages that favor them. On the other hand, it makes the re-indentation of interpolated string a bit more subtle: currently, what is saved is just a number of characters to re-add to the beginning of each line. But if the input used, say, only tabulations, the re-identation would turn those to spaces, which is maybe not desirable. Should we rather store a whole indentation prefix with interpolated expressions to fix this ? Or just forget about tabs ?
 - raw strings are a low-hanging fruit, just changing `m` to `r` and the special meaning of `${ }` and stuff.