### PR TITLE
[Syntax]Support line comments

### DIFF
--- a/src/parser/lexer.rs
+++ b/src/parser/lexer.rs
@@ -234,6 +234,8 @@ pub enum NormalToken<'input> {
     RAngleBracket,
     #[token(">=")]
     GreaterOrEq,
+    #[regex("//[^\n]*")]
+    LineComment,
 }
 
 /// The tokens in string mode.
@@ -542,6 +544,8 @@ impl<'input> Iterator for Lexer<'input> {
             | Some(MultiStr(MultiStringToken::Error)) => {
                 return Some(Err(LexicalError::Generic(span.start, span.end)))
             }
+            // Ignore comment
+            Some(Normal(NormalToken::LineComment)) => return self.next(),
             _ => (),
         }
 

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -294,3 +294,19 @@ fn multiline_str_escape() {
         mk_single_chunk("#Hel##{lo###{"),
     );
 }
+
+#[test]
+fn line_comments() {
+    assert_eq!(
+        parse_without_pos("// 1 +\n1 + 1// + 3\n//+ 2"),
+        parse_without_pos("1 + 1")
+    );
+    assert_eq!(
+        parse_without_pos(
+            "{ // Some comment
+            field = foo; // Some description
+            } // Some other"
+        ),
+        parse_without_pos("{field = foo}")
+    );
+}


### PR DESCRIPTION
Related to #207. Support for line comments using `//`: `1 + 1 // This is a number`.