### PR TITLE
[Refactoring]Add and use helpers to build Nickel terms

### DIFF
--- a/src/grammar.lalrpop
+++ b/src/grammar.lalrpop
@@ -1,5 +1,7 @@
 use crate::identifier::Ident;
 use crate::term::{BinaryOp, RichTerm, Term, UnaryOp, StrChunk};
+use crate::term::make as mk_term;
+use crate::mk_app;
 use crate::types::{Types, AbsType};
 use super::utils::{mk_span, mk_label};
 use super::lexer::{Token, NormalToken, StringToken, LexicalError};
@@ -20,12 +22,12 @@ SpTerm<Rule>: RichTerm =
     };
 
 LeftOp<Op, Current, Previous>: RichTerm =
-    <t1: Current> <op: Op> <t2: Previous> => RichTerm::new(Term::Op2(op, t1,
-    t2));
+    <t1: Current> <op: Op> <t2: Previous> => mk_term::op2(op, t1,
+    t2);
 
 LeftOpLazy<Op, Current, Previous>: RichTerm =
     <t1: Current> <op: Op> <t2: Previous> =>
-        RichTerm::app(RichTerm::new(Term::Op1(op, t1)), t2);
+        mk_app!(Term::Op1(op, t1), t2);
 
 RichTerm: RichTerm = {
     <l: @L> "fun" <ps:Pattern+> "=>" <t: SpTerm<Term>> <r: @R> => {
@@ -36,17 +38,17 @@ RichTerm: RichTerm = {
         })
     },
     "let" <id:Ident> "=" <t1:SpTerm<Term>> "in" <t2:SpTerm<Term>> =>
-        RichTerm::new(Term::Let(id, t1, t2)),
+        mk_term::let_in(id, t1, t2),
     "if" <b:SpTerm<Term>> "then" <t:SpTerm<Term>> "else" <e:SpTerm<Term>> =>
-        RichTerm::app(RichTerm::app(RichTerm::new(Term::Op1(UnaryOp::Ite(), b)), t), e),
-    "import" <s: Str> => RichTerm::new(Term::Import(s)),
+        mk_app!(Term::Op1(UnaryOp::Ite(), b), t, e),
+    "import" <s: Str> => RichTerm::from(Term::Import(s)),
     SpTerm<InfixExpr>,
 };
 
 Applicative: RichTerm = {
-    <t1:SpTerm< Applicative>> <t2: SpTerm<Atom>> => RichTerm::new(Term::App(t1, t2)),
-    <op: UOp> <t: SpTerm<Atom>> => RichTerm::new(Term::Op1(op, t)),
-    <op: BOpPre> <t1: SpTerm<Atom>> <t2: SpTerm<Atom>> => RichTerm::new(Term::Op2(op, t1, t2)),
+    <t1:SpTerm< Applicative>> <t2: SpTerm<Atom>> => mk_app!(t1, t2),
+    <op: UOp> <t: SpTerm<Atom>> => mk_term::op1(op, t),
+    <op: BOpPre> <t1: SpTerm<Atom>> <t2: SpTerm<Atom>> => mk_term::op2(op, t1, t2),
     SpTerm<RecordOperationChain>,
     SpTerm<Atom>,
 };
