### PR TITLE
Full evaluation

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -637,12 +637,10 @@ fn subst(rt: RichTerm, global_env: &Environment, env: &Environment) -> RichTerm 
                     .into_iter()
                     .map(|chunk| match chunk {
                         chunk @ StrChunk::Literal(_) => chunk,
-                        StrChunk::Expr(t) => StrChunk::Expr(subst_(
-                            t,
-                            global_env,
-                            env,
-                            Cow::Borrowed(bound.as_ref()),
-                        )),
+                        StrChunk::Expr(t, indent) => StrChunk::Expr(
+                            subst_(t, global_env, env, Cow::Borrowed(bound.as_ref())),
+                            indent,
+                        ),
                     })
                     .collect();
 

--- a/src/program.rs
+++ b/src/program.rs
@@ -1623,6 +1623,10 @@ too
         ));
         assert_eq!(t, *expd.term);
 
-        // let t = parse("{ foo = [(1 + 1), if true then false else true]; bar = \"a${\"b\"}c${\"d\"}\"; baz = { nested = { foo = 1 + 1 } } }").unwrap();
+        // /!\ [MAY OVERFLOW STACK]
+        // Check that substitution do not replace bound variables. Before the fixing commit, this
+        // example would go into an infinite loop, and stack overflow. If it does, this just means
+        // that this test fails.
+        eval_string_full("{y = fun x => x; x = fun y => y}").unwrap();
     }
 }

--- a/src/program.rs
+++ b/src/program.rs
@@ -1616,7 +1616,7 @@ too
             )
             .unwrap(),
         );
-        // Records are parsed as RecRecords, so we need to build it by hand
+        // Records are parsed as RecRecords, so we need to build one by hand
         let expd = mk_record!((
             "foo",
             mk_record!(("bar", mk_record!(("baz", Term::Num(2.0)))))

--- a/src/program.rs
+++ b/src/program.rs
@@ -234,7 +234,19 @@ impl Program {
         let global_env = self.mk_global_env()?;
         type_check(&t, &global_env, self).map_err(|err| Error::from(err))?;
         let t = transformations::transform(t, self).map_err(|err| Error::ImportError(err))?;
-        eval::eval(t, global_env, self).map_err(|e| e.into())
+        eval::eval(t, &global_env, self).map_err(|e| e.into())
+    }
+
+    #[cfg(test)]
+    /// Same as `eval`, but proceeds to a full evaluation.
+    pub fn eval_full(&mut self) -> Result<Term, Error> {
+        let t = self
+            .parse_with_cache(self.main_id)
+            .map_err(|e| Error::from(e))?;
+        let global_env = self.mk_global_env()?;
+        type_check(&t, &global_env, self).map_err(|err| Error::from(err))?;
+        let t = transformations::transform(t, self).map_err(|err| Error::ImportError(err))?;
+        eval::eval_full(t, &global_env, self).map_err(|e| e.into())
     }
 
     /// Parse a source file. Do not try to get it from the cache, and do not populate the cache at
@@ -457,7 +469,21 @@ mod tests {
     use super::*;
     use crate::error::EvalError;
     use crate::identifier::Ident;
+    use crate::parser::{grammar, lexer};
     use std::io::Cursor;
+
+    fn parse(s: &str) -> Option<RichTerm> {
+        let id = Files::new().add("<test>", String::from(s));
+
+        grammar::TermParser::new()
+            .parse(id, lexer::Lexer::new(&s))
+            .map(|mut t| {
+                t.clean_pos();
+                t
+            })
+            .map_err(|err| println!("{:?}", err))
+            .ok()
+    }
 
     fn eval_string(s: &str) -> Result<Term, Error> {
         let src = Cursor::new(s);
@@ -466,6 +492,15 @@ mod tests {
             Error::EvalError(EvalError::Other(format!("IO error: {}", io_err), None))
         })?;
         p.eval()
+    }
+
+    fn eval_string_full(s: &str) -> Result<Term, Error> {
+        let src = Cursor::new(s);
+
+        let mut p = Program::new_from_source(src, "<test>").map_err(|io_err| {
+            Error::EvalError(EvalError::Other(format!("IO error: {}", io_err), None))
+        })?;
+        p.eval_full()
     }
 
     /// Assert if a given Nickel expression evaluates to a record, given as a vector of bindings
@@ -1549,5 +1584,45 @@ too
   not
   me""#
         );
+    }
+
+    #[test]
+    fn evaluation_full() {
+        use crate::mk_record;
+
+        // Clean all the position information in a term.
+        fn clean_pos(t: Term) -> Term {
+            let mut tmp = RichTerm::new(t, None);
+            tmp.clean_pos();
+            *tmp.term
+        }
+
+        use crate::term::make as mk_term;
+
+        let t =
+            clean_pos(eval_string_full("[(1 + 1), (\"a\" ++ \"b\"), ([ 1, [1 + 2] ])]").unwrap());
+        let mut expd = parse("[2, \"ab\", [1, [3]]]").unwrap();
+        // String are parsed as StrChunks, but evaluated to Str, so we need to hack list a bit
+        if let Term::List(ref mut data) = *expd.term {
+            std::mem::replace(data.get_mut(1).unwrap(), mk_term::string("ab"));
+        } else {
+            panic!();
+        }
+        assert_eq!(t, *expd.term);
+
+        let t = clean_pos(
+            eval_string_full(
+                "let x = 1 in let y = 1 + x in let z = { foo = {bar = { baz  = y } } } in z",
+            )
+            .unwrap(),
+        );
+        // Records are parsed as RecRecords, so we need to build it by hand
+        let expd = mk_record!((
+            "foo",
+            mk_record!(("bar", mk_record!(("baz", Term::Num(2.0)))))
+        ));
+        assert_eq!(t, *expd.term);
+
+        // let t = parse("{ foo = [(1 + 1), if true then false else true]; bar = \"a${\"b\"}c${\"d\"}\"; baz = { nested = { foo = 1 + 1 } } }").unwrap();
     }
 }

