### PR TITLE
Eliminate the inner terms of primitive operators 1: Switch

### DIFF
--- a/src/grammar.lalrpop
+++ b/src/grammar.lalrpop
@@ -3,7 +3,7 @@ use crate::term::{BinaryOp, RichTerm, Term, UnaryOp, StrChunk};
 use crate::term::make as mk_term;
 use crate::mk_app;
 use crate::types::{Types, AbsType};
-use super::utils::{StringKind, mk_span, mk_label, strip_indent};
+use super::utils::{StringKind, mk_span, mk_label, strip_indent, SwitchCase};
 use super::lexer::{Token, NormalToken, StringToken, MultiStringToken, LexicalError};
 use std::collections::HashMap;
 use either::*;
@@ -59,6 +59,27 @@ RichTerm: RichTerm = {
         };
 
         mk_term::let_in(id, t1, t2)
+    },
+    "switch" "{" <cases: (switch_case ",")*> <last: switch_case?> "}" <exp: SpTerm<RichTerm>> => {
+        let mut acc = HashMap::with_capacity(cases.len());
+        let mut default = None;
+
+        for case in cases.into_iter().map(|x| x.0).chain(last.into_iter()) {
+            match case {
+                SwitchCase::Normal(id, t) => acc.insert(id, t),
+                // If there are multiple default cases, the last one silently
+                // erases the others. We should have a dedicated error for that
+                SwitchCase::Default(t) => default.replace(t),
+            };
+        }
+
+        RichTerm::from(
+            Term::Switch(
+                exp,
+                acc,
+                default,
+            )
+        )
     },
     "if" <b:Term> "then" <t:Term> "else" <e:SpTerm<RichTerm>> =>
         mk_app!(Term::Op1(UnaryOp::Ite(), b), t, e),
