### PR TITLE
[Fix]Typechecking interpolated expressions

### DIFF
--- a/src/typecheck.rs
+++ b/src/typecheck.rs
@@ -459,7 +459,7 @@ fn type_check_(
                     match chunk {
                         StrChunk::Literal(_) => Ok(()),
                         StrChunk::Expr(t, _) => {
-                            type_check_(state, envs.clone(), strict, t, mk_typewrapper::dynamic())
+                            type_check_(state, envs.clone(), strict, t, mk_typewrapper::str())
                         }
                     }
                 })


### PR DESCRIPTION
The typechecker was accepting interpolated expressions to have type `Dyn`, while currently the abstract machine requires `Str`.