@@ -57,32 +59,32 @@ RecordOperand: RichTerm = {
 }
 
 RecordOperationChain: RichTerm = {
-    <t: SpTerm<RecordOperand>> "." <id: Ident> => RichTerm::new(Term::Op1(UnaryOp::StaticAccess(id), t)),
-    <t: SpTerm<RecordOperand>> ".$" <t_id: SpTerm<Atom>> => RichTerm::new(Term::Op2(BinaryOp::DynAccess(), t_id, t)),
-    <t: SpTerm<RecordOperand>> "-$" <t_id: SpTerm<Atom>> => RichTerm::new(Term::Op2(BinaryOp::DynRemove(), t_id, t)),
+    <t: SpTerm<RecordOperand>> "." <id: Ident> => mk_term::op1(UnaryOp::StaticAccess(id), t),
+    <t: SpTerm<RecordOperand>> ".$" <t_id: SpTerm<Atom>> => mk_term::op2(BinaryOp::DynAccess(), t_id, t),
+    <t: SpTerm<RecordOperand>> "-$" <t_id: SpTerm<Atom>> => mk_term::op2(BinaryOp::DynRemove(), t_id, t),
     <r: SpTerm<RecordOperand>> "$[" <id: SpTerm<Term>> "=" <t: SpTerm<Term>> "]" =>
-        RichTerm::new(Term::Op2(BinaryOp::DynExtend(t), id, r)),
+        mk_term::op2(BinaryOp::DynExtend(t), id, r),
 };
 
 Atom: RichTerm = {
     "(" <SpTerm<Term>> ")",
     <l: @L> "Promise(" <ty: Types> "," <t: SpTerm<Term>> ")" <r: @R> =>
-        RichTerm::new(Term::Promise(ty.clone(), mk_label(ty, src_id, l, r), t)),
+        RichTerm::from(Term::Promise(ty.clone(), mk_label(ty, src_id, l, r), t)),
     <l: @L> "Assume(" <ty: Types> "," <t: SpTerm<Term>> ")" <r: @R> =>
-        RichTerm::new(Term::Assume(ty.clone(), mk_label(ty, src_id, l, r), t)),
+        RichTerm::from(Term::Assume(ty.clone(), mk_label(ty, src_id, l, r), t)),
     <l: @L> "Contract(" <ty: Types> ")" <r: @R> =>
-        RichTerm::new(Term::Contract(ty.clone(), mk_label(ty, src_id, l, r))),
-    "Default(" <t: SpTerm<Term>> ")" => RichTerm::new(Term::DefaultValue(t)),
+        RichTerm::from(Term::Contract(ty.clone(), mk_label(ty, src_id, l, r))),
+    "Default(" <t: SpTerm<Term>> ")" => RichTerm::from(Term::DefaultValue(t)),
     <l: @L> "ContractDefault(" <ty: Types> "," <t: SpTerm<Term>> ")" <r: @R> =>
-        RichTerm::new(Term::ContractWithDefault(ty.clone(),
+        RichTerm::from(Term::ContractWithDefault(ty.clone(),
             mk_label(ty, src_id, l, r), t)
         ),
-    "Docstring(" <s: Str> "," <t: SpTerm<Term>> ")" => RichTerm::new(Term::Docstring(s, t)),
-    "num literal" => RichTerm::new(Term::Num(<>)),
-    Bool => RichTerm::new(Term::Bool(<>)),
+    "Docstring(" <s: Str> "," <t: SpTerm<Term>> ")" => RichTerm::from(Term::Docstring(s, t)),
+    "num literal" => RichTerm::from(Term::Num(<>)),
+    Bool => RichTerm::from(Term::Bool(<>)),
     <StrChunks>,
-    Ident => RichTerm::new(Term::Var(<>)),
-    "`" <Ident> => RichTerm::new(Term::Enum(<>)),
+    Ident => RichTerm::from(Term::Var(<>)),
+    "`" <Ident> => RichTerm::from(Term::Enum(<>)),
     "{" <fields: (RecordField ";")*> <last: RecordField?> "}" => {
         let mut static_map = HashMap::new();
         let mut dynamic_fields = Vec::new();
@@ -96,18 +98,18 @@ Atom: RichTerm = {
                 Right(t) => dynamic_fields.push(t),
             });
 
-        let static_rec = RichTerm::new(Term::RecRecord(static_map));
+        let static_rec = RichTerm::from(Term::RecRecord(static_map));
 
         dynamic_fields.into_iter().fold(static_rec, |rec, field| {
             let (id_t, t) = field;
-            RichTerm::new(Term::Op2(BinaryOp::DynExtend(t), id_t, rec))
+            RichTerm::from(Term::Op2(BinaryOp::DynExtend(t), id_t, rec))
         })
     },
     "[" <terms: (SpTerm<Atom> ",")*> <last: SpTerm<Term>?> "]" => {
         let terms : Vec<RichTerm> = terms.into_iter()
             .map(|x| x.0)
             .chain(last.into_iter()).collect();
-        RichTerm::new(Term::List(terms))
+        RichTerm::from(Term::List(terms))
     }
 };
 
@@ -144,10 +146,10 @@ StrChunks : RichTerm =
             .rev()
             .collect();
 
-        RichTerm::new(Term::StrChunks(chunks))
+        RichTerm::from(Term::StrChunks(chunks))
     };
 