@@ -248,11 +269,6 @@ UOp: UnaryOp<RichTerm> = {
     "tag" <s: Str> => UnaryOp::Tag(s),
     "wrap" => UnaryOp::Wrap(),
     "embed" <Ident> => UnaryOp::Embed(<>),
-    "switch" "{" <ds: (switch_case ",")*> <default: switch_default?> "}" =>
-        UnaryOp::Switch(
-            ds.into_iter().map(|x| x.0).collect(),
-            default,
-        ),
     "map" <Atom> => UnaryOp::ListMap(<>),
     "recordMap" <Atom> => UnaryOp::RecordMap(<>),
     "seq" => UnaryOp::Seq(),
@@ -263,12 +279,9 @@ UOp: UnaryOp<RichTerm> = {
     "fieldsOf" => UnaryOp::FieldsOf(),
 };
 
-switch_case: (Ident, RichTerm) = {
-    <id: Ident> "=>" <t: SpTerm<Atom> > => (id, t),
-}
-
-switch_default: RichTerm = {
-    "_" "=>" <SpTerm<Atom>> "," => <>,
+switch_case: SwitchCase = {
+    <id: Ident> "=>" <t: Term> => SwitchCase::Normal(id, t),
+    "_" "=>" <t: Term> => SwitchCase::Default(<>),
 }
 
 // TODO: convenience for messing with precedence levels during development. Once

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -1,9 +1,9 @@
 use super::lexer::{Lexer, LexicalError, NormalToken, StringToken, Token};
 use crate::identifier::Ident;
-use crate::mk_app;
 use crate::term::make as mk_term;
 use crate::term::Term::*;
 use crate::term::{BinaryOp, RichTerm, StrChunk, UnaryOp};
+use crate::{mk_app, mk_switch};
 use codespan::Files;
 
 fn parse(s: &str) -> Option<RichTerm> {
@@ -155,18 +155,7 @@ fn enum_terms() {
 
     assert_eq!(
         parse_without_pos("switch { foo => true, bar => false, _ => 456, } 123"),
-        mk_term::op1(
-            UnaryOp::Switch(
-                vec![
-                    (Ident::from("foo"), Bool(true).into()),
-                    (Ident::from("bar"), Bool(false).into())
-                ]
-                .into_iter()
-                .collect(),
-                Some(Num(456.).into())
-            ),
-            Num(123.),
-        )
+        mk_switch!(Num(123.), ("foo", Bool(true)), ("bar", Bool(false)) ; Num(456.))
     )
 }
 

--- a/src/parser/utils.rs
+++ b/src/parser/utils.rs
@@ -1,3 +1,4 @@
+use crate::identifier::Ident;
 /// A few helpers to generate position spans and labels easily during parsing
 use crate::label::Label;
 use crate::position::RawSpan;
@@ -11,6 +12,13 @@ use codespan::FileId;
 pub enum StringKind {
     Standard,
     Multiline,
+}
+
+/// Distinguish between a normal case `id => exp` and a default case `_ => exp`.
+#[derive(Clone, Debug)]
+pub enum SwitchCase {
+    Normal(Ident, RichTerm),
+    Default(RichTerm),
 }
 
 /// Make a span from parser byte offsets.

--- a/src/typecheck.rs
+++ b/src/typecheck.rs
@@ -535,6 +535,31 @@ fn type_check_(
             type_check_(state, envs.clone(), strict, e, arr)?;
             type_check_(state, envs, strict, t, src)
         }
+        Term::Switch(exp, cases, default) => {
+            // Currently, if it has a default value, we typecheck the whole thing as
+            // taking ANY enum, since it's more permissive and there's no loss of information
+            let res = TypeWrapper::Ptr(new_var(state.table));
+
+            for case in cases.values() {
+                type_check_(state, envs.clone(), strict, case, res.clone())?;
+            }
+
+            let row = match default {
+                Some(t) => {
+                    type_check_(state, envs.clone(), strict, t, res.clone())?;
+                    TypeWrapper::Ptr(new_var(state.table))
+                }
+                None => cases.iter().try_fold(
+                    mk_typewrapper::row_empty(),
+                    |acc, x| -> Result<TypeWrapper, TypecheckError> {
+                        Ok(mk_tyw_enum_row!(x.0.clone(), acc))
+                    },
+                )?,
+            };
+
+            unify(state, strict, ty, res).map_err(|err| err.to_typecheck_err(state, &rt.pos))?;
+            type_check_(state, envs, strict, exp, mk_tyw_enum!(row))
+        }
         Term::Var(x) => {
             let x_ty = envs
                 .get(&x)
@@ -1358,35 +1383,8 @@ pub fn get_uop_type(
             constraint(state, row.clone(), id.clone()).unwrap();
             mk_tyw_arrow!(mk_tyw_enum!(row.clone()), mk_tyw_enum!(id.clone(), row))
         }
-        // 1. rows -> a
-        // 2. forall b. b -> a
-        // Rows is ( `label1, .., `labeln ) for label in l.keys().
-        // Unify each branch in l.values() with a.
-        // If the switch has a default case, the more general type 2. is used.
-        UnaryOp::Switch(l, d) => {
-            // Currently, if it has a default value, we typecheck the whole thing as
-            // taking ANY enum, since it's more permissive and there's not a loss of information
-            let res = TypeWrapper::Ptr(new_var(state.table));
-
-            for exp in l.values() {
-                type_check_(state, envs.clone(), strict, exp, res.clone())?;
-            }
-
-            let row = match d {
-                Some(e) => {
-                    type_check_(state, envs.clone(), strict, e, res.clone())?;
-                    TypeWrapper::Ptr(new_var(state.table))
-                }
-                None => l.iter().try_fold(
-                    mk_typewrapper::row_empty(),
-                    |acc, x| -> Result<TypeWrapper, TypecheckError> {
-                        Ok(mk_tyw_enum_row!(x.0.clone(), acc))
-                    },
-                )?,
-            };
-
-            mk_tyw_arrow!(mk_tyw_enum!(row), res)
-        }
+        // This should not happen, as Switch() is only produced during evaluation.
+        UnaryOp::Switch(_) => panic!("cannot typecheck Switch()"),
         // Dyn -> Dyn
         UnaryOp::ChangePolarity() | UnaryOp::GoDom() | UnaryOp::GoCodom() | UnaryOp::Tag(_) => {
             mk_tyw_arrow!(AbsType::Dyn(), AbsType::Dyn())

--- a/src/types.rs
+++ b/src/types.rs
@@ -220,9 +220,10 @@ impl Types {
                                 rest_contract,
                                 mk_fun!(
                                     "x",
-                                    mk_term::op1(
-                                        UnaryOp::Switch(map, Some(Term::Bool(false).into())),
-                                        mk_term::var("x"),
+                                    mk_app!(
+                                        mk_term::op1(UnaryOp::Switch(true), mk_term::var("x")),
+                                        Term::Record(map),
+                                        Term::Bool(false)
                                     )
                                 )
                             )


### PR DESCRIPTION
Depend on #247. Since we're at it, let us continue what we started for equality in #247: do not store additional state and/or parameters internally inside primitive operators themselves, but rather use the stack.

The goal is to eventually get rid of the dependency of `UnaryOp<CapturedTerm>/BinaryOp<CapturedTerm>` to `CapturedTerm`, which causes special casing and code duplication. For example, the typechecking of such operators, environment management (which is done both for standard application, primitive application, and for these subterms inside primitive operators), and so on. 

This PR focuses on the `switch` construct, which goes from a `Switch(cases: HashMap<Ident, CapturedTerm>, default: CapturedTerm)` operator applied to the expression to test, to a unary operator `Switch(has_default: bool)` which retrieves the cases and a potential default case from the stack, eliminating any dependency to `RichTerm`.

Although the parser could directly generate an appropriate application of this operator, this would make the tyepchecking of switch quite hacky: thus, we rather add a dedicated `Switch(exp, cases, default)` node to the AST for typechecking purpose, which evaluates to an application of the corresponding primitive operator.

Also include small syntax fixes (the last comma is now optional, and the default case needs not to be in last position).