--- a/src/term.rs
+++ b/src/term.rs
@@ -708,6 +708,14 @@ pub struct RichTerm {
 }
 
 impl RichTerm {
+    /// Create a new value from a term and an optional position.
+    pub fn new(t: Term, pos: Option<RawSpan>) -> Self {
+        RichTerm {
+            term: Box::new(t),
+            pos,
+        }
+    }
+
     /// Erase recursively the positional information.
     ///
     /// It allows to use rust `Eq` trait to compare the values of the underlying terms.
@@ -1009,6 +1017,23 @@ pub mod make {
         };
         ( $id1:expr, $id2:expr , $( $rest:expr ),+ ) => {
             mk_fun!($crate::identifier::Ident::from($id1), mk_fun!($id2, $( $rest ),+))
+        };
+    }
+
+    /// Multi field record for types implementing `Into<Ident>` (for the identifiers), and
+    /// `Into<RichTerm>` for the fields. Identifiers and corresponding content are specified as a
+    /// tuple: `mk_record!(("field1", t1), ("field2", t2))` corresponds to the record `{ field1 =
+    /// t1; field2 = t2 }`.
+    #[macro_export]
+    macro_rules! mk_record {
+        ( $( ($id:expr, $body:expr) ),* ) => {
+            {
+                let mut map = std::collections::HashMap::new();
+                $(
+                    map.insert($id.into(), $body.into());
+                )*
+                $crate::term::RichTerm::from($crate::term::Term::Record(map))
+            }
         };
     }
 


### PR DESCRIPTION
Depends on #203. Required for #196.

The result of evaluation is not just a term, but a term within an environment. In order to perform JSON serialization, one either needs to carry around the environment in order to be able to fetch the content of variables when needed, or to get rid of it entirely by substituting all variable occurrences in the final result.

While the first option is worth considering eventually for performance reasons, [serde](https://github.com/serde-rs/serde) doesn't support passing state out of the box, so doing it requires some amount of boilerplate around the lib. There's also a fork [serde_state](https://github.com/Marwes/serde_state) that does this specifically, but it doesn't seem regularly updated or popular enough to have maintenance guarantees.

For now, it seems the cheapest route is to go with the second option: pass closed terms to the serializer, while enjoying most of `serde`'s deriving features.

**what it does**
 - implement a `subst` function to recursively substitute all variable of a term within an environment and get back a closed term
 - add an `eval_full` function that recursively force all suterms, apply `subst`, and return a fully evaluated and closed term