### PR TITLE
[Fix]Mishandling of `#` in mutliline strings

### DIFF
--- a/src/parser/lexer.rs
+++ b/src/parser/lexer.rs
@@ -278,7 +278,7 @@ pub enum MultiStringToken<'input> {
     #[regex("\"#+m")]
     CandidateEnd(&'input str),
     // Same as `FalseEnd` and `CandidateEnd` but for an interpolation sequence.
-    #[token("#+")]
+    #[regex("#+")]
     FalseInterpolation(&'input str),
     #[regex("#+\\{")]
     CandidateInterpolation(&'input str),

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -281,3 +281,16 @@ fn str_escape() {
         mk_single_chunk("#a#b#c#{d#"),
     );
 }
+
+/// Regression test for [#230](https://github.com/tweag/nickel/issues/230).
+#[test]
+fn multiline_str_escape() {
+    assert_eq!(
+        parse_without_pos(r##"m#"#Hel##lo###"#m"##),
+        mk_single_chunk("#Hel##lo###"),
+    );
+    assert_eq!(
+        parse_without_pos(r##"m#"#Hel##{lo###{"#m"##),
+        mk_single_chunk("#Hel##{lo###{"),
+    );
+}


### PR DESCRIPTION
Close #230.