### PR TITLE
[Refactoring]Add dedicated modules to access stdlib functions

### DIFF
--- a/src/operation.rs
+++ b/src/operation.rs
@@ -15,6 +15,7 @@ use crate::merge;
 use crate::merge::merge;
 use crate::position::RawSpan;
 use crate::stack::Stack;
+use crate::stdlib;
 use crate::term::make as mk_term;
 use crate::term::{BinaryOp, RichTerm, StrChunk, Term, UnaryOp};
 use crate::transformations::Closurizable;
@@ -827,14 +828,7 @@ fn process_binary_operation(
                     .collect();
                 // lists.all (fun x => x) subeqs
                 Term::App(
-                    mk_app!(
-                        // lists.all
-                        mk_term::op1(
-                            UnaryOp::StaticAccess(Ident::from("all")),
-                            mk_term::var("lists"),
-                        ),
-                        mk_term::id()
-                    ),
+                    mk_app!(stdlib::lists::all(), mk_term::id()),
                     Term::List(subeqs).into(),
                 )
             }

--- a/src/stdlib.rs
+++ b/src/stdlib.rs
@@ -1,3 +1,52 @@
 //! Load the Nickel standard library in strings at compile-time.
+
+use crate::identifier::Ident;
+use crate::term::make as mk_term;
+use crate::term::{RichTerm, UnaryOp};
+
 pub const CONTRACTS: &str = include_str!("../stdlib/contracts.ncl");
 pub const LISTS: &str = include_str!("../stdlib/lists.ncl");
+
+/// Accessors to the lists standard library.
+pub mod lists {
+    use super::*;
+
+    pub fn all() -> RichTerm {
+        mk_term::op1(
+            UnaryOp::StaticAccess(Ident::from("all")),
+            mk_term::var("lists"),
+        )
+    }
+}
+
+/// Accessors to the builtin contracts.
+pub mod contracts {
+    use super::*;
+
+    macro_rules! generate_accessor {
+        ($value:ident) => {
+            pub fn $value() -> RichTerm {
+                mk_term::var(stringify!($value))
+            }
+        };
+    }
+
+    // `dyn` is a reserved keyword in rust
+    pub fn dynamic() -> RichTerm {
+        mk_term::var("dyn")
+    }
+
+    generate_accessor!(num);
+    generate_accessor!(bool);
+    generate_accessor!(string);
+    generate_accessor!(list);
+    generate_accessor!(func);
+    generate_accessor!(forall_var);
+    generate_accessor!(fail);
+    generate_accessor!(row_extend);
+    generate_accessor!(record);
+    generate_accessor!(dyn_record);
+    generate_accessor!(record_extend);
+    generate_accessor!(forall_tail);
+    generate_accessor!(empty_tail);
+}


### PR DESCRIPTION
Depend on #198. Address https://github.com/tweag/nickel/pull/159#discussion_r502206850. Use dedicated modules to access standard library functions, rather than referring to it via strings.