### PR TITLE
Remove isZero operator

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -778,12 +778,6 @@ mod tests {
     }
 
     #[test]
-    fn simple_is_zero() {
-        let t = mk_term::op1(UnaryOp::IsZero(), Term::Num(7.0));
-        assert_eq!(Ok(Term::Bool(false)), eval_no_import(t));
-    }
-
-    #[test]
     fn asking_for_various_types() {
         let num = mk_term::op1(UnaryOp::IsNum(), Term::Num(45.3));
         assert_eq!(Ok(Term::Bool(true)), eval_no_import(num));

--- a/src/grammar.lalrpop
+++ b/src/grammar.lalrpop
@@ -234,7 +234,6 @@ ChunkLiteralPart: Either<&'input str, char> = {
     };
 
 UOp: UnaryOp<RichTerm> = {
-    "isZero" => UnaryOp::IsZero(),
     "isNum" => UnaryOp::IsNum(),
     "isBool" => UnaryOp::IsBool(),
     "isStr" => UnaryOp::IsStr(),
@@ -531,7 +530,6 @@ extern {
         "ContractDefault(" => Token::Normal(NormalToken::ContractDeflt),
         "Docstring(" => Token::Normal(NormalToken::Docstring),
 
-        "isZero" => Token::Normal(NormalToken::IsZero),
         "isNum" => Token::Normal(NormalToken::IsNum),
         "isBool" => Token::Normal(NormalToken::IsBool),
         "isStr" => Token::Normal(NormalToken::IsStr),

--- a/src/operation.rs
+++ b/src/operation.rs
@@ -124,19 +124,6 @@ fn process_unary_operation(
                 ))
             }
         }
