### PR TITLE
[Syntax]Use colon as the static typing operator

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -148,7 +148,7 @@ pub enum TypecheckError {
     /// argument of a wrong type in some cases:
     ///
     /// ```
-    /// Promise(Num, let id_mono = fun x => x in let _ign = id_mono true in id_mono 0)
+    /// let id_mono = fun x => x in let _ign = id_mono true in id_mono 0 : Num
     /// ```
     ///
     /// This specific error stores additionally the [type path](../label/ty_path/index.html) that

--- a/src/examples/fibo.ncl
+++ b/src/examples/fibo.ncl
@@ -1,8 +1,8 @@
 let Y = Assume(((Num -> Num) -> Num -> Num) -> Num -> Num, fun f => (fun x => f (x x)) (fun x => f (x x))) in
-let dec = Promise(Num -> Num, fun x => x + (-1)) in
+let dec : Num -> Num = fun x => x + (-1) in
 let or = Assume(Bool -> Bool -> Bool, fun x y => if x then x else y) in
 
-let fibo = Promise(Num -> Num, Y (fun fibo =>
-    (fun x => if or (isZero x) (isZero (dec x)) then 1 else (fibo (dec x)) + (fibo (dec (dec x)))))) in
-let val = Promise(Num, 6) in
+let fibo : Num -> Num = Y (fun fibo =>
+    (fun x => if or (isZero x) (isZero (dec x)) then 1 else (fibo (dec x)) + (fibo (dec (dec x))))) in
+let val : Num = 6 in
 fibo val

--- a/src/examples/flatPromise.ncl
+++ b/src/examples/flatPromise.ncl
@@ -1,4 +1,4 @@
 let alwaysTrue = fun l t => let boolT = Assume(Bool, t) in
     if boolT then boolT else blame l in
-let id = Promise(#alwaysTrue -> Bool -> #alwaysTrue, fun b x => if x then b else b) in
-Promise(#alwaysTrue -> Bool -> #alwaysTrue, id )  false true
+let id : #alwaysTrue -> Bool -> #alwaysTrue = fun b x => if x then b else b in
+(id : #alwaysTrue -> Bool -> #alwaysTrue) false true

--- a/src/examples/flatPromise2.ncl
+++ b/src/examples/flatPromise2.ncl
@@ -1,4 +1,4 @@
 let alwaysTrue = fun l t => let boolT = Assume(Bool, t) in
     if boolT then boolT else blame l in
-let id = Promise(#alwaysTrue -> Bool -> #alwaysTrue, fun b x => if x then Assume(#alwaysTrue, true) else b) in
-Promise(Bool -> #alwaysTrue, id   Assume(#alwaysTrue, false) ) true
+let id : #alwaysTrue -> Bool -> #alwaysTrue = fun b x => if x then Assume(#alwaysTrue, true) else b in
+(id Assume(#alwaysTrue, false) : Bool -> #alwaysTrue) true

--- a/src/examples/forall.ncl
+++ b/src/examples/forall.ncl
@@ -1,2 +1,2 @@
-let f = Promise(forall a. (forall b. a -> b ->  a), fun x y => x) in
+let f : forall a. (forall b. a -> b ->  a) = fun x y => x in
 f

--- a/src/examples/forall2.ncl
+++ b/src/examples/forall2.ncl
@@ -1,2 +1,2 @@
-let f = Promise(forall a. (forall b. b -> b) -> a -> a, fun f x => f x) in
-Promise(Num, (f Promise(forall b. b -> b, fun x => x)) 3)
+let f : forall a. (forall b. b -> b) -> a -> a = fun f x => f x in
+(f (fun x => x : forall b. b -> b) 3) : Num

--- a/src/examples/forall3.ncl
+++ b/src/examples/forall3.ncl
@@ -1,3 +1,4 @@
-Promise(
-    ((forall a. a -> a) -> Num) -> Num,
-    fun f => f Promise(forall b. b -> b, fun y => y) ) (fun g => 3)
+let f0 : ((forall a. a -> a) -> Num) -> Num = fun f =>
+  f (fun y => y : forall b.  b -> b)
+in
+f0 (fun g => 3)

--- a/src/examples/forall4.ncl
+++ b/src/examples/forall4.ncl
@@ -1,3 +1,3 @@
-let g = Promise(forall a. a -> a, fun y => (fun x => x) y) in
-let f = Promise(forall a. a -> a, fun y => g y) in
+let g : forall a. a -> a = fun y => (fun x => x) y in
+let f : forall a. a -> a = fun y => g y in
 f

--- a/src/examples/lists-all-any.ncl
+++ b/src/examples/lists-all-any.ncl
@@ -1,7 +1,7 @@
 let Y = fun f => (fun x => f (x x)) (fun x => f (x x)) in
 let foldr_ =
     fun self f acc l =>
-        if isZero (length l) then acc
+        if length l == 0 then acc
         else
             let h = head l in
             let t = tail l in
@@ -9,20 +9,9 @@ let foldr_ =
             f next_acc h
 in
 let foldr = Y foldr_ in
-let and = Promise(Bool -> Bool -> Bool,
-    fun x y =>
-        if x then
-            if y then true else false
-        else false)
-in
-let or = Promise(Bool -> Bool -> Bool,
-    fun x y =>
-        if x then
-            true
-        else
-            if y then true else false)
-in
+let and : Bool -> Bool -> Bool = fun x y => x && y in
+let or : Bool -> Bool -> Bool = fun x y => x || y in
 let all = fun pred l => foldr and true (map pred l) in
 let any = fun pred l => foldr or false (map pred l) in
-let isZ = fun x => isZero x in
+let isZ = fun x => x == 0 in
 or (any isZ [1, 1, 1, 1]) (all isZ [0, 0, 0, 0])

--- a/src/examples/lists-flatten.ncl
+++ b/src/examples/lists-flatten.ncl
@@ -9,6 +9,6 @@ let foldl_ =
             seq next_acc (self f next_acc t)
 in
 let foldl = Y foldl_ in
-let concat = Promise(List -> List -> List, fun x y => x @ y) in
+let concat : List -> List -> List = fun x y => x @ y in
 let flatten = foldl concat [] in
 flatten [[1,2],[3,4],[]]

--- a/src/examples/mergeEnriched.ncl
+++ b/src/examples/mergeEnriched.ncl
@@ -1,7 +1,7 @@
-let or = Promise(Bool -> Bool -> Bool, fun a b =>
-    if a then true else b) in
-let and = Promise(Bool -> Bool -> Bool, fun a b =>
-    if a then (if b then true else false) else false) in
+let or : Bool -> Bool -> Bool = fun a b =>
+    if a then true else b in
+let and : Bool -> Bool -> Bool = fun a b =>
+    if a then (if b then true else false) else false in
 let oneOrTwo = fun l x =>
     if and (isNum x)
            (or (isZero (x + (-1))) (isZero (x + (-2)))) then

--- a/src/examples/std.ncl
+++ b/src/examples/std.ncl
@@ -1,4 +1,4 @@
-let safePlus = fun x y => Promise(Num, Promise(Num, x) + Promise(Num, y)) in
+let safePlus = fun x y => ((x : Num) + (y : Num) : Num) in
 let const = fun x y => if isNum y then y else 2 in
-let safeAppTwice = fun f y => Promise(Num -> Num, f) ( Promise(Bool -> Num, f)  y) in
+let safeAppTwice = fun f y => (f : Num -> Num) ((f : Bool -> Num) y) in
 safeAppTwice (const 3) true

--- a/src/examples/std2.ncl
+++ b/src/examples/std2.ncl
@@ -1,7 +1,7 @@
 let const = fun x y => x in
 let safeAppTwice = fun f y => f (f y) in
-let ma = Promise((Dyn -> Num) -> Dyn -> Num, safeAppTwice)
-         (Promise(Dyn -> Dyn -> Dyn, const) Promise(Bool, 1))
-         Promise(Bool, true)
+let ma = (safeAppTwice : (Dyn -> Num) -> Dyn -> Num)
+         ((const : Dyn -> Dyn -> Dyn) (1 : Bool))
+         (true : Bool)
          in
-Promise(Dyn, ma)
+ma : Dyn

--- a/src/grammar.lalrpop
+++ b/src/grammar.lalrpop
@@ -11,8 +11,6 @@ use codespan::FileId;
 
 grammar<'input>(src_id: FileId);
 
-pub Term: RichTerm = SpTerm<RichTerm>;
-
 SpTerm<Rule>: RichTerm =
     <l: @L> <t: Rule> <r: @R> => match t {
         RichTerm {term: t, pos: _} => RichTerm {
@@ -20,6 +18,8 @@ SpTerm<Rule>: RichTerm =
             pos: Some(mk_span(src_id, l, r))
         }
     };
+
+TypeAnnot: (usize, Types, usize) = ":" <l: @L> <ty: Types> <r: @R> => (l, ty, r);
 
 LeftOp<Op, Current, Previous>: RichTerm =
     <t1: Current> <op: Op> <t2: Previous> => mk_term::op2(op, t1,
@@ -29,24 +29,45 @@ LeftOpLazy<Op, Current, Previous>: RichTerm =
     <t1: Current> <op: Op> <t2: Previous> =>
         mk_app!(Term::Op1(op, t1), t2);
 
+pub Term: RichTerm = {
+    SpTerm<RichTerm>,
+    SpTerm<TypedTerm>,
+};
+
+TypedTerm: RichTerm = {
+    <t: SpTerm<RichTerm>> <ann: TypeAnnot> => {
+        let (l, ty, r) = ann;
+        RichTerm::from(Term::Promise(ty.clone(), mk_label(ty, src_id, l, r), t))
+    }
+};
+
 RichTerm: RichTerm = {
-    <l: @L> "fun" <ps:Pattern+> "=>" <t: SpTerm<Term>> <r: @R> => {
+    <l: @L> "fun" <ps:Pattern+> "=>" <t: SpTerm<RichTerm>> <r: @R> => {
         let pos = Some(mk_span(src_id, l, r));
         ps.into_iter().rev().fold(t, |t, p| RichTerm {
             term: Box::new(Term::Fun(p, t)),
             pos: pos.clone()
         })
     },
-    "let" <id:Ident> "=" <t1:SpTerm<Term>> "in" <t2:SpTerm<Term>> =>
-        mk_term::let_in(id, t1, t2),
-    "if" <b:SpTerm<Term>> "then" <t:SpTerm<Term>> "else" <e:SpTerm<Term>> =>
+    "let" <id:Ident> <ann: TypeAnnot?> "=" <t1: Term> "in" <t2:SpTerm<RichTerm>> => {
+        let t1 = if let Some((l, ty, r)) = ann {
+            let pos = t1.pos.clone();
+            RichTerm::new(Term::Promise(ty.clone(), mk_label(ty, src_id, l, r), t1), pos)
+        }
+        else {
+            t1
+        };
+
+        mk_term::let_in(id, t1, t2)
+    },
+    "if" <b:Term> "then" <t:Term> "else" <e:SpTerm<RichTerm>> =>
         mk_app!(Term::Op1(UnaryOp::Ite(), b), t, e),
     "import" <s: Str> => RichTerm::from(Term::Import(s)),
     SpTerm<InfixExpr>,
 };
 
 Applicative: RichTerm = {
-    <t1:SpTerm< Applicative>> <t2: SpTerm<Atom>> => mk_app!(t1, t2),
+    <t1:SpTerm<Applicative>> <t2: SpTerm<Atom>> => mk_app!(t1, t2),
     <op: UOp> <t: SpTerm<Atom>> => mk_term::op1(op, t),
     <op: BOpPre> <t1: SpTerm<Atom>> <t2: SpTerm<Atom>> => mk_term::op2(op, t1, t2),
     SpTerm<RecordOperationChain>,
@@ -62,24 +83,22 @@ RecordOperationChain: RichTerm = {
     <t: SpTerm<RecordOperand>> "." <id: Ident> => mk_term::op1(UnaryOp::StaticAccess(id), t),
     <t: SpTerm<RecordOperand>> ".$" <t_id: SpTerm<Atom>> => mk_term::op2(BinaryOp::DynAccess(), t_id, t),
     <t: SpTerm<RecordOperand>> "-$" <t_id: SpTerm<Atom>> => mk_term::op2(BinaryOp::DynRemove(), t_id, t),
-    <r: SpTerm<RecordOperand>> "$[" <id: SpTerm<Term>> "=" <t: SpTerm<Term>> "]" =>
+    <r: SpTerm<RecordOperand>> "$[" <id: Term> "=" <t: Term> "]" =>
         mk_term::op2(BinaryOp::DynExtend(t), id, r),
 };
 
 Atom: RichTerm = {
-    "(" <SpTerm<Term>> ")",
-    <l: @L> "Promise(" <ty: Types> "," <t: SpTerm<Term>> ")" <r: @R> =>
-        RichTerm::from(Term::Promise(ty.clone(), mk_label(ty, src_id, l, r), t)),
-    <l: @L> "Assume(" <ty: Types> "," <t: SpTerm<Term>> ")" <r: @R> =>
+    "(" <Term> ")",
+    <l: @L> "Assume(" <ty: Types> "," <t: Term> ")" <r: @R> =>
         RichTerm::from(Term::Assume(ty.clone(), mk_label(ty, src_id, l, r), t)),
     <l: @L> "Contract(" <ty: Types> ")" <r: @R> =>
         RichTerm::from(Term::Contract(ty.clone(), mk_label(ty, src_id, l, r))),
-    "Default(" <t: SpTerm<Term>> ")" => RichTerm::from(Term::DefaultValue(t)),
-    <l: @L> "ContractDefault(" <ty: Types> "," <t: SpTerm<Term>> ")" <r: @R> =>
+    "Default(" <t: Term> ")" => RichTerm::from(Term::DefaultValue(t)),
+    <l: @L> "ContractDefault(" <ty: Types> "," <t: Term> ")" <r: @R> =>
         RichTerm::from(Term::ContractWithDefault(ty.clone(),
             mk_label(ty, src_id, l, r), t)
         ),
-    "Docstring(" <s: Str> "," <t: SpTerm<Term>> ")" => RichTerm::from(Term::Docstring(s, t)),
+    "Docstring(" <s: Str> "," <t: Term> ")" => RichTerm::from(Term::Docstring(s, t)),
     "num literal" => RichTerm::from(Term::Num(<>)),
     Bool => RichTerm::from(Term::Bool(<>)),
     <StrChunks>,
@@ -105,7 +124,7 @@ Atom: RichTerm = {
             RichTerm::from(Term::Op2(BinaryOp::DynExtend(t), id_t, rec))
         })
     },
-    "[" <terms: (SpTerm<Atom> ",")*> <last: SpTerm<Term>?> "]" => {
+    "[" <terms: (SpTerm<Atom> ",")*> <last: Term?> "]" => {
         let terms : Vec<RichTerm> = terms.into_iter()
             .map(|x| x.0)
             .chain(last.into_iter()).collect();
@@ -114,10 +133,28 @@ Atom: RichTerm = {
 };
 
 RecordField: Either<(Ident, RichTerm), (RichTerm, RichTerm)> = {
-    <id: Ident> "=" <t: SpTerm<Term>> =>
-        Either::Left((id, t)),
-    "$" <id: SpTerm<Term>> "=" <t: SpTerm<Term>> =>
-        Either::Right((id, t)),
+    <id: Ident> <ann: TypeAnnot?> "=" <t: Term> => {
+        let t = if let Some((l, ty, r)) = ann {
+            let pos = t.pos.clone();
+            RichTerm::new(Term::Promise(ty.clone(), mk_label(ty, src_id, l, r), t), pos)
+        }
+        else {
+            t
+        };
+
+        Either::Left((id, t))
+    },
+    "$" <id: SpTerm<Atom>> <ann: TypeAnnot?> "=" <t: Term> => {
+        let t = if let Some((l, ty, r)) = ann {
+            let pos = t.pos.clone();
+            RichTerm::new(Term::Promise(ty.clone(), mk_label(ty, src_id, l, r), t), pos)
+        }
+        else {
+            t
+        };
+
+        Either::Right((id, t))
+    }
 }
 
 Pattern: Ident = {

--- a/stdlib/lists.ncl
+++ b/stdlib/lists.ncl
@@ -1,37 +1,38 @@
 {
   lists = {
-    concat = Promise(List -> List -> List, fun l1 l2 => l1 @ l2);
+    concat : List -> List -> List = fun l1 l2 => l1 @ l2;
 
-    foldl = Promise(forall a. (a -> Dyn -> a) -> a -> List -> a,
+    foldl : forall a. (a -> Dyn -> a) -> a -> List -> a =
       fun f fst l =>
         if length l == 0 then
           fst
         else
           let rest = foldl f fst (tail l) in
-          seq rest (f rest (head l)));
+          seq rest (f rest (head l));
 
-    fold = Promise(forall a. (Dyn -> a -> a) -> List -> a -> a,
+    fold : forall a. (Dyn -> a -> a) -> List -> a -> a =
       fun f l fst =>
         if length l == 0 then
           fst
         else
-          f (head l) (fold f (tail l) fst));
+          f (head l) (fold f (tail l) fst);
 
-    cons = Promise(Dyn -> List -> List, fun x l => [x] @ l);
+    cons : Dyn -> List -> List = fun x l => [x] @ l;
 
-    filter = Promise((Dyn -> Bool) -> List -> List,
+    filter : (Dyn -> Bool) -> List -> List =
       fun pred l =>
-        fold (fun x acc => if pred x then acc @ [x] else acc) l []);
+        fold (fun x acc => if pred x then acc @ [x] else acc) l [];
 
-    flatten = Promise(List -> List, fun l =>
-      fold (fun l acc => acc @ Assume(List, l)) l []);
+    flatten : List -> List =
+      fun l =>
+        fold (fun l acc => acc @ Assume(List, l)) l [];
 
-    all = Promise((Dyn -> Bool) -> List -> Bool,
+    all : (Dyn -> Bool) -> List -> Bool =
       fun pred l =>
-        fold (fun x acc => if pred x then acc else false) l true);
+        fold (fun x acc => if pred x then acc else false) l true;
 
-    any = Promise((Dyn -> Bool) -> List -> Bool,
+    any : (Dyn -> Bool) -> List -> Bool =
       fun pred l =>
-        fold (fun x acc => if pred x then true else acc) l false);
+        fold (fun x acc => if pred x then true else acc) l false;
   }
 }


### PR DESCRIPTION
Use the `:` as the static typing operator, as discussed in #183. Support annotations directly on a let binding or at at record field declaration, as well as inside arbitrary expressions. Examples:

```
(1 : Num) + (2 : Num) : Num
let x : Num = 1 + 1 in x
let incr : Num -> Num = fun x => x + 1 in incr 2 : Num
{
  concat : List -> List -> List = fun l1 l2 => l1 @ l2;
}
```