### PR TITLE
[Cleaning]Implement clippy's recommandations

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,5 +1,3 @@
-use lalrpop;
-
 fn main() {
     lalrpop::process_root().unwrap();
 }

--- a/src/label.rs
+++ b/src/label.rs
@@ -60,10 +60,8 @@ pub mod ty_path {
 
     /// Determine if the path is not higher order, that is, if it doesn't contain any arrow.
     pub fn has_no_arrow(p: &Path) -> bool {
-        !p.iter().any(|elt| match *elt {
-            Elem::Domain | Elem::Codomain => true,
-            _ => false,
-        })
+        !p.iter()
+            .any(|elt| matches!(*elt, Elem::Domain | Elem::Codomain))
     }
 
     /// Return the position span encoded by a type path in the string representation of the

--- a/src/main.rs
+++ b/src/main.rs
@@ -128,7 +128,7 @@ fn main() {
 
     if let Some(Command::REPL) = opts.command {
         #[cfg(feature = "repl")]
-        if let Err(_) = rustyline_frontend::repl() {
+        if rustyline_frontend::repl().is_err() {
             process::exit(1);
         }
 
@@ -171,10 +171,7 @@ fn main() {
             }
             Some(Command::Typecheck) => program.typecheck().map(|_| ()),
             Some(Command::REPL) => unreachable!(),
-            None => program.eval().and_then(|t| {
-                println!("Done: {:?}", t);
-                Ok(())
-            }),
+            None => program.eval().map(|t| println!("Done: {:?}", t)),
         };
 
         if let Err(err) = result {

--- a/src/merge.rs
+++ b/src/merge.rs
@@ -115,7 +115,7 @@ pub fn merge(
             }
         }
         (Term::Num(n1), Term::Num(n2)) => {
-            if n1 == n2 {
+            if (n1 - n2).abs() < f64::EPSILON {
                 Ok(Closure::atomic_closure(Term::Num(n1).into()))
             } else {
                 Err(EvalError::MergeIncompatibleArgs(

--- a/src/parser/utils.rs
+++ b/src/parser/utils.rs
@@ -47,7 +47,7 @@ pub fn mk_label(types: Types, src_id: FileId, l: usize, r: usize) -> Label {
 /// indentation level of a line is the number of consecutive whitespace characters, which are
 /// either a space or a tab, counted from the beginning of the line. If a line is empty or consist
 /// only of whitespace characters, it is ignored.
-pub fn min_indent(chunks: &Vec<StrChunk<RichTerm>>) -> usize {
+pub fn min_indent(chunks: &[StrChunk<RichTerm>]) -> usize {
     let mut min: usize = std::usize::MAX;
     let mut current = 0;
     let mut start_line = true;
@@ -224,7 +224,7 @@ pub fn strip_indent(mut chunks: Vec<StrChunk<RichTerm>>) -> Vec<StrChunk<RichTer
                     }
                 }
 
-                std::mem::replace(s, buffer);
+                *s = buffer;
             }
             StrChunk::Expr(_, ref mut indent) => {
                 if start_line {

--- a/src/program.rs
+++ b/src/program.rs
@@ -1472,7 +1472,6 @@ too
     fn evaluation_full() {
         use crate::mk_record;
         use crate::term::make as mk_term;
-        use std::mem;
 
         // Clean all the position information in a term.
         fn clean_pos(t: Term) -> Term {
@@ -1486,7 +1485,7 @@ too
         let mut expd = parse("[2, \"ab\", [1, [3]]]").unwrap();
         // String are parsed as StrChunks, but evaluated to Str, so we need to hack list a bit
         if let Term::List(ref mut data) = *expd.term {
-            mem::replace(data.get_mut(1).unwrap(), mk_term::string("ab"));
+            *data.get_mut(1).unwrap() = mk_term::string("ab");
         } else {
             panic!();
         }

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -46,7 +46,7 @@ pub trait REPL {
     /// Query the metadata of an expression.
     fn query(&mut self, exp: &str) -> Result<Term, Error>;
     /// Required for error reporting on the frontend.
-    fn cache_mut<'a>(&'a mut self) -> &'a mut Cache;
+    fn cache_mut(&mut self) -> &mut Cache;
 }
 
 /// Standard implementation of the REPL backend.
@@ -164,7 +164,7 @@ impl REPL for REPLImpl {
         program::query(&mut self.cache, file_id, &self.eval_env, None)
     }
 
-    fn cache_mut<'a>(&'a mut self) -> &'a mut Cache {
+    fn cache_mut(&mut self) -> &mut Cache {
         &mut self.cache
     }
 }
@@ -259,7 +259,7 @@ pub mod command {
         type Err = REPLError;
 
         fn from_str(s: &str) -> Result<Self, Self::Err> {
-            let cmd_end = s.find(" ").unwrap_or(s.len());
+            let cmd_end = s.find(' ').unwrap_or_else(|| s.len());
             let cmd_str: String = s.chars().take(cmd_end).collect();
             let cmd: CommandType = cmd_str
                 .parse()
@@ -354,7 +354,7 @@ pub mod rustyline_frontend {
         fn validate(&self, ctx: &mut ValidationContext<'_>) -> rustyline::Result<ValidationResult> {
             let input = ctx.input();
 
-            if input.starts_with(":") || input.trim().is_empty() {
+            if input.starts_with(':') || input.trim().is_empty() {
                 return Ok(ValidationResult::Valid(None));
             }
 
@@ -415,7 +415,7 @@ pub mod rustyline_frontend {
 
             match line {
                 Ok(line) if line.trim().is_empty() => (),
-                Ok(line) if line.starts_with(":") => {
+                Ok(line) if line.starts_with(':') => {
                     let cmd = line.chars().skip(1).collect::<String>().parse::<Command>();
                     let result = match cmd {
                         Ok(Command::Load(path)) => {
@@ -433,7 +433,7 @@ pub mod rustyline_frontend {
                             query_print::print_query_result(&t, query_print::Attributes::default());
                         }),
                         Ok(Command::Help(arg)) => {
-                            print_help(arg.as_ref().map(String::as_str));
+                            print_help(arg.as_deref());
                             Ok(())
                         }
                         Ok(Command::Exit) => {
@@ -560,7 +560,7 @@ pub mod query_print {
         }
 
         fn print_doc(&self, content: &str) {
-            if content.find("\n").is_none() {
+            if content.find('\n').is_none() {
                 self.print_metadata("documentation", &content);
             } else {
                 println!("* documentation\n");
@@ -608,7 +608,7 @@ pub mod query_print {
         }
 
         fn print_doc(&self, content: &str) {
-            if content.find("\n").is_none() {
+            if content.find('\n').is_none() {
                 self.skin
                     .print_text(&format!("* **documentation**: {}", content));
             } else {

--- a/src/stack.rs
+++ b/src/stack.rs
@@ -45,45 +45,27 @@ pub enum Marker {
 
 impl Marker {
     pub fn is_arg(&self) -> bool {
-        match *self {
-            Marker::Arg(_, _) => true,
-            _ => false,
-        }
+        matches!(*self, Marker::Arg(..))
     }
 
     pub fn is_thunk(&self) -> bool {
-        match *self {
-            Marker::Thunk(_) => true,
-            _ => false,
-        }
+        matches!(*self, Marker::Thunk(..))
     }
 
     pub fn is_cont(&self) -> bool {
-        match *self {
-            Marker::Cont(_, _, _) => true,
-            _ => false,
-        }
+        matches!(*self, Marker::Cont(..))
     }
 
     pub fn is_eq(&self) -> bool {
-        match *self {
-            Marker::Eq(..) => true,
-            _ => false,
-        }
+        matches!(*self, Marker::Eq(..))
     }
 
     pub fn is_str_chunk(&self) -> bool {
-        match *self {
-            Marker::StrChunk(..) => true,
-            _ => false,
-        }
+        matches!(*self, Marker::StrChunk(..))
     }
 
     pub fn is_str_acc(&self) -> bool {
-        match *self {
-            Marker::StrAcc(..) => true,
-            _ => false,
-        }
+        matches!(*self, Marker::StrAcc(..))
     }
 }
 
@@ -287,7 +269,7 @@ mod tests {
 
     fn some_thunk_marker() -> Marker {
         let mut thunk = Thunk::new(some_closure(), IdentKind::Let());
-        Marker::Thunk(thunk.to_update_frame().unwrap())
+        Marker::Thunk(thunk.mk_update_frame().unwrap())
     }
 
     fn some_cont_marker() -> Marker {
@@ -319,9 +301,9 @@ mod tests {
         assert_eq!(0, s.count_thunks());
 
         let mut thunk = Thunk::new(some_closure(), IdentKind::Let());
-        s.push_thunk(thunk.to_update_frame().unwrap());
+        s.push_thunk(thunk.mk_update_frame().unwrap());
         thunk = Thunk::new(some_closure(), IdentKind::Let());
-        s.push_thunk(thunk.to_update_frame().unwrap());
+        s.push_thunk(thunk.mk_update_frame().unwrap());
 
         assert_eq!(2, s.count_thunks());
         s.pop_thunk().expect("Already checked");
@@ -331,11 +313,11 @@ mod tests {
     #[test]
     fn thunk_blackhole() {
         let mut thunk = Thunk::new(some_closure(), IdentKind::Let());
-        let thunk_upd = thunk.to_update_frame();
+        let thunk_upd = thunk.mk_update_frame();
         assert_matches!(thunk_upd, Ok(..));
-        assert_matches!(thunk.to_update_frame(), Err(..));
+        assert_matches!(thunk.mk_update_frame(), Err(..));
         thunk_upd.unwrap().update(some_closure());
-        assert_matches!(thunk.to_update_frame(), Ok(..));
+        assert_matches!(thunk.mk_update_frame(), Ok(..));
     }
 
     #[test]

--- a/src/term.rs
+++ b/src/term.rs
@@ -299,7 +299,7 @@ impl Term {
             | Term::ResolvedImport(_)
             | Term::StrChunks(_) => None,
         }
-        .map(|s| String::from(s))
+        .map(String::from)
     }
 
     /// Return a shallow string representation of a term, used for error reporting.
@@ -311,10 +311,10 @@ impl Term {
             Term::Str(s) => format!("\"{}\"", s),
             Term::StrChunks(chunks) => {
                 let chunks_str: Vec<String> = chunks
-                    .into_iter()
+                    .iter()
                     .map(|chunk| match chunk {
                         StrChunk::Literal(s) => s,
-                        StrChunk::Expr(_, _) => "${ ... }",
+                        StrChunk::Expr(..) => "${ ... }",
                     })
                     .map(String::from)
                     .collect();
@@ -344,7 +344,7 @@ impl Term {
                     "value"
                 };
                 let value = if let Some(t) = &meta.value {
-                    format!("{}", t.as_ref().shallow_repr())
+                    t.as_ref().shallow_repr()
                 } else {
                     String::from("none")
                 };

--- a/src/transformations.rs
+++ b/src/transformations.rs
@@ -57,7 +57,6 @@ pub mod share_normal_form {
     /// traversal to obtain a full transformation.
     pub fn transform_one(rt: RichTerm) -> RichTerm {
         let RichTerm { term, pos } = rt;
-        let pos = pos.clone();
         match *term {
             Term::Record(map) => {
                 let mut bindings = Vec::with_capacity(map.len());
@@ -166,15 +165,13 @@ pub mod share_normal_form {
         bindings: Vec<(Ident, RichTerm)>,
         pos: Option<RawSpan>,
     ) -> RichTerm {
-        let result = bindings.into_iter().fold(
+        bindings.into_iter().fold(
             RichTerm {
                 term: Box::new(body),
                 pos,
             },
             |acc, (id, t)| Term::Let(id, t, acc).into(),
-        );
-
-        result.into()
+        )
     }
 }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -142,10 +142,10 @@ impl<Ty> AbsType<Ty> {
 
     /// Determine if a type is a row type.
     pub fn is_row_type(&self) -> bool {
-        match self {
-            AbsType::RowExtend(_, _, _) | AbsType::RowEmpty() | AbsType::Dyn() => true,
-            _ => false,
-        }
+        matches!(
+            self,
+            AbsType::RowExtend(..) | AbsType::RowEmpty() | AbsType::Dyn()
+        )
     }
 }
 
@@ -316,7 +316,7 @@ impl Types {
         let next = self.row_find(&path[0]);
 
         if path.len() == 1 {
-            return next;
+            next
         } else {
             match next {
                 Some(ty) => ty.row_find_path(&path[1..]),


### PR DESCRIPTION
Ran `cargo clippy` and implemented most of the linter's recommendations, excepted a few one that would hurt readability. It should be mostly semantic-preserving small rewrites.