### PR TITLE
[Refactor]Change the representation of metavalues

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -94,7 +94,7 @@ use crate::operation::{continuate_operation, OperationCont};
 use crate::position::RawSpan;
 use crate::program::ImportResolver;
 use crate::stack::Stack;
-use crate::term::{make as mk_term, RichTerm, StrChunk, Term, UnaryOp, MetaValue};
+use crate::term::{make as mk_term, MetaValue, RichTerm, StrChunk, Term, UnaryOp};
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::rc::{Rc, Weak};
@@ -426,10 +426,7 @@ where
                 }
                 // TODO: improve error message using some positions
                 else {
-                    return Err(EvalError::Other(
-                        String::from("empty metavalue"),
-                        pos,
-                    ));
+                    return Err(EvalError::Other(String::from("empty metavalue"), pos));
                 }
             }
             Term::Contract(_, _) if enriched_strict => {
@@ -738,7 +735,7 @@ fn subst(rt: RichTerm, global_env: &Environment, env: &Environment) -> RichTerm 
                     doc: meta.doc,
                     contract,
                     priority: meta.priority,
-                    value
+                    value,
                 };
 
                 RichTerm::new(Term::MetaValue(meta), pos)

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -392,11 +392,11 @@ where
             // Unwrapping of enriched terms
             Term::MetaValue(meta) if enriched_strict => {
                 if meta.value.is_some() {
-                    /* Since we are forcing a meta value, we are morally evaluating `force t`
-                     * rather than `t` iteself.  Updating a thunk after having performed this
-                     * forcing may alter the semantics of the program in an unexpected way (see
-                     * issue https://github.com/tweag/nickel/issues/123): we update potential
-                     * thunks now so that their content remains an enriched value.
+                    /* Since we are forcing a metavalue, we are morally evaluating `force t` rather
+                     * than `t` iteself.  Updating a thunk after having performed this forcing may
+                     * alter the semantics of the program in an unexpected way (see issue
+                     * https://github.com/tweag/nickel/issues/123): we update potential thunks now
+                     * so that their content remains a meta value.
                      */
                     let update_closure = Closure {
                         body: RichTerm {

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -390,7 +390,7 @@ where
                 }
             }
             // Unwrapping of enriched terms
-            Term::MetaValue(meta) => {
+            Term::MetaValue(meta) if enriched_strict => {
                 if meta.value.is_some() {
                     /* Since we are forcing a meta value, we are morally evaluating `force t`
                      * rather than `t` iteself.  Updating a thunk after having performed this

--- a/src/grammar.lalrpop
+++ b/src/grammar.lalrpop
@@ -1,5 +1,6 @@
 use crate::identifier::Ident;
-use crate::term::{BinaryOp, RichTerm, Term, UnaryOp, StrChunk};
+use crate::term::{BinaryOp, RichTerm, Term, UnaryOp, StrChunk, MetaValue,
+    MergePriority};
 use crate::term::make as mk_term;
 use crate::mk_app;
 use crate::types::{Types, AbsType};
@@ -92,13 +93,49 @@ Atom: RichTerm = {
     <l: @L> "Assume(" <ty: Types> "," <t: Term> ")" <r: @R> =>
         RichTerm::from(Term::Assume(ty.clone(), mk_label(ty, src_id, l, r), t)),
     <l: @L> "Contract(" <ty: Types> ")" <r: @R> =>
-        RichTerm::from(Term::Contract(ty.clone(), mk_label(ty, src_id, l, r))),
-    "Default(" <t: Term> ")" => RichTerm::from(Term::DefaultValue(t)),
-    <l: @L> "ContractDefault(" <ty: Types> "," <t: Term> ")" <r: @R> =>
-        RichTerm::from(Term::ContractWithDefault(ty.clone(),
-            mk_label(ty, src_id, l, r), t)
+        RichTerm::from(
+            Term::MetaValue(
+                MetaValue {
+                    doc: None,
+                    contract: Some((ty.clone(), mk_label(ty, src_id, l, r))),
+                    priority: Default::default(),
+                    value: None,
+                }
+            )
         ),
-    "Docstring(" <s: Str> "," <t: Term> ")" => RichTerm::from(Term::Docstring(s, t)),
+    "Default(" <t: Term> ")" =>
+        RichTerm::from(
+            Term::MetaValue(
+                MetaValue {
+                    doc: None,
+                    contract: None,
+                    priority: MergePriority::Default,
+                    value: Some(t),
+                }
+            )
+        ),
+    <l: @L> "ContractDefault(" <ty: Types> "," <t: Term> ")" <r: @R> =>
+        RichTerm::from(
+            Term::MetaValue(
+                MetaValue {
+                    doc: None,
+                    contract: Some((ty.clone(), mk_label(ty, src_id, l, r))),
+                    priority: MergePriority::Default,
+                    value: Some(t),
+                }
+            )
+        ),
+    "Docstring(" <s: Str> "," <t: Term> ")" =>
+        RichTerm::from(
+            Term::MetaValue(
+                MetaValue {
+                    doc: Some(s),
+                    contract: None,
+                    priority: Default::default(),
+                    value: Some(t)
+                }
+            )
+        ),
     "num literal" => RichTerm::from(Term::Num(<>)),
     Bool => RichTerm::from(Term::Bool(<>)),
     <StrChunks>,

--- a/src/merge.rs
+++ b/src/merge.rs
@@ -56,7 +56,7 @@ use crate::eval::{Closure, Environment};
 use crate::label::Label;
 use crate::position::RawSpan;
 use crate::term::make as mk_term;
-use crate::term::{BinaryOp, MergePriority, MetaValue, RichTerm, Term};
+use crate::term::{BinaryOp, MetaValue, RichTerm, Term};
 use crate::transformations::Closurizable;
 use crate::types::{AbsType, Types};
 use crate::{mk_app, mk_fun};
@@ -234,7 +234,7 @@ pub fn merge(
                 _ => panic!("unreachable case"),
             };
 
-            let contract = merge_contracts_main(&mut env, contract1, env1, contract2, env2);
+            let contract = merge_contracts_meta(&mut env, contract1, env1, contract2, env2);
 
             let meta = MetaValue {
                 doc,
@@ -433,7 +433,7 @@ fn merge_doc(doc1: Option<String>, doc2: Option<String>) -> Option<String> {
 }
 
 /// Merge the two optional contracts of a metavalue.
-fn merge_contracts_main(
+fn merge_contracts_meta(
     env: &mut Environment,
     c1: Option<(Types, Label)>,
     env1: Environment,

--- a/src/merge.rs
+++ b/src/merge.rs
@@ -193,12 +193,10 @@ pub fn merge(
             let (value1, val_env1) = match (value1, &contract2) {
                 (Some(t), Some((ty, lbl))) if priority1 >= priority2 => {
                     let mut env = Environment::new();
-                    let ty_closure = ty.clone().closurize(&mut env, env2.clone());
-                    let t_closure = t.closurize(&mut env, env1.clone());
-                    (
-                        Some(Term::Assume(ty_closure, lbl.clone(), t_closure).into()),
-                        env,
-                    )
+                    let mut env1_local = env1.clone();
+                    let ty_closure = ty.clone().closurize(&mut env1_local, env2.clone());
+                    let t: RichTerm = Term::Assume(ty_closure, lbl.clone(), t).into();
+                    (Some(t.closurize(&mut env, env1_local)), env)
                 }
                 (value1, _) => (value1, env1.clone()),
             };
@@ -207,12 +205,10 @@ pub fn merge(
             let (value2, val_env2) = match (value2, &contract1) {
                 (Some(t), Some((ty, lbl))) if priority2 >= priority1 => {
                     let mut env = Environment::new();
-                    let ty_closure = ty.clone().closurize(&mut env, env1.clone());
-                    let t_closure = t.closurize(&mut env, env2.clone());
-                    (
-                        Some(Term::Assume(ty_closure, lbl.clone(), t_closure).into()),
-                        env,
-                    )
+                    let mut env2_local = env2.clone();
+                    let ty_closure = ty.clone().closurize(&mut env2_local, env1.clone());
+                    let t: RichTerm = Term::Assume(ty_closure, lbl.clone(), t).into();
+                    (Some(t.closurize(&mut env, env2_local)), env)
                 }
                 (value2, _) => (value2, env2.clone()),
             };

--- a/src/merge.rs
+++ b/src/merge.rs
@@ -56,7 +56,7 @@ use crate::eval::{Closure, Environment};
 use crate::label::Label;
 use crate::position::RawSpan;
 use crate::term::make as mk_term;
-use crate::term::{BinaryOp, RichTerm, Term};
+use crate::term::{BinaryOp, MergePriority, MetaValue, RichTerm, Term};
 use crate::transformations::Closurizable;
 use crate::types::{AbsType, Types};
 use crate::{mk_app, mk_fun};
@@ -70,6 +70,22 @@ pub fn merge(
     env2: Environment,
     pos_op: Option<RawSpan>,
 ) -> Result<Closure, EvalError> {
+    // Merging a simple value and a metavalue is equivalent to first wrapping the simple value in a
+    // new metavalue (with no attribute set excepted the value), and then merging the two
+    let (t1, t2) = match (t1.term.is_enriched(), t2.term.is_enriched()) {
+        (true, false) => {
+            let pos = t2.pos.clone();
+            let t = Term::MetaValue(MetaValue::from(t2));
+            (t1, RichTerm::new(t, pos))
+        }
+        (false, true) => {
+            let pos = t1.pos.clone();
+            let t = Term::MetaValue(MetaValue::from(t1));
+            (RichTerm::new(t, pos), t2)
+        }
+        _ => (t1, t2),
+    };
+
     let RichTerm {
         term: t1,
         pos: pos1,
@@ -78,6 +94,7 @@ pub fn merge(
         term: t2,
         pos: pos2,
     } = t2;
+
     match (*t1, *t2) {
         // Merge is idempotent on basic terms
         (Term::Bool(b1), Term::Bool(b2)) => {
@@ -147,6 +164,88 @@ pub fn merge(
                     pos_op,
                 ))
             }
+        }
+        (Term::MetaValue(meta1), Term::MetaValue(meta2)) => {
+            // For now, we blindly closurize things and copy environments in this section. A
+            // careful analysis would make it possible to spare a few closurize operations and more
+            // generally environment cloning.
+
+            let MetaValue {
+                doc: doc1,
+                contract: contract1,
+                priority: priority1,
+                value: value1,
+            } = meta1;
+            let MetaValue {
+                doc: doc2,
+                contract: contract2,
+                priority: priority2,
+                value: value2,
+            } = meta2;
+
+            let doc = merge_doc(doc1, doc2);
+
+            // If:
+            // 1. meta1 has a value
+            // 2. meta2 has a contract
+            // 3. The priorities are such that meta1's value will be used in the final value
+            // We apply meta2's contract to meta1.
+            let (value1, val_env1) = match (value1, &contract2) {
+                (Some(t), Some((ty, lbl))) if priority1 >= priority2 => {
+                    let mut env = Environment::new();
+                    let ty_closure = ty.clone().closurize(&mut env, env2.clone());
+                    let t_closure = t.closurize(&mut env, env1.clone());
+                    (
+                        Some(Term::Assume(ty_closure, lbl.clone(), t_closure).into()),
+                        env,
+                    )
+                }
+                (value1, _) => (value1, env1.clone()),
+            };
+
+            // Same thing for the dual situation.
+            let (value2, val_env2) = match (value2, &contract1) {
+                (Some(t), Some((ty, lbl))) if priority2 >= priority1 => {
+                    let mut env = Environment::new();
+                    let ty_closure = ty.clone().closurize(&mut env, env1.clone());
+                    let t_closure = t.closurize(&mut env, env2.clone());
+                    (
+                        Some(Term::Assume(ty_closure, lbl.clone(), t_closure).into()),
+                        env,
+                    )
+                }
+                (value2, _) => (value2, env2.clone()),
+            };
+
+            let (value, priority, mut env) = match (value1, value2) {
+                (Some(t1), Some(t2)) if priority1 == priority2 => {
+                    let mut env = Environment::new();
+                    (
+                        Some(merge_closurize(&mut env, t1, val_env1, t2, val_env2)),
+                        priority1,
+                        env,
+                    )
+                }
+                (Some(t1), _) if priority1 > priority2 => (Some(t1), priority1, val_env1),
+                (Some(t1), None) => (Some(t1), priority1, val_env1),
+                (_, Some(t2)) if priority2 > priority1 => (Some(t2), priority2, val_env2),
+                (None, Some(t2)) => (Some(t2), priority2, val_env2),
+                (None, None) => (None, Default::default(), Environment::new()),
+                _ => panic!("unreachable case"),
+            };
+
+            let contract = merge_contracts_main(&mut env, contract1, env1, contract2, env2);
+
+            let meta = MetaValue {
+                doc,
+                contract,
+                priority,
+                value,
+            };
+            Ok(Closure {
+                body: Term::MetaValue(meta).into(),
+                env,
+            })
         }
         // Right-biased: when merging two docstrings (s1,t2) and (s2,t2), the right one will end up
         // as the outermost position in the resulting term (s2,(s1,merge t1 t2))
@@ -324,6 +423,31 @@ pub fn merge(
             },
             pos_op,
         )),
+    }
+}
+
+/// Merge the two optional documentations of a metavalue.
+fn merge_doc(doc1: Option<String>, doc2: Option<String>) -> Option<String> {
+    //FIXME: how to merge documentation? Just concatenate?
+    doc1.or(doc2)
+}
+
+/// Merge the two optional contracts of a metavalue.
+fn merge_contracts_main(
+    env: &mut Environment,
+    c1: Option<(Types, Label)>,
+    env1: Environment,
+    c2: Option<(Types, Label)>,
+    env2: Environment,
+) -> Option<(Types, Label)> {
+    match (c1, c2) {
+        (Some((ty1, lbl1)), Some((ty2, lbl2))) => Some((
+            merge_types_closure(env, ty1, lbl1, env1, ty2, lbl2, env2),
+            Label::dummy(),
+        )),
+        (Some((ty1, lbl1)), None) => Some((ty1.closurize(env, env1), lbl1)),
+        (None, Some((ty2, lbl2))) => Some((ty2.closurize(env, env2), lbl2)),
+        (None, None) => None,
     }
 }
 

--- a/src/merge.rs
+++ b/src/merge.rs
@@ -217,6 +217,8 @@ pub fn merge(
                 (value2, _) => (value2, env2.clone()),
             };
 
+            // Selecting either meta1's value, meta2's value, or the merge of the two values,
+            // depending on which is defined and respective priorities.
             let (value, priority, mut env) = match (value1, value2) {
                 (Some(t1), Some(t2)) if priority1 == priority2 => {
                     let mut env = Environment::new();
@@ -242,6 +244,7 @@ pub fn merge(
                 priority,
                 value,
             };
+
             Ok(Closure {
                 body: Term::MetaValue(meta).into(),
                 env,

--- a/src/serialize.rs
+++ b/src/serialize.rs
@@ -2,9 +2,9 @@
 use crate::error::SerializationError;
 use crate::identifier::Ident;
 use crate::label::Label;
-use crate::term::{RichTerm, Term};
+use crate::term::{MetaValue, RichTerm, Term};
 use crate::types::Types;
-use serde::ser::{Serialize, SerializeMap, Serializer};
+use serde::ser::{Error, Serialize, SerializeMap, Serializer};
 use std::collections::HashMap;
 
 /// Serializer for docstring. Ignore the meta-data and serialize the underlying term.
@@ -27,6 +27,19 @@ where
     S: Serializer,
 {
     t.serialize(serializer)
+}
+
+/// Serializer for metavalues.
+pub fn serialize_meta_value<S>(meta: &MetaValue, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    if let Some(ref t) = meta.value {
+        t.serialize(serializer)
+    } else {
+        // This error should not happen if the input term is validated before serialization
+        Err(Error::custom("empty metavalue"))
+    }
 }
 
 /// Serializer for a record. Serialize fields in alphabetical order to get a deterministic output

--- a/src/term.rs
+++ b/src/term.rs
@@ -148,8 +148,7 @@ pub enum Term {
     #[serde(skip_deserializing)]
     ContractWithDefault(Types, Label, RichTerm),
 
-    // #[serde(serialize_with = "crate::serialize::serialize_meta_value")]
-    #[serde(skip)]
+    #[serde(serialize_with = "crate::serialize::serialize_meta_value")]
     MetaValue(MetaValue),
 
     /// A term together with its documentation string. Enriched value.

--- a/src/term.rs
+++ b/src/term.rs
@@ -191,11 +191,10 @@ impl From<RichTerm> for MetaValue {
             doc: None,
             contract: None,
             priority: Default::default(),
-            value: Some(rt)
+            value: Some(rt),
         }
     }
 }
-
 /// A chunk of a string with interpolated expressions inside. Same as `Either<String,
 /// RichTerm>` but with explicit constructor names.
 #[derive(Debug, PartialEq, Clone)]
@@ -273,10 +272,12 @@ impl Term {
                 func(t);
             }
             MetaValue(ref mut meta) => {
-                meta.contract.iter_mut().for_each(|(ref mut ty, _)| match ty.0 {
-                    AbsType::Flat(ref mut rt) => func(rt),
-                    _ => (),
-                });
+                meta.contract
+                    .iter_mut()
+                    .for_each(|(ref mut ty, _)| match ty.0 {
+                        AbsType::Flat(ref mut rt) => func(rt),
+                        _ => (),
+                    });
                 meta.value.iter_mut().for_each(func);
             }
             Let(_, ref mut t1, ref mut t2)
@@ -375,11 +376,14 @@ impl Term {
                     content.push_str("contract,");
                 }
 
-                let value_label = if meta.priority == MergePriority::Default { "default" } else { "value" };
+                let value_label = if meta.priority == MergePriority::Default {
+                    "default"
+                } else {
+                    "value"
+                };
                 let value = if let Some(t) = &meta.value {
                     format!("{}", t.as_ref().shallow_repr())
-                }
-                else {
+                } else {
                     String::from("none")
                 };
 
@@ -1057,26 +1061,29 @@ impl RichTerm {
                 )
             }
             Term::MetaValue(meta) => {
-                let contract = meta.contract.map(|(ty, lbl)| {
-                    let ty = match ty {
-                        Types(AbsType::Flat(t)) => Types(AbsType::Flat(t.traverse(f, state)?)),
-                        ty => ty,
-                    }
-;
-                    Ok((ty, lbl))
-                })
-                // Transpose from Option<Result> to Result<Option>. There is a `transpose`
-                // method in Rust, but it has currently not made it to the stable version yet
-                .map_or(Ok(None), |res| res.map(Some))?;
+                let contract = meta
+                    .contract
+                    .map(|(ty, lbl)| {
+                        let ty = match ty {
+                            Types(AbsType::Flat(t)) => Types(AbsType::Flat(t.traverse(f, state)?)),
+                            ty => ty,
+                        };
+                        Ok((ty, lbl))
+                    })
+                    // Transpose from Option<Result> to Result<Option>. There is a `transpose`
+                    // method in Rust, but it has currently not made it to the stable version yet
+                    .map_or(Ok(None), |res| res.map(Some))?;
 
-                let value = meta.value.map(|t| t.traverse(f, state))
-                .map_or(Ok(None), |res| res.map(Some))?;
+                let value = meta
+                    .value
+                    .map(|t| t.traverse(f, state))
+                    .map_or(Ok(None), |res| res.map(Some))?;
 
                 let meta = MetaValue {
                     doc: meta.doc,
                     contract,
                     priority: meta.priority,
-                    value
+                    value,
                 };
 
                 f(

--- a/src/typecheck.rs
+++ b/src/typecheck.rs
@@ -46,7 +46,7 @@ use crate::identifier::Ident;
 use crate::label::ty_path;
 use crate::position::RawSpan;
 use crate::program::ImportResolver;
-use crate::term::{BinaryOp, RichTerm, StrChunk, Term, UnaryOp};
+use crate::term::{BinaryOp, RichTerm, StrChunk, Term, UnaryOp, MetaValue};
 use crate::types::{AbsType, Types};
 use crate::{mk_tyw_arrow, mk_tyw_enum, mk_tyw_enum_row, mk_tyw_record, mk_tyw_row};
 use std::collections::{HashMap, HashSet};
@@ -615,8 +615,17 @@ fn type_check_(
         Term::Wrapped(_, t)
         | Term::DefaultValue(t)
         | Term::ContractWithDefault(_, _, t)
-        | Term::Docstring(_, t) => type_check_(state, envs, strict, t, ty),
-        Term::Contract(_, _) => Ok(()),
+        | Term::Docstring(_, t)
+        | Term::MetaValue(MetaValue {contract: None, value: Some(t), ..}) => type_check_(state, envs, strict, t, ty),
+        // Handle a metavalue with a contract together with a value in the same way as an assume
+        Term::MetaValue(MetaValue {contract: Some((ty2, _)), value: Some(t), ..}) => {
+            unify(state, strict, ty.clone(), to_typewrapper(ty2.clone()))
+                .map_err(|err| err.to_typecheck_err(state, &rt.pos))?;
+            let new_ty = TypeWrapper::Ptr(new_var(state.table));
+            type_check_(state, envs, false, t, new_ty)
+        },
+        Term::Contract(_, _)
+        | Term::MetaValue(_) => Ok(()),
         Term::Import(_) => unify(state, strict, ty, mk_typewrapper::dynamic())
             .map_err(|err| err.to_typecheck_err(state, &rt.pos)),
         Term::ResolvedImport(file_id) => {

--- a/src/types.rs
+++ b/src/types.rs
@@ -371,6 +371,8 @@ mod test {
 
     /// Parse a type represented as a string.
     fn parse_type(s: &str) -> Types {
+        use crate::term::MetaValue;
+
         // Wrap the type in a contract to have it accepted by the parser.
         let wrapper = format!("Contract({})", s);
         let id = Files::new().add("<test>", wrapper.clone());
@@ -378,7 +380,10 @@ mod test {
         let rt = TermParser::new().parse(id, Lexer::new(&wrapper)).unwrap();
 
         match *rt.term {
-            Term::Contract(ty, _) => ty,
+            Term::MetaValue(MetaValue {
+                contract: Some((ty, _)),
+                ..
+            }) => ty,
             _ => panic!("types::test::parse_type(): expected contract"),
         }
     }


### PR DESCRIPTION
Preliminary for #232. The type of the representation of a metavalue (enriched value) can be seen as a product of optional attributes: documentation, contract, etc. Thinking of `Option<T>` algebraically as `1 + T`, a metavalue is thus of type `(1 + T1)...(1 + TN)`, where `T1,..,TN` are the types of the respective attributes, for example `T1 = String` for the documentation, `T2 = (Types, Label)` for the contract, and so on.

Currently, the representation rather corresponds to an expanded form of the previous formula, that is `1 + T1 + .. + TN + T1T2 + .. + T1TN + ...`: in the AST, there is directly a `Contract` node, a `Documentation` node, a `ContractWithDefault` node, etc. This is combinatorially big, and will be even more as we add new attributes to metavalues (merge strategy, example, etc.). It also makes the code handling metavalues less uniform.

This PRs changes the representation to a product, that is, to a single node `MetaValue` in the AST which holds a struct `{doc: Option<String>, contract: Option<(Types, Label)>, priority: MergePriority, value: Option<RichTerm>}`.

**what it does**
 - add a `MetaValue` node in the AST, which hold a `MetaValue` structure as defined above
 - build terms using this new representation in the parser
 - adapt typechecking, merging, program transformations, and so on to the new representation

**what it does not**
 - to keep a readable diff, the old code is still there, although not used. It will be cleaned in a coming PR.
 - do some vocabulary standardization: the new representation is called `metavalue`, as opposed to the previous name `enriched value`. We should probably settle the vocabulary, and do the appropriate search&replace in the code and in the documentation to avoid confusion.