### PR TITLE
Make `blame` and `tag` available in the stdlib

### DIFF
--- a/stdlib/contracts.ncl
+++ b/stdlib/contracts.ncl
@@ -71,4 +71,9 @@
   empty_tail = fun acc l t =>
       if t == {} then acc
       else %blame% (%tag% "extra field `#{%head% (%fieldsOf% t)}`" l);
+
+  contracts = {
+    blame = fun l => %blame% l;
+    tag = fun msg l => %tag% msg l;
+  };
 }


### PR DESCRIPTION
In #243, a specific syntax for primitive operations was introduced, and function wrappers were added to the stdlib. However, `blame` and `tag` didn't get their wrapper, so they are currently only accessible via `%tag%` and `%blame%`, and must be fully applied.

This PR adds missing wrappers in a `contracts` record of the stdlib, making them accessible via `contracts.blame` and `contracts.tag`.