### PR TITLE
[Syntax]Use the `&` binary operator for merging

### DIFF
--- a/src/examples/merge.ncl
+++ b/src/examples/merge.ncl
@@ -8,4 +8,4 @@ let r2 = {
     c = if true then 1 + 1 else 2 + 0;
     d = true;
 } in
-(merge r1 r2).b
+(r1 & r2).b

--- a/src/examples/merge2.ncl
+++ b/src/examples/merge2.ncl
@@ -1,2 +1,2 @@
-let f = fun y => merge ((fun x => {a=y}) 0) ({b=false}) in
+let f = fun y => ((fun x => {a=y}) 0) & ({b=false}) in
 (f 1).a

--- a/src/examples/merge3.ncl
+++ b/src/examples/merge3.ncl
@@ -1,4 +1,4 @@
 let rNest1 = {b={c=10}} in
 let rNest2 = (fun x => {a=x; b={c=x}}) 10 in
-let r = merge rNest1 rNest2 in
+let r = rNest1 & rNest2 in
 r.b.c

--- a/src/examples/mergeContracts.ncl
+++ b/src/examples/mergeContracts.ncl
@@ -26,5 +26,4 @@ let toCtr = fun f l x => (
 ) in
 let isEven = toCtr isEven_ in
 let isDivBy3 = toCtr isDivBy3_ in
