### PR TITLE
Open record contracts

### DIFF
--- a/src/grammar.lalrpop
+++ b/src/grammar.lalrpop
@@ -368,6 +368,11 @@ BaseType: Types = {
     "List" => Types(AbsType::List()),
 };
 
+RowTail: Types = {
+    <Ident> => Types(AbsType::Var(<>)),
+    "Dyn" => Types(AbsType::Dyn()),
+}
+
 subType : Types = {
     <BaseType>,
     <Ident> => Types(AbsType::Var(<>)),
@@ -394,7 +399,7 @@ subType : Types = {
     },
     "{" <rows:(<Ident> ":" <Types> ",")*>
         <last:(<Ident> ":" <Types>)?>
-        <tail: ("|" <Ident>)?> "}" => {
+        <tail: ("|" <RowTail>)?> "}" => {
         let ty = rows.into_iter()
             .chain(last.into_iter())
             // As we build row types as a linked list via a fold on the original
@@ -403,12 +408,7 @@ subType : Types = {
             // order for error reporting.
             .rev()
             .fold(
-                Types(
-                    match tail {
-                        Some(id) => AbsType::Var(id),
-                        None => AbsType::RowEmpty(),
-                    }
-                ),
+                tail.unwrap_or(Types(AbsType::RowEmpty())),
                 |t, i_ty| {
                     let (i, ty) = i_ty;
                     Types(AbsType::RowExtend(i, Some(Box::new(ty)), Box::new(t)))

--- a/src/program.rs
+++ b/src/program.rs
@@ -1411,9 +1411,6 @@ Assume(#alwaysTrue -> #alwaysFalse, not ) true
     }
 
     #[test]
-    fn records_contracts_dyn() {}
-
-    #[test]
     fn records_contracts_poly() {
         let id = "let f = Assume(forall a. { | a} -> { | a }, fun x => x) in f";
         let extd =
@@ -1470,6 +1467,23 @@ Assume(#alwaysTrue -> #alwaysFalse, not ) true
             f (fun x => x) {a = 1; b = bool; c = 3}",
         )
         .unwrap_err();
+    }
+
+    #[test]
+    fn records_contracts_dyn() {
+        assert_peq!(
+            "Assume({a: Num, b: Str | Dyn}, {a = 1; b = \"b\"})",
+            "{a = 1; b = \"b\"}"
+        );
+        assert_peq!(
+            "Assume({a: Num, b: Str | Dyn}, {a = 1; b = \"b\"; c = false})",
+            "{a = 1; b = \"b\"; c = false}"
+        );
+        assert_peq!(
+            "Assume({a: Num | Dyn} -> Dyn, fun r => r.b) {a = 1; b = 2}",
+            "{a = 1; b = 2}"
+        );
+        eval_string("Assume({a: Num, b: Str | Dyn}, {a = 1})").unwrap_err();
     }
 
     #[test]

--- a/src/program.rs
+++ b/src/program.rs
@@ -1481,7 +1481,7 @@ Assume(#alwaysTrue -> #alwaysFalse, not ) true
         );
         assert_peq!(
             "Assume({a: Num | Dyn} -> Dyn, fun r => r.b) {a = 1; b = 2}",
-            "{a = 1; b = 2}"
+            "2"
         );
         eval_string("Assume({a: Num, b: Str | Dyn}, {a = 1})").unwrap_err();
     }

--- a/src/stdlib.rs
+++ b/src/stdlib.rs
@@ -48,5 +48,6 @@ pub mod contracts {
     generate_accessor!(dyn_record);
     generate_accessor!(record_extend);
     generate_accessor!(forall_tail);
+    generate_accessor!(dyn_tail);
     generate_accessor!(empty_tail);
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -137,7 +137,7 @@ impl<Ty> AbsType<Ty> {
     /// Determine if a type is a row type.
     pub fn is_row_type(&self) -> bool {
         match self {
-            AbsType::RowExtend(_, _, _) | AbsType::RowEmpty() => true,
+            AbsType::RowExtend(_, _, _) | AbsType::RowEmpty() | AbsType::Dyn() => true,
             _ => false,
         }
     }
@@ -351,6 +351,7 @@ impl fmt::Display for Types {
                 match tail.0 {
                     AbsType::RowEmpty() => write!(f, "{}", tail),
                     AbsType::Var(_) => write!(f, " | {}", tail),
+                    AbsType::Dyn() => write!(f, " | Dyn"),
                     _ => write!(f, ", {}", tail),
                 }
             }

--- a/src/types.rs
+++ b/src/types.rs
@@ -248,6 +248,7 @@ impl Types {
                 ) -> RichTerm {
                     match &ty.0 {
                         AbsType::RowEmpty() => contracts::empty_tail(),
+                        AbsType::Dyn() => contracts::dyn_tail(),
                         AbsType::Var(id) => {
                             let (_, rt) = h
                                 .get(&id)

--- a/stdlib/contracts.ncl
+++ b/stdlib/contracts.ncl
@@ -65,6 +65,8 @@
         else
             acc$[magic_fld = wrap sy t];
 
+    dyn_tail = fun acc l t => acc & t;
+
     empty_tail = fun acc l t =>
         if t == {} then acc
         else blame (tag "extra field" l);


### PR DESCRIPTION
Close #158. Allow the dynamic type in row tail position to represent a record open contract. An open contract is a contract that checks the presence and the conformity of some fields, but also allow additional ones. Ex:

```
Assume({a: Num}, {a = 1; b = 2}) //error: extra field `b`
Assume({a: Num | Dyn}, {a = 1; b = 2}) //ok
```

## Syntax

The chosen syntax is similar to the one of [this paper](https://wgt20.irif.fr/wgt20-final35-acmpaginated.pdf), where the unitype `*` is used directly instead of a type variable. Another possible syntax would be `{a : Num | _: Dyn}`, which is slightly more verbose, but more consistent with the already existing dynamic record type `{_: Type}`. It would also make it possible to use a different type for the tail, like `{name: Str | _: Num}`. In this case we would probably get rid of the dynamic record type `{_: Type}` (which is currently a separate type), that could be written as `{ | _: Type}`.

## Typechecking

This PR extends the typechecker in a conservative way: a dynamic tail doesn't unify with anything but itself, and must explicitly be cast to/from, much as the standard dynamic type. It's probably gonna be used mainly for contracts, and a proper treatment of this kind of types doesn't look trivial, likely requiring something like subtyping/existential.