### PR TITLE
Use variable length `#{` for interpolation

### DIFF
--- a/src/grammar.lalrpop
+++ b/src/grammar.lalrpop
@@ -218,19 +218,17 @@ ChunkLiteral : String =
         })
     };
 
-ChunkExpr: StrChunk<RichTerm> = DollarBrace <t: SpTerm<RichTerm>> "}" => StrChunk::Expr(t, 0);
+ChunkExpr: StrChunk<RichTerm> = HashBrace <t: SpTerm<RichTerm>> "}" => StrChunk::Expr(t, 0);
 
-DollarBrace = { "${", "multstr ${" };
+HashBrace = { "#{", "multstr #{" };
 
 Str: String = "\"" <s: ChunkLiteral> "\"" => s;
 
 ChunkLiteralPart: Either<&'input str, char> = {
     "str literal" => Either::Left(<>),
-    "str $" => Either::Left(<>),
+    "str #" => Either::Left(<>),
     "multstr literal" => Either::Left(<>),
-    "multstr $" => Either::Left(<>),
-    "multstr \\" => Either::Left(<>),
-    "multstr \\${" => Either::Left(<>),
+    "false interpolation" => Either::Left(<>),
     "false end" => Either::Left(<>),
     "str esc char" => Either::Right(<>),
     };
