### PR TITLE
Native REPL frontend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,6 +25,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "ansi_term"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "ascii-canvas"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -526,6 +534,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "nickel"
 version = "0.1.0"
 dependencies = [
+ "ansi_term 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "codespan 0.9.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "codespan-reporting 0.9.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "either 1.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -540,7 +549,6 @@ dependencies = [
  "serde_json 1.0.59 (registry+https://github.com/rust-lang/crates.io-index)",
  "simple-counter 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "structopt 0.3.20 (registry+https://github.com/rust-lang/crates.io-index)",
- "termcolor 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "termimad 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1195,6 +1203,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum aho-corasick 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)" = "81ce3d38065e618af2d7b77e10c5ad9a069859b4be3c2250f674af3840d9c8a5"
 "checksum aho-corasick 0.7.15 (registry+https://github.com/rust-lang/crates.io-index)" = "7404febffaa47dac81aa44dba71523c9d069b1bdc50a77db41195149e17f68e5"
 "checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
+"checksum ansi_term 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
 "checksum ascii-canvas 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b385d69402821a1c254533a011a312531cbcc0e3e24f19bbb4747a5a2daf37e2"
 "checksum atty 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)" = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 "checksum autocfg 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "1d49d90015b3c36167a20fe2810c5cd875ad504b39cff3d4eae7977e6b7c1cb2"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -540,6 +540,7 @@ dependencies = [
  "serde_json 1.0.59 (registry+https://github.com/rust-lang/crates.io-index)",
  "simple-counter 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "structopt 0.3.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "termcolor 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "termimad 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -105,6 +105,11 @@ version = "1.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "cc"
+version = "1.0.66"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "cfg-if"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -261,6 +266,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs-next"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "dirs-sys-next 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "dirs-sys-next"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.80 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_users 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "docopt"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -300,6 +324,15 @@ version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.80 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "fuchsia-cprng"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -310,6 +343,16 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "typenum 1.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.80 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasi 0.10.1+wasi-snapshot-preview1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -492,12 +535,24 @@ dependencies = [
  "minimad 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "pretty_assertions 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustyline 7.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.117 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.59 (registry+https://github.com/rust-lang/crates.io-index)",
  "simple-counter 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "structopt 0.3.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "termimad 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "nix"
+version = "0.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.66 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.80 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -728,6 +783,23 @@ version = "0.1.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "redox_syscall"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "getrandom 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "regex"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -762,6 +834,26 @@ dependencies = [
 name = "regex-syntax"
 version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "rustyline"
+version = "7.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "dirs-next 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fs2 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.80 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 2.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "nix 0.19.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "scopeguard 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-segmentation 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-width 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "utf8parse 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "ryu"
@@ -1037,6 +1129,11 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "utf8parse"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "vec_map"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1049,6 +1146,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "void"
 version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "wasi"
+version = "0.10.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -1104,6 +1206,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum block-padding 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "fa79dedbb091f449f1f39e53edf88d5dbe95f895dae6135a8d7b881fb5af73f5"
 "checksum byte-tools 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 "checksum byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
+"checksum cc 1.0.66 (registry+https://github.com/rust-lang/crates.io-index)" = "4c0496836a84f8d0495758516b8621a622beb77c0fed418570e50764093ced48"
 "checksum cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 "checksum cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 "checksum clap 2.33.3 (registry+https://github.com/rust-lang/crates.io-index)" = "37e58ac78573c40708d45522f0d80fa2f01cc4f9b4e2bf749807255454312002"
@@ -1121,14 +1224,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum diff 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "0e25ea47919b1560c4e3b7fe0aaab9becf5b84a10325ddf7db0f0ba5e1026499"
 "checksum difference 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198"
 "checksum digest 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
+"checksum dirs-next 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
+"checksum dirs-sys-next 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
 "checksum docopt 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7f525a586d310c87df72ebcd98009e57f1cc030c8c268305287a476beb653969"
 "checksum either 1.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 "checksum ena 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f56c93cc076508c549d9bb747f79aa9b4eb098be7b8cad8830c3137ef52d1e00"
 "checksum fake-simd 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
 "checksum fixedbitset 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "86d4de0081402f5e88cdac65c8dcdcc73118c1a7a465e2a05f0da05843a8ea33"
 "checksum fnv 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)" = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+"checksum fs2 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
 "checksum fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 "checksum generic-array 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c68f0274ae0e023facc3c97b2e00f076be70e254bc851d972503b328db79b2ec"
+"checksum getrandom 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4060f4657be78b8e766215b02b18a2e862d83745545de804638e2b545e81aee6"
 "checksum heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
 "checksum hermit-abi 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)" = "5aca5565f760fb5b220e499d72710ed156fdb74e631659e99377d9ebfbd13ae8"
 "checksum itertools 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f56a2d0bc861f9165be4eb3442afd3c236d8a98afd426f65d92324ae1091a484"
@@ -1149,6 +1256,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum mio 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)" = "f33bc887064ef1fd66020c9adfc45bb9f33d75a42096c81e7c56c65b75dd1a8b"
 "checksum miow 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "5a33c1b55807fbed163481b5ba66db4b2fa6cde694a5027be10fb724206c5897"
 "checksum new_debug_unreachable 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "e4a24736216ec316047a1fc4252e27dabb04218aa4a3f37c6e7ddbf1f9782b54"
+"checksum nix 0.19.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b2ccba0cfe4fdf15982d1674c69b1fd80bad427d293849982668dfe454bd61f2"
 "checksum ntapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "3f6bb902e437b6d86e03cce10a7e2af662292c5dfef23b65899ea3ac9354ad44"
 "checksum opaque-debug 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
 "checksum ordermap 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "a86ed3f5f244b372d6b1a00b72ef7f8876d0bc6a78a4c9985c53614041512063"
@@ -1175,10 +1283,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum rand_xorshift 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cbf7e9e623549b0e21f6e97cf8ecf247c1a8fd2e8a992ae265314300b2455d5c"
 "checksum rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
 "checksum redox_syscall 0.1.57 (registry+https://github.com/rust-lang/crates.io-index)" = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
+"checksum redox_syscall 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "05ec8ca9416c5ea37062b502703cd7fcb207736bc294f6e0cf367ac6fc234570"
+"checksum redox_users 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "528532f3d801c87aec9def2add9ca802fe569e44a544afe633765267840abe64"
 "checksum regex 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "9329abc99e39129fcceabd24cf5d85b4671ef7c29c50e972bc5afe32438ec384"
 "checksum regex 1.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "38cf2c13ed4745de91a5eb834e11c00bcc3709e773173b2ce4c56c9fbde04b9c"
 "checksum regex-syntax 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)" = "7d707a4fa2637f2dca2ef9fd02225ec7661fe01a53623c1e6515b6916511f7a7"
 "checksum regex-syntax 0.6.21 (registry+https://github.com/rust-lang/crates.io-index)" = "3b181ba2dcf07aaccad5448e8ead58db5b742cf85dfe035e2227f137a539a189"
+"checksum rustyline 7.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8227301bfc717136f0ecbd3d064ba8199e44497a0bdd46bb01ede4387cfd2cec"
 "checksum ryu 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
 "checksum scopeguard 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 "checksum serde 1.0.117 (registry+https://github.com/rust-lang/crates.io-index)" = "b88fa983de7720629c9387e9f517353ed404164b1e482c970a90c1a4aaf7dc1a"
@@ -1214,9 +1325,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 "checksum unicode-xid 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
 "checksum utf8-ranges 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "b4ae116fef2b7fea257ed6440d3cfcff7f190865f170cdad00bb6465bf18ecba"
+"checksum utf8parse 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "936e4b492acfd135421d8dca4b1aa80a7bfc26e702ef3af710e0752684df5372"
 "checksum vec_map 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 "checksum version_check 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed"
 "checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
+"checksum wasi 0.10.1+wasi-snapshot-preview1 (registry+https://github.com/rust-lang/crates.io-index)" = "93c6c3420963c5c64bca373b25e77acb562081b9bb4dd5bb864187742186cea9"
 "checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
 "checksum winapi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
 "checksum winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,10 +8,10 @@ description = "Programmable configuration files."
 edition = "2018"
 
 [features]
-default = ["markdown"]
+default = ["markdown", "repl"]
 # markdown = ["termimad", "minimad", "lazy_static", "crossterm"]
 markdown = ["termimad", "minimad"]
-repl-native = ["rustyline"]
+repl = ["rustyline"]
 
 [build-dependencies] # <-- We added this and everything after!
 lalrpop = "0.16.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ edition = "2018"
 default = ["markdown"]
 # markdown = ["termimad", "minimad", "lazy_static", "crossterm"]
 markdown = ["termimad", "minimad"]
+repl-native = ["rustyline"]
 
 [build-dependencies] # <-- We added this and everything after!
 lalrpop = "0.16.2"
@@ -33,6 +34,8 @@ termimad = { version = "0.9.1", optional = true }
 minimad = { version = "0.6.7", optional = true }
 # lazy_static = { version = "1.4", optional = true }
 # crossterm = { version = "0.17.7", optional = true }
+
+rustyline = {version = "7.1.0", optional = true}
 
 [dev-dependencies]
 pretty_assertions = "0.5.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 default = ["markdown", "repl"]
 # markdown = ["termimad", "minimad", "lazy_static", "crossterm"]
 markdown = ["termimad", "minimad"]
-repl = ["rustyline", "termcolor"]
+repl = ["rustyline", "ansi_term"]
 
 [build-dependencies]
 lalrpop = "0.16.2"
@@ -33,8 +33,7 @@ termimad = { version = "0.9.1", optional = true }
 # Use the same version as termimad
 minimad = { version = "0.6.7", optional = true }
 
-# Use the same version as codespan-reporting
-termcolor = { version = "^1", optional = true }
+ansi_term = { version = "0.12", optional = true }
 
 rustyline = {version = "7.1.0", optional = true}
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,9 +11,9 @@ edition = "2018"
 default = ["markdown", "repl"]
 # markdown = ["termimad", "minimad", "lazy_static", "crossterm"]
 markdown = ["termimad", "minimad"]
-repl = ["rustyline"]
+repl = ["rustyline", "termcolor"]
 
-[build-dependencies] # <-- We added this and everything after!
+[build-dependencies]
 lalrpop = "0.16.2"
 
 [dependencies]
@@ -32,8 +32,9 @@ void = "1"
 termimad = { version = "0.9.1", optional = true }
 # Use the same version as termimad
 minimad = { version = "0.6.7", optional = true }
-# lazy_static = { version = "1.4", optional = true }
-# crossterm = { version = "0.17.7", optional = true }
+
+# Use the same version as codespan-reporting
+termcolor = { version = "^1", optional = true }
 
 rustyline = {version = "7.1.0", optional = true}
 

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -226,8 +226,9 @@ impl Cache {
         id
     }
 
-    /// Load a temporary source. If a source with the same name exists, this updates destructively
-    /// not only the name-id table entry, but also the content of the source itself.
+    /// Load a temporary source. If a source with the same name exists, clear the corresponding
+    /// term cache entry, and destructively update not only the name-id table entry, but also the
+    /// content of the source itself.
     ///
     /// Used to store intermediate short-lived generated snippets that needs to have a
     /// corresponding `FileId`, such as when querying or reporting errors.
@@ -235,6 +236,7 @@ impl Cache {
         let source_name = source_name.into();
         if let Some(file_id) = self.id_of(&source_name) {
             self.files.update(file_id, s);
+            self.terms.remove(&file_id);
             file_id
         } else {
             let file_id = self.files.add(source_name.clone(), s);

--- a/src/error.rs
+++ b/src/error.rs
@@ -1233,7 +1233,7 @@ impl ToDiagnostic<FileId> for REPLError {
             REPLError::UnknownCommand(s) => vec![Diagnostic::error()
                 .with_message(format!("unkown command `{}`", s))
                 .with_notes(vec![String::from(
-                    "Type :? or :help for a list of available commands.",
+                    "type `:?` or `:help` for a list of available commands.",
                 )])],
             REPLError::MissingArg { cmd, msg_opt } => {
                 let mut notes = msg_opt

--- a/src/error.rs
+++ b/src/error.rs
@@ -4,13 +4,13 @@
 //! [codespan](https://crates.io/crates/codespan-reporting) diagnostic from them.
 use crate::eval::{CallStack, StackElem};
 use crate::identifier::Ident;
-use crate::label;
 use crate::label::ty_path;
 use crate::parser::lexer::LexicalError;
 use crate::parser::utils::mk_span;
 use crate::position::RawSpan;
 use crate::term::RichTerm;
 use crate::types::Types;
+use crate::{label, repl};
 use codespan::{FileId, Files};
 use codespan_reporting::diagnostic::{Diagnostic, Label, LabelStyle};
 use std::fmt::Write;
@@ -228,7 +228,7 @@ pub struct IOError(pub String);
 pub enum REPLError {
     UnknownCommand(String),
     MissingArg {
-        cmd: String,
+        cmd: repl::command::CommandType,
         msg_opt: Option<String>,
     },
 }
@@ -1231,7 +1231,7 @@ impl ToDiagnostic<FileId> for REPLError {
     ) -> Vec<Diagnostic<FileId>> {
         match self {
             REPLError::UnknownCommand(s) => vec![Diagnostic::error()
-                .with_message(format!("unkown command {}", s))
+                .with_message(format!("unkown command `{}`", s))
                 .with_notes(vec![String::from(
                     "Type :? or :help for a list of available commands.",
                 )])],

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,10 +19,9 @@ mod typecheck;
 mod types;
 
 use crate::error::{Error, IOError, SerializationError};
-use crate::label::Label;
 use crate::program::Program;
 use crate::repl::rustyline_frontend;
-use crate::term::{MergePriority, MetaValue, RichTerm, Term};
+use crate::term::{RichTerm, Term};
 use std::io::Write;
 use std::path::PathBuf;
 use std::str::FromStr;

--- a/src/main.rs
+++ b/src/main.rs
@@ -100,6 +100,7 @@ enum Command {
         #[structopt(parse(from_os_str))]
         output: Option<PathBuf>,
     },
+    /// Print the metadata attached to an attribute, given as a path
     Query {
         path: Option<String>,
         #[structopt(long)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -120,7 +120,9 @@ fn main() {
 
     if let Some(Command::REPL) = opts.command {
         #[cfg(feature = "repl")]
-        rustyline_frontend::repl();
+        if let Err(_) = rustyline_frontend::repl() {
+            process::exit(1);
+        }
 
         #[cfg(not(feature = "repl"))]
         eprintln!("error: this executable was not compiled with REPL support");

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -234,6 +234,10 @@ pub mod rustyline_frontend {
                             print_help(&arg);
                             Ok(())
                         }
+                        "exit" => {
+                            println!("{}", Style::new().bold().paint("Exiting"));
+                            return Ok(());
+                        }
                         cmd => Err(Error::REPLError(REPLError::UnknownCommand(String::from(
                             cmd,
                         )))),
@@ -264,8 +268,34 @@ pub mod rustyline_frontend {
         }
     }
 
-    fn print_help(_arg: &str) {
-        println!("Available commands: ? help query load typecheck");
+    fn print_help(arg: &str) {
+        match arg.trim() {
+            "help" => {
+                println!(":help [command]");
+                println!("Prints a list of available commands or the help of the given command");
+            }
+            "query" => {
+                println!(":query <expression>");
+                println!("Print the metadata attached to an attribute");
+            }
+            "load" => {
+                println!(":load <file>");
+                print!("Evaluate the content of <file> to a record and load its attributes in the environment.");
+                println!(" Fail if the content of <file> doesn't evaluate to a record");
+            }
+            "typecheck" => {
+                println!(":typecheck <expression>");
+                println!("Typecheck the given expression and print its top-level type");
+            }
+            "exit" => {
+                println!(":exit");
+                println!("Exit the REPL session");
+            }
+            "" => println!("Available commands: ? help query load typecheck"),
+            _ => (),
+        };
+
+        println!();
     }
 }
 

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -27,7 +27,7 @@ pub trait REPL {
     /// Typecheck an expression and return the apparent type.
     fn typecheck(&mut self, exp: &str) -> Result<Types, Error>;
     /// Query the metadata of an expression.
-    fn query(&mut self, exp: &str, path: Option<&str>) -> Result<Term, Error>;
+    fn query(&mut self, exp: &str) -> Result<Term, Error>;
     /// Required for error reporting on the frontend.
     fn cache_mut<'a>(&'a mut self) -> &'a mut Cache;
 }
@@ -128,16 +128,11 @@ impl REPL for REPLImpl {
         )
     }
 
-    fn query(&mut self, exp: &str, path: Option<&str>) -> Result<Term, Error> {
+    fn query(&mut self, exp: &str) -> Result<Term, Error> {
         use crate::program;
 
         let file_id = self.cache.add_tmp("<repl-query>", String::from(exp));
-        program::query(
-            &mut self.cache,
-            file_id,
-            &self.eval_env,
-            path.map(String::from),
-        )
+        program::query(&mut self.cache, file_id, &self.eval_env, None)
     }
 
     fn cache_mut<'a>(&'a mut self) -> &'a mut Cache {
@@ -173,8 +168,6 @@ pub mod rustyline_frontend {
     }
 
     pub fn repl() -> Result<(), InitError> {
-        use crate::program::{MetavalueQuery, ParseQueryError};
-
         let mut repl = REPLImpl::new();
         match repl.load_stdlib() {
             Ok(()) => (),
@@ -203,18 +196,9 @@ pub mod rustyline_frontend {
                             _ => (),
                         }),
                         "typecheck" => repl.typecheck(&arg).map(|types| println!("Ok: {}", types)),
-                        "query" => {
-                            let mut chars = arg.chars();
-                            match MetavalueQuery::from_iter(&mut chars) {
-                                Ok(query) => program::query(&mut cache, panic!(), panic!(), query),
-                                Err(ParseQueryError::UnexpectedToken(c)) => (),
-                                Err(ParseQueryError::UnterminatedString) => (),
-                                Err(ParseQueryError::ExpectedSep(char)) => (),
-                                Err(ParseQueryError::EmptyIdentifier) => (),
-                            }
-
-                            Ok(())
-                        }
+                        "query" => repl.query(&arg).map(|t| {
+                            query_print::print_query_result(&t, query_print::Attributes::default())
+                        }),
                         "?" | "help" => {
                             print_help(&arg);
                             Ok(())
@@ -226,13 +210,13 @@ pub mod rustyline_frontend {
                     };
 
                     if let Err(err) = result {
-                        report(repl.cache_mut(), err);
+                        program::report(repl.cache_mut(), err);
                     }
                 }
                 Ok(line) => {
                     match repl.eval(&line) {
                         Ok(t) => println!("{}\n", t.shallow_repr()),
-                        Err(err) => report(repl.cache_mut(), err),
+                        Err(err) => program::report(repl.cache_mut(), err),
                     };
                 }
                 Err(ReadlineError::Interrupted) => {
@@ -241,7 +225,7 @@ pub mod rustyline_frontend {
                 }
                 Err(ReadlineError::Eof) => (),
                 Err(err) => {
-                    report(
+                    program::report(
                         repl.cache_mut(),
                         Error::IOError(IOError(format!("{}", err))),
                     );
@@ -252,5 +236,221 @@ pub mod rustyline_frontend {
 
     fn print_help(_arg: &str) {
         println!("Available commands: ? help query load typecheck");
+    }
+}
+
+pub mod query_print {
+    use crate::identifier::Ident;
+    use crate::label::Label;
+    use crate::term::{MergePriority, MetaValue, Term};
+
+    pub trait QueryPrinter {
+        fn print_metadata(&self, attr: &str, value: &str);
+        fn print_doc(&self, content: &str);
+        /// Print the list of fields of a record.
+        fn print_fields<'a, I>(&self, fields: I)
+        where
+            I: Iterator<Item = &'a Ident>;
+    }
+
+    #[cfg(feature = "markdown")]
+    pub struct MarkdownRenderer {
+        skin: termimad::MadSkin,
+    }
+
+    pub struct SimpleRenderer {}
+
+    /// Helper to render the result of the `query` sub-command with markdown support.
+    impl QueryPrinter for SimpleRenderer {
+        fn print_metadata(&self, attr: &str, value: &str) {
+            println!("* {}: {}", attr, value);
+        }
+
+        fn print_doc(&self, content: &str) {
+            if content.find("\n").is_none() {
+                self.print_metadata("documentation", &content);
+            } else {
+                println!("* documentation\n");
+                println!("{}", content);
+            }
+        }
+
+        fn print_fields<'a, I>(&self, fields: I)
+        where
+            I: Iterator<Item = &'a Ident>,
+        {
+            println!("Available fields:");
+
+            for field in fields {
+                println!(" - {}", field);
+            }
+        }
+    }
+
+    #[cfg(feature = "markdown")]
+    impl MarkdownRenderer {
+        pub fn new() -> Self {
+            MarkdownRenderer {
+                skin: termimad::MadSkin::default(),
+            }
+        }
+    }
+
+    /// Helper to render the result of the `query` sub-command with markdown support.
+    #[cfg(feature = "markdown")]
+    impl QueryPrinter for MarkdownRenderer {
+        fn print_metadata(&self, attr: &str, value: &str) {
+            use minimad::*;
+            use termimad::*;
+
+            let mut expander = OwningTemplateExpander::new();
+            let template = TextTemplate::from("* **${attr}**: *${value}*");
+
+            expander.set("attr", attr);
+            expander.set("value", value);
+            let text = expander.expand(&template);
+            let (width, _) = terminal_size();
+            let fmt_text = FmtText::from_text(&self.skin, text, Some(width as usize));
+            print!("{}", fmt_text);
+        }
+
+        fn print_doc(&self, content: &str) {
+            if content.find("\n").is_none() {
+                self.skin
+                    .print_text(&format!("* **documentation**: {}", content));
+            } else {
+                self.skin.print_text("* **documentation**\n\n");
+                self.skin.print_text(content);
+            }
+        }
+
+        fn print_fields<'a, I>(&self, fields: I)
+        where
+            I: Iterator<Item = &'a Ident>,
+        {
+            use minimad::*;
+            use termimad::*;
+
+            let (width, _) = terminal_size();
+            let mut expander = OwningTemplateExpander::new();
+            let template = TextTemplate::from("* ${field}");
+
+            self.skin.print_text("## Available fields");
+
+            for field in fields {
+                expander.set("field", field.to_string());
+                let text = expander.expand(&template);
+                let fmt_text = FmtText::from_text(&self.skin, text, Some(width as usize));
+                print!("{}", fmt_text);
+            }
+        }
+    }
+
+    /// Which attributes are requested.
+    #[derive(Clone, Copy, Eq, PartialEq)]
+    pub struct Attributes {
+        pub doc: bool,
+        pub contract: bool,
+        pub default: bool,
+        pub value: bool,
+    }
+
+    impl Default for Attributes {
+        fn default() -> Self {
+            Attributes {
+                doc: true,
+                contract: true,
+                default: true,
+                value: true,
+            }
+        }
+    }
+
+    pub fn print_query_result(term: &Term, selected_attrs: Attributes) {
+        #[cfg(feature = "markdown")]
+        let renderer = MarkdownRenderer::new();
+
+        #[cfg(not(feature = "markdown"))]
+        let renderer = SimpleRenderer {};
+
+        print_query_result_(term, selected_attrs, &renderer)
+    }
+
+    pub fn print_query_result_<R: QueryPrinter>(
+        term: &Term,
+        selected_attrs: Attributes,
+        renderer: &R,
+    ) {
+        // Print a list the fields of a term if it is a record, or do nothing otherwise.
+        fn print_fields<R: QueryPrinter>(renderer: &R, t: &Term) {
+            println!();
+            match t {
+                Term::Record(map) | Term::RecRecord(map) if !map.is_empty() => {
+                    let mut fields: Vec<_> = map.keys().collect();
+                    fields.sort();
+                    renderer.print_fields(fields.into_iter());
+                }
+                Term::Record(_) | Term::RecRecord(_) => renderer.print_metadata("value", "{}"),
+                _ => (),
+            }
+        }
+
+        match term {
+            Term::MetaValue(meta) => {
+                let mut found = false;
+                match &meta.contract {
+                    Some((_, Label { types, .. })) if selected_attrs.contract => {
+                        renderer.print_metadata("contract", &format!("{}", types));
+                        found = true;
+                    }
+                    _ => (),
+                }
+
+                match &meta {
+                    MetaValue {
+                        priority: MergePriority::Default,
+                        value: Some(t),
+                        ..
+                    } if selected_attrs.default => {
+                        renderer.print_metadata("default", &t.as_ref().shallow_repr());
+                        found = true;
+                    }
+                    MetaValue {
+                        priority: MergePriority::Normal,
+                        value: Some(t),
+                        ..
+                    } if selected_attrs.value => {
+                        renderer.print_metadata("value", &t.as_ref().shallow_repr());
+                        found = true;
+                    }
+                    _ => (),
+                }
+
+                match meta.doc {
+                    Some(ref s) if selected_attrs.doc => {
+                        renderer.print_doc(s);
+                        found = true;
+                    }
+                    _ => (),
+                }
+
+                if !found {
+                    println!("Requested metadata were not found for this value.");
+                    meta.value
+                        .iter()
+                        .for_each(|rt| print_fields(renderer, rt.as_ref()));
+                }
+            }
+            t @ Term::Record(_) | t @ Term::RecRecord(_) => {
+                println!("No metadata found for this value.");
+                print_fields(renderer, &t)
+            }
+            t => {
+                println!("No metadata found for this value.\n");
+                if selected_attrs.value {
+                    renderer.print_metadata("value", &t.shallow_repr());
+                }
+            }
+        }
     }
 }

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -166,7 +166,7 @@ pub mod rustyline_frontend {
     pub fn config() -> Config {
         Config::builder()
             .history_ignore_space(true)
-            .edit_mode(EditMode::Emacs)
+            .edit_mode(EditMode::Vi)
             .output_stream(OutputStreamType::Stdout)
             .build()
     }
@@ -242,6 +242,6 @@ pub mod rustyline_frontend {
     }
 
     fn help() {
-        println!("Not implemented");
+        println!("Available commands: ? help query load typecheck");
     }
 }

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -297,7 +297,7 @@ pub mod rustyline_frontend {
     pub fn config() -> Config {
         Config::builder()
             .history_ignore_space(true)
-            .edit_mode(EditMode::Vi)
+            .edit_mode(EditMode::Emacs)
             .output_stream(OutputStreamType::Stdout)
             .build()
     }


### PR DESCRIPTION
Depend on #260. Partly address #257. Implement a basic CLI REPL using [rustyline](https://github.com/kkawakam/rustyline):

Support the following commands:
- `load`: as in Nix, open a file, expect a record, and add the content to the current environment
- `query`, `typecheck` and  `help`:  counterparts of the corresponding subcommands of the main executable. Typecheck also shows the deduced type.
- `exit`

Inherit rustyline's [features](https://github.com/kkawakam/rustyline#actions): history with search supported and standard emacs binding for edition in particular.

**immediate next steps**
- top-level let-bindings: allow the user to add new bindings to the current environment using the syntax `let foo = bar` (a `let` without the `in`)
- multiline edition: currently, hitting enter ends the input, even if non terminated, making typing anything else than a one-liner painful.

**next steps**
- basic completion
- basic syntax highlighting
- polish the UX and the interface, have a consistent style across errors and commands output.

Screenshot:

![repl-first](https://user-images.githubusercontent.com/6530104/104758623-fd1cd680-575e-11eb-8840-481a4afeacc9.png)

