### PR TITLE
Support importing multiple formats (JSON, YAML, TOML)

### DIFF
--- a/src/cache.rs
+++ b/src/cache.rs
@@ -325,9 +325,12 @@ impl Cache {
                     .map_err(|err| ParseError::from_lalrpop(err, file_id))?;
                 Ok(t)
             }
-            InputFormat::Json => Ok(serde_json::from_str(self.files.source(file_id)).unwrap()),
-            InputFormat::Yaml => Ok(serde_yaml::from_str(self.files.source(file_id)).unwrap()),
-            InputFormat::Toml => Ok(toml::from_str(self.files.source(file_id)).unwrap()),
+            InputFormat::Json => serde_json::from_str(self.files.source(file_id))
+                .map_err(|err| ParseError::from_serde_json(err, file_id, &self.files)),
+            InputFormat::Yaml => serde_yaml::from_str(self.files.source(file_id))
+                .map_err(|err| ParseError::from_serde_yaml(err, file_id)),
+            InputFormat::Toml => toml::from_str(self.files.source(file_id))
+                .map_err(|err| ParseError::from_toml(err, file_id, &self.files)),
         }
     }
 

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -19,6 +19,27 @@ use std::result::Result;
 use std::time::SystemTime;
 use void::Void;
 
+/// Supported input formats.
+#[derive(Clone, Copy, Eq, Debug, PartialEq)]
+pub enum InputFormat {
+    Nickel,
+    Json,
+    Yaml,
+    Toml,
+}
+
+impl InputFormat {
+    fn from_path_buf(path_buf: &PathBuf) -> Option<InputFormat> {
+        match path_buf.extension().and_then(OsStr::to_str) {
+            Some("ncl") => Some(InputFormat::Nickel),
+            Some("json") => Some(InputFormat::Json),
+            Some("yaml") => Some(InputFormat::Yaml),
+            Some("toml") => Some(InputFormat::Toml),
+            _ => None,
+        }
+    }
+}
+
 /// File and terms cache.
 ///
 /// Manage a file database, which stores a set of sources (the original source code as string) and
@@ -263,13 +284,51 @@ impl Cache {
         }
     }
 
+    /// Parse a source and populate the corresponding entry in the cache, or do nothing if the
+    /// entry has already been parsed.
+    pub fn parse_multi(
+        &mut self,
+        file_id: FileId,
+        format: InputFormat,
+    ) -> Result<CacheOp<()>, ParseError> {
+        if self.terms.contains_key(&file_id) {
+            Ok(CacheOp::Cached(()))
+        } else {
+            self.terms.insert(
+                file_id,
+                (
+                    self.parse_nocache_multi(file_id, format)?,
+                    EntryState::Parsed,
+                ),
+            );
+            Ok(CacheOp::Done(()))
+        }
+    }
+
     /// Parse a source without querying nor populating the cache.
     pub fn parse_nocache(&self, file_id: FileId) -> Result<RichTerm, ParseError> {
+        self.parse_nocache_multi(file_id, InputFormat::Nickel)
+    }
+
+    /// Parse a source without querying nor populating the cache. Support multiple formats.
+    pub fn parse_nocache_multi(
+        &self,
+        file_id: FileId,
+        format: InputFormat,
+    ) -> Result<RichTerm, ParseError> {
         let buf = self.files.source(file_id);
-        let t = parser::grammar::TermParser::new()
-            .parse(file_id, Lexer::new(&buf))
-            .map_err(|err| ParseError::from_lalrpop(err, file_id))?;
-        Ok(t)
+
+        match format {
+            InputFormat::Nickel => {
+                let t = parser::grammar::TermParser::new()
+                    .parse(file_id, Lexer::new(&buf))
+                    .map_err(|err| ParseError::from_lalrpop(err, file_id))?;
+                Ok(t)
+            }
+            InputFormat::Json => Ok(serde_json::from_str(self.files.source(file_id)).unwrap()),
+            InputFormat::Yaml => Ok(serde_yaml::from_str(self.files.source(file_id)).unwrap()),
+            InputFormat::Toml => Ok(toml::from_str(self.files.source(file_id)).unwrap()),
+        }
     }
 
     /// Typecheck an entry of the cache and update its state accordingly, or do nothing if the
@@ -619,6 +678,7 @@ impl ImportResolver for Cache {
         pos: &Option<RawSpan>,
     ) -> Result<(ResolvedTerm, FileId), ImportError> {
         let path_buf = with_parent(path, parent.clone());
+        let format = InputFormat::from_path_buf(&path_buf).unwrap_or(InputFormat::Nickel);
         let id_op = self.get_or_add_file(&path_buf).map_err(|err| {
             ImportError::IOError(
                 path.to_string_lossy().into_owned(),
@@ -631,7 +691,7 @@ impl ImportResolver for Cache {
             CacheOp::Done(id) => id,
         };
 
-        self.parse(file_id)
+        self.parse_multi(file_id, format)
             .map_err(|err| ImportError::ParseError(err, pos.clone()))?;
 
         Ok((

--- a/src/serialize.rs
+++ b/src/serialize.rs
@@ -2,6 +2,8 @@
 use crate::error::SerializationError;
 use crate::identifier::Ident;
 use crate::term::{MetaValue, RichTerm, Term};
+use codespan::FileId;
+use serde::de::{Deserialize, DeserializeSeed, Deserializer, MapAccess, SeqAccess, Visitor};
 use serde::ser::{Error, Serialize, SerializeMap, Serializer};
 use std::collections::HashMap;
 
@@ -42,6 +44,16 @@ impl Serialize for RichTerm {
         S: Serializer,
     {
         (*self.term).serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for RichTerm {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let t: Term = Term::deserialize(deserializer)?;
+        Ok(RichTerm::new(t, None))
     }
 }
 

--- a/src/serialize.rs
+++ b/src/serialize.rs
@@ -2,8 +2,7 @@
 use crate::error::SerializationError;
 use crate::identifier::Ident;
 use crate::term::{MetaValue, RichTerm, Term};
-use codespan::FileId;
-use serde::de::{Deserialize, DeserializeSeed, Deserializer, MapAccess, SeqAccess, Visitor};
+use serde::de::{Deserialize, Deserializer};
 use serde::ser::{Error, Serialize, SerializeMap, Serializer};
 use std::collections::HashMap;
 

--- a/src/term.rs
+++ b/src/term.rs
@@ -21,7 +21,7 @@ use crate::label::Label;
 use crate::position::RawSpan;
 use crate::types::{AbsType, Types};
 use codespan::FileId;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::ffi::OsString;
 
@@ -30,7 +30,7 @@ use std::ffi::OsString;
 /// Parsed terms also need to store their position in the source for error reporting.  This is why
 /// this type is nested with [`RichTerm`](type.RichTerm.html).
 ///
-#[derive(Debug, PartialEq, Clone, Serialize)]
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum Term {
     /// A boolean value.
@@ -135,6 +135,7 @@ pub enum Term {
     Wrapped(i32, RichTerm),
 
     #[serde(serialize_with = "crate::serialize::serialize_meta_value")]
+    #[serde(skip_deserializing)]
     MetaValue(MetaValue),
 
     /// An unresolved import.


### PR DESCRIPTION
Depend on #281. Allow importing other file formats than pure Nickel:

```
//file: data.json
{
  "a": 1.0,
  "b": [
    1.0,
    "3",
    false
  ],
  "c": {
    "d": {
      "e": 2.0
    }
  }
}

//file: test.ncl
let x = import "data.json" in
x.a + (lists.elemAt x.b 1) + x.c.d.e
```

The format is currently determined by the file extension.