@@ -463,13 +461,11 @@ extern {
     enum Token<'input> {
         "identifier" => Token::Normal(NormalToken::Identifier(<&'input str>)),
         "str literal" => Token::Str(StringToken::Literal(<&'input str>)),
-        "str $" => Token::Str(StringToken::Dollar(<&'input str>)),
+        "str #" => Token::Str(StringToken::Hash(<&'input str>)),
         "str esc char" => Token::Str(StringToken::EscapedChar(<char>)),
         "multstr literal" => Token::MultiStr(MultiStringToken::Literal(<&'input str>)),
-        "multstr $" => Token::MultiStr(MultiStringToken::Dollar(<&'input str>)),
-        "multstr \\${" => Token::MultiStr(MultiStringToken::BackslashDollarBrace(<&'input str>)),
-        "multstr \\" => Token::MultiStr(MultiStringToken::Backslash(<&'input str>)),
         "false end" => Token::MultiStr(MultiStringToken::FalseEnd(<&'input str>)),
+        "false interpolation" => Token::MultiStr(MultiStringToken::FalseInterpolation(<&'input str>)),
         "num literal" => Token::Normal(NormalToken::NumLiteral(<f64>)),
 
         "if" => Token::Normal(NormalToken::If),
@@ -492,11 +488,8 @@ extern {
         "." => Token::Normal(NormalToken::Dot),
         ".$" => Token::Normal(NormalToken::DotDollar),
         "$[" => Token::Normal(NormalToken::DollarBracket),
-        "${" => Token::Str(StringToken::DollarBrace),
-        // `${` and `multstr ${` are morally the same token used in the same places,
-        // but they correspond to two different modes, so we need to have two
-        // distinct token
-        "multstr ${" => Token::MultiStr(MultiStringToken::DollarBrace),
+        "#{" => Token::Str(StringToken::HashBrace),
+        "multstr #{" => Token::MultiStr(MultiStringToken::Interpolation),
         "-$" => Token::Normal(NormalToken::MinusDollar),
 
         "+" => Token::Normal(NormalToken::Plus),

--- a/src/parser/lexer.rs
+++ b/src/parser/lexer.rs
@@ -269,7 +269,7 @@ pub enum MultiStringToken<'input> {
     // look-aheads in the lexer (which Logos doesn't support for performance reason), we just use a
     // separate token. This one has lowest matching priority according to Logos' rules, so it is
     // matched only if `CandidateEnd` cannot be
-    #[regex("\"(#+|(#+[^m]))?")]
+    #[regex("\"#*")]
     FalseEnd(&'input str),
     // A candidate end. A multiline string starting delimiter `MultiStringStart` can have a
     // variable number of `#` character, so the lexer matchs candidate end delimiter, compare the

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -235,11 +235,11 @@ fn string_lexing() {
     );
 
     assert_eq!(
-        lex_without_pos("\"1 + ${ 1 } + 2\""),
+        lex_without_pos("\"1 + #{ 1 } + 2\""),
         Ok(vec![
             Token::Normal(NormalToken::DoubleQuote),
             Token::Str(StringToken::Literal("1 + ")),
-            Token::Str(StringToken::DollarBrace),
+            Token::Str(StringToken::HashBrace),
             Token::Normal(NormalToken::NumLiteral(1.0)),
             Token::Normal(NormalToken::RBrace),
             Token::Str(StringToken::Literal(" + 2")),
@@ -248,13 +248,13 @@ fn string_lexing() {
     );
 
     assert_eq!(
-        lex_without_pos("\"1 + ${ \"${ 1 }\" } + 2\""),
+        lex_without_pos("\"1 + #{ \"#{ 1 }\" } + 2\""),
         Ok(vec![
             Token::Normal(NormalToken::DoubleQuote),
             Token::Str(StringToken::Literal("1 + ")),
-            Token::Str(StringToken::DollarBrace),
+            Token::Str(StringToken::HashBrace),
             Token::Normal(NormalToken::DoubleQuote),
-            Token::Str(StringToken::DollarBrace),
+            Token::Str(StringToken::HashBrace),
             Token::Normal(NormalToken::NumLiteral(1.0)),
             Token::Normal(NormalToken::RBrace),
             Token::Normal(NormalToken::DoubleQuote),
@@ -273,11 +273,11 @@ fn str_escape() {
         mk_single_chunk("str\twith\nescapes"),
     );
     assert_eq!(
-        parse_without_pos(r#""\$\${ }\$""#),
-        mk_single_chunk("$${ }$"),
+        parse_without_pos("\"\\#\\#{ }\\#\""),
+        mk_single_chunk("##{ }#"),
     );
     assert_eq!(
-        parse_without_pos(r#""$a$b$c\${d\$""#),
-        mk_single_chunk("$a$b$c${d$"),
+        parse_without_pos("\"#a#b#c\\#{d#\""),
+        mk_single_chunk("#a#b#c#{d#"),
     );
 }

--- a/src/program.rs
+++ b/src/program.rs
@@ -1160,28 +1160,28 @@ Assume(#alwaysTrue -> #alwaysFalse, not ) true
         }
 
         assert_eval_str(
-            r#""simple ${"interp" ++ "olation"} here""#,
+            r#""simple #{"interp" ++ "olation"} here""#,
             "simple interpolation here",
         );
-        assert_eval_str(r#""${"alone"}""#, "alone");
+        assert_eval_str(r##""#{"alone"}""##, "alone");
         assert_eval_str(
-            r#""nested ${ "${(fun x => "${x}") "expression"}" }""#,
+            r##""nested #{ "#{(fun x => "#{x}") "expression"}" }""##,
             "nested expression",
         );
         assert_eval_str(
-            r#""${"some"}${" " ++ "se" ++ "qu"}${"${"ence"}"}""#,
+            r##""#{"some"}#{" " ++ "se" ++ "qu"}#{"#{"ence"}"}""##,
             "some sequence",
         );
         assert_eval_str(
-            r#""nested ${ {str = {a = "braces"}.a}.str } !""#,
+            r##""nested #{ {str = {a = "braces"}.a}.str } !""##,
             "nested braces !",
         );
         assert_eval_str(
-            r#"let x = "world" in "Hello, ${x}! Welcome in ${let y = "universe" in "the ${x}-${y}"}""#,
+            r##"let x = "world" in "Hello, #{x}! Welcome in #{let y = "universe" in "the #{x}-#{y}"}""##,
             "Hello, world! Welcome in the world-universe",
         );
 
-        match eval_string(r#""bad type ${1 + 1}""#) {
+        match eval_string(r##""bad type #{1 + 1}""##) {
             Err(Error::EvalError(EvalError::TypeError(_, _, _, _))) => (),
             _ => assert!(false),
         };
@@ -1234,7 +1234,7 @@ Assume(#alwaysTrue -> #alwaysFalse, not ) true
     fn poly_eq() {
         assert_peq!("0", "0 + 0 + 0");
         assert_peq!("true", "if true then true else false");
-        assert_peq!("\"a\" ++ \"b\" ++ \"c\"", "\"${\"a\" ++ \"b\"}\" ++ \"c\"");
+        assert_peq!("\"a\" ++ \"b\" ++ \"c\"", "\"#{\"a\" ++ \"b\"}\" ++ \"c\"");
 
         assert_npeq!("1 + 1", "0");
         assert_npeq!("true", "if true then false else true");
@@ -1537,12 +1537,33 @@ Assume(#alwaysTrue -> #alwaysFalse, not ) true
     #[test]
     fn multiline_interpolation() {
         assert_peq!(
+            r##"m#"Simple #{"interpolated"} string"#m"##,
+            "\"Simple interpolated string\""
+        );
+        assert_peq!(
+            r###"m##"Double ##{"interpolated"} string"##m"###,
+            "\"Double interpolated string\""
+        );
+        assert_peq!(
+            r###"m##"Not #{"interpolated"}"##m"###,
+            "\"Not \\#{\\\"interpolated\\\"}\""
+        );
+        assert_peq!(
+            r####"m###"###{"Triple"} ##{not} #{interpolated}"###m"####,
+            "\"Triple #\\#{not} \\#{interpolated}\""
+        );
+        assert_peq!(
+            r###"m#"#{m##"##{"Not"} #{interpolated}"##m} ##{"string"}"#m"###,
+            "\"Not \\#{interpolated} #\\#{\\\"string\\\"}\""
+        );
+
+        assert_peq!(
             r###"
                 m#"
-                   ${m#"thi"#m ++ "s"}
-                       ${"is" ++ " an"}
+                   #{m#"thi"#m ++ "s"}
+                       #{"is" ++ " an"}
                        indented
-                   ${"${m##"te"##m}xt"}
+                   #{"#{m##"te"##m}xt"}
                 "#m
             "###,
             "\"this\n    is an\n    indented\ntext\""
@@ -1553,8 +1574,8 @@ Assume(#alwaysTrue -> #alwaysFalse, not ) true
                 let x = "I\n need\n  indent!" in
                 m#"
                   base
-                    ${x}
-                  ${x}
+                    #{x}
+                  #{x}
                 "#m
             "##,
             r#""base
@@ -1572,8 +1593,8 @@ I
                 let y = "me\ntoo" in
                 m#"
                   strip
-                    ${x} ${y}
-                    ${"not\nme"}
+                    #{x} #{y}
+                    #{"not\nme"}
                 "#m
             "##,
             r#""strip

--- a/src/serialize.rs
+++ b/src/serialize.rs
@@ -118,7 +118,7 @@ mod tests {
     fn basic() {
         assert_json_eq!("1 + 1", 2.0);
         assert_json_eq!("if true then false else true", false);
-        assert_json_eq!(r#""Hello, ${"world"}!""#, "Hello, world!");
+        assert_json_eq!(r##""Hello, #{"world"}!""##, "Hello, world!");
         assert_json_eq!("`foo", "foo");
     }
 
@@ -127,7 +127,7 @@ mod tests {
         assert_json_eq!("[]", json!([]));
         assert_json_eq!("[(1+1), (2+2), (3+3)]", json!([2.0, 4.0, 6.0]));
         assert_json_eq!(
-            r#"[`a, ("b" ++ "c"), "d${"e"}f", "g"]"#,
+            r##"[`a, ("b" ++ "c"), "d#{"e"}f", "g"]"##,
             json!(["a", "bc", "def", "g"])
         );
         assert_json_eq!(


### PR DESCRIPTION
Close #224. As suggested initially in https://github.com/tweag/nickel/pull/197#issuecomment-726815882:
 - Switch from `${exp}` to `#{exp}` for interpolated expression, the rationale being that `${` is common in shell scripts and would clash when generating such scripts from Nickel.
 - In simple strings, everything is as before, excepted that `${` is replaced by `#{`. `#{` follows the same escaping rules as `${` did.
 - In multiline indented strings, the syntax depends on the opening delimiter, of the form `m#..."` where `#...` denotes a string which is a sequence of `n > 0` consecutive hash characters `#`. The interpolation sequence is then `#...{`, where the number of `#` must be the same as the in the opening delimiter.

Since one can chose an appropriate opening delimiter, and in last resort use nested interpolation to write an arbitrary sequence of characters, `\#...{` is not an escaping sequence anymore in multiline strings: `m#"\#{"esc"}"#m` gives the string `\esc`.

Some examples:
```
"#foo #{"b" ++ "ar"} \#{baz}" // => #foo bar #{baz}
m#" #{"f" ++ "oo"} ##{"bar"} baz"#m // => foo ##{"bar"} baz
m##" #{"f" ++ "oo"} ##{"bar"} baz"##m // => #{"f" ++ "oo"} bar baz
```