-ChunkLiteral: String = 
+ChunkLiteral: String =
     <parts: ChunkLiteralPart+> => {
         parts.into_iter().fold(String::new(), |mut acc, part| {
             match part {
@@ -215,7 +217,7 @@ InfixExpr0: RichTerm = {
 PrefixExpr1: RichTerm = {
     InfixExpr0,
     "-" <t: PrefixExpr1> =>
-        RichTerm::new(Term::Op2(BinaryOp::Sub(), Term::Num(0.0).into(), t)),
+        mk_term::op2(BinaryOp::Sub(), Term::Num(0.0), t),
 }
 
 BinOp2: BinaryOp<RichTerm> = {
@@ -251,7 +253,7 @@ InfixExpr4: RichTerm = {
 
 PrefixExpr5: RichTerm = {
     InfixExpr4,
-    "!" <PrefixExpr5> => RichTerm::new(Term::Op1(UnaryOp::BoolNot(), <>)), 
+    "!" <PrefixExpr5> => mk_term::op1(UnaryOp::BoolNot(), <>),
 }
 
 BinOp6: BinaryOp<RichTerm> = {

--- a/src/merge.rs
+++ b/src/merge.rs
@@ -55,9 +55,11 @@ use crate::error::EvalError;
 use crate::eval::{Closure, Environment};
 use crate::label::Label;
 use crate::position::RawSpan;
+use crate::term::make as mk_term;
 use crate::term::{BinaryOp, RichTerm, Term};
 use crate::transformations::Closurizable;
 use crate::types::{AbsType, Types};
+use crate::{mk_app, mk_fun};
 use std::collections::HashMap;
 
 /// Compute the merge of two evaluated operands.
@@ -356,21 +358,16 @@ fn mk_merge_closure(t1: RichTerm, env1: Environment, t2: RichTerm, env2: Environ
 /// notes](https://github.com/tweag/nickel/blob/master/notes/intersection-and-union-types.md) in
 /// the repository).
 fn merge_contracts(c1: RichTerm, l1: Label, c2: RichTerm, l2: Label) -> Types {
-    let contract = RichTerm::fun(
-        "_l".to_string(),
-        RichTerm::fun(
-            "x".to_string(),
-            RichTerm::app(
-                RichTerm::app(c1, Term::Lbl(l1).into()),
-                RichTerm::app(
-                    RichTerm::app(c2, Term::Lbl(l2).into()),
-                    RichTerm::var("x".to_string()),
-                ),
-            ),
-        ),
+    let contract: RichTerm = mk_fun!(
+        "_l",
+        "x",
+        mk_app!(
+            c1,
+            Term::Lbl(l1),
+            mk_app!(c2, Term::Lbl(l2), mk_term::var("x"))
+        )
     );
-
-    Types(AbsType::Flat(contract.into()))
+    Types(AbsType::Flat(contract))
 }
 
 /// [Closurize](../transformations/trait.Closurizable.html) two types with their respective

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -1,5 +1,7 @@
 use super::lexer::{Lexer, LexicalError, NormalToken, StringToken, Token};
 use crate::identifier::Ident;
+use crate::mk_app;
+use crate::term::make as mk_term;
 use crate::term::Term::*;
 use crate::term::{BinaryOp, RichTerm, StrChunk, UnaryOp};
 use codespan::Files;
@@ -7,7 +9,6 @@ use codespan::Files;
 fn parse(s: &str) -> Option<RichTerm> {
     let id = Files::new().add("<test>", String::from(s));
 
-    println!("Parsing {}", s);
     super::grammar::TermParser::new()
         .parse(id, Lexer::new(&s))
         .map_err(|err| println!("{:?}", err))
@@ -100,36 +101,20 @@ fn booleans() {
 fn ite() {
     assert_eq!(
         parse_without_pos("if true then 3 else 4"),
-        RichTerm::app(
-            RichTerm::app(
-                Op1(UnaryOp::Ite(), Bool(true).into()).into(),
-                Num(3.0).into()
-            ),
-            Num(4.0).into()
-        )
+        mk_app!(mk_term::op1(UnaryOp::Ite(), Bool(true)), Num(3.0), Num(4.0))
     );
 }
 
 #[test]
 fn applications() {
-    println!("1 true 2: {:?}", parse_without_pos("1 true 2"));
-
     assert_eq!(
         parse_without_pos("1 true 2"),
-        RichTerm::app(
-            RichTerm::app(Num(1.0).into(), Bool(true).into()),
-            Num(2.0).into()
-        ),
+        mk_app!(Num(1.0), Bool(true), Num(2.0))
     );
+
     assert_eq!(
         parse_without_pos("1 (2 3) 4"),
-        RichTerm::app(
-            RichTerm::app(
-                Num(1.0).into(),
-                RichTerm::app(Num(2.0).into(), Num(3.0).into())
-            ),
-            Num(4.0).into()
-        ),
+        mk_app!(Num(1.0), mk_app!(Num(2.0), Num(3.0)), Num(4.0))
     );
 }
 
@@ -140,10 +125,7 @@ fn variables() {
 
 #[test]
 fn functions() {
-    assert_eq!(
-        parse_without_pos("fun x => x"),
-        Fun(Ident("x".into()), RichTerm::var("x".into())).into(),
-    );
+    assert_eq!(parse_without_pos("fun x => x"), mk_term::id());
 }
 
 #[test]
@@ -156,39 +138,35 @@ fn lets() {
 fn unary_op() {
     assert_eq!(
         parse_without_pos("isZero x"),
-        Op1(UnaryOp::IsZero(), RichTerm::var("x".to_string())).into()
+        mk_term::op1(UnaryOp::IsZero(), mk_term::var("x"))
     );
     assert_eq!(
         parse_without_pos("isZero x y"),
-        RichTerm::app(
-            Op1(UnaryOp::IsZero(), RichTerm::var("x".to_string())).into(),
-            RichTerm::var("y".to_string())
-        )
+        mk_app!(
+            mk_term::op1(UnaryOp::IsZero(), mk_term::var("x")),
+            mk_term::var("y")
+        ),
     );
 }
 
 #[test]
 fn enum_terms() {
-    assert_eq!(
-        parse_without_pos("`foo"),
-        Enum(Ident("foo".to_string())).into(),
-    );
+    assert_eq!(parse_without_pos("`foo"), Enum(Ident::from("foo")).into(),);
 
     assert_eq!(
         parse_without_pos("switch { foo => true, bar => false, _ => 456, } 123"),
-        Op1(
+        mk_term::op1(
             UnaryOp::Switch(
                 vec![
-                    (Ident("foo".to_string()), Bool(true).into()),
-                    (Ident("bar".to_string()), Bool(false).into())
+                    (Ident::from("foo"), Bool(true).into()),
+                    (Ident::from("bar"), Bool(false).into())
                 ]
                 .into_iter()
                 .collect(),
                 Some(Num(456.).into())
             ),
-            Num(123.).into()
+            Num(123.),
         )
-        .into()
     )
 }
 
@@ -198,9 +176,9 @@ fn record_terms() {
         parse_without_pos("{ a = 1; b = 2; c = 3;}"),
         RecRecord(
             vec![
-                (Ident("a".to_string()), Num(1.).into()),
-                (Ident("b".to_string()), Num(2.).into()),
-                (Ident("c".to_string()), Num(3.).into())
+                (Ident::from("a"), Num(1.).into()),
+                (Ident::from("b"), Num(2.).into()),
+                (Ident::from("c"), Num(3.).into())
             ]
             .into_iter()
             .collect()
@@ -210,26 +188,22 @@ fn record_terms() {
 
     assert_eq!(
         parse_without_pos("{ a = 1; $123 = (if 4 then 5 else 6); d = 42;}"),
-        Op2(
-            BinaryOp::DynExtend(
-                App(
-                    App(Op1(UnaryOp::Ite(), Num(4.).into()).into(), Num(5.).into()).into(),
-                    Num(6.).into()
-                )
-                .into()
-            ),
-            Num(123.).into(),
+        mk_term::op2(
+            BinaryOp::DynExtend(mk_app!(
+                mk_term::op1(UnaryOp::Ite(), Num(4.)),
+                Num(5.),
+                Num(6.)
+            )),
+            Num(123.),
             RecRecord(
                 vec![
-                    (Ident("a".to_string()), Num(1.).into()),
-                    (Ident("d".to_string()), Num(42.).into()),
+                    (Ident::from("a"), Num(1.).into()),
+                    (Ident::from("d"), Num(42.).into()),
                 ]
                 .into_iter()
                 .collect()
             )
-            .into()
         )
-        .into()
     );
 }
 

--- a/src/program.rs
+++ b/src/program.rs
@@ -1339,6 +1339,7 @@ Assume(#alwaysTrue -> #alwaysFalse, not ) true
         eval_string("\"a\" || false").unwrap_err();
     }
 
+    #[test]
     fn records_contracts_simple() {
         assert_peq!("Assume({ {| |} }, {})", "{}");
         eval_string("Assume({ {| |} }, {a=1})").unwrap_err();

--- a/src/typecheck.rs
+++ b/src/typecheck.rs
@@ -1640,8 +1640,10 @@ mod tests {
     use super::*;
     use crate::error::ImportError;
     use crate::label::Label;
+    use crate::mk_app;
     use crate::parser::lexer;
     use crate::program::resolvers::{DummyResolver, SimpleResolver};
+    use crate::term::make as mk_term;
     use crate::transformations::transform;
     use codespan::Files;
 
@@ -1667,20 +1669,14 @@ mod tests {
 
         type_check_no_import(&Term::Bool(true).into())?;
         type_check_no_import(&Term::Num(45.).into())?;
-        type_check_no_import(&RichTerm::fun(String::from("x"), RichTerm::var("x".into())).into())?;
-        type_check_no_import(&RichTerm::let_in(
-            "x",
-            Term::Num(3.).into(),
-            RichTerm::var("x".into()),
-        ))?;
+        type_check_no_import(&mk_term::id())?;
+        type_check_no_import(&mk_term::let_in("x", Term::Num(3.0), mk_term::var("x")))?;
 
-        type_check_no_import(&RichTerm::app(
-            Term::Num(5.).into(),
-            Term::Bool(true).into(),
-        ))?;
-        type_check_no_import(&RichTerm::plus(
-            Term::Num(4.).into(),
-            Term::Bool(false).into(),
+        type_check_no_import(&mk_app!(Term::Num(5.0), Term::Bool(true)))?;
+        type_check_no_import(&mk_term::op2(
+            BinaryOp::Plus(),
+            Term::Num(4.),
+            Term::Bool(false),
         ))?;
 
         Ok(())
@@ -1688,7 +1684,7 @@ mod tests {
 
     #[test]
     fn unbound_variable_always_throws() {
-        type_check_no_import(&RichTerm::var(String::from("x"))).unwrap_err();
+        type_check_no_import(&mk_term::var("x")).unwrap_err();
     }
 
     #[test]
@@ -2076,11 +2072,7 @@ mod tests {
             R: ImportResolver,
         {
             transform(
-                RichTerm::let_in(
-                    "x",
-                    Term::Import(String::from(import)).into(),
-                    RichTerm::var(String::from("x")),
-                ),
+                mk_term::let_in("x", Term::Import(String::from(import)), mk_term::var("x")),
                 resolver,
             )
         };


### PR DESCRIPTION
Add helper functions and macros to make building terms directly a bit easier and readable, trying to reduce the `(a.into(), b.into()).into()` kind of pattern. Doing so, make a few other details more consistent across the code base (ex: remove the `RichTerm::new` constructor which is redundant with the `From<Term>` trait implementation, and both were used in different places), and remove trailing `println!` debug statements.