### PR TITLE
Query sub-command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -48,6 +48,11 @@ version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "autocfg"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "beef"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -105,6 +110,11 @@ version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "clap"
 version = "2.33.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -141,6 +151,95 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "termcolor 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-width 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "crossbeam"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-channel 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-deque 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-epoch 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-queue 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-utils 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "crossbeam-utils 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "maybe-uninit 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "crossbeam-epoch 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-utils 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "maybe-uninit 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "autocfg 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-utils 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "maybe-uninit 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memoffset 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "scopeguard 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-utils 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "maybe-uninit 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "autocfg 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "crossterm"
+version = "0.17.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossterm_winapi 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.80 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mio 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parking_lot 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "signal-hook 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -291,6 +390,14 @@ version = "0.2.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "lock_api"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "scopeguard 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "log"
 version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -321,9 +428,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "maybe-uninit"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "memchr"
 version = "2.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "memoffset"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "autocfg 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "minimad"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "mio"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.80 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "miow 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ntapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "miow"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "socket2 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "new_debug_unreachable"
@@ -340,12 +489,22 @@ dependencies = [
  "lalrpop 0.16.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "lalrpop-util 0.16.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "logos 0.11.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "minimad 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "pretty_assertions 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.117 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.59 (registry+https://github.com/rust-lang/crates.io-index)",
  "simple-counter 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "structopt 0.3.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "termimad 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "ntapi"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -357,6 +516,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "ordermap"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "parking_lot"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "lock_api 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parking_lot_core 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.80 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.57 (registry+https://github.com/rust-lang/crates.io-index)",
+ "smallvec 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "petgraph"
@@ -541,6 +722,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.1.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "regex"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -579,6 +765,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "ryu"
 version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "scopeguard"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -621,6 +812,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "signal-hook"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.80 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mio 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "signal-hook-registry 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.80 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "simple-counter"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -629,6 +838,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "siphasher"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "smallvec"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "socket2"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.80 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.57 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "string_cache"
@@ -721,11 +946,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "termimad"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "crossbeam 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossterm 0.17.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "minimad 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thiserror 1.0.22 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-width 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "textwrap"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "unicode-width 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "thiserror-impl 1.0.22 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -833,6 +1089,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum ascii-canvas 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b385d69402821a1c254533a011a312531cbcc0e3e24f19bbb4747a5a2daf37e2"
 "checksum atty 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)" = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 "checksum autocfg 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "1d49d90015b3c36167a20fe2810c5cd875ad504b39cff3d4eae7977e6b7c1cb2"
+"checksum autocfg 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 "checksum beef 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "474a626a67200bd107d44179bb3d4fc61891172d11696609264589be6a0e6a43"
 "checksum bit-set 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6e11e16035ea35e4e5997b393eacbf6f63983188f7a2ad25bfb13465f5ad59de"
 "checksum bit-vec 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "5f0dc55f2d8a1a85650ac47858bb001b4c0dd73d79e3c455a842925e68d29cd3"
@@ -842,10 +1099,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum byte-tools 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 "checksum byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
 "checksum cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
+"checksum cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 "checksum clap 2.33.3 (registry+https://github.com/rust-lang/crates.io-index)" = "37e58ac78573c40708d45522f0d80fa2f01cc4f9b4e2bf749807255454312002"
 "checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
 "checksum codespan 0.9.5 (registry+https://github.com/rust-lang/crates.io-index)" = "8ebaf6bb6a863ad6aa3a18729e9710c53d75df03306714d9cc1f7357a00cd789"
 "checksum codespan-reporting 0.9.5 (registry+https://github.com/rust-lang/crates.io-index)" = "6e0762455306b1ed42bc651ef6a2197aabda5e1d4a43c34d5eab5c1a3634e81d"
+"checksum crossbeam 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "69323bff1fb41c635347b8ead484a5ca6c3f11914d784170b158d8449ab07f8e"
+"checksum crossbeam-channel 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "b153fe7cbef478c567df0f972e02e6d736db11affe43dfc9c56a9374d1adfb87"
+"checksum crossbeam-deque 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "9f02af974daeee82218205558e51ec8768b48cf524bd01d550abe5573a608285"
+"checksum crossbeam-epoch 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "058ed274caafc1f60c4997b5fc07bf7dc7cca454af7c6e81edffe5f33f70dace"
+"checksum crossbeam-queue 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "774ba60a54c213d409d5353bda12d49cd68d14e45036a285234c8d6f91f92570"
+"checksum crossbeam-utils 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8"
+"checksum crossterm 0.17.7 (registry+https://github.com/rust-lang/crates.io-index)" = "6f4919d60f26ae233e14233cc39746c8c8bb8cd7b05840ace83604917b51b6c7"
+"checksum crossterm_winapi 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c2265c3f8e080075d9b6417aa72293fc71662f34b4af2612d8d1b074d29510db"
 "checksum diff 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "0e25ea47919b1560c4e3b7fe0aaab9becf5b84a10325ddf7db0f0ba5e1026499"
 "checksum difference 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198"
 "checksum digest 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
@@ -866,13 +1132,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum lalrpop-util 0.16.3 (registry+https://github.com/rust-lang/crates.io-index)" = "33b27d8490dbe1f9704b0088d61e8d46edc10d5673a8829836c6ded26a9912c7"
 "checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 "checksum libc 0.2.80 (registry+https://github.com/rust-lang/crates.io-index)" = "4d58d1b70b004888f764dfbf6a26a3b0342a1632d33968e4a179d8011c760614"
+"checksum lock_api 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "c4da24a77a3d8a6d4862d95f72e6fdb9c09a643ecdb402d754004a557f2bec75"
 "checksum log 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)" = "4fabed175da42fed1fa0746b0ea71f412aa9d35e76e95e59b192c64b9dc2bf8b"
 "checksum logos 0.11.4 (registry+https://github.com/rust-lang/crates.io-index)" = "b91c49573597a5d6c094f9031617bb1fed15c0db68c81e6546d313414ce107e4"
 "checksum logos-derive 0.11.5 (registry+https://github.com/rust-lang/crates.io-index)" = "797b1f8a0571b331c1b47e7db245af3dc634838da7a92b3bef4e30376ae1c347"
+"checksum maybe-uninit 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
 "checksum memchr 2.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
+"checksum memoffset 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)" = "043175f069eda7b85febe4a74abbaeff828d9f8b448515d3151a14a3542811aa"
+"checksum minimad 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)" = "24fe6f533320d060be6644ff3967df0ddb2e3061164ab4976c9157995702e887"
+"checksum mio 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)" = "f33bc887064ef1fd66020c9adfc45bb9f33d75a42096c81e7c56c65b75dd1a8b"
+"checksum miow 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "5a33c1b55807fbed163481b5ba66db4b2fa6cde694a5027be10fb724206c5897"
 "checksum new_debug_unreachable 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "e4a24736216ec316047a1fc4252e27dabb04218aa4a3f37c6e7ddbf1f9782b54"
+"checksum ntapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "3f6bb902e437b6d86e03cce10a7e2af662292c5dfef23b65899ea3ac9354ad44"
 "checksum opaque-debug 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
 "checksum ordermap 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "a86ed3f5f244b372d6b1a00b72ef7f8876d0bc6a78a4c9985c53614041512063"
+"checksum parking_lot 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d3a704eb390aafdc107b0e392f56a82b668e3a71366993b5340f5833fd62505e"
+"checksum parking_lot_core 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d58c7c768d4ba344e3e8d72518ac13e259d7c7ade24167003b8488e10b6740a3"
 "checksum petgraph 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)" = "9c3659d1ee90221741f65dd128d9998311b0e40c5d3c23a62445938214abce4f"
 "checksum phf_generator 0.7.24 (registry+https://github.com/rust-lang/crates.io-index)" = "09364cc93c159b8b06b1f4dd8a4398984503483891b0c26b867cf431fb132662"
 "checksum phf_shared 0.7.24 (registry+https://github.com/rust-lang/crates.io-index)" = "234f71a15de2288bcb7e3b6515828d22af7ec8598ee6d24c3b526fa0a80b67a0"
@@ -893,17 +1168,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum rand_pcg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "abf9b09b01790cfe0364f52bf32995ea3c39f4d2dd011eac241d2914146d0b44"
 "checksum rand_xorshift 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cbf7e9e623549b0e21f6e97cf8ecf247c1a8fd2e8a992ae265314300b2455d5c"
 "checksum rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
+"checksum redox_syscall 0.1.57 (registry+https://github.com/rust-lang/crates.io-index)" = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
 "checksum regex 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "9329abc99e39129fcceabd24cf5d85b4671ef7c29c50e972bc5afe32438ec384"
 "checksum regex 1.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "38cf2c13ed4745de91a5eb834e11c00bcc3709e773173b2ce4c56c9fbde04b9c"
 "checksum regex-syntax 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)" = "7d707a4fa2637f2dca2ef9fd02225ec7661fe01a53623c1e6515b6916511f7a7"
 "checksum regex-syntax 0.6.21 (registry+https://github.com/rust-lang/crates.io-index)" = "3b181ba2dcf07aaccad5448e8ead58db5b742cf85dfe035e2227f137a539a189"
 "checksum ryu 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
+"checksum scopeguard 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 "checksum serde 1.0.117 (registry+https://github.com/rust-lang/crates.io-index)" = "b88fa983de7720629c9387e9f517353ed404164b1e482c970a90c1a4aaf7dc1a"
 "checksum serde_derive 1.0.117 (registry+https://github.com/rust-lang/crates.io-index)" = "cbd1ae72adb44aab48f325a02444a5fc079349a8d804c1fc922aed3f7454c74e"
 "checksum serde_json 1.0.59 (registry+https://github.com/rust-lang/crates.io-index)" = "dcac07dbffa1c65e7f816ab9eba78eb142c6d44410f4eeba1e26e4f5dfa56b95"
 "checksum sha2 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a256f46ea78a0c0d9ff00077504903ac881a1dafdc20da66545699e7776b3e69"
+"checksum signal-hook 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "604508c1418b99dfe1925ca9224829bb2a8a9a04dda655cc01fcad46f4ab05ed"
+"checksum signal-hook-registry 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "ce32ea0c6c56d5eacaeb814fbed9960547021d3edd010ded1425f180536b20ab"
 "checksum simple-counter 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4bb57743b52ea059937169c0061d70298fe2df1d2c988b44caae79dd979d9b49"
 "checksum siphasher 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "0b8de496cf83d4ed58b6be86c3a275b8602f6ffe98d3024a869e124147a9a3ac"
+"checksum smallvec 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7acad6f34eb9e8a259d3283d1e8c1d34d7415943d4895f65cc73813c7396fc85"
+"checksum socket2 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)" = "2c29947abdee2a218277abeca306f25789c938e500ea5a9d4b12a5a504466902"
 "checksum string_cache 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)" = "89c058a82f9fd69b1becf8c274f412281038877c553182f1d02eb027045a2d67"
 "checksum string_cache_codegen 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "f0f45ed1b65bf9a4bf2f7b7dc59212d1926e9eaf00fa998988e420fd124467c6"
 "checksum string_cache_shared 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b1884d1bc09741d466d9b14e6d37ac89d6909cbcac41dd9ae982d4d063bbedfc"
@@ -914,7 +1195,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum syn 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)" = "cc371affeffc477f42a221a1e4297aedcea33d47d19b61455588bd9d8f6b19ac"
 "checksum term 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "fa63644f74ce96fbeb9b794f66aff2a52d601cbd5e80f4b97123e3899f4570f1"
 "checksum termcolor 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bb6bfa289a4d7c5766392812c0a1f4c1ba45afa1ad47803c11e1f407d846d75f"
+"checksum termimad 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "fe9709f7deb2582e81b8bffd71ddc33ca46857c30fee361bcf6c0fd63caf8146"
 "checksum textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
+"checksum thiserror 1.0.22 (registry+https://github.com/rust-lang/crates.io-index)" = "0e9ae34b84616eedaaf1e9dd6026dbe00dcafa92aa0c8077cb69df1fcfe5e53e"
+"checksum thiserror-impl 1.0.22 (registry+https://github.com/rust-lang/crates.io-index)" = "9ba20f23e85b10754cd195504aebf6a27e2e6cbe28c17778a0c930724628dd56"
 "checksum thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
 "checksum thread_local 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d40c6d1b69745a6ec6fb1ca717914848da4b44ae29d9b3080cbee91d72a69b14"
 "checksum typenum 1.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "373c8a200f9e67a0c95e62a4f52fbf80c23b4381c05a17845531982fa99e6b33"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,11 @@ readme = "README.md"
 description = "Programmable configuration files."
 edition = "2018"
 
+[features]
+default = ["markdown"]
+# markdown = ["termimad", "minimad", "lazy_static", "crossterm"]
+markdown = ["termimad", "minimad"]
+
 [build-dependencies] # <-- We added this and everything after!
 lalrpop = "0.16.2"
 
@@ -21,6 +26,12 @@ logos = "0.11.4"
 serde = "1.0.117"
 serde_json = "1.0.59"
 structopt = "0.3"
+
+termimad = { version = "0.9.1", optional = true }
+# Use the same version as termimad
+minimad = { version = "0.6.7", optional = true }
+# lazy_static = { version = "1.4", optional = true }
+# crossterm = { version = "0.17.7", optional = true }
 
 [dev-dependencies]
 pretty_assertions = "0.5.1"

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -187,7 +187,7 @@ pub fn eval_meta<R>(
     t: RichTerm,
     global_env: &Environment,
     resolver: &mut R,
-) -> Result<Option<MetaValue>, EvalError>
+) -> Result<Term, EvalError>
 where
     R: ImportResolver,
 {
@@ -217,11 +217,12 @@ where
                 meta.value.replace(t);
             }
 
-            Ok(Some(meta))
+            Ok(Term::MetaValue(meta))
         }
-        _ => Ok(None),
+        term => Ok(term),
     }
 }
+
 /// The main loop of evaluation.
 ///
 /// Implement the evaluation of the core language, which includes application, thunk update,

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,8 +17,9 @@ mod typecheck;
 mod types;
 
 use crate::error::{Error, IOError, SerializationError};
+use crate::label::Label;
 use crate::program::Program;
-use crate::term::{RichTerm, Term};
+use crate::term::{MergePriority, MetaValue, RichTerm, Term};
 use std::io::Write;
 use std::path::PathBuf;
 use std::str::FromStr;
@@ -96,6 +97,15 @@ enum Command {
         #[structopt(parse(from_os_str))]
         output: Option<PathBuf>,
     },
+    Query {
+        path: Option<String>,
+        #[structopt(long)]
+        doc: bool,
+        #[structopt(long)]
+        contract: bool,
+        #[structopt(long)]
+        default: bool,
+    },
     /// Typecheck a program, but do not run it
     Typecheck,
 }
