### PR TITLE
[Fix]Wrong apparent type for list literals

### DIFF
--- a/src/typecheck.rs
+++ b/src/typecheck.rs
@@ -810,7 +810,7 @@ pub fn apparent_type(t: &Term, envs: Option<&Envs>) -> ApparentType {
         Term::Sym(_) => ApparentType::Inferred(Types(AbsType::Sym())),
         Term::Str(_) | Term::StrChunks(_) => ApparentType::Inferred(Types(AbsType::Str())),
         Term::List(_) => {
-            ApparentType::Inferred(Types(AbsType::List(Box::new(Types(AbsType::Dyn())))))
+            ApparentType::Approximated(Types(AbsType::List(Box::new(Types(AbsType::Dyn())))))
         }
         Term::Var(id) => envs
             .and_then(|envs| envs.get(id))

--- a/src/typecheck.rs
+++ b/src/typecheck.rs
@@ -2385,4 +2385,13 @@ mod tests {
         parse_and_typecheck("let x = false in (x || true : Bool)").unwrap();
         parse_and_typecheck("let x = false in let y = x in let z = y in (z : Bool)").unwrap();
     }
+
+    /// Regression test following, see [#297](https://github.com/tweag/nickel/pull/297). Check that
+    /// [apparent_type](../fn.apparent_type.html) doesn't silently convert list literals from `List
+    /// T` (for `T` a type or a type variable) to `List Dyn`.
+    #[test]
+    fn apparent_type_lists() {
+        parse_and_typecheck("{foo = [1]} : {foo : List Num}").unwrap();
+        parse_and_typecheck("(let y = [] in y) : forall a. List a").unwrap();
+    }
 }


### PR DESCRIPTION
When encountering a binding to a list literal, of the form `let x = [ .. ]` or inside a record `{ foo = [ .. ] }`, the typechecker uses the `apparent_type` function first to determine quickly the type of such binding. This functions either returns what it thinks is the actual type of the expression, such as `Inferred(Num)`, or an approximation. In statically typed code, this approximation is ignored, since we can actually precisely determine the type of this binding by generating a new type variable and checking the body. However, if `Inferred(..)` is returned, the typechecker takes this type for granted and goes on.

Thus, on important property is that 

`apparent_type(exp) == Inferred(Type)` => Type is a principal type for exp (modulo generalization)

This property was violated in case of lists, where `apparent_type` was returning the less precise type `Inferred(List Dyn)`. Hence, some type information was lost when inside let-bindings or record fields:
```
$nickel repl
nickel>:typecheck [] : forall a. List a
Ok: forall a. List a
nickel>:typecheck { right = []; wrong = [] } : forall a. { right : List a, wrong: List a }
error: Incompatible rows declaration
  ┌─ <repl-typecheck>:1:1
  │
1 │ { right = []; wrong = [] } : forall a. { right : List a, wrong: List a }
  │ ^^^^^^^^^^^^^^^^^^^^^^^^^^ this expression
  │
  = The type of the expression was expected to be `{right: List a, wrong: List a}`
  = The type of the expression was inferred to be `{right: List, wrong: List}`
  = Could not match the two declaration of `right`
```

This PR fixes this by switching the result of `apparent_type` to `Approximates(List Dyn)`, saying to the typechecker that it should infer a more precise type when in a statically typed block.