### PR TITLE
[Fix]Lists.flatten reversed

### DIFF
--- a/stdlib/lists.ncl
+++ b/stdlib/lists.ncl
@@ -25,7 +25,7 @@
 
     flatten : List -> List =
       fun l =>
-        fold (fun l acc => acc @ Assume(List, l)) l [];
+        fold (fun l acc => Assume(List, l) @ acc) l [];
 
     all : (Dyn -> Bool) -> List -> Bool =
       fun pred l =>


### PR DESCRIPTION
The implementation of `lists.flatten` concatenate in the wrong order when folding, causing flatten to change the order of elements: `lists.flatten [[1,2],[3,4]]` gives `[3,4,1,2]` instead of `[1,2,3,4]`. This PR fixes the problem.