@@ -115,47 +125,13 @@ fn main() {
         });
 
     let result = match opts.command {
-        Some(Command::Export { format, output }) => {
-            program.eval_full().map(RichTerm::from).and_then(|rt| {
-                serialize::validate(&rt).map_err(Error::from)?;
-
-                let format = format.unwrap_or_default();
-
-                if let Some(file) = output {
-                    let mut file = fs::File::create(&file).map_err(IOError::from)?;
-
-                    match format {
-                        ExportFormat::Json => serde_json::to_writer_pretty(file, &rt)
-                            .map_err(|err| SerializationError::Other(err.to_string())),
-                        ExportFormat::Raw => match *rt.term {
-                            Term::Str(s) => file
-                                .write_all(s.as_bytes())
-                                .map_err(|err| SerializationError::Other(err.to_string())),
-                            t => Err(SerializationError::Other(format!(
-                                "raw export requires a `Str`, got {}",
-                                t.type_of().unwrap()
-                            ))),
-                        },
-                    }?
-                } else {
-                    match format {
-                        ExportFormat::Json => serde_json::to_writer_pretty(io::stdout(), &rt)
-                            .map_err(|err| SerializationError::Other(err.to_string())),
-                        ExportFormat::Raw => match *rt.term {
-                            Term::Str(s) => std::io::stdout()
-                                .write_all(s.as_bytes())
-                                .map_err(|err| SerializationError::Other(err.to_string())),
-                            t => Err(SerializationError::Other(format!(
-                                "raw export requires a `Str`, got {}",
-                                t.type_of().unwrap()
-                            ))),
-                        },
-                    }?
-                }
-
-                Ok(())
-            })
-        }
+        Some(Command::Export { format, output }) => export(&mut program, format, output),
+        Some(Command::Query {
+            path,
+            doc,
+            contract,
+            default,
+        }) => query(&mut program, path, doc, contract, default),
         Some(Command::Typecheck) => program.typecheck().map(|_| ()),
         None => program.eval().and_then(|t| {
             println!("Done: {:?}", t);
@@ -166,5 +142,171 @@ fn main() {
     if let Err(err) = result {
         program.report(err);
         process::exit(1)
+    }
+}
+
+fn export(
+    program: &mut Program,
+    format: Option<ExportFormat>,
+    output: Option<PathBuf>,
+) -> Result<(), Error> {
+    let rt = program.eval_full().map(RichTerm::from)?;
+    serialize::validate(&rt)?;
+
+    let format = format.unwrap_or_default();
+
+    if let Some(file) = output {
+        let mut file = fs::File::create(&file).map_err(IOError::from)?;
+
+        match format {
+            ExportFormat::Json => serde_json::to_writer_pretty(file, &rt)
+                .map_err(|err| SerializationError::Other(err.to_string())),
+            ExportFormat::Raw => match *rt.term {
+                Term::Str(s) => file
+                    .write_all(s.as_bytes())
+                    .map_err(|err| SerializationError::Other(err.to_string())),
+                t => Err(SerializationError::Other(format!(
+                    "raw export requires a `Str`, got {}",
+                    t.type_of().unwrap()
+                ))),
+            },
+        }?
+    } else {
+        match format {
+            ExportFormat::Json => serde_json::to_writer_pretty(io::stdout(), &rt)
+                .map_err(|err| SerializationError::Other(err.to_string())),
+            ExportFormat::Raw => match *rt.term {
+                Term::Str(s) => std::io::stdout()
+                    .write_all(s.as_bytes())
+                    .map_err(|err| SerializationError::Other(err.to_string())),
+                t => Err(SerializationError::Other(format!(
+                    "raw export requires a `Str`, got {}",
+                    t.type_of().unwrap()
+                ))),
+            },
+        }?
+    }
+
+    Ok(())
+}
+
+fn query(
+    program: &mut Program,
+    path: Option<String>,
+    doc: bool,
+    contract: bool,
+    default: bool,
+) -> Result<(), Error> {
+    let all = !doc && !contract && !default;
+    let meta_opt = program.eval_meta(path)?;
+
+    if let Some(meta) = meta_opt {
+        let mut found = false;
+        match &meta.contract {
+            Some((_, Label { types, .. })) if contract || all => {
+                print_metadata("contract", &format!("{}", types));
+                found = true;
+            }
+            _ => (),
+        }
+
+        match meta {
+            MetaValue {
+                priority: MergePriority::Default,
+                value: Some(t),
+                ..
+            } if default || all => {
+                print_metadata("default", &t.as_ref().shallow_repr());
+                found = true;
+            }
+            MetaValue {
+                priority: MergePriority::Normal,
+                value: Some(t),
+                ..
+            } if all => {
+                print_metadata("value", &t.as_ref().shallow_repr());
+                found = true;
+            }
+            _ => (),
+        }
+
+        match meta.doc {
+            Some(s) if doc || all => {
+                print_metadata_doc(s);
+                found = true;
+            }
+            _ => (),
+        }
+
+        if !found {
+            println!("Requested metadata were not found for this value.");
+        }
+    } else {
+        println!("No metadata found for this value.");
+    }
+
+    Ok(())
+}
+
+#[cfg(feature = "markdown")]
+fn print_metadata(attr: &str, value: &String) {
+    use minimad::*;
+    use termimad::*;
+
+    let skin = mk_skin();
+    let mut expander = OwningTemplateExpander::new();
+    let template = TextTemplate::from("* **${attr}**: *${value}*");
+
+    expander.set("attr", attr);
+    expander.set("value", value);
+    let text = expander.expand(&template);
+    let (width, _) = terminal_size();
+    let fmt_text = FmtText::from_text(&skin, text, Some(width as usize));
+    print!("{}", fmt_text);
+}
+//
+//     let skin = MadSkin::default();
+//     let text_template = TextTemplate::from(r#"
+//         # ${app-name} v${app-version}
+//         It is *very* ${adj}.
+//         "#);
+//     let mut expander = text_template.expander();
+//     expander
+//         .set("app-name", "MyApp")
+//         .set("adj", "pretty")
+//         .set("app-version", "42.5.3");
+//     skin.print_expander(expander);
+// }
+
+#[cfg(feature = "markdown")]
+fn print_metadata_doc(content: String) {
+    let skin = mk_skin();
+
+    if content.find("\n").is_none() {
+        skin.print_text(&format!("* **documentation**: {}", content));
+    } else {
+        skin.print_text("* **documentation**\n\n");
+        skin.print_text(&content);
+    }
+}
+
+#[cfg(feature = "markdown")]
+fn mk_skin() -> termimad::MadSkin {
+    use termimad::MadSkin;
+    MadSkin::default()
+}
+
+#[cfg(not(feature = "markdown"))]
+fn print_metadata(name: &str, content: &String) {
+    println!("* {}: {}");
+}
+
+#[cfg(not(feature = "markdown"))]
+fn print_metadata_doc(content: &String) {
+    if content.find("\n").is_none() {
+        print_metadata("documentation", &content);
+    } else {
+        skin.print_text("* **documentation**\n\n");
+        println(content);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -201,7 +201,14 @@ fn query(
     fn print_fields(t: &Term) {
         println!();
         match t {
-            Term::Record(map) if !map.is_empty() => query::print_fields(map.keys()),
+            Term::Record(map) | Term::RecRecord(map) if !map.is_empty() => {
+                let mut fields: Vec<_> = map.keys().collect();
+                fields.sort();
+                query::print_fields(fields.into_iter());
+            }
+            Term::Record(_) | Term::RecRecord(_) => {
+                query::print_metadata("value", &String::from("{}"))
+            }
             _ => (),
         }
     }
@@ -253,9 +260,15 @@ fn query(
                 meta.value.iter().for_each(|rt| print_fields(rt.as_ref()));
             }
         }
-        t => {
+        t @ Term::Record(_) | t @ Term::RecRecord(_) => {
             println!("No metadata found for this value.");
             print_fields(&t)
+        }
+        t => {
+            println!("No metadata found for this value.\n");
+            if all {
+                query::print_metadata("value", &t.shallow_repr());
+            }
         }
     }
 

--- a/src/program.rs
+++ b/src/program.rs
@@ -264,7 +264,7 @@ impl Program {
     ///
     /// As opposed to normal evaluation, it does not try to unwrap the content of a metavalue: the
     /// evaluation stops as soon as a metavalue is encountered.
-    pub fn eval_meta(&mut self, path: Option<String>) -> Result<Option<MetaValue>, Error> {
+    pub fn eval_meta(&mut self, path: Option<String>) -> Result<Term, Error> {
         let (t, global_env) = self.prepare_eval()?;
 
         let t = if let Some(p) = path {

--- a/src/program.rs
+++ b/src/program.rs
@@ -268,9 +268,9 @@ impl Program {
         let (t, global_env) = self.prepare_eval()?;
 
         let t = if let Some(p) = path {
-            // Parsing `hole.path`
-            let hole = "hole___";
-            let source = format!("{}.{}", hole, p);
+            // Parsing `hole.path`. We `seq` it to force the evaluation of the underlying value,
+            // which can be then showed to the user.
+            let source = format!("let x = (y.{}) in seq x x", p);
             let file_id = self.files.add("<query path>", source.clone());
             let new_term = parser::grammar::TermParser::new()
                 .parse(file_id, Lexer::new(&source))
@@ -283,7 +283,7 @@ impl Program {
                 env: eval::Environment::new(),
             };
             env.insert(
-                Ident::from(hole),
+                Ident::from("y"),
                 (Rc::new(RefCell::new(closure)), eval::IdentKind::Let()),
             );
 

--- a/src/program.rs
+++ b/src/program.rs
@@ -26,7 +26,7 @@ use crate::identifier::Ident;
 use crate::parser::lexer::Lexer;
 use crate::position::RawSpan;
 use crate::stdlib as nickel_stdlib;
-use crate::term::{MetaValue, RichTerm, Term};
+use crate::term::{RichTerm, Term};
 use crate::typecheck::type_check;
 use crate::types::Types;
 use crate::{eval, parser, transformations};
@@ -778,7 +778,7 @@ Assume(#alwaysTrue, false)
         assert_eq!(res, Ok(Term::Num(2.)));
 
         let res = eval_string(
-            "let f : forall r. <foo, bar | r> -> Num = 
+            "let f : forall r. <foo, bar | r> -> Num =
             fun x => switch { foo => 1, bar => 2, _ => 3, } x in
             f `boo",
         );

--- a/src/program.rs
+++ b/src/program.rs
@@ -22,10 +22,11 @@
 //! [`mk_global_env`](./struct.Program.html#method.mk_global_env)).  Each such value is added to
 //! the global environment before the evaluation of the program.
 use crate::error::{Error, ImportError, ParseError, ToDiagnostic, TypecheckError};
+use crate::identifier::Ident;
 use crate::parser::lexer::Lexer;
 use crate::position::RawSpan;
 use crate::stdlib as nickel_stdlib;
-use crate::term::{RichTerm, Term};
+use crate::term::{MetaValue, RichTerm, Term};
 use crate::typecheck::type_check;
 use crate::types::Types;
 use crate::{eval, parser, transformations};
@@ -257,6 +258,41 @@ impl Program {
     pub fn eval_full(&mut self) -> Result<Term, Error> {
         let (t, global_env) = self.prepare_eval()?;
         eval::eval_full(t, &global_env, self).map_err(|e| e.into())
+    }
+
+    /// Parse if necessary, typecheck, and evaluate the program until a metavalue is encountered.
+    ///
+    /// As opposed to normal evaluation, it does not try to unwrap the content of a metavalue: the
+    /// evaluation stops as soon as a metavalue is encountered.
+    pub fn eval_meta(&mut self, path: Option<String>) -> Result<Option<MetaValue>, Error> {
+        let (t, global_env) = self.prepare_eval()?;
+
+        let t = if let Some(p) = path {
+            // Parsing `hole.path`
+            let hole = "hole___";
+            let source = format!("{}.{}", hole, p);
+            let file_id = self.files.add("<query path>", source.clone());
+            let new_term = parser::grammar::TermParser::new()
+                .parse(file_id, Lexer::new(&source))
+                .map_err(|err| ParseError::from_lalrpop(err, file_id))?;
+
+            // Substituting `___HOLE` for `t`
+            let mut env = eval::Environment::new();
+            let closure = eval::Closure {
+                body: t,
+                env: eval::Environment::new(),
+            };
+            env.insert(
+                Ident::from(hole),
+                (Rc::new(RefCell::new(closure)), eval::IdentKind::Let()),
+            );
+
+            eval::subst(new_term, &eval::Environment::new(), &env)
+        } else {
+            t
+        };
+
+        Ok(eval::eval_meta(t, &global_env, self)?)
     }
 
     pub fn typecheck(&mut self) -> Result<Types, Error> {

--- a/src/program.rs
+++ b/src/program.rs
@@ -269,8 +269,9 @@ impl Program {
 
         let t = if let Some(p) = path {
             // Parsing `hole.path`. We `seq` it to force the evaluation of the underlying value,
-            // which can be then showed to the user.
-            let source = format!("let x = (y.{}) in seq x x", p);
+            // which can be then showed to the user. The newline gives better messages in case of
+            // errors.
+            let source = format!("let x = (y.{})\n in %seq% x x", p);
             let file_id = self.files.add("<query path>", source.clone());
             let new_term = parser::grammar::TermParser::new()
                 .parse(file_id, Lexer::new(&source))

--- a/src/stack.rs
+++ b/src/stack.rs
@@ -279,7 +279,7 @@ mod tests {
     }
 
     fn some_cont() -> OperationCont {
-        OperationCont::Op1(UnaryOp::IsNum(), None)
+        OperationCont::Op1(UnaryOp::IsNum(), None, true)
     }
 
     fn some_arg_marker() -> Marker {


### PR DESCRIPTION
Depend on #234. Close #232.

**what it does**
- add required functions in `eval` and `program` to be able to evaluate a term, but to stop when a meta-value is reached (the default behavior of the interpreter is to silently force meta-values). This was already almost supported via the `enriched_strict` flag but needed small adaptations.
- add support for rendering markdown in the terminal. This feature can be disabled at compile time (an embedded nickel interpreter is probably better off without too much dependencies)
- add a `query` sub-command taking an optional path parameter. Evaluate the term (or `term.path` if `path` option is set) in non-strict mode (wrt metavalues) and print corresponding metadata. If the result is a record without metadata, or without the requested metadata, the list of its fields is printed. Documentation is interpreted as markdown if markdown support is enabled.

It uses the default markdown skin but this is configurable if we don't like the look & feel.