### PR TITLE
Json serialization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -153,7 +153,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.117 (registry+https://github.com/rust-lang/crates.io-index)",
  "strsim 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -207,6 +207,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "itoa"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "kernel32-sys"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -231,8 +236,8 @@ dependencies = [
  "petgraph 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex-syntax 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.117 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.117 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "string_cache 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "term 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -306,6 +311,8 @@ dependencies = [
  "logos 0.11.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "pretty_assertions 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.117 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.59 (registry+https://github.com/rust-lang/crates.io-index)",
  "simple-counter 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -516,21 +523,36 @@ version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "ryu"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "serde"
-version = "1.0.102"
+version = "1.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "serde_derive 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.117 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.102"
+version = "1.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 1.0.45 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.59"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "itoa 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ryu 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.117 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -563,7 +585,7 @@ dependencies = [
  "new_debug_unreachable 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "phf_shared 0.7.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "precomputed-hash 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.117 (registry+https://github.com/rust-lang/crates.io-index)",
  "string_cache_codegen 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "string_cache_shared 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -723,6 +745,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 "checksum generic-array 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c68f0274ae0e023facc3c97b2e00f076be70e254bc851d972503b328db79b2ec"
 "checksum itertools 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "87fa75c9dea7b07be3138c49abbb83fd4bea199b5cdc76f9804458edc5da0d6e"
+"checksum itoa 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "dc6f3ad7b9d11a0c00842ff8de1b60ee58661048eb8049ed33c73594f359d7e6"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum lalrpop 0.16.3 (registry+https://github.com/rust-lang/crates.io-index)" = "4e2e80bee40b22bca46665b4ef1f3cd88ed0fb043c971407eac17a0712c02572"
 "checksum lalrpop-util 0.16.3 (registry+https://github.com/rust-lang/crates.io-index)" = "33b27d8490dbe1f9704b0088d61e8d46edc10d5673a8829836c6ded26a9912c7"
@@ -757,8 +780,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dc220bd33bdce8f093101afe22a037b8eb0e5af33592e6a9caafff0d4cb81cbd"
 "checksum regex-syntax 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)" = "7d707a4fa2637f2dca2ef9fd02225ec7661fe01a53623c1e6515b6916511f7a7"
 "checksum regex-syntax 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)" = "11a7e20d1cce64ef2fed88b66d347f88bd9babb82845b2b858f3edbf59a4f716"
-"checksum serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)" = "0c4b39bd9b0b087684013a792c59e3e07a46a01d2322518d8a1104641a0b1be0"
-"checksum serde_derive 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)" = "ca13fc1a832f793322228923fbb3aba9f3f44444898f835d31ad1b74fa0a2bf8"
+"checksum ryu 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
+"checksum serde 1.0.117 (registry+https://github.com/rust-lang/crates.io-index)" = "b88fa983de7720629c9387e9f517353ed404164b1e482c970a90c1a4aaf7dc1a"
+"checksum serde_derive 1.0.117 (registry+https://github.com/rust-lang/crates.io-index)" = "cbd1ae72adb44aab48f325a02444a5fc079349a8d804c1fc922aed3f7454c74e"
+"checksum serde_json 1.0.59 (registry+https://github.com/rust-lang/crates.io-index)" = "dcac07dbffa1c65e7f816ab9eba78eb142c6d44410f4eeba1e26e4f5dfa56b95"
 "checksum sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7b4d8bfd0e469f417657573d8451fb33d16cfe0989359b93baf3a1ffc639543d"
 "checksum simple-counter 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4bb57743b52ea059937169c0061d70298fe2df1d2c988b44caae79dd979d9b49"
 "checksum siphasher 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "0b8de496cf83d4ed58b6be86c3a275b8602f6ffe98d3024a869e124147a9a3ac"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,8 @@ simple-counter = "0.1.0"
 codespan = "0.9.5"
 codespan-reporting = "0.9.5"
 logos = "0.11.4"
+serde = "1.0.117"
+serde_json = "1.0.59"
 
 [dev-dependencies]
 pretty_assertions = "0.5.1"

--- a/src/error.rs
+++ b/src/error.rs
@@ -195,6 +195,10 @@ pub enum ImportError {
     ),
 }
 
+/// A term contains constructs that cannot be serialized.
+#[derive(Debug, PartialEq, Clone)]
+pub struct NonSerializableError(pub RichTerm);
+
 impl From<EvalError> for Error {
     fn from(error: EvalError) -> Error {
         Error::EvalError(error)
@@ -1105,5 +1109,17 @@ impl ToDiagnostic<FileId> for ImportError {
                 diagnostic
             }
         }
+    }
+}
+
+impl ToDiagnostic<FileId> for NonSerializableError {
+    fn to_diagnostic(
+        &self,
+        files: &mut Files<String>,
+        _contract_id: Option<FileId>,
+    ) -> Vec<Diagnostic<FileId>> {
+        vec![Diagnostic::error()
+            .with_message("non serializable term")
+            .with_labels(vec![primary_term(&self.0, files)])]
     }
 }

