### PR TITLE
Use type information of metavalues

### DIFF
--- a/src/typecheck.rs
+++ b/src/typecheck.rs
@@ -658,6 +658,15 @@ fn type_check_(
 fn apparent_type(t: &Term, table: &mut UnifTable, strict: bool) -> TypeWrapper {
     match t {
         Term::Assume(ty, _, _) | Term::Promise(ty, _, _) => to_typewrapper(ty.clone()),
+        Term::MetaValue(MetaValue {
+            contract: Some((ty, _)),
+            ..
+        }) => to_typewrapper(ty.clone()),
+        Term::MetaValue(MetaValue {
+            contract: None,
+            value: Some(v),
+            ..
+        }) => apparent_type(v.as_ref(), table, strict),
         _ if strict => TypeWrapper::Ptr(new_var(table)),
         _ => mk_typewrapper::dynamic(),
     }


### PR DESCRIPTION
In untyped code, the typechecker approximates the type of a binding `let x = bound in exp` in the following way (it has to, since `x` may be used in a typed context in `exp`):
- If `bound` is annotated, i.e. is either a `Promise`or an `Assume`, use the type annotation.
- Otherwise, use `Dyn`

This ignores type annotations coming from metavalues, as for example (using a metavalue syntax from an experimental branch, because the example is not representable using current syntax, see #186):
```
{
  foo | Num = if true then 1 else "a";
  bar : Num = foo + 1; // Typemismatch: expected `Num`, got `Dyn`
}
```

This PR makes a metavalue with a contract being considered the same as other type annotations, making the above example pass typechecking.