-let composed = merge Contract(#isEven) Contract(#isDivBy3) in
-merge 12 composed
+12 & Contract(#isEven) & Contract(#isDivBy3)

--- a/src/examples/mergeEnriched.ncl
+++ b/src/examples/mergeEnriched.ncl
@@ -20,9 +20,9 @@ let confValidation = {
     gcc = Contract(Str);
     specialFlag = Contract(#oneOrTwo);
 } in
-let confValAndDef = merge confValidation confDefault in
+let confValAndDef = confValidation & confDefault in
 let myConf = {
     gcc = "gcc -02";
 } in
-let result = merge myConf confValAndDef in
+let result = myConf & confValAndDef in
 result.specialFlag

--- a/src/grammar.lalrpop
+++ b/src/grammar.lalrpop
@@ -285,37 +285,37 @@ PrefixExpr5: RichTerm = {
 }
 
 BinOp6: BinaryOp<RichTerm> = {
+    "&" => BinaryOp::Merge(),
+}
+
+PrefixExpr6: RichTerm = {
+    PrefixExpr5,
+    LeftOp<BinOp6, PrefixExpr6, PrefixExpr5> => <>,
+}
+
+BinOp7: BinaryOp<RichTerm> = {
     "<" => BinaryOp::LessThan(),
     "<=" => BinaryOp::LessOrEq(),
     ">" => BinaryOp::GreaterThan(),
     ">=" => BinaryOp::GreaterOrEq(),
 }
 
-InfixExpr6: RichTerm = {
-    PrefixExpr5,
-    LeftOp<BinOp6, InfixExpr6, PrefixExpr5> => <>,
-}
-
-BinOp7: BinaryOp<RichTerm> = {
-    "==" => BinaryOp::Eq(),
-}
-
 InfixExpr7: RichTerm = {
-    InfixExpr6,
-    LeftOp<BinOp7, InfixExpr7, InfixExpr6> => <>,
+    PrefixExpr6,
+    LeftOp<BinOp7, InfixExpr7, PrefixExpr6> => <>,
 }
 
-LazyBinOp8: UnaryOp<RichTerm> = {
-    "&&" => UnaryOp::BoolAnd(),
+BinOp8: BinaryOp<RichTerm> = {
+    "==" => BinaryOp::Eq(),
 }
 
 InfixExpr8: RichTerm = {
     InfixExpr7,
-    LeftOpLazy<LazyBinOp8, InfixExpr8, InfixExpr7> => <>
+    LeftOp<BinOp8, InfixExpr8, InfixExpr7> => <>,
 }
 
 LazyBinOp9: UnaryOp<RichTerm> = {
-    "||" => UnaryOp::BoolOr(),
+    "&&" => UnaryOp::BoolAnd(),
 }
 
 InfixExpr9: RichTerm = {
@@ -323,10 +323,19 @@ InfixExpr9: RichTerm = {
     LeftOpLazy<LazyBinOp9, InfixExpr9, InfixExpr8> => <>
 }
 
+LazyBinOp10: UnaryOp<RichTerm> = {
+    "||" => UnaryOp::BoolOr(),
+}
+
+InfixExpr10: RichTerm = {
+    InfixExpr9,
+    LeftOpLazy<LazyBinOp10, InfixExpr10, InfixExpr9> => <>
+}
+
 // TODO: convenience for adding precedence levels during development. Once
 // operators are fixed, we should turn the last level into `InfixExpr` directly
 InfixExpr: RichTerm = {
-    InfixExpr9,
+    InfixExpr10,
 }
 
 BOpPre: BinaryOp<RichTerm> = {
@@ -335,7 +344,6 @@ BOpPre: BinaryOp<RichTerm> = {
     "hasField" => BinaryOp::HasField(),
     "map" => BinaryOp::ListMap(),
     "elemAt" => BinaryOp::ListElemAt(),
-    "merge" => BinaryOp::Merge(),
 }
 
 Types: Types = {
@@ -443,6 +451,7 @@ extern {
         "$" => Token::Normal(NormalToken::Dollar),
         "=" => Token::Normal(NormalToken::Equals),
         ";" => Token::Normal(NormalToken::SemiCol),
+        "&" => Token::Normal(NormalToken::Ampersand),
         "." => Token::Normal(NormalToken::Dot),
         ".$" => Token::Normal(NormalToken::DotDollar),
         "$[" => Token::Normal(NormalToken::DollarBracket),

--- a/src/parser/lexer.rs
+++ b/src/parser/lexer.rs
@@ -84,6 +84,8 @@ pub enum NormalToken<'input> {
     Equals,
     #[token(";")]
     SemiCol,
+    #[token("&")]
+    Ampersand,
     #[token(".")]
     Dot,
     #[token(".$")]

--- a/src/program.rs
+++ b/src/program.rs
@@ -885,7 +885,7 @@ Assume(#alwaysTrue -> #alwaysFalse, not ) true
     #[test]
     fn merge_record_simple() {
         assert_eval_to_record(
-            "merge {a=1;} {b=true;}",
+            "{a=1;} & {b=true;}",
             vec![("a", Term::Num(1.0)), ("b", Term::Bool(true))],
         );
     }
@@ -893,13 +893,13 @@ Assume(#alwaysTrue -> #alwaysFalse, not ) true
     #[test]
     #[should_panic]
     fn merge_record_failure() {
-        eval_string("(merge {a=1} {a=2}).a").unwrap();
+        eval_string("({a=1} & {a=2}).a").unwrap();
     }
 
     #[test]
     fn merge_record_intersection() {
         assert_eval_to_record(
-            "merge {a=1;b=2;} {b=2;c=3;}",
+            "{a=1;b=2;} & {b=2;c=3;}",
             vec![
                 ("a", Term::Num(1.0)),
                 ("b", Term::Num(2.0)),
@@ -911,7 +911,7 @@ Assume(#alwaysTrue -> #alwaysFalse, not ) true
     #[test]
     fn merge_record_nested() {
         assert_eval_to_record(
-            "(merge {a={b=1;};} {a={c=true;};}).a ",
+            "({a={b=1;};} & {a={c=true;};}).a ",
             vec![("b", Term::Num(1.0)), ("c", Term::Bool(true))],
         );
     }
@@ -921,7 +921,7 @@ Assume(#alwaysTrue -> #alwaysFalse, not ) true
         assert_eval_to_record(
             "let rec1 = {a=false;b=(if true then (1 + 1) else (2 + 0)); c=(((fun x => x) (fun y => y)) 2);} in
              let rec2 = {b=(((fun x => x) (fun y => y)) 2); c=(if true then (1 + 1) else (2 + 0)); d=true;} in
-             merge rec1 rec2",
+             rec1 & rec2",
              vec![("a", Term::Bool(false)), ("b", Term::Num(2.0)), ("c", Term::Num(2.0)), ("d", Term::Bool(true))]
          );
     }
@@ -929,7 +929,7 @@ Assume(#alwaysTrue -> #alwaysFalse, not ) true
     #[test]
     fn merge_record_with_env() {
         assert_eq!(
-            eval_string("((fun y => merge ((fun x => {a=y;}) 1) ({b=false;})) 2).a"),
+            eval_string("((fun y => ((fun x => {a=y}) 1) & ({b=false})) 2).a"),
             Ok(Term::Num(2.0))
         );
     }
@@ -938,8 +938,8 @@ Assume(#alwaysTrue -> #alwaysFalse, not ) true
     fn merge_record_with_env_nested() {
         assert_eq!(
             eval_string(
-                "let rec = merge ({b={c=10;};}) ((fun x => {a=x; b={c=x;};}) 10) in
-                         (rec.b).c"
+                "let rec = {b={c=10}} & ((fun x => {a=x; b={c=x}}) 10) in
+                         rec.b.c"
             ),
             Ok(Term::Num(10.0))
         );
@@ -961,7 +961,7 @@ Assume(#alwaysTrue -> #alwaysFalse, not ) true
     #[test]
     fn enriched_terms_thunk_update() {
         assert_eq!(
-            eval_string("let x = {a=(fun x => Default(1)) 1} in seq (x.a) ((merge x {a=2}).a)"),
+            eval_string("let x = {a=(fun x => Default(1)) 1} in seq (x.a) ((x & {a=2}).a)"),
             Ok(Term::Num(2.0))
         );
     }
@@ -969,51 +969,51 @@ Assume(#alwaysTrue -> #alwaysFalse, not ) true
     #[test]
     fn merge_default() {
         assert_eval_to_record(
-            "merge {a=2;} {a=Default(0);b=Default(true);}",
+            "{a=2;} & {a=Default(0);b=Default(true);}",
             vec![("a", Term::Num(2.0)), ("b", Term::Bool(true))],
         );
 
         assert_eval_to_record(
-            "(merge {a=Default({x=1;});} {a=Default({y=\"y\";});}).a",
+            "({a=Default({x=1;});} & {a=Default({y=\"y\";});}).a",
             vec![("x", Term::Num(1.0)), ("y", Term::Str(String::from("y")))],
         );
 
-        eval_string("(merge {a=Default(1);} {a=Default(2);}).a").unwrap_err();
+        eval_string("({a=Default(1);} & {a=Default(2);}).a").unwrap_err();
     }
 
     #[test]
     fn merge_contract() {
         assert_eval_to_record(
-            "merge {a=2;b=Contract(Bool);} {a=Contract(Num);b=Default(true);}",
+            "{a=2;b=Contract(Bool);} & {a=Contract(Num);b=Default(true);}",
             vec![("a", Term::Num(2.0)), ("b", Term::Bool(true))],
         );
 
-        eval_string("let r = merge {a=2;} {a=Contract(Bool)} in r.a").unwrap_err();
+        eval_string("let r = {a=2;} & {a=Contract(Bool)} in r.a").unwrap_err();
     }
 
     #[test]
     fn merge_default_contract() {
         assert_eval_to_record(
-            "merge {a=2;} {a=ContractDefault(Num, 0);b=Default(true);}",
+            "{a=2;} & {a=ContractDefault(Num, 0);b=Default(true)}",
             vec![("a", Term::Num(2.0)), ("b", Term::Bool(true))],
         );
 
         assert_eval_to_record(
-            "merge (merge {a=2;} {a=Contract(Num);}) {a=Default(3);}",
+            "{a=2} & {a=Contract(Num)} & {a=Default(3)}",
             vec![("a", Term::Num(2.0))],
         );
 
         assert_eq!(
-            eval_string("(merge (merge {a=2;} {b=Contract(Num);}) {b=Default(3);}).b"),
+            eval_string("({a=2;} & {b=Contract(Num)} & {b=Default(3);}).b"),
             Ok(Term::Num(3.0)),
         );
 
         assert_eq!(
-            eval_string("(merge (merge {a=Default(1);} {b=Contract(Num);}) {a=Default(1);}).a"),
+            eval_string("({a=Default(1)} & {b=Contract(Num)} & {a=Default(1)}).a"),
             Ok(Term::Num(1.0)),
         );
 
-        eval_string("(merge (merge {a=2;} {b=Contract(Num);}) {b=Default(true);}).b").unwrap_err();
+        eval_string("({a=2;} & {b=Contract(Num)} & {b=Default(true)}).b").unwrap_err();
     }
 
     fn make_composed_contract(value: &str) -> Result<Term, Error> {
@@ -1046,8 +1046,8 @@ Assume(#alwaysTrue -> #alwaysFalse, not ) true
              ) in
              let isEven = toCtr isEven_ in
              let isDivBy3 = toCtr isDivBy3_ in
-             let composed = merge {{a=Contract(#isEven);}} {{a=Contract(#isDivBy3);}} in
-             (merge {{a={};}} composed).a",
+             let composed = {{a=Contract(#isEven)}} & {{a=Contract(#isDivBy3)}} in
+             ({{a={}}} & composed).a",
             value
         );
 
@@ -1082,7 +1082,7 @@ Assume(#alwaysTrue -> #alwaysFalse, not ) true
         // `definitions`, and then access the `a` field
         let merge_elts = |elts: Vec<&str>| -> Result<Term, Error> {
             let term = elts.into_iter().fold(String::from("{}"), |term, op| {
-                format!("merge ({}) ({})", op, term)
+                format!("({}) & ({})", op, term)
             });
             eval_string(&format!("{} ({}).a", definitions, term))
         };
@@ -1093,13 +1093,10 @@ Assume(#alwaysTrue -> #alwaysFalse, not ) true
             Ok(Term::Num(1.0))
         );
         // default/value <- value/contract
-        assert_eq!(
-            merge_elts(vec!["def", "merge val ctr_num"]),
-            Ok(Term::Num(1.0))
-        );
+        assert_eq!(merge_elts(vec!["def", "val & ctr_num"]), Ok(Term::Num(1.0)));
         // default/contract-> contract-default/contract-default <- contract/default
         assert_eq!(
-            merge_elts(vec!["merge def ctr_num", "merge ctr_id def2"]),
+            merge_elts(vec!["def & ctr_num", "ctr_id & def2"]),
             Ok(Term::Num(2.0))
         );
         // default/contract -> contract-default/contract -> contract-default/value
@@ -1113,10 +1110,7 @@ Assume(#alwaysTrue -> #alwaysFalse, not ) true
             Ok(Term::Num(2.0))
         );
         // value/contract-default <- contract/contract-default
-        assert_eq!(
-            merge_elts(vec!["val", "merge ctr_num def"]),
-            Ok(Term::Num(1.0))
-        );
+        assert_eq!(merge_elts(vec!["val", "ctr_num & def"]), Ok(Term::Num(1.0)));
     }
 
     #[test]

--- a/stdlib/contracts.ncl
+++ b/stdlib/contracts.ncl
@@ -57,7 +57,7 @@
                 if (t -$ magic_fld) == {} then
                     let fail = blame (tag "polymorphic tail mismatch" l) in
                     let inner = unwrap sy (t.$magic_fld) fail in
-                    merge acc inner
+                    acc & inner
                 else
                     blame (tag "extra field" l)
             else


### PR DESCRIPTION
Close #187. The proposal of `&` seems to be non controversial. This PR changes the syntax of merging from the built-in function `merge` to the binary operator `&`. It is left-associative by convention, but merging is associative anyway (even with overriding). The precedence is copied from the one of `//` in Nix.