### PR TITLE
[Fix]Failing CI on master (old Promise syntax)

### DIFF
--- a/src/typecheck.rs
+++ b/src/typecheck.rs
@@ -2189,14 +2189,14 @@ mod tests {
 
     #[test]
     fn dynamic_row_tail() {
-        parse_and_typecheck("let r = Assume({a: Num | Dyn}, {a = 1; b = 2}) in Promise(Num, r.a)")
+        parse_and_typecheck("let r = Assume({a: Num | Dyn}, {a = 1; b = 2}) in (r.a : Num)")
             .unwrap();
-        parse_and_typecheck("Promise({a: Num | Dyn}, Assume({a: Num | Dyn}, {a = 1; b = 2}))")
-            .unwrap();
-        // Currently, typechecking is conservative wrt the dynamic row type, meaning it can
-        parse_and_typecheck("Promise({a: Num | Dyn}, {a = 1; b = 2})").unwrap_err();
-        parse_and_typecheck("Promise({a: Num | Dyn}, {a = 1})").unwrap_err();
-        parse_and_typecheck("Promise({a: Num}, Assume({a: Num | Dyn}, {a = 1}))").unwrap_err();
-        parse_and_typecheck("Promise({a: Num | Dyn}, {a = 1})").unwrap_err();
+        parse_and_typecheck("Assume({a: Num | Dyn}, {a = 1; b = 2}) : {a: Num | Dyn}").unwrap();
+        // Currently, typechecking is conservative wrt the dynamic row type, meaning it can't to a
+        // less precise type with a dynamic tail.
+        parse_and_typecheck("{a = 1; b = 2} : {a: Num | Dyn}").unwrap_err();
+        parse_and_typecheck("{a = 1} : {a: Num | Dyn}").unwrap_err();
+        parse_and_typecheck("Assume({a: Num | Dyn}, {a = 1}) : {a: Num}").unwrap_err();
+        parse_and_typecheck("{a = 1} : {a: Num | Dyn}").unwrap_err();
     }
 }


### PR DESCRIPTION
#217 was just merged, but was written before #219, so tests were using the old `Promise(...)` syntax.