### PR TITLE
Basic REPL backend

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,7 @@ mod operation;
 mod parser;
 mod position;
 mod program;
+mod repl;
 mod serialize;
 mod stack;
 mod stdlib;

--- a/src/main.rs
+++ b/src/main.rs
@@ -213,7 +213,7 @@ fn query(
     }
 
     let all = !doc && !contract && !default;
-    let term = program.eval_meta(path)?;
+    let term = program.query(path)?;
 
     match term {
         Term::MetaValue(meta) => {

--- a/src/program.rs
+++ b/src/program.rs
@@ -167,7 +167,7 @@ pub fn query(
     use std::cell::RefCell;
     use std::rc::Rc;
 
-    cache.prepare(file_id, global_env);
+    cache.prepare(file_id, global_env)?;
 
     let t = if let Some(p) = path {
         // Parsing `y.path`. We `seq` it to force the evaluation of the underlying value,

--- a/src/program.rs
+++ b/src/program.rs
@@ -174,10 +174,10 @@ pub fn query(
         // which can be then showed to the user. The newline gives better messages in case of
         // errors.
         let source = format!("let x = (y.{})\n in %seq% x x", p);
-        let file_id = cache.add_tmp("<query>", source.clone());
+        let query_file_id = cache.add_tmp("<query>", source.clone());
         let new_term = parser::grammar::TermParser::new()
-            .parse(file_id, Lexer::new(&source))
-            .map_err(|err| ParseError::from_lalrpop(err, file_id))?;
+            .parse(query_file_id, Lexer::new(&source))
+            .map_err(|err| ParseError::from_lalrpop(err, query_file_id))?;
 
         // Substituting `y` for `t`
         let mut env = eval::Environment::new();

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -1,0 +1,81 @@
+//! The Nickel REPL.
+use crate::cache::Cache;
+use crate::error::{Error, EvalError, ImportError, ParseError, ToDiagnostic, TypecheckError};
+use crate::identifier::Ident;
+use crate::parser::lexer::Lexer;
+use crate::position::RawSpan;
+use crate::stdlib as nickel_stdlib;
+use crate::term::{RichTerm, Term};
+use crate::typecheck::type_check;
+use crate::types::Types;
+use crate::{eval, parser, transformations, typecheck};
+use codespan::{FileId, Files};
+use codespan_reporting::term::termcolor::{ColorChoice, StandardStream};
+use simple_counter::*;
+use std::cell::RefCell;
+use std::collections::HashMap;
+use std::ffi::OsStr;
+use std::ffi::OsString;
+use std::fs;
+use std::io::{self, Read};
+use std::path::{Path, PathBuf};
+use std::rc::Rc;
+use std::result::Result;
+
+generate_counter!(InputNameCounter, usize);
+
+/// Interface of the REPL.
+pub trait REPL {
+    fn eval(&mut self, exp: &str) -> Result<Term, Error>;
+    fn load(&mut self, path: impl AsRef<OsStr>) -> Result<Term, EvalError>;
+    fn typecheck(&mut self, exp: &str) -> Result<Types, TypecheckError>;
+    fn type_of(&mut self, exp: &str) -> Result<Types, Error>;
+    fn query(&self, exp: &str) -> Result<String, Error>;
+}
+
+/// Implementation of the REPL.
+pub struct REPLImpl {
+    cache: Cache,
+    eval_env: eval::Environment,
+    type_env: typecheck::Environment,
+}
+
+impl REPLImpl {
+    pub fn new() -> Self {
+        REPLImpl {
+            cache: Cache::new(),
+            eval_env: eval::Environment::new(),
+            type_env: typecheck::Environment::new(),
+        }
+    }
+}
+
+impl REPL for REPLImpl {
+    fn eval(&mut self, exp: &str) -> Result<Term, Error> {
+        let file_id = self.cache.add_string(
+            format!("input-{}", InputNameCounter::next()),
+            String::from(exp),
+        );
+        self.cache.prepare(file_id, &self.eval_env)?;
+        Ok(eval::eval(
+            self.cache.get_owned(file_id).expect(
+                "repl::eval(): term was prepared for evaluation but is missing from the term cache",
+            ),
+            &self.eval_env,
+            &mut self.cache,
+        )?)
+    }
+
+    fn load(&mut self, path: impl AsRef<OsStr>) -> Result<Term, EvalError> {
+        panic!("not implemented")
+    }
+    fn typecheck(&mut self, exp: &str) -> Result<Types, TypecheckError> {
+        panic!("not implemented")
+    }
+    fn type_of(&mut self, exp: &str) -> Result<Types, Error> {
+        panic!("not implemented")
+    }
+    fn query(&self, exp: &str) -> Result<String, Error> {
+        panic!("not implemented")
+    }
+}

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -1,4 +1,11 @@
 //! The Nickel REPL.
+//!
+//! A backend designates a module which actually execute a sequence of REPL commands, while being
+//! agnostic to the user interface and the presentation of the results.
+//!
+//! Dually, the frontend is the user-facing part, which may be a CLI, a web application, a
+//! jupyter-kernel (which is not exactly user-facing, but still manages input/output and
+//! formatting), etc.
 use crate::cache::Cache;
 use crate::error::{Error, EvalError, IOError};
 use crate::term::{RichTerm, Term};
@@ -11,7 +18,7 @@ use std::result::Result;
 
 generate_counter!(InputNameCounter, usize);
 
-/// Interface of the REPL.
+/// Interface of the REPL backend.
 pub trait REPL {
     /// Eval an expression.
     fn eval(&mut self, exp: &str) -> Result<Term, Error>;
@@ -23,7 +30,7 @@ pub trait REPL {
     fn query(&mut self, exp: &str, path: Option<&str>) -> Result<Term, Error>;
 }
 
-/// Implementation of the REPL.
+/// Standard implementation of the REPL backend.
 pub struct REPLImpl {
     /// The underlying cache, storing input, loaded files and parsed terms.
     cache: Cache,

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -1,13 +1,15 @@
 //! The Nickel REPL.
 use crate::cache::Cache;
-use crate::error::{Error, EvalError, ImportError, ParseError, ToDiagnostic, TypecheckError};
+use crate::error::{
+    Error, EvalError, IOError, ImportError, ParseError, ToDiagnostic, TypecheckError,
+};
 use crate::identifier::Ident;
 use crate::parser::lexer::Lexer;
 use crate::position::RawSpan;
 use crate::stdlib as nickel_stdlib;
 use crate::term::{RichTerm, Term};
 use crate::typecheck::type_check;
-use crate::types::Types;
+use crate::types::{AbsType, Types};
 use crate::{eval, parser, transformations, typecheck};
 use codespan::{FileId, Files};
 use codespan_reporting::term::termcolor::{ColorChoice, StandardStream};
@@ -27,9 +29,8 @@ generate_counter!(InputNameCounter, usize);
 /// Interface of the REPL.
 pub trait REPL {
     fn eval(&mut self, exp: &str) -> Result<Term, Error>;
-    fn load(&mut self, path: impl AsRef<OsStr>) -> Result<Term, EvalError>;
-    fn typecheck(&mut self, exp: &str) -> Result<Types, TypecheckError>;
-    fn type_of(&mut self, exp: &str) -> Result<Types, Error>;
+    fn load(&mut self, path: impl AsRef<OsStr>) -> Result<RichTerm, Error>;
+    fn typecheck(&mut self, exp: &str) -> Result<Types, Error>;
     fn query(&self, exp: &str) -> Result<String, Error>;
 }
 
@@ -41,40 +42,83 @@ pub struct REPLImpl {
 }
 
 impl REPLImpl {
-    pub fn new() -> Self {
-        REPLImpl {
-            cache: Cache::new(),
-            eval_env: eval::Environment::new(),
-            type_env: typecheck::Environment::new(),
-        }
+    /// Create a new REPL with the stdlib processed, loaded in the environment, and the
+    /// corresponding typing environment.
+    pub fn new() -> Result<Self, Error> {
+        let mut cache = Cache::new();
+        cache.prepare_stdlib()?;
+
+        let eval_env = cache.mk_global_env().unwrap();
+        let type_env = typecheck::Envs::mk_global(&eval_env);
+
+        Ok(REPLImpl {
+            cache,
+            eval_env,
+            type_env,
+        })
     }
 }
 
 impl REPL for REPLImpl {
     fn eval(&mut self, exp: &str) -> Result<Term, Error> {
         let file_id = self.cache.add_string(
-            format!("input-{}", InputNameCounter::next()),
+            format!("repl-input-{}", InputNameCounter::next()),
             String::from(exp),
         );
         self.cache.prepare(file_id, &self.eval_env)?;
         Ok(eval::eval(
             self.cache.get_owned(file_id).expect(
-                "repl::eval(): term was prepared for evaluation but is missing from the term cache",
+                "repl::eval(): term was prepared for evaluation but it is missing from the term cache",
             ),
             &self.eval_env,
             &mut self.cache,
         )?)
     }
 
-    fn load(&mut self, path: impl AsRef<OsStr>) -> Result<Term, EvalError> {
-        panic!("not implemented")
+    fn load(&mut self, path: impl AsRef<OsStr>) -> Result<RichTerm, Error> {
+        let file_id = self
+            .cache
+            .add_file(OsString::from(path.as_ref()))
+            .map_err(IOError::from)?;
+        self.cache.parse(file_id)?;
+        let RichTerm { term, pos } = self.cache.get_ref(file_id).unwrap();
+
+        // Check that the entry is a record, otherwise transform_inner panics
+        match term.as_ref() {
+            Term::Record(_) | Term::RecRecord(_) => (),
+            _ => {
+                return Err(Error::EvalError(EvalError::Other(
+                    String::from("load: expected a record"),
+                    pos.clone(),
+                )))
+            }
+        };
+        self.cache.transform_inner(file_id).map_err(|err| {
+            err.unwrap_error("load(): expected term to be parsed before transformation")
+        })?;
+        eval::env_add_term(&mut self.eval_env, self.cache.get_owned(file_id).unwrap()).unwrap();
+        //TODO: typecheck::env_add_term(..)
+        Ok(self.cache.get_owned(file_id).unwrap())
     }
-    fn typecheck(&mut self, exp: &str) -> Result<Types, TypecheckError> {
-        panic!("not implemented")
+
+    fn typecheck(&mut self, exp: &str) -> Result<Types, Error> {
+        let file_id = self.cache.add_string(
+            format!("repl-input-{}", InputNameCounter::next()),
+            String::from(exp),
+        );
+
+        self.cache.parse(file_id)?;
+        self.cache
+            .typecheck_in_env(file_id, &self.type_env)
+            .map_err(|cache_err| {
+                cache_err.unwrap_error("repl: expected source to be parsed before typechecking")
+            })?;
+        Ok(
+            typecheck::apparent_type(self.cache.get_ref(file_id).unwrap().as_ref())
+                .unwrap_or(Types(AbsType::Dyn())),
+        )
     }
-    fn type_of(&mut self, exp: &str) -> Result<Types, Error> {
-        panic!("not implemented")
-    }
+
     fn query(&self, exp: &str) -> Result<String, Error> {
         panic!("not implemented")
     }


### PR DESCRIPTION
Depend on #259. Partly address #257. Implement a simple REPL backend, that is a module capable of executing a sequence of basic commands (load, eval, query, typecheck) while maintaining an eval environment and a typing environment.

This doesn't implement a user-facing interface yet. More thorough testing is postponed to the end of this REPL PR series.