### PR TITLE
Eliminate the inner terms of primitive operators 4: DynExtend

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -295,11 +295,6 @@ where
                 Closure { body: t, env }
             }
             Term::Op2(op, fst, snd) => {
-                let op = op.map(|t| Closure {
-                    body: t,
-                    env: env.clone(),
-                });
-
                 let prev_strict = enriched_strict;
                 enriched_strict = op.is_strict();
                 stack.push_op_cont(

--- a/src/grammar.lalrpop
+++ b/src/grammar.lalrpop
@@ -106,7 +106,7 @@ RecordOperationChain: RichTerm = {
     <t: SpTerm<RecordOperand>> ".$" <t_id: SpTerm<Atom>> => mk_term::op2(BinaryOp::DynAccess(), t_id, t),
     <t: SpTerm<RecordOperand>> "-$" <t_id: SpTerm<Atom>> => mk_term::op2(BinaryOp::DynRemove(), t_id, t),
     <r: SpTerm<RecordOperand>> "$[" <id: Term> "=" <t: Term> "]" =>
-        mk_term::op2(BinaryOp::DynExtend(t), id, r),
+        mk_app!(mk_term::op2(BinaryOp::DynExtend(), id, r), t),
 };
 
 Atom: RichTerm = {
@@ -179,7 +179,7 @@ Atom: RichTerm = {
 
         dynamic_fields.into_iter().fold(static_rec, |rec, field| {
             let (id_t, t) = field;
-            RichTerm::from(Term::Op2(BinaryOp::DynExtend(t), id_t, rec))
+            mk_app!(mk_term::op2(BinaryOp::DynExtend(), id_t, rec), t)
         })
     },
     "[" <terms: (SpTerm<Atom> ",")*> <last: Term?> "]" => {
@@ -333,7 +333,7 @@ PrefixExpr1: RichTerm = {
         mk_term::op2(BinaryOp::Sub(), Term::Num(0.0), t),
 }
 
-BinOp2: BinaryOp<RichTerm> = {
+BinOp2: BinaryOp = {
     "++" => BinaryOp::PlusStr(),
     "@" => BinaryOp::ListConcat(),
 }
@@ -343,7 +343,7 @@ InfixExpr2: RichTerm = {
     LeftOp<BinOp2, InfixExpr2, PrefixExpr1> => <>,
 }
 
-BinOp3: BinaryOp<RichTerm> = {
+BinOp3: BinaryOp = {
     "*" => BinaryOp::Mult(),
     "/" => BinaryOp::Div(),
     "%" => BinaryOp::Modulo(),
@@ -354,7 +354,7 @@ InfixExpr3: RichTerm = {
     LeftOp<BinOp3, InfixExpr3, InfixExpr2> => <>,
 }
 
-BinOp4: BinaryOp<RichTerm> = {
+BinOp4: BinaryOp = {
     "+" => BinaryOp::Plus(),
     "-" => BinaryOp::Sub(),
 }
@@ -369,7 +369,7 @@ PrefixExpr5: RichTerm = {
     "!" <PrefixExpr5> => mk_term::op1(UnaryOp::BoolNot(), <>),
 }
 
-BinOp6: BinaryOp<RichTerm> = {
+BinOp6: BinaryOp = {
     "&" => BinaryOp::Merge(),
 }
 
@@ -378,7 +378,7 @@ PrefixExpr6: RichTerm = {
     LeftOp<BinOp6, PrefixExpr6, PrefixExpr5> => <>,
 }
 
-BinOp7: BinaryOp<RichTerm> = {
+BinOp7: BinaryOp = {
     "<" => BinaryOp::LessThan(),
     "<=" => BinaryOp::LessOrEq(),
     ">" => BinaryOp::GreaterThan(),
@@ -390,7 +390,7 @@ InfixExpr7: RichTerm = {
     LeftOp<BinOp7, InfixExpr7, PrefixExpr6> => <>,
 }
 
-BinOp8: BinaryOp<RichTerm> = {
+BinOp8: BinaryOp = {
     "==" => BinaryOp::Eq(),
 }
 
@@ -423,7 +423,7 @@ InfixExpr: RichTerm = {
     InfixExpr10,
 }
 
-BOpPre: BinaryOp<RichTerm> = {
+BOpPre: BinaryOp = {
     "unwrap" => BinaryOp::Unwrap(),
     "goField" => BinaryOp::GoField(),
     "hasField" => BinaryOp::HasField(),

--- a/src/grammar.lalrpop
+++ b/src/grammar.lalrpop
@@ -303,7 +303,6 @@ UOp: UnaryOp = {
     "polarity" => UnaryOp::Pol(),
     "goDom" => UnaryOp::GoDom(),
     "goCodom" => UnaryOp::GoCodom(),
-    "tag" <s: Str> => UnaryOp::Tag(s),
     "wrap" => UnaryOp::Wrap(),
     "embed" <Ident> => UnaryOp::Embed(<>),
     "map"  => UnaryOp::ListMap(),
@@ -428,6 +427,7 @@ BOpPre: BinaryOp = {
     "goField" => BinaryOp::GoField(),
     "hasField" => BinaryOp::HasField(),
     "elemAt" => BinaryOp::ListElemAt(),
+    "tag" => BinaryOp::Tag(),
 }
 
 Types: Types = {

--- a/src/operation.rs
+++ b/src/operation.rs
@@ -367,19 +367,6 @@ fn process_unary_operation(
                 ))
             }
         }
-        UnaryOp::Tag(s) => {
-            if let Term::Lbl(mut l) = *t {
-                l.tag = String::from(&s);
-                Ok(Closure::atomic_closure(Term::Lbl(l).into()))
-            } else {
-                Err(EvalError::TypeError(
-                    String::from("Label"),
-                    String::from("tag"),
-                    arg_pos,
-                    RichTerm { term: t, pos },
-                ))
-            }
-        }
         UnaryOp::Wrap() => {
             if let Term::Sym(s) = *t {
                 Ok(Closure::atomic_closure(mk_fun!(
@@ -871,6 +858,34 @@ fn process_binary_operation(
                 Err(EvalError::TypeError(
                     String::from("Sym"),
                     String::from("unwrap, 1st argument"),
+                    fst_pos,
+                    RichTerm {
+                        term: t1,
+                        pos: pos1,
+                    },
+                ))
+            }
+        }
+        BinaryOp::Tag() => {
+            if let Term::Str(s) = *t1 {
+                if let Term::Lbl(mut l) = *t2 {
+                    l.tag = s;
+                    Ok(Closure::atomic_closure(Term::Lbl(l).into()))
+                } else {
+                    Err(EvalError::TypeError(
+                        String::from("Label"),
+                        String::from("tag, 2nd argument"),
+                        snd_pos,
+                        RichTerm {
+                            term: t2,
+                            pos: pos2,
+                        },
+                    ))
+                }
+            } else {
+                Err(EvalError::TypeError(
+                    String::from("Str"),
+                    String::from("tag, 1st argument"),
                     fst_pos,
                     RichTerm {
                         term: t1,

--- a/src/operation.rs
+++ b/src/operation.rs
@@ -49,13 +49,13 @@ pub enum OperationCont {
     ),
     // The last parameter saves the strictness mode before the evaluation of the operator
     Op2First(
-        /* the binary operation */ BinaryOp<Closure>,
+        /* the binary operation */ BinaryOp,
         /* second argument, to evaluate next */ Closure,
         /* original position of the first argument */ Option<RawSpan>,
         /* previous value of enriched_strict */ bool,
     ),
     Op2Second(
-        /* binary operation */ BinaryOp<Closure>,
+        /* binary operation */ BinaryOp,
         /* first argument, evaluated */ Closure,
         /* original position of the first argument before evaluation */ Option<RawSpan>,
         /* original position of the second argument before evaluation */ Option<RawSpan>,
@@ -660,7 +660,7 @@ fn process_unary_operation(
 /// Both arguments are expected to be evaluated (in WHNF). `pos_op` corresponds to the whole
 /// operation position, that may be needed for error reporting.
 fn process_binary_operation(
-    b_op: BinaryOp<Closure>,
+    b_op: BinaryOp,
     fst_clos: Closure,
     fst_pos: Option<RawSpan>,
     clos: Closure,
@@ -1098,7 +1098,11 @@ fn process_binary_operation(
                 ))
             }
         }
-        BinaryOp::DynExtend(clos) => {
+        BinaryOp::DynExtend() => {
+            let (clos, _) = stack.pop_arg().ok_or_else(|| {
+                EvalError::NotEnoughArgs(3, String::from("$[ .. ]"), pos_op.clone())
+            })?;
+
             if let Term::Str(id) = *t1 {
                 if let Term::Record(mut static_map) = *t2 {
                     let as_var = clos.body.closurize(&mut env2, clos.env);

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -177,21 +177,20 @@ fn record_terms() {
 
     assert_eq!(
         parse_without_pos("{ a = 1; $123 = (if 4 then 5 else 6); d = 42;}"),
-        mk_term::op2(
-            BinaryOp::DynExtend(mk_app!(
-                mk_term::op1(UnaryOp::Ite(), Num(4.)),
-                Num(5.),
-                Num(6.)
-            )),
-            Num(123.),
-            RecRecord(
-                vec![
-                    (Ident::from("a"), Num(1.).into()),
-                    (Ident::from("d"), Num(42.).into()),
-                ]
-                .into_iter()
-                .collect()
-            )
+        mk_app!(
+            mk_term::op2(
+                BinaryOp::DynExtend(),
+                Num(123.),
+                RecRecord(
+                    vec![
+                        (Ident::from("a"), Num(1.).into()),
+                        (Ident::from("d"), Num(42.).into()),
+                    ]
+                    .into_iter()
+                    .collect()
+                )
+            ),
+            mk_app!(mk_term::op1(UnaryOp::Ite(), Num(4.)), Num(5.), Num(6.))
         )
     );
 }

--- a/src/term.rs
+++ b/src/term.rs
@@ -530,8 +530,6 @@ pub enum UnaryOp {
     ///
     /// See `GoDom`.
     GoCodom(),
-    /// Append text to the tag of a label.
-    Tag(String),
 
     /// Wrap a term with a type tag (see `Wrapped` in [`Term`](enum.Term.html)).
     Wrap(),
@@ -594,6 +592,8 @@ pub enum BinaryOp {
     ///
     /// See `GoDom`.
     GoField(),
+    /// Set the tag text of a blame label.
+    Tag(),
     /// Extend a record with a dynamic field.
     ///
     /// Dynamic means that the field name may be an expression instead of a statically known

--- a/src/typecheck.rs
+++ b/src/typecheck.rs
@@ -622,7 +622,7 @@ fn type_check_(
             }
         }
         Term::Op1(op, t) => {
-            let ty_op = get_uop_type(state, envs.clone(), strict, op)?;
+            let ty_op = get_uop_type(state, op)?;
 
             let src = TypeWrapper::Ptr(new_var(state.table));
             let arr = mk_tyw_arrow!(src.clone(), ty);
@@ -631,7 +631,7 @@ fn type_check_(
             type_check_(state, envs.clone(), strict, t, src)
         }
         Term::Op2(op, e, t) => {
-            let ty_op = get_bop_type(state, envs.clone(), strict, op)?;
+            let ty_op = get_bop_type(state, op)?;
 
             let src1 = TypeWrapper::Ptr(new_var(state.table));
             let src2 = TypeWrapper::Ptr(new_var(state.table));
@@ -1355,12 +1355,7 @@ fn instantiate_foralls(state: &mut State, mut ty: TypeWrapper, inst: ForallInst)
 }
 
 /// Type of unary operations.
-pub fn get_uop_type(
-    state: &mut State,
-    _envs: Envs,
-    _strict: bool,
-    op: &UnaryOp,
-) -> Result<TypeWrapper, TypecheckError> {
+pub fn get_uop_type(state: &mut State, op: &UnaryOp) -> Result<TypeWrapper, TypecheckError> {
     Ok(match op {
         // forall a. bool -> a -> a -> a
         UnaryOp::Ite() => {
@@ -1469,12 +1464,7 @@ pub fn get_uop_type(
 }
 
 /// Type of a binary operation.
-pub fn get_bop_type(
-    state: &mut State,
-    envs: Envs,
-    strict: bool,
-    op: &BinaryOp<RichTerm>,
-) -> Result<TypeWrapper, TypecheckError> {
+pub fn get_bop_type(state: &mut State, op: &BinaryOp) -> Result<TypeWrapper, TypecheckError> {
     Ok(match op {
         // Num -> Num -> Num
         BinaryOp::Plus()
@@ -1510,16 +1500,14 @@ pub fn get_bop_type(
 
             mk_tyw_arrow!(AbsType::Str(), mk_typewrapper::dyn_record(res.clone()), res)
         }
-        // Str -> { _ : a } -> { _ : a }
-        // Unify t with a.
-        BinaryOp::DynExtend(t) => {
+        // forall a. Str -> { _ : a } -> a -> { _ : a }
+        BinaryOp::DynExtend() => {
             let res = TypeWrapper::Ptr(new_var(state.table));
-
-            type_check_(state, envs.clone(), strict, t, res.clone())?;
 
             mk_tyw_arrow!(
                 AbsType::Str(),
                 mk_typewrapper::dyn_record(res.clone()),
+                res.clone(),
                 mk_typewrapper::dyn_record(res)
             )
         }

--- a/src/typecheck.rs
+++ b/src/typecheck.rs
@@ -1403,7 +1403,7 @@ pub fn get_uop_type(state: &mut State, op: &UnaryOp) -> Result<TypeWrapper, Type
         // This should not happen, as Switch() is only produced during evaluation.
         UnaryOp::Switch(_) => panic!("cannot typecheck Switch()"),
         // Dyn -> Dyn
-        UnaryOp::ChangePolarity() | UnaryOp::GoDom() | UnaryOp::GoCodom() | UnaryOp::Tag(_) => {
+        UnaryOp::ChangePolarity() | UnaryOp::GoDom() | UnaryOp::GoCodom() => {
             mk_tyw_arrow!(AbsType::Dyn(), AbsType::Dyn())
         }
         // Sym -> Dyn -> Dyn
@@ -1481,6 +1481,8 @@ pub fn get_bop_type(state: &mut State, op: &BinaryOp) -> Result<TypeWrapper, Typ
             AbsType::Dyn(),
             AbsType::Dyn()
         ),
+        // Str -> Dyn -> Dyn
+        BinaryOp::Tag() => mk_tyw_arrow!(AbsType::Str(), AbsType::Dyn(), AbsType::Dyn()),
         // forall a b. a -> b -> Bool
         BinaryOp::Eq() => mk_tyw_arrow!(
             TypeWrapper::Ptr(new_var(state.table)),

--- a/stdlib/contracts.ncl
+++ b/stdlib/contracts.ncl
@@ -48,18 +48,19 @@
           let t = t -$ field in
           cont acc l t
       else
-          %blame% (%tag% "missing field" l);
+          %blame% (%tag% "missing field `#{field}`" l);
 
   forall_tail = fun sy pol acc l t =>
       let magic_fld = "_%wrapped" in
       if pol == (%polarity% l) then
           if %hasField% magic_fld t then
-              if (t -$ magic_fld) == {} then
+              let rest = (t -$ magic_fld) in
+              if rest == {} then
                   let fail = %blame% (%tag% "polymorphic tail mismatch" l) in
                   let inner = %unwrap% sy (t.$magic_fld) fail in
                   acc & inner
               else
-                  %blame% (%tag% "extra field" l)
+                  %blame% (%tag% "extra field `#{%head% (%fieldsOf% rest)}`" l)
           else
               %blame% (%tag% "missing polymorphic part" l)
       else
@@ -69,5 +70,5 @@
 
   empty_tail = fun acc l t =>
       if t == {} then acc
-      else %blame% (%tag% "extra field" l);
+      else %blame% (%tag% "extra field `#{%head% (%fieldsOf% t)}`" l);
 }


### PR DESCRIPTION
Depend on #250. Follow-up of #247, #248, #249, and #250. Last PR of this series. Use the stack to store the non-strict argument of `DynExtend`. `DynExtend` is the dynamic record extension operator, currently written as `someRecord $[foo=bar]` which extends `someRecord` with the field `field = bar` if the `foo` expression evaluates to the string `"field"`, where `bar` is said non-strict argument. This terminates the elimination of the dependency of `UnaryOp` and `BinaryOp` on `RichTerm`.