### PR TITLE
Pipe syntax in records and toplevel lets

### DIFF
--- a/src/grammar.lalrpop
+++ b/src/grammar.lalrpop
@@ -84,6 +84,15 @@ pub ExtendedTerm: ExtendedTerm = {
 
         ExtendedTerm::ToplevelLet(id, t1)
     },
+    "let" <id:Ident> <meta: MetaAnnot> "=" <t1: Term> => {
+        //TODO: bump LALRPOP version to >= 0.18.0 which allows mutable x in
+        //actions and remove this
+        let mut meta = meta;
+        let pos = t1.pos.clone();
+        meta.value = Some(t1);
+
+        ExtendedTerm::ToplevelLet(id, RichTerm::new(Term::MetaValue(meta), pos))
+    },
     Term => ExtendedTerm::RichTerm(<>),
 }
 
@@ -271,6 +280,14 @@ RecordField: Either<(Ident, RichTerm), (RichTerm, RichTerm)> = {
         };
 
         Either::Left((id, t))
+    },
+    <l: @L> <id: Ident> <meta: MetaAnnot> <r: @R> <t: ("=" <Term>)?> => {
+        let mut meta = meta;
+        let pos = t.as_ref()
+            .map(|t| t.pos.clone())
+            .unwrap_or(Some(mk_span(src_id, l, r)));
+        meta.value = t;
+        Either::Left((id, RichTerm::new(Term::MetaValue(meta), pos)))
     },
     "$" <id: SpTerm<Atom>> <ann: TypeAnnot?> "=" <t: Term> => {
         let t = if let Some((l, ty, r)) = ann {


### PR DESCRIPTION
The pipe syntax introduced in #266 was only enabled on let-bindings, such as `let x | #Num = 5`, but not on record fields, such as 
```
{
  field | #Num 
        | doc "this is **THE** field"
        | default = 5
}
```
Which is useful to define schemas. This PR fixes it and also adds support for pipe syntax on toplevel let definitions in the REPL, such as in
```
nickel> let x | #Num = val
nickel>
```