-        UnaryOp::IsZero() => {
-            if let Term::Num(n) = *t {
-                // TODO Discuss and decide on this comparison for 0 on f64
-                Ok(Closure::atomic_closure(Term::Bool(n == 0.).into()))
-            } else {
-                Err(EvalError::TypeError(
-                    String::from("Num"),
-                    String::from("isZero"),
-                    arg_pos,
-                    RichTerm { term: t, pos },
-                ))
-            }
-        }
         UnaryOp::IsNum() => {
             if let Term::Num(_) = *t {
                 Ok(Closure::atomic_closure(Term::Bool(true).into()))

--- a/src/parser/lexer.rs
+++ b/src/parser/lexer.rs
@@ -156,8 +156,6 @@ pub enum NormalToken<'input> {
     #[token("Docstring(")]
     Docstring,
 
-    #[token("isZero")]
-    IsZero,
     #[token("isNum")]
     IsNum,
     #[token("isBool")]

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -137,13 +137,13 @@ fn lets() {
 #[test]
 fn unary_op() {
     assert_eq!(
-        parse_without_pos("isZero x"),
-        mk_term::op1(UnaryOp::IsZero(), mk_term::var("x"))
+        parse_without_pos("isNum x"),
+        mk_term::op1(UnaryOp::IsNum(), mk_term::var("x"))
     );
     assert_eq!(
-        parse_without_pos("isZero x y"),
+        parse_without_pos("isNum x y"),
         mk_app!(
-            mk_term::op1(UnaryOp::IsZero(), mk_term::var("x")),
+            mk_term::op1(UnaryOp::IsNum(), mk_term::var("x")),
             mk_term::var("y")
         ),
     );

--- a/src/program.rs
+++ b/src/program.rs
@@ -614,7 +614,7 @@ g true",
             let or : Bool -> Bool -> Bool = fun x => fun y => if x then x else y in
 
             let fibo : Num -> Num = Y (fun fibo =>
-                (fun x => if or (isZero x) (isZero (dec x)) then 1 else (fibo (dec x)) + (fibo (dec (dec x))))) in
+                (fun x => if or (x == 0) (dec x == 0) then 1 else (fibo (dec x)) + (fibo (dec (dec x))))) in
             let val : Num = 4 in
             fibo val",
         );
@@ -900,7 +900,7 @@ Assume(#alwaysTrue -> #alwaysFalse, not ) true
                 "let Y = fun f => (fun x => f (x x)) (fun x => f (x x)) in
                 let foldr_ =
                     fun self => fun f => fun acc => fun l =>
-                        if isZero (length l) then acc
+                        if length l == 0 then acc
                         else
                             let h = head l in
                             let t = tail l in
@@ -915,7 +915,7 @@ Assume(#alwaysTrue -> #alwaysFalse, not ) true
                         else false
                 in
                 let all = fun pred => fun l => foldr and true (map pred l) in
-                let isZ = fun x => isZero x in
+                let isZ = fun x => x == 0 in
                 all isZ [0, 0, 0, 1]"
             ),
             Ok(Term::Bool(false))
@@ -1063,18 +1063,18 @@ Assume(#alwaysTrue -> #alwaysFalse, not ) true
              let or = fun x => fun y => if x then x else y in
              let isEven_ = Y (fun f =>
                  (fun x =>
-                     if (isZero x) then true
+                     if x == 0 then true
                      else (
-                         if (isZero (dec x)) then false
+                         if dec x == 0 then false
                          else (f (dec (dec x)))
                      )
                  )
              ) in
              let isDivBy3_ = Y (fun f =>
                  (fun x =>
-                     if (isZero x) then true
+                     if x == 0 then true
                      else (
-                         if or (isZero (dec (dec x))) (isZero (dec x)) then false
+                         if or (dec (dec x) == 0) (dec x == 0) then false
                          else (f (dec (dec (dec x))))
                      )
                  )
@@ -1194,12 +1194,12 @@ Assume(#alwaysTrue -> #alwaysFalse, not ) true
             Ok(Term::Num(3.0))
         );
         assert_eq!(
-            eval_string("{f = fun x y => if isZero x then y else f (x + (-1)) (y + 1)}.f 5 5"),
+            eval_string("{f = fun x y => if x == 0 then y else f (x + (-1)) (y + 1)}.f 5 5"),
             Ok(Term::Num(10.0))
         );
         assert_eq!(
             eval_string("
-                let with_res = fun res => { f = fun x => if isZero x then res else g x; g = fun y => f (y + (-1)) }.f 10 in
+                let with_res = fun res => { f = fun x => if x == 0 then res else g x; g = fun y => f (y + (-1)) }.f 10 in
                 with_res \"done\""),
             Ok(Term::Str(String::from("done")))
         );

--- a/src/stack.rs
+++ b/src/stack.rs
@@ -166,7 +166,7 @@ mod tests {
     }
 
     fn some_cont() -> OperationCont {
-        OperationCont::Op1(UnaryOp::IsZero(), None)
+        OperationCont::Op1(UnaryOp::IsNum(), None)
     }
 
     fn some_arg_marker() -> Marker {

--- a/src/term.rs
+++ b/src/term.rs
@@ -446,11 +446,6 @@ pub enum UnaryOp<CapturedTerm> {
     /// If-then-else.
     Ite(),
 
-    /// Test if a number is zero.
-    ///
-    /// Will be removed once there is a reasonable equality.
-    IsZero(),
-
     /// Test if a term is a numeral.
     IsNum(),
     /// Test if a term is a boolean.
@@ -580,8 +575,6 @@ impl<Ty> UnaryOp<Ty> {
             MapRec(t) => MapRec(f(t)),
 
             Ite() => Ite(),
-
-            IsZero() => IsZero(),
 
             IsNum() => IsNum(),
             IsBool() => IsBool(),

--- a/src/typecheck.rs
+++ b/src/typecheck.rs
@@ -1299,8 +1299,6 @@ pub fn get_uop_type(
                 branches
             )
         }
-        // Num -> Bool
-        UnaryOp::IsZero() => mk_tyw_arrow!(AbsType::Num(), AbsType::Bool()),
         // forall a. a -> Bool
         UnaryOp::IsNum()
         | UnaryOp::IsBool()
@@ -2113,11 +2111,11 @@ mod tests {
         // Fields in recursive records are treated in the type environment in the same way as let-bound expressions
         parse_and_typecheck("{a = 1; b = 1 + a} : {a : Num, b : Num}").unwrap();
         parse_and_typecheck(
-            "{ f = fun x => if isZero x then 1 else 1 + (f (x + (-1)));} : {f : Num -> Num}",
+            "{ f = fun x => if x == 0 then 1 else 1 + (f (x + (-1)));} : {f : Num -> Num}",
         )
         .unwrap();
         parse_and_typecheck(
-            "{ f = fun x => if isZero x then false else 1 + (f (x + (-1)))} : {f : Num -> Num}",
+            "{ f = fun x => if x == 0 then false else 1 + (f (x + (-1)))} : {f : Num -> Num}",
         )
         .unwrap_err();
     }


### PR DESCRIPTION
Remove the `isZero` builtin operator, which is deprecated now that we have an equality operator.