### PR TITLE
Pipe syntax for metavalues

### DIFF
--- a/src/grammar.lalrpop
+++ b/src/grammar.lalrpop
@@ -4,10 +4,12 @@ use crate::term::{BinaryOp, RichTerm, Term, UnaryOp, StrChunk, MetaValue,
 use crate::term::make as mk_term;
 use crate::mk_app;
 use crate::types::{Types, AbsType};
-use super::utils::{StringKind, mk_span, mk_label, strip_indent, SwitchCase};
+use super::utils::{StringKind, mk_span, mk_label, strip_indent, SwitchCase,
+    strip_indent_doc};
 use std::ffi::OsString;
 use super::lexer::{Token, NormalToken, StringToken, MultiStringToken, LexicalError};
 use std::collections::HashMap;
+use std::cmp::min;
 use either::*;
 use codespan::FileId;
 
@@ -23,6 +25,39 @@ SpTerm<Rule>: RichTerm =
 
 TypeAnnot: (usize, Types, usize) = ":" <l: @L> <ty: Types> <r: @R> => (l, ty, r);
 
+MetaAnnotAtom: MetaValue = {
+    "|" <l: @L> <ty: Types> <r: @R> => MetaValue {
+        doc: None,
+        contract: Some((ty.clone(), mk_label(ty, src_id, l, r))),
+        priority: Default::default(),
+        value: None,
+    },
+    "|" "default" => MetaValue {
+        doc: None,
+        contract: None,
+        priority: MergePriority::Default,
+        value: None,
+    },
+    "|" "doc" <s: Str> => MetaValue {
+        doc: Some(strip_indent_doc(s)),
+        contract: None,
+        priority: Default::default(),
+        value: None,
+    },
+};
+
+MetaAnnot: MetaValue =
+    <anns: MetaAnnotAtom+> => {
+        anns.into_iter().fold(MetaValue::new(), |acc, meta| {
+            MetaValue {
+                doc: meta.doc.or(acc.doc),
+                contract: meta.contract.or(acc.contract),
+                priority: min(acc.priority, meta.priority),
+                value: meta.value.or(acc.value),
+            }
+        })
+    };
+
 LeftOp<Op, Current, Previous>: RichTerm =
     <t1: Current> <op: Op> <t2: Previous> => mk_term::op2(op, t1,
     t2);
@@ -33,12 +68,24 @@ LeftOpLazy<Op, Current, Previous>: RichTerm =
 pub Term: RichTerm = {
     SpTerm<RichTerm>,
     SpTerm<TypedTerm>,
+    SpTerm<MetaTerm>,
 };
 
 TypedTerm: RichTerm = {
     <t: SpTerm<RichTerm>> <ann: TypeAnnot> => {
         let (l, ty, r) = ann;
         RichTerm::from(Term::Promise(ty.clone(), mk_label(ty, src_id, l, r), t))
+    }
+};
+
+MetaTerm: RichTerm = {
+    <t: SpTerm<RichTerm>> <meta: MetaAnnot> => {
+        let pos = t.pos.clone();
+        //TODO: bump LALRPOP version to >= 0.18.0 which allows mutable x in
+        //actions and remove this
+        let mut meta = meta;
+        meta.value = Some(t);
+        RichTerm::new(Term::MetaValue(meta), pos)
     }
 };
 
@@ -60,6 +107,13 @@ RichTerm: RichTerm = {
         };
 
         mk_term::let_in(id, t1, t2)
+    },
+    "let" <id:Ident> <meta: MetaAnnot> "=" <t1: Term> "in" <t2:SpTerm<RichTerm>> => {
+        //TODO: bump LALRPOP version to >= 0.18.0 which allows mutable x in
+        //actions and remove this
+        let mut meta = meta;
+        meta.value = Some(t1);
+        mk_term::let_in(id, Term::MetaValue(meta), t2)
     },
     "switch" "{" <cases: (switch_case ",")*> <last: switch_case?> "}" <exp: SpTerm<RichTerm>> => {
         let mut acc = HashMap::with_capacity(cases.len());
@@ -579,7 +633,6 @@ extern {
         "Contract(" => Token::Normal(NormalToken::Contract),
         "ContractDefault(" => Token::Normal(NormalToken::ContractDeflt),
         "Docstring(" => Token::Normal(NormalToken::Docstring),
-
         "isNum" => Token::Normal(NormalToken::IsNum),
         "isBool" => Token::Normal(NormalToken::IsBool),
         "isStr" => Token::Normal(NormalToken::IsStr),
@@ -606,6 +659,9 @@ extern {
         "hasField" => Token::Normal(NormalToken::HasField),
         "map" => Token::Normal(NormalToken::Map),
         "elemAt" => Token::Normal(NormalToken::ElemAt),
+        "merge" => Token::Normal(NormalToken::Merge),
+        "default" => Token::Normal(NormalToken::Default),
+        "doc" => Token::Normal(NormalToken::Doc),
 
         "{" => Token::Normal(NormalToken::LBrace),
         "}" => Token::Normal(NormalToken::RBrace),

--- a/src/parser/lexer.rs
+++ b/src/parser/lexer.rs
@@ -209,6 +209,12 @@ pub enum NormalToken<'input> {
     Map,
     #[token("%elemAt%")]
     ElemAt,
+    #[token("merge")]
+    Merge,
+    #[token("default")]
+    Default,
+    #[token("doc")]
+    Doc,
 
     #[token("{")]
     LBrace,

--- a/src/parser/utils.rs
+++ b/src/parser/utils.rs
@@ -249,3 +249,17 @@ pub fn strip_indent(mut chunks: Vec<StrChunk<RichTerm>>) -> Vec<StrChunk<RichTer
 
     chunks
 }
+
+/// Strip the indentation of a documentation metavalue. Wrap it as a literal string chunk and call
+/// [`strip_indent`](./fn.strip_indent.html).
+pub fn strip_indent_doc(doc: String) -> String {
+    let chunk = vec![StrChunk::Literal(doc)];
+    strip_indent(chunk)
+        .into_iter()
+        .map(|chunk| match chunk {
+            StrChunk::Literal(s) => s,
+            _ => panic!("expected literal string after indentation of documentation"),
+        })
+        .next()
+        .expect("expected non-empty chunks after indentation of documentation")
+}

--- a/src/term.rs
+++ b/src/term.rs
@@ -175,6 +175,18 @@ impl From<RichTerm> for MetaValue {
         }
     }
 }
