### PR TITLE
[Refactor]Caching, part 2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -497,6 +497,7 @@ dependencies = [
  "simple-counter 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "structopt 0.3.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "termimad 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1046,6 +1047,11 @@ version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "void"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "winapi"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1210,6 +1216,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum utf8-ranges 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "b4ae116fef2b7fea257ed6440d3cfcff7f190865f170cdad00bb6465bf18ecba"
 "checksum vec_map 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 "checksum version_check 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed"
+"checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 "checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
 "checksum winapi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
 "checksum winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ logos = "0.11.4"
 serde = "1.0.117"
 serde_json = "1.0.59"
 structopt = "0.3"
+void = "1"
 
 termimad = { version = "0.9.1", optional = true }
 # Use the same version as termimad

--- a/src/program.rs
+++ b/src/program.rs
@@ -74,24 +74,13 @@ impl Program {
 
     /// Load and parse the standard library in the cache.
     pub fn load_stdlib(&mut self) -> Result<Vec<FileId>, Error> {
-        let file_ids = vec![
-            self.cache.add_string(
-                OsString::from("<stdlib/contracts.ncl>"),
-                String::from(nickel_stdlib::CONTRACTS),
-            ),
-            self.cache.add_string(
-                OsString::from("<stdlib/builtins.ncl>"),
-                String::from(nickel_stdlib::BUILTINS),
-            ),
-            self.cache.add_string(
-                OsString::from("<stdlib/lists.ncl>"),
-                String::from(nickel_stdlib::LISTS),
-            ),
-            self.cache.add_string(
-                OsString::from("<stdlib/records.ncl>"),
-                String::from(nickel_stdlib::RECORDS),
-            ),
-        ];
+        let file_ids: Vec<FileId> = nickel_stdlib::modules()
+            .into_iter()
+            .map(|(name, content)| {
+                self.cache
+                    .add_string(OsString::from(name), String::from(content))
+            })
+            .collect();
 
         file_ids
             .iter()

--- a/src/stdlib.rs
+++ b/src/stdlib.rs
@@ -3,10 +3,21 @@
 use crate::term::make as mk_term;
 use crate::term::RichTerm;
 
-pub const BUILTINS: &str = include_str!("../stdlib/builtins.ncl");
-pub const CONTRACTS: &str = include_str!("../stdlib/contracts.ncl");
-pub const LISTS: &str = include_str!("../stdlib/lists.ncl");
-pub const RECORDS: &str = include_str!("../stdlib/records.ncl");
+pub const BUILTINS: (&str, &str) = (
+    "<stdlib/builtins.ncl>",
+    include_str!("../stdlib/builtins.ncl"),
+);
+pub const CONTRACTS: (&str, &str) = (
+    "<stdlib/contracts.ncl>",
+    include_str!("../stdlib/contracts.ncl"),
+);
+pub const LISTS: (&str, &str) = ("<stdlib/lists>", include_str!("../stdlib/lists.ncl"));
+pub const RECORDS: (&str, &str) = ("<stdlib/records>", include_str!("../stdlib/records.ncl"));
+
+/// Return the list `(name, source_code)` of all the stdlib modules.
+pub fn modules() -> Vec<(&'static str, &'static str)> {
+    vec![BUILTINS, CONTRACTS, LISTS, RECORDS]
+}
 
 /// Accessors to the builtin contracts.
 pub mod contracts {


### PR DESCRIPTION
Depend on #258. Required for #257. Follow-up of #258. Also move stdlib related helpers (loading, transforming and typechecking) from the program module to the cache module to make them available to the future REPL (and later, the LSP server) as well.