--- a/src/identifier.rs
+++ b/src/identifier.rs
@@ -2,7 +2,7 @@
 use serde::{Deserialize, Serialize};
 use std::fmt;
 
-#[derive(Debug, Eq, Hash, PartialEq, Clone, Serialize, Deserialize)]
+#[derive(Debug, Eq, Hash, PartialEq, Ord, PartialOrd, Clone, Serialize, Deserialize)]
 pub struct Ident(pub String);
 
 impl fmt::Display for Ident {

--- a/src/identifier.rs
+++ b/src/identifier.rs
@@ -1,7 +1,8 @@
 //! Define the type of an identifier.
+use serde::{Deserialize, Serialize};
 use std::fmt;
 
-#[derive(Debug, Eq, Hash, PartialEq, Clone)]
+#[derive(Debug, Eq, Hash, PartialEq, Clone, Serialize, Deserialize)]
 pub struct Ident(pub String);
 
 impl fmt::Display for Ident {

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@ mod operation;
 mod parser;
 mod position;
 mod program;
+mod serialize;
 mod stack;
 mod stdlib;
 mod term;

--- a/src/program.rs
+++ b/src/program.rs
@@ -123,7 +123,7 @@ impl Program {
     }
 
     /// Create a program by reading it from a generic source.
-    fn new_from_source<T: Read>(
+    pub fn new_from_source<T: Read>(
         mut source: T,
         source_name: impl Into<OsString>,
     ) -> std::io::Result<Program> {

--- a/src/program.rs
+++ b/src/program.rs
@@ -237,7 +237,6 @@ impl Program {
         eval::eval(t, &global_env, self).map_err(|e| e.into())
     }
 
-    #[cfg(test)]
     /// Same as `eval`, but proceeds to a full evaluation.
     pub fn eval_full(&mut self) -> Result<Term, Error> {
         let t = self
@@ -275,7 +274,10 @@ impl Program {
     ///
     /// This function is located here in `Program` because errors need a reference to `files` in
     /// order to produce a diagnostic (see [`label_alt`](../error/fn.label_alt.html)).
-    pub fn report(&mut self, error: Error) {
+    pub fn report<E>(&mut self, error: E)
+    where
+        E: ToDiagnostic<FileId>,
+    {
         let writer = StandardStream::stderr(ColorChoice::Always);
         let config = codespan_reporting::term::Config::default();
         let diagnostics = error.to_diagnostic(

--- a/src/serialize.rs
+++ b/src/serialize.rs
@@ -1,9 +1,11 @@
 //! Serialization of an evaluated program to various data format.
 use crate::error::NonSerializableError;
+use crate::identifier::Ident;
 use crate::label::Label;
 use crate::term::{RichTerm, Term};
 use crate::types::Types;
-use serde::ser::{Serialize, Serializer};
+use serde::ser::{Serialize, SerializeMap, Serializer};
+use std::collections::HashMap;
 
 /// Serializer for docstring. Ignore the meta-data and serialize the underlying term.
 pub fn serialize_docstring<S>(_doc: &String, t: &RichTerm, serializer: S) -> Result<S::Ok, S::Error>
@@ -27,6 +29,23 @@ where
     t.serialize(serializer)
 }
 
+/// Serializer for a record. Serialize fields in alphabetical order to get a deterministic output
+/// (by default, `HashMap`'s randomness implies a randomized order of fields in the output).
+pub fn serialize_record<S>(map: &HashMap<Ident, RichTerm>, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    let mut entries: Vec<(_, _)> = map.iter().collect();
+    entries.sort_by(|(k1, _), (k2, _)| k1.cmp(k2));
+
+    let mut map_ser = serializer.serialize_map(Some(entries.len()))?;
+    for (id, t) in entries.iter() {
+        map_ser.serialize_entry(&id.to_string(), &t)?
+    }
+
+    map_ser.end()
+}
+
 impl Serialize for RichTerm {
     /// Serialize the underlying term.
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
@@ -37,12 +56,14 @@ impl Serialize for RichTerm {
     }
 }
 
+/// Check that a term is serializable. Serilizable terms are booleans, numbers, strings, enum,
+/// lists of serializable terms or records of serializable terms.
 pub fn validate(t: &RichTerm) -> Result<(), NonSerializableError> {
     use Term::*;
 
     match t.term.as_ref() {
         Bool(_) | Num(_) | Str(_) | Enum(_) => Ok(()),
-        Record(map) => {
+        Record(map) | RecRecord(map) => {
             map.iter().try_for_each(|(_, t)| validate(t))?;
             Ok(())
         }
@@ -55,47 +76,107 @@ pub fn validate(t: &RichTerm) -> Result<(), NonSerializableError> {
     }
 }
 
-// pub trait SerializeSeed<T> {
-//     fn serialize_seed<S>(&self, serializer: S, seed: &T) -> Result<S::Ok, S::Error> where S: Serializer;
-// }
-//
-// pub struct StateSerializer<'a, T, S> {
-//     state: &'a T,
-//     serializer: S
-// }
-//
-// pub trait SerializerSeed {
-//     type Ok
-//     type Error: Error
-//
-// }
-// impl Serialize for Term {
-//     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error> where S: Serializer {
-//         use Term::*;
-//
-//         match self {
-//             Bool(b) => serializer.serialize_bool(*b),
-//             Num(n) => serializer.serialize_f64(*n),
-//             Str(s) => serializer.serialize_str(s),
-//             Enum(id) => id.serialize(serializer),
-//             Record(map) => map.serialize(serializer),
-//             List(vec) => vec.serialize(serializer),
-//             DefaultValue(t) | ContractWithDefault(_, _, t) | Docstring(_, t) =>
-//                 t.as_ref().serialize(serializer),
-//             _ => panic!(),
-//         }
-//     }
-// }
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::error::{Error, EvalError};
+    use crate::program::Program;
+    use serde_json::json;
+    use std::io::Cursor;
 
-// impl<T> Serialize for SerializeSeed<T> {
-//     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error> where S: Serializer {
-//
-//     }
-// }
+    fn mk_program(s: &str) -> Result<Program, Error> {
+        let src = Cursor::new(s);
 
-//
-// impl Serialize for Closure {
-//     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error> where S: Serializer {
-//         panic!("not implemented")
-//     }
-// }
+        Program::new_from_source(src, "<test>").map_err(|io_err| {
+            Error::EvalError(EvalError::Other(format!("IO error: {}", io_err), None))
+        })
+    }
+
+    macro_rules! assert_json_eq {
+        ( $term:expr, $result:expr ) => {
+            assert_eq!(
+                serde_json::to_string(&mk_program($term).and_then(|mut p| p.eval_full()).unwrap())
+                    .unwrap(),
+                serde_json::to_string(&$result).unwrap()
+            )
+        };
+    }
+
+    macro_rules! assert_non_serializable {
+        ( $term:expr ) => {
+            validate(
+                &mk_program($term)
+                    .and_then(|mut p| p.eval_full())
+                    .unwrap()
+                    .into(),
+            )
+            .unwrap_err();
+        };
+    }
+
+    #[test]
+    fn basic() {
+        assert_json_eq!("1 + 1", 2.0);
+        assert_json_eq!("if true then false else true", false);
+        assert_json_eq!(r#""Hello, ${"world"}!""#, "Hello, world!");
+        assert_json_eq!("`foo", "foo");
+    }
+
+    #[test]
+    fn lists() {
+        assert_json_eq!("[]", json!([]));
+        assert_json_eq!("[(1+1), (2+2), (3+3)]", json!([2.0, 4.0, 6.0]));
+        assert_json_eq!(
+            r#"[`a, ("b" ++ "c"), "d${"e"}f", "g"]"#,
+            json!(["a", "bc", "def", "g"])
+        );
+        assert_json_eq!(
+            r#"lists.fold (fun elt acc => [[elt]] @ acc) [1, 2, 3, 4] []"#,
+            json!([[1.0], [2.0], [3.0], [4.0]])
+        );
+        assert_json_eq!("[\"a\", 1, false, `foo]", json!(["a", 1.0, false, "foo"]));
+    }
+
+    #[test]
+    fn records() {
+        assert_json_eq!(
+            "{a = 1; b = 2+2; c = 3}",
+            json!({"a": 1.0, "b": 4.0, "c": 3.0})
+        );
+
+        assert_json_eq!(
+            "{a = merge {} {b = {c = if true then `richtig else `falsche}}}",
+            json!({"a": {"b": {"c": "richtig"}}})
+        );
+
+        assert_json_eq!(
+            "{foo = let z = 0.5 + 0.5 in z; bar = [\"str\", true || false]; baz = merge {subfoo = !false} {subbar = 1 - 1}}",
+            json!({"foo": 1.0, "bar": ["str", true], "baz": {"subfoo": true, "subbar": 0.0}})
+        );
+    }
+
+    #[test]
+    fn enriched_values() {
+        assert_json_eq!(
+            "{a = Default(1); b = Docstring(\"doc\", 2+2); c = 3}",
+            json!({"a": 1.0, "b": 4.0, "c": 3.0})
+        );
+
+        assert_json_eq!(
+            "{a = merge {b = Default({})} {b = {c = Default(if true then `faux else `vrai)}}}",
+            json!({"a": {"b": {"c": "faux"}}})
+        );
+
+        assert_json_eq!(
+            "{baz = Default(merge {subfoo = Default(!false)} {subbar = Default(1 - 1)})}",
+            json!({"baz": {"subfoo": true, "subbar": 0.0}})
+        );
+    }
+
+    #[test]
+    fn prevalidation() {
+        assert_non_serializable!("{a = 1; b = { c = fun x => x }}");
+        assert_non_serializable!("{foo = { bar = let y = \"a\" in y}; b = [[fun x => x]] }");
+        assert_non_serializable!("{foo = { bar = let y = \"a\" in y}; b = [[fun x => x]] }");
+    }
+}

--- a/src/serialize.rs
+++ b/src/serialize.rs
@@ -177,6 +177,5 @@ mod tests {
     fn prevalidation() {
         assert_non_serializable!("{a = 1; b = { c = fun x => x }}");
         assert_non_serializable!("{foo = { bar = let y = \"a\" in y}; b = [[fun x => x]] }");
-        assert_non_serializable!("{foo = { bar = let y = \"a\" in y}; b = [[fun x => x]] }");
     }
 }

--- a/src/serialize.rs
+++ b/src/serialize.rs
@@ -56,7 +56,7 @@ impl Serialize for RichTerm {
     }
 }
 
-/// Check that a term is serializable. Serilizable terms are booleans, numbers, strings, enum,
+/// Check that a term is serializable. Serializable terms are booleans, numbers, strings, enum,
 /// lists of serializable terms or records of serializable terms.
 pub fn validate(t: &RichTerm) -> Result<(), NonSerializableError> {
     use Term::*;

--- a/src/serialize.rs
+++ b/src/serialize.rs
@@ -1,0 +1,101 @@
+//! Serialization of an evaluated program to various data format.
+use crate::error::NonSerializableError;
+use crate::label::Label;
+use crate::term::{RichTerm, Term};
+use crate::types::Types;
+use serde::ser::{Serialize, Serializer};
+
+/// Serializer for docstring. Ignore the meta-data and serialize the underlying term.
+pub fn serialize_docstring<S>(_doc: &String, t: &RichTerm, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    t.serialize(serializer)
+}
+
+/// Serializer for a contract with a default value. Ignore the meta-data and serialize the
+/// underlying term.
+pub fn serialize_contract_default<S>(
+    _ty: &Types,
+    _l: &Label,
+    t: &RichTerm,
+    serializer: S,
+) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    t.serialize(serializer)
+}
+
+impl Serialize for RichTerm {
+    /// Serialize the underlying term.
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        (*self.term).serialize(serializer)
+    }
+}
+
+pub fn validate(t: &RichTerm) -> Result<(), NonSerializableError> {
+    use Term::*;
+
+    match t.term.as_ref() {
+        Bool(_) | Num(_) | Str(_) | Enum(_) => Ok(()),
+        Record(map) => {
+            map.iter().try_for_each(|(_, t)| validate(t))?;
+            Ok(())
+        }
+        List(vec) => {
+            vec.iter().try_for_each(validate)?;
+            Ok(())
+        }
+        DefaultValue(ref t) | ContractWithDefault(_, _, ref t) | Docstring(_, ref t) => validate(t),
+        _ => Err(NonSerializableError(t.clone())),
+    }
+}
+
+// pub trait SerializeSeed<T> {
+//     fn serialize_seed<S>(&self, serializer: S, seed: &T) -> Result<S::Ok, S::Error> where S: Serializer;
+// }
+//
+// pub struct StateSerializer<'a, T, S> {
+//     state: &'a T,
+//     serializer: S
+// }
+//
+// pub trait SerializerSeed {
+//     type Ok
+//     type Error: Error
+//
+// }
+// impl Serialize for Term {
+//     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error> where S: Serializer {
+//         use Term::*;
+//
+//         match self {
+//             Bool(b) => serializer.serialize_bool(*b),
+//             Num(n) => serializer.serialize_f64(*n),
+//             Str(s) => serializer.serialize_str(s),
+//             Enum(id) => id.serialize(serializer),
+//             Record(map) => map.serialize(serializer),
+//             List(vec) => vec.serialize(serializer),
+//             DefaultValue(t) | ContractWithDefault(_, _, t) | Docstring(_, t) =>
+//                 t.as_ref().serialize(serializer),
+//             _ => panic!(),
+//         }
+//     }
+// }
+
+// impl<T> Serialize for SerializeSeed<T> {
+//     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error> where S: Serializer {
+//
+//     }
+// }
+
+//
+// impl Serialize for Closure {
+//     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error> where S: Serializer {
+//         panic!("not implemented")
+//     }
+// }

--- a/src/term.rs
+++ b/src/term.rs
@@ -69,6 +69,7 @@ pub enum Term {
     Enum(Ident),
 
     /// A record, mapping identifiers to terms.
+    #[serde(serialize_with = "crate::serialize::serialize_record")]
     Record(HashMap<Ident, RichTerm>),
     /// A recursive record, where the fields can reference each others.
     #[serde(skip)]


### PR DESCRIPTION
Depend on #204. Partly address #196. Use the [serde](https://github.com/serde-rs/serde) library to allow the serialization of evaluated terms to JSON. This PR just adds the feature internally together with tests. A coming PR will add a corresponding sub-command to the executable to trigger JSON serialization.

Rust's `HashMap`, which is used to represent records, is not an ordered datastructure. What's more, the hash algorithm is randomized, meaning that the default serializer outputs the fields of a record in a random order, which changes at each execution, even for the same program. One probably expects and relies on the fact that for a specific Nickel program, the JSON output is deterministic. To this end, this PR orders fields in the alphabetical order (using built-in Rust comparison), using the same order as the `fieldOf` built-in operator.