### PR TITLE
Extend the builtins stdlib with hash, (de)serialization, and a few others

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -91,9 +91,9 @@ dependencies = [
 
 [[package]]
 name = "bit-vec"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0dc55f2d8a1a85650ac47858bb001b4c0dd73d79e3c455a842925e68d29cd3"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bitflags"
@@ -110,7 +110,16 @@ dependencies = [
  "block-padding",
  "byte-tools",
  "byteorder",
- "generic-array",
+ "generic-array 0.12.3",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
+dependencies = [
+ "generic-array 0.14.4",
 ]
 
 [[package]]
@@ -130,9 +139,9 @@ checksum = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 
 [[package]]
 name = "byteorder"
-version = "1.3.4"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
+checksum = "ae44d1a3d5a19df61dd0c8beb138458ac2a53a7ac09eba97d55592540004306b"
 
 [[package]]
 name = "cc"
@@ -196,12 +205,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam"
-version = "0.7.3"
+name = "const_fn"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69323bff1fb41c635347b8ead484a5ca6c3f11914d784170b158d8449ab07f8e"
+checksum = "28b9d6de7f49e22cf97ad17fc4036ece69300032f45f78f30b4a4482cdc3f4a6"
+
+[[package]]
+name = "cpuid-bool"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8aebca1129a03dc6dc2b127edd729435bbc4a37e1d5f4d7513165089ceb02634"
+
+[[package]]
+name = "crossbeam"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd01a6eb3daaafa260f6fc94c3a6c36390abc2080e38e3e34ced87393fb77d80"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "crossbeam-channel",
  "crossbeam-deque",
  "crossbeam-epoch",
@@ -211,59 +232,57 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.4.4"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b153fe7cbef478c567df0f972e02e6d736db11affe43dfc9c56a9374d1adfb87"
+checksum = "dca26ee1f8d361640700bde38b2c37d8c22b3ce2d360e1fc1c74ea4b0aa7d775"
 dependencies = [
+ "cfg-if 1.0.0",
  "crossbeam-utils",
- "maybe-uninit",
 ]
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.7.3"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f02af974daeee82218205558e51ec8768b48cf524bd01d550abe5573a608285"
+checksum = "94af6efb46fef72616855b036a624cf27ba656ffc9be1b9a3c931cfc7749a9a9"
 dependencies = [
+ "cfg-if 1.0.0",
  "crossbeam-epoch",
  "crossbeam-utils",
- "maybe-uninit",
 ]
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.8.2"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "058ed274caafc1f60c4997b5fc07bf7dc7cca454af7c6e81edffe5f33f70dace"
+checksum = "a1aaa739f95311c2c7887a76863f500026092fb1dce0161dab577e559ef3569d"
 dependencies = [
- "autocfg 1.0.1",
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
+ "const_fn",
  "crossbeam-utils",
  "lazy_static",
- "maybe-uninit",
  "memoffset",
  "scopeguard",
 ]
 
 [[package]]
 name = "crossbeam-queue"
-version = "0.2.3"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "774ba60a54c213d409d5353bda12d49cd68d14e45036a285234c8d6f91f92570"
+checksum = "0f6cb3c7f5b8e51bc3ebb73a2327ad4abdbd119dc13223f14f961d2f38486756"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "crossbeam-utils",
- "maybe-uninit",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.7.2"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8"
+checksum = "02d96d1e189ef58269ebe5b97953da3274d83a93af647c2ddd6f9dab28cedb8d"
 dependencies = [
  "autocfg 1.0.1",
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "lazy_static",
 ]
 
@@ -310,7 +329,16 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
 dependencies = [
- "generic-array",
+ "generic-array 0.12.3",
+]
+
+[[package]]
+name = "digest"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
+dependencies = [
+ "generic-array 0.14.4",
 ]
 
 [[package]]
@@ -341,7 +369,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f525a586d310c87df72ebcd98009e57f1cc030c8c268305287a476beb653969"
 dependencies = [
  "lazy_static",
- "regex 1.4.2",
+ "regex 1.4.3",
  "serde",
  "strsim 0.9.3",
 ]
@@ -411,6 +439,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "501466ecc8a30d1d3b7fc9229b122b2ce8ed6e9d9223f1138d4babb253e51817"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -423,18 +461,18 @@ dependencies = [
 
 [[package]]
 name = "heck"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
+checksum = "87cbf45460356b7deeb5e3415b5563308c0a9b057c85e12b06ad551f98d0a6ac"
 dependencies = [
  "unicode-segmentation",
 ]
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.17"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aca5565f760fb5b220e499d72710ed156fdb74e631659e99377d9ebfbd13ae8"
+checksum = "322f4de77956e22ed0e5032c359a0f1273f1f7f0d79bfa3b8ffbc730d7fbcc5c"
 dependencies = [
  "libc",
 ]
@@ -450,9 +488,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc6f3ad7b9d11a0c00842ff8de1b60ee58661048eb8049ed33c73594f359d7e6"
+checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
 
 [[package]]
 name = "kernel32-sys"
@@ -479,11 +517,11 @@ dependencies = [
  "itertools",
  "lalrpop-util",
  "petgraph",
- "regex 1.4.2",
- "regex-syntax 0.6.21",
+ "regex 1.4.3",
+ "regex-syntax 0.6.22",
  "serde",
  "serde_derive",
- "sha2",
+ "sha2 0.8.2",
  "string_cache",
  "term",
  "unicode-xid 0.1.0",
@@ -503,9 +541,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.80"
+version = "0.2.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d58d1b70b004888f764dfbf6a26a3b0342a1632d33968e4a179d8011c760614"
+checksum = "7ccac4b00700875e6a07c6cde370d44d32fa01c5a65cdd2fca6858c479d28bb3"
 
 [[package]]
 name = "linked-hash-map"
@@ -524,11 +562,11 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.11"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fabed175da42fed1fa0746b0ea71f412aa9d35e76e95e59b192c64b9dc2bf8b"
+checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -550,16 +588,21 @@ dependencies = [
  "fnv",
  "proc-macro2",
  "quote",
- "regex-syntax 0.6.21",
+ "regex-syntax 0.6.22",
  "syn",
  "utf8-ranges",
 ]
 
 [[package]]
-name = "maybe-uninit"
-version = "2.0.0"
+name = "md-5"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
+checksum = "7b5a279bb9607f9f53c22d496eade00d138d1bdcccd07d74650387cf94942a15"
+dependencies = [
+ "block-buffer 0.9.0",
+ "digest 0.9.0",
+ "opaque-debug 0.3.0",
+]
 
 [[package]]
 name = "memchr"
@@ -569,27 +612,27 @@ checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
 
 [[package]]
 name = "memoffset"
-version = "0.5.6"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "043175f069eda7b85febe4a74abbaeff828d9f8b448515d3151a14a3542811aa"
+checksum = "157b4208e3059a8f9e78d559edc658e13df41410cb3ae03979c83130067fdd87"
 dependencies = [
  "autocfg 1.0.1",
 ]
 
 [[package]]
 name = "minimad"
-version = "0.6.7"
+version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24fe6f533320d060be6644ff3967df0ddb2e3061164ab4976c9157995702e887"
+checksum = "cb5ed7ea8b54916318ac7ec6ff06b2b428fdf9cb54d1867714f699dbd1659ad4"
 dependencies = [
  "lazy_static",
 ]
 
 [[package]]
 name = "mio"
-version = "0.7.6"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f33bc887064ef1fd66020c9adfc45bb9f33d75a42096c81e7c56c65b75dd1a8b"
+checksum = "e50ae3f04d169fcc9bde0b547d1c205219b7157e07ded9c5aff03e0637cb3ed7"
 dependencies = [
  "libc",
  "log",
@@ -626,6 +669,7 @@ dependencies = [
  "lalrpop",
  "lalrpop-util",
  "logos",
+ "md-5",
  "minimad",
  "pretty_assertions",
  "regex 0.2.11",
@@ -634,6 +678,8 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "sha-1",
+ "sha2 0.9.3",
  "simple-counter",
  "structopt",
  "termimad",
@@ -663,10 +709,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "once_cell"
+version = "1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13bd41f508810a131401606d54ac32a467c97172d74ba7662562ebba5ad07fa0"
+
+[[package]]
 name = "opaque-debug"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
+
+[[package]]
+name = "opaque-debug"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "ordermap"
@@ -778,9 +836,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa563d17ecb180e500da1cfd2b028310ac758de548efdd203e18f283af693f37"
+checksum = "991431c3519a3f36861882da93630ce66b52918dcf1b8e2fd66b397fc96f28df"
 dependencies = [
  "proc-macro2",
 ]
@@ -940,14 +998,14 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.4.2"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38cf2c13ed4745de91a5eb834e11c00bcc3709e773173b2ce4c56c9fbde04b9c"
+checksum = "d9251239e129e16308e70d853559389de218ac275b515068abc96829d05b948a"
 dependencies = [
  "aho-corasick 0.7.15",
  "memchr",
- "regex-syntax 0.6.21",
- "thread_local 1.0.1",
+ "regex-syntax 0.6.22",
+ "thread_local 1.1.2",
 ]
 
 [[package]]
@@ -961,9 +1019,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.21"
+version = "0.6.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b181ba2dcf07aaccad5448e8ead58db5b742cf85dfe035e2227f137a539a189"
+checksum = "b5eb417147ba9860a96cfe72a0b93bf88fee1744b5636ec99ab20c1aa9376581"
 
 [[package]]
 name = "rustyline"
@@ -1010,18 +1068,18 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "serde"
-version = "1.0.117"
+version = "1.0.123"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b88fa983de7720629c9387e9f517353ed404164b1e482c970a90c1a4aaf7dc1a"
+checksum = "92d5161132722baa40d802cc70b15262b98258453e85e5d1d365c757c73869ae"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.117"
+version = "1.0.123"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbd1ae72adb44aab48f325a02444a5fc079349a8d804c1fc922aed3f7454c74e"
+checksum = "9391c295d64fc0abb2c556bad848f33cb8296276b1ad2677d1ae1ace4f258f31"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1030,9 +1088,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.59"
+version = "1.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcac07dbffa1c65e7f816ab9eba78eb142c6d44410f4eeba1e26e4f5dfa56b95"
+checksum = "4fceb2595057b6891a4ee808f70054bd2d12f0e97f1cbb78689b59f676df325a"
 dependencies = [
  "itoa",
  "ryu",
@@ -1041,9 +1099,9 @@ dependencies = [
 
 [[package]]
 name = "serde_yaml"
-version = "0.8.15"
+version = "0.8.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "971be8f6e4d4a47163b405a3df70d14359186f9ab0f3a3ec37df144ca1ce089f"
+checksum = "bdd2af560da3c1fdc02cb80965289254fc35dff869810061e2d8290ee48848ae"
 dependencies = [
  "dtoa",
  "linked-hash-map",
@@ -1052,22 +1110,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha-1"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4b312c3731e3fe78a185e6b9b911a7aa715b8e31cce117975219aab2acf285d"
+dependencies = [
+ "block-buffer 0.9.0",
+ "cfg-if 1.0.0",
+ "cpuid-bool",
+ "digest 0.9.0",
+ "opaque-debug 0.3.0",
+]
+
+[[package]]
 name = "sha2"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a256f46ea78a0c0d9ff00077504903ac881a1dafdc20da66545699e7776b3e69"
 dependencies = [
- "block-buffer",
- "digest",
+ "block-buffer 0.7.3",
+ "digest 0.8.1",
  "fake-simd",
- "opaque-debug",
+ "opaque-debug 0.2.3",
+]
+
+[[package]]
+name = "sha2"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa827a14b29ab7f44778d14a88d3cb76e949c45083f7dbfa507d0cb699dc12de"
+dependencies = [
+ "block-buffer 0.9.0",
+ "cfg-if 1.0.0",
+ "cpuid-bool",
+ "digest 0.9.0",
+ "opaque-debug 0.3.0",
 ]
 
 [[package]]
 name = "signal-hook"
-version = "0.1.16"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "604508c1418b99dfe1925ca9224829bb2a8a9a04dda655cc01fcad46f4ab05ed"
+checksum = "7e31d442c16f047a671b5a71e2161d6e68814012b7f5379d269ebd915fac2729"
 dependencies = [
  "libc",
  "mio",
@@ -1076,9 +1160,9 @@ dependencies = [
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.2.2"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce32ea0c6c56d5eacaeb814fbed9960547021d3edd010ded1425f180536b20ab"
+checksum = "16f1d0fef1604ba8f7a073c7e701f213e056707210e9020af4528e0101ce11a6"
 dependencies = [
  "libc",
 ]
@@ -1097,19 +1181,18 @@ checksum = "0b8de496cf83d4ed58b6be86c3a275b8602f6ffe98d3024a869e124147a9a3ac"
 
 [[package]]
 name = "smallvec"
-version = "1.5.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7acad6f34eb9e8a259d3283d1e8c1d34d7415943d4895f65cc73813c7396fc85"
+checksum = "fe0f37c9e8f3c5a4a66ad655a93c74daac4ad00c441533bf5c6e7990bb42604e"
 
 [[package]]
 name = "socket2"
-version = "0.3.17"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c29947abdee2a218277abeca306f25789c938e500ea5a9d4b12a5a504466902"
+checksum = "122e570113d28d773067fab24266b66753f6ea915758651696b6e35e49f88d6e"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
- "redox_syscall 0.1.57",
  "winapi 0.3.9",
 ]
 
@@ -1161,9 +1244,9 @@ checksum = "6446ced80d6c486436db5c078dde11a9f73d42b57fb273121e160b84f63d894c"
 
 [[package]]
 name = "structopt"
-version = "0.3.20"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "126d630294ec449fae0b16f964e35bf3c74f940da9dca17ee9b905f7b3112eb8"
+checksum = "5277acd7ee46e63e5168a80734c9f6ee81b1367a7d8772a2d765df2a3705d28c"
 dependencies = [
  "clap",
  "lazy_static",
@@ -1172,9 +1255,9 @@ dependencies = [
 
 [[package]]
 name = "structopt-derive"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65e51c492f9e23a220534971ff5afc14037289de430e3c83f9daf6a1b6ae91e8"
+checksum = "5ba9cdfda491b814720b6b06e0cac513d922fc407582032e8706e9f137976f90"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -1185,9 +1268,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.48"
+version = "1.0.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc371affeffc477f42a221a1e4297aedcea33d47d19b61455588bd9d8f6b19ac"
+checksum = "c700597eca8a5a762beb35753ef6b94df201c81cca676604f547495a0d7f0081"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1206,18 +1289,18 @@ dependencies = [
 
 [[package]]
 name = "termcolor"
-version = "1.1.0"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb6bfa289a4d7c5766392812c0a1f4c1ba45afa1ad47803c11e1f407d846d75f"
+checksum = "2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4"
 dependencies = [
  "winapi-util",
 ]
 
 [[package]]
 name = "termimad"
-version = "0.9.1"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe9709f7deb2582e81b8bffd71ddc33ca46857c30fee361bcf6c0fd63caf8146"
+checksum = "9c0301aa5081d4c41d5ebf728ec7c3e825cebd1d8f301d95d65e27a9d93fef18"
 dependencies = [
  "crossbeam",
  "crossterm",
@@ -1238,18 +1321,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e9ae34b84616eedaaf1e9dd6026dbe00dcafa92aa0c8077cb69df1fcfe5e53e"
+checksum = "76cc616c6abf8c8928e2fdcc0dbfab37175edd8fb49a4641066ad1364fdab146"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ba20f23e85b10754cd195504aebf6a27e2e6cbe28c17778a0c930724628dd56"
+checksum = "9be73a2caec27583d0046ef3796c3794f868a5bc813db689eed00c7631275cd1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1267,11 +1350,11 @@ dependencies = [
 
 [[package]]
 name = "thread_local"
-version = "1.0.1"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d40c6d1b69745a6ec6fb1ca717914848da4b44ae29d9b3080cbee91d72a69b14"
+checksum = "d8208a331e1cb318dd5bd76951d2b8fc48ca38a69f5f4e4af1b6a9f8c6236915"
 dependencies = [
- "lazy_static",
+ "once_cell",
 ]
 
 [[package]]
@@ -1297,9 +1380,9 @@ checksum = "c85f514e095d348c279b1e5cd76795082cf15bd59b93207832abe0b1d8fed236"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.7.0"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db8716a166f290ff49dabc18b44aa407cb7c6dbe1aa0971b44b8a24b0ca35aae"
+checksum = "bb0d2e7be6ae3a5fa87eed5fb451aff96f2573d2694942e40543ae0bbe19c796"
 
 [[package]]
 name = "unicode-width"
@@ -1351,9 +1434,9 @@ checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 
 [[package]]
 name = "wasi"
-version = "0.10.1+wasi-snapshot-preview1"
+version = "0.10.2+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93c6c3420963c5c64bca373b25e77acb562081b9bb4dd5bb864187742186cea9"
+checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "winapi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,9 @@ serde_yaml = "0.8.15"
 toml = "0.5.8"
 structopt = "0.3"
 void = "1"
+sha-1 = "0.9.3"
+sha2 = "0.9.3"
+md-5 = "0.9.1"
 
 termimad = { version = "0.9.1", optional = true }
 # Use the same version as termimad

--- a/src/error.rs
+++ b/src/error.rs
@@ -1026,7 +1026,7 @@ impl ToDiagnostic<FileId> for EvalError {
                 let labels = span_opt
                     .as_ref()
                     .map(|span| vec![primary(span).with_message("here")])
-                    .unwrap_or(Vec::new());
+                    .unwrap_or_default();
 
                 vec![Diagnostic::error()
                     .with_message(format!("{} parse error: {}", format, msg))

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -590,9 +590,8 @@ where
             Term::RecRecord(ts) => {
                 // Thanks to the share normal form transformation, the content is either a constant or a
                 // variable.
-                let rec_env =
-                    ts.iter()
-                        .try_fold(HashMap::new(), |mut rec_env, (id, rt)| match rt.as_ref() {
+                let rec_env = ts.iter().try_fold::<_, _, Result<Environment, EvalError>>(
+                        HashMap::new(), |mut rec_env, (id, rt)| match rt.as_ref() {
                             Term::Var(ref var_id) => {
                                 let thunk = env.get(var_id).ok_or_else(|| {
                                     EvalError::UnboundIdentifier(var_id.clone(), rt.pos.clone())

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -591,26 +591,28 @@ where
                 // Thanks to the share normal form transformation, the content is either a constant or a
                 // variable.
                 let rec_env = ts.iter().try_fold::<_, _, Result<Environment, EvalError>>(
-                        HashMap::new(), |mut rec_env, (id, rt)| match rt.as_ref() {
-                            Term::Var(ref var_id) => {
-                                let thunk = env.get(var_id).ok_or_else(|| {
-                                    EvalError::UnboundIdentifier(var_id.clone(), rt.pos.clone())
-                                })?;
-                                rec_env.insert(id.clone(), thunk.clone());
-                                Ok(rec_env)
-                            }
-                            _ => {
-                                // If we are in this branch, the term must be a constant after the
-                                // share normal form transformation, hence it should not need an
-                                // environment, which is why it is dropped.
-                                let closure = Closure {
-                                    body: rt.clone(),
-                                    env: HashMap::new(),
-                                };
-                                rec_env.insert(id.clone(), Thunk::new(closure, IdentKind::Let()));
-                                Ok(rec_env)
-                            }
-                        })?;
+                    HashMap::new(),
+                    |mut rec_env, (id, rt)| match rt.as_ref() {
+                        Term::Var(ref var_id) => {
+                            let thunk = env.get(var_id).ok_or_else(|| {
+                                EvalError::UnboundIdentifier(var_id.clone(), rt.pos.clone())
+                            })?;
+                            rec_env.insert(id.clone(), thunk.clone());
+                            Ok(rec_env)
+                        }
+                        _ => {
+                            // If we are in this branch, the term must be a constant after the
+                            // share normal form transformation, hence it should not need an
+                            // environment, which is why it is dropped.
+                            let closure = Closure {
+                                body: rt.clone(),
+                                env: HashMap::new(),
+                            };
+                            rec_env.insert(id.clone(), Thunk::new(closure, IdentKind::Let()));
+                            Ok(rec_env)
+                        }
+                    },
+                )?;
 
                 let new_ts = ts.into_iter().map(|(id, rt)| {
                     let RichTerm { term, pos } = rt;

--- a/src/grammar.lalrpop
+++ b/src/grammar.lalrpop
@@ -516,6 +516,9 @@ BOpPre: BinaryOp = {
     "hasField" => BinaryOp::HasField(),
     "elemAt" => BinaryOp::ListElemAt(),
     "tag" => BinaryOp::Tag(),
+    "hash" => BinaryOp::Hash(),
+    "serialize" => BinaryOp::Serialize(),
+    "deserialize" => BinaryOp::Deserialize(),
 }
 
 Types: Types = {
@@ -700,6 +703,10 @@ extern {
         "merge" => Token::Normal(NormalToken::Merge),
         "default" => Token::Normal(NormalToken::Default),
         "doc" => Token::Normal(NormalToken::Doc),
+
+        "hash" => Token::Normal(NormalToken::OpHash),
+        "serialize" => Token::Normal(NormalToken::Serialize),
+        "deserialize" => Token::Normal(NormalToken::Deserialize),
 
         "{" => Token::Normal(NormalToken::LBrace),
         "}" => Token::Normal(NormalToken::RBrace),

--- a/src/main.rs
+++ b/src/main.rs
@@ -199,11 +199,10 @@ fn export(
                 .map_err(|err| SerializationError::Other(err.to_string())),
             ExportFormat::Yaml => serde_yaml::to_writer(file, &rt)
                 .map_err(|err| SerializationError::Other(err.to_string())),
-            ExportFormat::Toml => toml::ser::to_string_pretty(&rt)
+            ExportFormat::Toml => toml::Value::try_from(&rt)
                 .map_err(|err| SerializationError::Other(err.to_string()))
-                .and_then(|s| {
-                    file.write_all(s.as_bytes())
-                        .map_err(|err| SerializationError::Other(err.to_string()))
+                .and_then(|v| {
+                    write!(file, "{}", v).map_err(|err| SerializationError::Other(err.to_string()))
                 }),
             ExportFormat::Raw => match *rt.term {
                 Term::Str(s) => file

--- a/src/operation.rs
+++ b/src/operation.rs
@@ -1355,9 +1355,7 @@ fn process_binary_operation(
                         _ => return mk_err_fst(t1),
                     };
 
-                    Ok(Closure::atomic_closure(
-                        Term::Str(String::from(result)).into(),
-                    ))
+                    Ok(Closure::atomic_closure(Term::Str(result).into()))
                 } else {
                     Err(EvalError::TypeError(
                         String::from("Str"),
@@ -1396,8 +1394,7 @@ fn process_binary_operation(
                     },
                     &global_env,
                     &env2,
-                )
-                .into();
+                );
                 serialize::validate(&rt2)?;
 
                 let result = match id.to_string().as_str() {
@@ -1411,9 +1408,7 @@ fn process_binary_operation(
                     _ => return mk_err_fst(t1),
                 };
 
-                Ok(Closure::atomic_closure(
-                    Term::Str(String::from(result)).into(),
-                ))
+                Ok(Closure::atomic_closure(Term::Str(result).into()))
             } else {
                 mk_err_fst(t1)
             }

--- a/src/operation.rs
+++ b/src/operation.rs
@@ -1405,7 +1405,8 @@ fn process_binary_operation(
                         .map_err(|err| SerializationError::Other(err.to_string()))?,
                     "Yaml" => serde_yaml::to_string(&rt2)
                         .map_err(|err| SerializationError::Other(err.to_string()))?,
-                    "Toml" => toml::ser::to_string_pretty(&rt2)
+                    "Toml" => toml::Value::try_from(&rt2)
+                        .map(|v| format!("{}", v))
                         .map_err(|err| SerializationError::Other(err.to_string()))?,
                     _ => return mk_err_fst(t1),
                 };

--- a/src/parser/lexer.rs
+++ b/src/parser/lexer.rs
@@ -218,6 +218,12 @@ pub enum NormalToken<'input> {
     #[token("doc")]
     Doc,
 
+    #[token("%hash%")]
+    OpHash,
+    #[token("%serialize%")]
+    Serialize,
+    #[token("%deserialize%")]
+    Deserialize,
     #[token("{")]
     LBrace,
     #[token("}")]

--- a/src/program.rs
+++ b/src/program.rs
@@ -213,6 +213,7 @@ mod tests {
     use crate::parser::{grammar, lexer};
     use assert_matches::assert_matches;
     use codespan::Files;
+    use serde_json::json;
     use std::io::Cursor;
 
     fn parse(s: &str) -> Option<RichTerm> {
@@ -1528,6 +1529,77 @@ too
         assert_matches!(
             eval_string("{x = (fun a => a + y) 0; y = (fun a => a + x) 0}.x"),
             Err(Error::EvalError(EvalError::InfiniteRecursion(..)))
+        );
+    }
+
+    /// Check that `deserialize (serialize term) == term`.
+    macro_rules! assert_ser_inv {
+        ($t:expr) => {
+            assert_peq!(
+                $t,
+                format!(
+                    "%deserialize% `Json (%serialize% `Json (let x = {} in %deepSeq% x x))",
+                    $t
+                )
+            );
+            assert_peq!(
+                $t,
+                format!(
+                    "%deserialize% `Yaml (%serialize% `Yaml (let x = {} in %deepSeq% x x))",
+                    $t
+                )
+            );
+            assert_peq!(
+                $t,
+                format!(
+                    "%deserialize% `Toml (%serialize% `Toml (let x = {} in %deepSeq% x x))",
+                    $t
+                )
+            );
+        };
+    }
+
+    /// Check that `serialize (deserialize s) == s`.
+    macro_rules! assert_deser_inv {
+        ($data:expr) => {
+            let as_str = serde_json::to_string_pretty(&$data).unwrap();
+            assert_peq!(
+                format!("\"{}\"", as_str.replace("\"", "\\\"")),
+                format!(
+                    "%serialize% `Json (%deserialize% `Json m##\"{}\"##m)",
+                    as_str
+                )
+            );
+            let as_str = serde_yaml::to_string(&$data).unwrap();
+            assert_peq!(
+                format!("\"{}\"", as_str.replace("\"", "\\\"")),
+                format!(
+                    "%serialize% `Yaml (%deserialize% `Yaml m##\"{}\"##m)",
+                    as_str
+                )
+            );
+            let as_str = format!("{}", toml::Value::try_from(&$data).unwrap());
+            assert_peq!(
+                format!("\"{}\"", as_str.replace("\"", "\\\"")),
+                format!(
+                    "%serialize% `Toml (%deserialize% `Toml m##\"{}\"##m)",
+                    as_str
+                )
+            );
+        };
+    }
+
+    #[test]
+    fn serialize_builtin_laws() {
+        assert_ser_inv!("{val = 1 + 1}");
+        assert_ser_inv!("{val = \"Some string\"}");
+        assert_ser_inv!("{val = [\"a\", 3, []]}");
+        assert_ser_inv!("{a = {foo = {bar = \"2\"}}; b = false; c = [{d = \"e\"}, {d = \"f\"}]}");
+
+        assert_deser_inv!(json!({"a": 1.0, "b": 4.0, "c": 3.0}));
+        assert_deser_inv!(json!({"a": {"b": {"c": "richtig"}}}));
+        assert_deser_inv!(
+            json!({"foo": 1.0, "bar": ["str", true], "baz": {"subfoo": true, "subbar": 0.0}})
         );
     }
 }

--- a/src/term.rs
+++ b/src/term.rs
@@ -631,6 +631,12 @@ pub enum BinaryOp {
     ListElemAt(),
     /// The merge operator (see the [merge module](../merge/index.html)).
     Merge(),
+    /// Hash a string.
+    Hash(),
+    /// Serialize a value to a string.
+    Serialize(),
+    /// Deserialize a string to a value.
+    Deserialize(),
 }
 
 impl BinaryOp {

--- a/src/typecheck.rs
+++ b/src/typecheck.rs
@@ -1676,6 +1676,33 @@ pub fn get_bop_type(state: &mut State, op: &BinaryOp) -> Result<TypeWrapper, Typ
         }
         // Dyn -> Dyn -> Dyn
         BinaryOp::Merge() => mk_tyw_arrow!(AbsType::Dyn(), AbsType::Dyn(), AbsType::Dyn()),
+        // <Md5, Sha1, Sha256, Sha512> -> Str -> Str
+        BinaryOp::Hash() => mk_tyw_arrow!(
+            mk_tyw_enum!(
+                "Md5",
+                "Sha1",
+                "Sha256",
+                "Sha512",
+                mk_typewrapper::row_empty()
+            ),
+            mk_typewrapper::str(),
+            mk_typewrapper::str()
+        ),
+        // forall a. <Json, Yaml, Toml> -> a -> Str
+        BinaryOp::Serialize() => {
+            let ty_input = TypeWrapper::Ptr(new_var(state.table));
+            mk_tyw_arrow!(
+                mk_tyw_enum!("Json", "Yaml", "Toml", mk_typewrapper::row_empty()),
+                ty_input,
+                mk_typewrapper::str()
+            )
+        }
+        // <Json, Yaml, Toml> -> Str -> Dyn
+        BinaryOp::Deserialize() => mk_tyw_arrow!(
+            mk_tyw_enum!("Json", "Yaml", "Toml", mk_typewrapper::row_empty()),
+            mk_typewrapper::str(),
+            mk_typewrapper::dynamic()
+        ),
     })
 }
 

--- a/stdlib/builtins.ncl
+++ b/stdlib/builtins.ncl
@@ -6,15 +6,21 @@
     isFun : Dyn -> Bool = fun x => %isFun% x;
     isList : Dyn -> Bool = fun x => %isList% x;
     isRecord : Dyn -> Bool = fun x => %isRecord% x;
-    typeOf : Dyn -> <TypeNum, TypeBool, TypeStr, TypeFun, TypeList, TypeRecord, Unknown>
-      = fun x =>
+    typeOf : Dyn -> <
+      TypeNum,
+      TypeBool,
+      TypeStr,
+      TypeFun,
+      TypeList,
+      TypeRecord,
+      Other> = fun x =>
       if %isNum% x then `TypeNum
       else if %isBool% x then `TypeBool
       else if %isStr% x then `TypeStr
       else if %isFun% x then `TypeFun
       else if %isList% x then `TypeList
       else if %isRecord% x then `TypeRecord
-      else `Unknown;
+      else `Other;
 
     seq : forall a. Dyn -> a -> a = fun x y => %seq% x y;
     deepSeq : forall a. Dyn -> a -> a = fun x y => %deepSeq% x y;

--- a/stdlib/builtins.ncl
+++ b/stdlib/builtins.ncl
@@ -6,8 +6,28 @@
     isFun : Dyn -> Bool = fun x => %isFun% x;
     isList : Dyn -> Bool = fun x => %isList% x;
     isRecord : Dyn -> Bool = fun x => %isRecord% x;
+    typeOf : Dyn -> <TypeNum, TypeBool, TypeStr, TypeFun, TypeList, TypeRecord, Unknown>
+      = fun x =>
+      if %isNum% x then `TypeNum
+      else if %isBool% x then `TypeBool
+      else if %isStr% x then `TypeStr
+      else if %isFun% x then `TypeFun
+      else if %isList% x then `TypeList
+      else if %isRecord% x then `TypeRecord
+      else `Unknown;
 
     seq : forall a. Dyn -> a -> a = fun x y => %seq% x y;
     deepSeq : forall a. Dyn -> a -> a = fun x y => %deepSeq% x y;
+
+    id : forall a. a -> a = fun x => x;
+
+    hash : <Md5, Sha1, Sha256, Sha512> -> Str -> Str =
+      fun type s => %hash% type s;
+
+    serialize : <Json, Toml, Yaml> -> Dyn -> Str = fun format x =>
+      %serialize% format (%deepSeq% x x);
+
+    deserialize : <Json, Toml, Yaml> -> Str -> Dyn = fun format x =>
+      %deserialize% format x;
   }
 }


### PR DESCRIPTION
Depend on #282. Partly address #254. Add `id`, `hash`, `serialize` and `deserialize` to the stdlib, as well as corresponding builtins operator. Hash supports the same algorithms as Nix (md5, sha1, sha256, sha512), and serialize/deserialize the same formats as the `export` subcommand: JSON, YAML and TOML.