### PR TITLE
[Fix]Cyclic type inference

### DIFF
--- a/src/typecheck.rs
+++ b/src/typecheck.rs
@@ -1123,6 +1123,7 @@ pub fn unify_(
                 TypeWrapper::Concrete(ty2),
             )),
         },
+        (TypeWrapper::Ptr(p1), TypeWrapper::Ptr(p2)) if p1 == p2 => Ok(()),
         // The two following cases are not merged just to correctly distinguish between the
         // expected type (first component of the tuple) and the inferred type when reporting a row
         // unification error.

--- a/src/typecheck.rs
+++ b/src/typecheck.rs
@@ -2267,7 +2267,7 @@ mod tests {
     }
 
     /// Regression test following [#270](https://github.com/tweag/nickel/issues/270). Check that
-    /// uniyfing a variable with itself doesn't introduce a loop. The failure of this test result
+    /// unifying a variable with itself doesn't introduce a loop. The failure of this test results
     /// in a stack overflow.
     #[test]
     fn unification_graph_cycle() {

--- a/src/typecheck.rs
+++ b/src/typecheck.rs
@@ -2265,4 +2265,13 @@ mod tests {
         parse_and_typecheck("Assume({a: Num | Dyn}, {a = 1}) : {a: Num}").unwrap_err();
         parse_and_typecheck("{a = 1} : {a: Num | Dyn}").unwrap_err();
     }
+
+    /// Regression test following [#270](https://github.com/tweag/nickel/issues/270). Check that
+    /// uniyfing a variable with itself doesn't introduce a loop. The failure of this test result
+    /// in a stack overflow.
+    #[test]
+    fn unification_graph_cycle() {
+        parse_and_typecheck("{gen_ = fun acc x => if x == 0 then acc else gen_ (acc @ [x]) (x - 1)}.gen_ : List -> Num -> List").unwrap();
+        parse_and_typecheck("{f = fun x => f x}.f : forall a. a -> a").unwrap();
+    }
 }


### PR DESCRIPTION
Fix #270. The typechecking algorithm was creating a cycle in the unification table when unifying a variable with itself.

Note that infinite loops are still possible because there's currently no occur check:
```
nickel typecheck <<< '{g = g 0}.g : Num'

thread 'main' has overflowed its stack
fatal runtime error: stack overflow
```

This will be fixed in another PR.