+
+impl MetaValue {
+    pub fn new() -> Self {
+        MetaValue {
+            doc: None,
+            contract: None,
+            priority: Default::default(),
+            value: None,
+        }
+    }
+}
+
 /// A chunk of a string with interpolated expressions inside. Same as `Either<String,
 /// RichTerm>` but with explicit constructor names.
 #[derive(Debug, PartialEq, Clone)]

--- a/stdlib/lists.ncl
+++ b/stdlib/lists.ncl
@@ -33,9 +33,11 @@
       fun pred l =>
         fold (fun x acc => if pred x then acc @ [x] else acc) l [];
 
+    //TODO: this enforces a List contract at each iteration. Get rid of it once
+    //parametrized list types lands and `fold` get a more precise type.
     flatten : List -> List =
       fun l =>
-        fold (fun l acc => Assume(List, l) @ acc) l [];
+        fold (fun l acc => (l | List) @ acc) l [];
 
     all : (Dyn -> Bool) -> List -> Bool =
       fun pred l =>


### PR DESCRIPTION
Implement the syntax described in #186 for metavalues, ignoring https://github.com/tweag/nickel/issues/186#issuecomment-762134504 for now.

The old syntax `Docstring(..)`, `Contract(..)` and so on is not removed, to avoid changing a lot of tests and keep this PR short. It will be done in next PR. Only the stdlib has been converted, since it was only one occurrence, and is more exposed to curious users.