### PR TITLE
Add the null value

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -786,7 +786,8 @@ pub fn subst(rt: RichTerm, global_env: &Environment, env: &Environment) -> RichT
                     subst_(closure.body, global_env, &closure.env, bound)
                 })
                 .unwrap_or_else(|| RichTerm::new(Term::Var(id), pos)),
-            v @ Term::Bool(_)
+            v @ Term::Null
+            | v @ Term::Bool(_)
             | v @ Term::Num(_)
             | v @ Term::Str(_)
             | v @ Term::Lbl(_)

--- a/src/grammar.lalrpop
+++ b/src/grammar.lalrpop
@@ -237,6 +237,7 @@ Atom: RichTerm = {
             )
         ),
     "num literal" => RichTerm::from(Term::Num(<>)),
+    "null" => RichTerm::from(Term::Null),
     Bool => RichTerm::from(Term::Bool(<>)),
     <StrChunks>,
     Ident => RichTerm::from(Term::Var(<>)),
@@ -619,6 +620,7 @@ extern {
         "let" => Token::Normal(NormalToken::Let),
         "switch" => Token::Normal(NormalToken::Switch),
 
+        "null" => Token::Normal(NormalToken::Null),
         "true" => Token::Normal(NormalToken::True),
         "false" => Token::Normal(NormalToken::False),
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,6 +21,7 @@ mod types;
 use crate::error::{Error, IOError, SerializationError};
 use crate::program::Program;
 use crate::repl::rustyline_frontend;
+use crate::serialize::ExportFormat;
 use crate::term::{RichTerm, Term};
 use std::io::Write;
 use std::path::PathBuf;
@@ -41,15 +42,6 @@ struct Opt {
     file: Option<PathBuf>,
     #[structopt(subcommand)]
     command: Option<Command>,
-}
-
-/// Available export formats.
-#[derive(Copy, Clone, Eq, PartialEq, Debug)]
-enum ExportFormat {
-    Raw,
-    Json,
-    Yaml,
-    Toml,
 }
 
 impl std::default::Default for ExportFormat {
@@ -187,9 +179,9 @@ fn export(
     output: Option<PathBuf>,
 ) -> Result<(), Error> {
     let rt = program.eval_full().map(RichTerm::from)?;
-    serialize::validate(&rt)?;
-
     let format = format.unwrap_or_default();
+
+    serialize::validate(&rt, format)?;
 
     if let Some(file) = output {
         let mut file = fs::File::create(&file).map_err(IOError::from)?;

--- a/src/operation.rs
+++ b/src/operation.rs
@@ -13,12 +13,12 @@ use crate::label::ty_path;
 use crate::merge;
 use crate::merge::merge;
 use crate::position::RawSpan;
-use crate::serialize;
 use crate::stack::Stack;
 use crate::term::make as mk_term;
 use crate::term::{BinaryOp, RichTerm, StrChunk, Term, UnaryOp};
 use crate::transformations::Closurizable;
 use crate::{mk_app, mk_fun};
+use crate::{serialize, serialize::ExportFormat};
 use md5::digest::Digest;
 use simple_counter::*;
 use std::collections::HashMap;
@@ -1395,16 +1395,24 @@ fn process_binary_operation(
                     &global_env,
                     &env2,
                 );
-                serialize::validate(&rt2)?;
 
                 let result = match id.to_string().as_str() {
-                    "Json" => serde_json::to_string_pretty(&rt2)
-                        .map_err(|err| SerializationError::Other(err.to_string()))?,
-                    "Yaml" => serde_yaml::to_string(&rt2)
-                        .map_err(|err| SerializationError::Other(err.to_string()))?,
-                    "Toml" => toml::Value::try_from(&rt2)
-                        .map(|v| format!("{}", v))
-                        .map_err(|err| SerializationError::Other(err.to_string()))?,
+                    "Json" => {
+                        serialize::validate(&rt2, ExportFormat::Json)?;
+                        serde_json::to_string_pretty(&rt2)
+                            .map_err(|err| SerializationError::Other(err.to_string()))?
+                    }
+                    "Yaml" => {
+                        serialize::validate(&rt2, ExportFormat::Yaml)?;
+                        serde_yaml::to_string(&rt2)
+                            .map_err(|err| SerializationError::Other(err.to_string()))?
+                    }
+                    "Toml" => {
+                        serialize::validate(&rt2, ExportFormat::Toml)?;
+                        toml::Value::try_from(&rt2)
+                            .map(|v| format!("{}", v))
+                            .map_err(|err| SerializationError::Other(err.to_string()))?
+                    }
                     _ => return mk_err_fst(t1),
                 };
 

--- a/src/operation.rs
+++ b/src/operation.rs
@@ -1528,6 +1528,7 @@ fn eq(env: &mut Environment, c1: Closure, c2: Closure) -> EqResult {
     }
 
     match (*t1, *t2) {
+        (Term::Null, Term::Null) => EqResult::Bool(true),
         (Term::Bool(b1), Term::Bool(b2)) => EqResult::Bool(b1 == b2),
         (Term::Num(n1), Term::Num(n2)) => EqResult::Bool(n1 == n2),
         (Term::Str(s1), Term::Str(s2)) => EqResult::Bool(s1 == s2),

--- a/src/parser/lexer.rs
+++ b/src/parser/lexer.rs
@@ -69,6 +69,8 @@ pub enum NormalToken<'input> {
     #[token("switch")]
     Switch,
 
+    #[token("null")]
+    Null,
     #[token("true")]
     True,
     #[token("false")]

--- a/src/program.rs
+++ b/src/program.rs
@@ -1000,6 +1000,7 @@ Assume(#alwaysTrue, false)
         assert_peq!("\"a\" ++ \"b\" ++ \"c\"", "\"#{\"a\" ++ \"b\"}\" ++ \"c\"");
         assert_peq!("`Less", "`Less");
         assert_peq!("`small", "`small");
+        assert_peq!("null", "null");
 
         assert_npeq!("1 + 1", "0");
         assert_npeq!("true", "if true then false else true");
@@ -1010,6 +1011,9 @@ Assume(#alwaysTrue, false)
         assert_npeq!("`Less", "`small");
         assert_npeq!("`Less", "0");
         assert_npeq!("`Greater", "false");
+        assert_npeq!("`Abc", "null");
+        assert_npeq!("0", "null");
+        assert_npeq!("null", "false");
     }
 
     #[test]

--- a/src/term.rs
+++ b/src/term.rs
@@ -33,6 +33,10 @@ use std::ffi::OsString;
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum Term {
+    /// The null value.
+    // #[serde(serialize_with = "crate::serialize::serialize_null")]
+    // #[serde(deserialize_with = "crate::serialize::deserialize_null")]
+    Null,
     /// A boolean value.
     Bool(bool),
     /// A floating-point value.
@@ -217,6 +221,7 @@ impl Term {
     {
         use self::Term::*;
         match self {
+            Null => (),
             Switch(ref mut t, ref mut cases, ref mut def) => {
                 cases.iter_mut().for_each(|c| {
                     let (_, t) = c;
@@ -276,6 +281,7 @@ impl Term {
     /// for records, `"Fun`" for functions, etc. If the term is not a WHNF, `None` is returned.
     pub fn type_of(&self) -> Option<String> {
         match self {
+            Term::Null => Some("Null"),
             Term::Bool(_) => Some("Bool"),
             Term::Num(_) => Some("Num"),
             Term::Str(_) => Some("Str"),
@@ -305,6 +311,7 @@ impl Term {
     /// Return a shallow string representation of a term, used for error reporting.
     pub fn shallow_repr(&self) -> String {
         match self {
+            Term::Null => String::from("null"),
             Term::Bool(true) => String::from("true"),
             Term::Bool(false) => String::from("false"),
             Term::Num(n) => format!("{}", n),
@@ -367,7 +374,8 @@ impl Term {
     /// Determine if a term is in evaluated from, called weak head normal form (WHNF).
     pub fn is_whnf(&self) -> bool {
         match self {
-            Term::Bool(_)
+            Term::Null
+            | Term::Bool(_)
             | Term::Num(_)
             | Term::Str(_)
             | Term::Fun(_, _)
@@ -395,40 +403,17 @@ impl Term {
 
     /// Determine if a term is an enriched value.
     pub fn is_enriched(&self) -> bool {
-        match self {
-            Term::MetaValue(_) => true,
-            Term::Bool(_)
-            | Term::Num(_)
-            | Term::Str(_)
-            | Term::StrChunks(_)
-            | Term::Fun(_, _)
-            | Term::Lbl(_)
-            | Term::Enum(_)
-            | Term::Record(_)
-            | Term::RecRecord(_)
-            | Term::List(_)
-            | Term::Sym(_)
-            | Term::Wrapped(_, _)
-            | Term::Let(_, _, _)
-            | Term::App(_, _)
-            | Term::Switch(..)
-            | Term::Var(_)
-            | Term::Op1(_, _)
-            | Term::Op2(_, _, _)
-            | Term::Promise(_, _, _)
-            | Term::Assume(_, _, _)
-            | Term::Import(_)
-            | Term::ResolvedImport(_) => false,
-        }
+        matches!(self, Term::MetaValue(..))
     }
 
     /// Determine if a term is a constant.
     ///
-    /// In this context, a constant is an atomic literal of the language: a boolean, a number, a
+    /// In this context, a constant is an atomic literal of the language: null, a boolean, a number, a
     /// string, a label, an enum tag or a symbol.
     pub fn is_constant(&self) -> bool {
         match self {
-            Term::Bool(_)
+            Term::Null
+            | Term::Bool(_)
             | Term::Num(_)
             | Term::Str(_)
             | Term::Lbl(_)
@@ -683,7 +668,8 @@ impl RichTerm {
     {
         let RichTerm { term, pos } = self;
         match *term {
-            v @ Term::Bool(_)
+            v @ Term::Null
+            | v @ Term::Bool(_)
             | v @ Term::Num(_)
             | v @ Term::Str(_)
             | v @ Term::Lbl(_)

--- a/src/transformations.rs
+++ b/src/transformations.rs
@@ -143,7 +143,8 @@ pub mod share_normal_form {
     /// subexpressions, such as a record, should be shared.
     fn should_share(t: &Term) -> bool {
         match t {
-            Term::Bool(_)
+            Term::Null
+            | Term::Bool(_)
             | Term::Num(_)
             | Term::Str(_)
             | Term::Lbl(_)

--- a/src/typecheck.rs
+++ b/src/typecheck.rs
@@ -496,6 +496,9 @@ fn type_check_(
     let RichTerm { term: t, pos } = rt;
 
     match t.as_ref() {
+        // null is inferred to be of type Dyn
+        Term::Null => unify(state, strict, ty, mk_typewrapper::dynamic())
+            .map_err(|err| err.into_typecheck_err(state, &rt.pos)),
         Term::Bool(_) => unify(state, strict, ty, mk_typewrapper::bool())
             .map_err(|err| err.into_typecheck_err(state, &rt.pos)),
         Term::Num(_) => unify(state, strict, ty, mk_typewrapper::num())


### PR DESCRIPTION
Some time ago, we agreed upon having `null` in the language, as we aim for easy interoperability with JSON. With the recent addition of multiple export and import formats, the time has come, especially since #282: if one tries to import a JSON or a YAML file with null values, this currently raises an error.

This PR adds the null value to the language. `null` is typechecked as `Dyn`. Serialization prevalidation ensures that formats that don't support null (such as TOML, for example) raise an appropriate error at export.