### PR TITLE
Piecewise record definition using attribute paths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -622,7 +622,6 @@ dependencies = [
  "assert_matches",
  "codespan",
  "codespan-reporting",
- "either",
  "lalrpop",
  "lalrpop-util",
  "logos",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,6 @@ lalrpop = "0.16.2"
 [dependencies]
 lalrpop-util = "0.16.2"
 regex = "0.2.1"
-either = "1.5.3"
 simple-counter = "0.1.0"
 codespan = "0.9.5"
 codespan-reporting = "0.9.5"

--- a/src/error.rs
+++ b/src/error.rs
@@ -8,6 +8,7 @@ use crate::label::ty_path;
 use crate::parser::lexer::LexicalError;
 use crate::parser::utils::mk_span;
 use crate::position::RawSpan;
+use crate::serialize::ExportFormat;
 use crate::term::RichTerm;
 use crate::types::Types;
 use crate::{label, repl};
@@ -224,6 +225,10 @@ pub enum ImportError {
 /// An error occurred during serialization.
 #[derive(Debug, PartialEq, Clone)]
 pub enum SerializationError {
+    /// Encountered a null value for a format that doesn't support them.
+    UnsupportedNull(ExportFormat, RichTerm),
+    /// Tried exporting something else than a `Str` to raw format.
+    NotAString(RichTerm),
     /// A term contains constructs that cannot be serialized.
     NonSerializable(RichTerm),
     Other(String),
@@ -1308,6 +1313,17 @@ impl ToDiagnostic<FileId> for SerializationError {
         _contract_id: Option<FileId>,
     ) -> Vec<Diagnostic<FileId>> {
         match self {
+            SerializationError::NotAString(rt) => vec![Diagnostic::error()
+                .with_message(format!(
+                    "raw export only supports `Str`, got {}",
+                    rt.as_ref()
+                        .type_of()
+                        .unwrap_or(String::from("<unevaluated>"))
+                ))
+                .with_labels(vec![primary_term(&rt, files)])],
+            SerializationError::UnsupportedNull(format, rt) => vec![Diagnostic::error()
+                .with_message(format!("{} doesn't support null values", format))
+                .with_labels(vec![primary_term(&rt, files)])],
             SerializationError::NonSerializable(rt) => vec![Diagnostic::error()
                 .with_message("non serializable term")
                 .with_labels(vec![primary_term(&rt, files)])],

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -785,7 +785,8 @@ pub fn subst(rt: RichTerm, global_env: &Environment, env: &Environment) -> RichT
                     subst_(closure.body, global_env, &closure.env, bound)
                 })
                 .unwrap_or_else(|| RichTerm::new(Term::Var(id), pos)),
-            v @ Term::Bool(_)
+            v @ Term::Null
+            | v @ Term::Bool(_)
             | v @ Term::Num(_)
             | v @ Term::Str(_)
             | v @ Term::Lbl(_)

--- a/src/grammar.lalrpop
+++ b/src/grammar.lalrpop
@@ -237,6 +237,7 @@ Atom: RichTerm = {
             )
         ),
     "num literal" => RichTerm::from(Term::Num(<>)),
+    "null" => RichTerm::from(Term::Null),
     Bool => RichTerm::from(Term::Bool(<>)),
     <StrChunks>,
     Ident => RichTerm::from(Term::Var(<>)),
@@ -616,6 +617,7 @@ extern {
         "let" => Token::Normal(NormalToken::Let),
         "switch" => Token::Normal(NormalToken::Switch),
 
+        "null" => Token::Normal(NormalToken::Null),
         "true" => Token::Normal(NormalToken::True),
         "false" => Token::Normal(NormalToken::False),
 

--- a/src/grammar.lalrpop
+++ b/src/grammar.lalrpop
@@ -182,7 +182,7 @@ RecordOperand: RichTerm = {
 
 RecordOperationChain: RichTerm = {
     <t: SpTerm<RecordOperand>> "." <id: Ident> => mk_term::op1(UnaryOp::StaticAccess(id), t),
-    <t: SpTerm<RecordOperand>> ".$" <t_id: SpTerm<Atom>> => mk_term::op2(BinaryOp::DynAccess(), t_id, t),
+    <t: SpTerm<RecordOperand>> "." <t_id: StrChunks> => mk_term::op2(BinaryOp::DynAccess(), t_id, t),
     <t: SpTerm<RecordOperand>> "-$" <t_id: SpTerm<Atom>> => mk_term::op2(BinaryOp::DynRemove(), t_id, t),
     <r: SpTerm<RecordOperand>> "$[" <id: Term> "=" <t: Term> "]" =>
         mk_app!(mk_term::op2(BinaryOp::DynExtend(), id, r), t),
@@ -287,8 +287,7 @@ FieldPath: Vec<FieldPathElem> = {
 
 FieldPathElem: FieldPathElem = {
     <Ident> => FieldPathElem::Ident(<>),
-    "\"" <ChunkLiteral> "\"" => FieldPathElem::Ident(Ident(<>)),
-    "$" <id: SpTerm<Atom>> => FieldPathElem::Expr(<>),
+    <StrChunks> => FieldPathElem::Expr(<>),
 };
 
 Pattern: Ident = {
@@ -616,7 +615,6 @@ extern {
         ";" => Token::Normal(NormalToken::SemiCol),
         "&" => Token::Normal(NormalToken::Ampersand),
         "." => Token::Normal(NormalToken::Dot),
-        ".$" => Token::Normal(NormalToken::DotDollar),
         "$[" => Token::Normal(NormalToken::DollarBracket),
         "#{" => Token::Str(StringToken::HashBrace),
         "multstr #{" => Token::MultiStr(MultiStringToken::Interpolation),
@@ -634,7 +632,6 @@ extern {
         "||" => Token::Normal(NormalToken::DoublePipe),
         "!" => Token::Normal(NormalToken::Bang),
 
-        "$=" => Token::Normal(NormalToken::DollarEquals),
         "fun" => Token::Normal(NormalToken::Fun),
         "import" => Token::Normal(NormalToken::Import),
         "|" => Token::Normal(NormalToken::Pipe),

--- a/src/grammar.lalrpop
+++ b/src/grammar.lalrpop
@@ -6,12 +6,12 @@ use crate::mk_app;
 use crate::types::{Types, AbsType};
 use super::ExtendedTerm;
 use super::utils::{StringKind, mk_span, mk_label, strip_indent, SwitchCase,
-    strip_indent_doc};
+    FieldPathElem, strip_indent_doc, build_record, elaborate_field_path,
+    ChunkLiteralPart};
 use std::ffi::OsString;
 use super::lexer::{Token, NormalToken, StringToken, MultiStringToken, LexicalError};
 use std::collections::HashMap;
 use std::cmp::min;
-use either::*;
 use codespan::FileId;
 
 grammar<'input>(src_id: FileId, );
@@ -242,25 +242,9 @@ Atom: RichTerm = {
     <StrChunks>,
     Ident => RichTerm::from(Term::Var(<>)),
     "`" <Ident> => RichTerm::from(Term::Enum(<>)),
-    "{" <fields: (RecordField ";")*> <last: RecordField?> "}" => {
-        let mut static_map = HashMap::new();
-        let mut dynamic_fields = Vec::new();
-
-        fields
-            .into_iter()
-            .map(|x| x.0)
-            .chain(last.into_iter())
-            .for_each(|field| match field {
-                Left((id, t)) => { static_map.insert(id, t) ;}
-                Right(t) => dynamic_fields.push(t),
-            });
-
-        let static_rec = RichTerm::from(Term::RecRecord(static_map));
-
-        dynamic_fields.into_iter().fold(static_rec, |rec, field| {
-            let (id_t, t) = field;
-            mk_app!(mk_term::op2(BinaryOp::DynExtend(), id_t, rec), t)
-        })
+    "{" <fields: (<RecordField> ";")*> <last: RecordField?> "}" => {
+        let fields = fields.into_iter().chain(last.into_iter());
+        RichTerm::from(build_record(fields))
     },
     "[" <terms: (SpTerm<Atom> ",")*> <last: Term?> "]" => {
         let terms : Vec<RichTerm> = terms.into_iter()
@@ -270,8 +254,8 @@ Atom: RichTerm = {
     }
 };
 
-RecordField: Either<(Ident, RichTerm), (RichTerm, RichTerm)> = {
-    <id: Ident> <ann: TypeAnnot?> "=" <t: Term> => {
+RecordField: (FieldPathElem, RichTerm) = {
+    <path: FieldPath> <ann: TypeAnnot?> "=" <t: Term> => {
         let t = if let Some((l, ty, r)) = ann {
             let pos = t.pos.clone();
             RichTerm::new(Term::Promise(ty.clone(), mk_label(ty, src_id, l, r), t), pos)
@@ -280,28 +264,32 @@ RecordField: Either<(Ident, RichTerm), (RichTerm, RichTerm)> = {
             t
         };
 
-        Either::Left((id, t))
+        elaborate_field_path(path, t)
     },
-    <l: @L> <id: Ident> <meta: MetaAnnot> <r: @R> <t: ("=" <Term>)?> => {
+    <l: @L> <path: FieldPath> <meta: MetaAnnot> <r: @R> <t: ("=" <Term>)?> => {
         let mut meta = meta;
         let pos = t.as_ref()
             .map(|t| t.pos.clone())
             .unwrap_or(Some(mk_span(src_id, l, r)));
         meta.value = t;
-        Either::Left((id, RichTerm::new(Term::MetaValue(meta), pos)))
-    },
-    "$" <id: SpTerm<Atom>> <ann: TypeAnnot?> "=" <t: Term> => {
-        let t = if let Some((l, ty, r)) = ann {
-            let pos = t.pos.clone();
-            RichTerm::new(Term::Promise(ty.clone(), mk_label(ty, src_id, l, r), t), pos)
-        }
-        else {
-            t
-        };
-
-        Either::Right((id, t))
+        let t = RichTerm::new(Term::MetaValue(meta), pos);
+        elaborate_field_path(path, t)
     }
 }
+
+FieldPath: Vec<FieldPathElem> = {
+    <elems: (<FieldPathElem> ".")*> <last: FieldPathElem> => {
+        let mut elems = elems;
+        elems.push(last);
+        elems
+    }
+};
+
+FieldPathElem: FieldPathElem = {
+    <Ident> => FieldPathElem::Ident(<>),
+    "\"" <ChunkLiteral> "\"" => FieldPathElem::Ident(Ident(<>)),
+    "$" <id: SpTerm<Atom>> => FieldPathElem::Expr(<>),
+};
 
 Pattern: Ident = {
     Ident,
@@ -356,8 +344,8 @@ ChunkLiteral : String =
     <parts: ChunkLiteralPart+> => {
         parts.into_iter().fold(String::new(), |mut acc, part| {
             match part {
-                Either::Left(s) => acc.push_str(s),
-                Either::Right(c) => acc.push(c),
+                ChunkLiteralPart::Str(s) => acc.push_str(s),
+                ChunkLiteralPart::Char(c) => acc.push(c),
             };
 
             acc
@@ -370,13 +358,13 @@ HashBrace = { "#{", "multstr #{" };
 
 Str: String = "\"" <s: ChunkLiteral> "\"" => s;
 
-ChunkLiteralPart: Either<&'input str, char> = {
-    "str literal" => Either::Left(<>),
-    "str #" => Either::Left(<>),
-    "multstr literal" => Either::Left(<>),
-    "false interpolation" => Either::Left(<>),
-    "false end" => Either::Left(<>),
-    "str esc char" => Either::Right(<>),
+ChunkLiteralPart: ChunkLiteralPart<'input> = {
+    "str literal" => ChunkLiteralPart::Str(<>),
+    "str #" => ChunkLiteralPart::Str(<>),
+    "multstr literal" => ChunkLiteralPart::Str(<>),
+    "false interpolation" => ChunkLiteralPart::Str(<>),
+    "false end" => ChunkLiteralPart::Str(<>),
+    "str esc char" => ChunkLiteralPart::Char(<>),
     };
 
 UOp: UnaryOp = {

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,8 +30,6 @@ use std::{fmt, fs, io, process};
 // use std::ffi::OsStr;
 use structopt::StructOpt;
 
-extern crate either;
-
 /// Command-line options and subcommands.
 #[derive(StructOpt, Debug)]
 /// The interpreter of the Nickel language.

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,6 +21,7 @@ mod types;
 use crate::error::{Error, IOError, SerializationError};
 use crate::program::Program;
 use crate::repl::rustyline_frontend;
+use crate::serialize::ExportFormat;
 use crate::term::{RichTerm, Term};
 use std::io::Write;
 use std::path::PathBuf;
@@ -41,15 +42,6 @@ struct Opt {
     file: Option<PathBuf>,
     #[structopt(subcommand)]
     command: Option<Command>,
-}
-
-/// Available export formats.
-#[derive(Copy, Clone, Eq, PartialEq, Debug)]
-enum ExportFormat {
-    Raw,
-    Json,
-    Yaml,
-    Toml,
 }
 
 impl std::default::Default for ExportFormat {
@@ -187,9 +179,9 @@ fn export(
     output: Option<PathBuf>,
 ) -> Result<(), Error> {
     let rt = program.eval_full().map(RichTerm::from)?;
-    serialize::validate(&rt)?;
-
     let format = format.unwrap_or_default();
+
+    serialize::validate(&rt, format)?;
 
     if let Some(file) = output {
         let mut file = fs::File::create(&file).map_err(IOError::from)?;

--- a/src/operation.rs
+++ b/src/operation.rs
@@ -1374,6 +1374,7 @@ fn eq(env: &mut Environment, c1: Closure, c2: Closure) -> EqResult {
     }
 
     match (*t1, *t2) {
+        (Term::Null, Term::Null) => EqResult::Bool(true),
         (Term::Bool(b1), Term::Bool(b2)) => EqResult::Bool(b1 == b2),
         (Term::Num(n1), Term::Num(n2)) => EqResult::Bool(n1 == n2),
         (Term::Str(s1), Term::Str(s2)) => EqResult::Bool(s1 == s2),

--- a/src/parser/lexer.rs
+++ b/src/parser/lexer.rs
@@ -69,6 +69,8 @@ pub enum NormalToken<'input> {
     #[token("switch")]
     Switch,
 
+    #[token("null")]
+    Null,
     #[token("true")]
     True,
     #[token("false")]

--- a/src/parser/lexer.rs
+++ b/src/parser/lexer.rs
@@ -90,12 +90,8 @@ pub enum NormalToken<'input> {
     Ampersand,
     #[token(".")]
     Dot,
-    #[token(".$")]
-    DotDollar,
     #[token("$[")]
     DollarBracket,
-    #[token("$=")]
-    DollarEquals,
     #[token("\"")]
     DoubleQuote,
     #[token("-$")]

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -177,11 +177,11 @@ fn record_terms() {
     );
 
     assert_eq!(
-        parse_without_pos("{ a = 1; $123 = (if 4 then 5 else 6); d = 42;}"),
+        parse_without_pos("{ a = 1; \"#{123}\" = (if 4 then 5 else 6); d = 42;}"),
         mk_app!(
             mk_term::op2(
                 BinaryOp::DynExtend(),
-                Num(123.),
+                StrChunks(vec![StrChunk::expr(RichTerm::from(Num(123.)))]),
                 RecRecord(
                     vec![
                         (Ident::from("a"), Num(1.).into()),

--- a/src/program.rs
+++ b/src/program.rs
@@ -501,23 +501,23 @@ Assume(#alwaysTrue, false)
         );
 
         assert_eq!(
-            eval_string("({ $(if true then \"foo\" else \"bar\") = false; bar = true; }).foo"),
+            eval_string("({ \"#{if true then \"foo\" else \"bar\"}\" = false; bar = true; }).foo"),
             Ok(Term::Bool(false)),
         );
 
         assert_eq!(
-            eval_string("({ foo = 3; bar = true; }).$(\"bar\")"),
+            eval_string("({ foo = 3; bar = true; }).\"bar\""),
             Ok(Term::Bool(true)),
         );
 
         assert_eq!(
             eval_string(
-                "({ $(if true then \"foo\" else \"bar\") = false; bar = true; }).$(\"foo\")"
+                "({ \"#{if true then \"foo\" else \"bar\"}\" = false; bar = true; }).\"foo\""
             ),
             Ok(Term::Bool(false)),
         );
 
-        eval_string("({ $(if false then \"foo\" else \"bar\") = false; bar = true; }).foo")
+        eval_string("({ \"#{if false then \"foo\" else \"bar\"}\" = false; bar = true; }).foo")
             .unwrap_err();
     }
 

--- a/src/program.rs
+++ b/src/program.rs
@@ -999,6 +999,7 @@ Assume(#alwaysTrue, false)
         assert_peq!("\"a\" ++ \"b\" ++ \"c\"", "\"#{\"a\" ++ \"b\"}\" ++ \"c\"");
         assert_peq!("`Less", "`Less");
         assert_peq!("`small", "`small");
+        assert_peq!("null", "null");
 
         assert_npeq!("1 + 1", "0");
         assert_npeq!("true", "if true then false else true");
@@ -1009,6 +1010,9 @@ Assume(#alwaysTrue, false)
         assert_npeq!("`Less", "`small");
         assert_npeq!("`Less", "0");
         assert_npeq!("`Greater", "false");
+        assert_npeq!("`Abc", "null");
+        assert_npeq!("0", "null");
+        assert_npeq!("null", "false");
     }
 
     #[test]

--- a/src/transformations.rs
+++ b/src/transformations.rs
@@ -143,7 +143,8 @@ pub mod share_normal_form {
     /// subexpressions, such as a record, should be shared.
     fn should_share(t: &Term) -> bool {
         match t {
-            Term::Bool(_)
+            Term::Null
+            | Term::Bool(_)
             | Term::Num(_)
             | Term::Str(_)
             | Term::Lbl(_)

--- a/src/typecheck.rs
+++ b/src/typecheck.rs
@@ -496,6 +496,9 @@ fn type_check_(
     let RichTerm { term: t, pos } = rt;
 
     match t.as_ref() {
+        // null is inferred to be of type Dyn
+        Term::Null => unify(state, strict, ty, mk_typewrapper::dynamic())
+            .map_err(|err| err.into_typecheck_err(state, &rt.pos)),
         Term::Bool(_) => unify(state, strict, ty, mk_typewrapper::bool())
             .map_err(|err| err.into_typecheck_err(state, &rt.pos)),
         Term::Num(_) => unify(state, strict, ty, mk_typewrapper::num())

--- a/src/typecheck.rs
+++ b/src/typecheck.rs
@@ -2201,13 +2201,14 @@ mod tests {
 
     #[test]
     fn dynamic_record_simple() {
-        parse_and_typecheck("{ $(if true then \"foo\" else \"bar\") = 2; } : {_ : Num}").unwrap();
+        parse_and_typecheck("{ \"#{if true then \"foo\" else \"bar\"}\" = 2; } : {_ : Num}")
+            .unwrap();
 
-        parse_and_typecheck("({ $(if true then \"foo\" else \"bar\") = 2; }.$(\"bla\")) : Num")
+        parse_and_typecheck("({ \"#{if true then \"foo\" else \"bar\"}\" = 2; }.\"bla\") : Num")
             .unwrap();
 
         parse_and_typecheck(
-            "({ $(if true then \"foo\" else \"bar\") = 2; $(\"foo\") = true; }.$(\"bla\")) : Num",
+            "({ \"#{if true then \"foo\" else \"bar\"}\" = 2; \"foo\" = true; }.\"bla\") : Num",
         )
         .unwrap_err();
 

--- a/stdlib/contracts.ncl
+++ b/stdlib/contracts.ncl
@@ -44,7 +44,7 @@
 
   record_extend = fun field contr cont acc l t =>
       if %hasField% field t then
-          let acc = acc$[field = contr (%goField% field l) (t.$field)] in
+          let acc = acc$[field = contr (%goField% field l) (t."#{field}")] in
           let t = t -$ field in
           cont acc l t
       else
@@ -57,7 +57,7 @@
               let rest = (t -$ magic_fld) in
               if rest == {} then
                   let fail = %blame% (%tag% "polymorphic tail mismatch" l) in
-                  let inner = %unwrap% sy (t.$magic_fld) fail in
+                  let inner = %unwrap% sy (t."#{magic_fld}") fail in
                   acc & inner
               else
                   %blame% (%tag% "extra field `#{%head% (%fieldsOf% rest)}`" l)


### PR DESCRIPTION
Depend on #292. Address #84. This PRs aims at making record definitions more pleasant. It is based on #84 and the early feedbacks of @garbas  and @Infinisil. It adds the following features:

## Field definition using attribute paths
Nested records can now be defined using a flat path 
```
{
   option.packages.stuff.enabled = true;
   other.foo.bar = 1;
}
// equivalent to
{
  option = { packages = { stuff = {enabled = true}}};
  other = {foo = { bar = 1}};
}
```
Type and metadata annotations are pushed to the leaf, that is
`{ foo.bar | default = 1}` is equivalent to `{foo = {bar | default = 1}}`.


## Field name escaping
To define a field which name is not a valid identifier, one currently has to resort to the interpolation syntax: `{ $"some-id.com" = stuff}`. The interpolation syntax supports arbitrary expressions, but the resulting expression must be a string anyway. The `$` is not used for interpolation anymore, so although it can be changed to `#`, it is out of sync. This PR changes it to a lighter syntax that just uses double quotes: `{"some-id.com" = stuff}`. Same for field access: `r."some-id.com"`. This syntax is common (supported in JSON, JavaScript, Nix, etc...). We can leverage stand strings to support interpolation out of the box, so that any previous dynamic interpolated expressions `{ $var = stuff}` can still be written as `{ "#{var}" = stuff}`, such that there's no new syntax.

## Piecewise definition
If the same field is defined multiple times, the different definitions are merged. This makes sense because merging is the natural semantics for combining multiple values in Nickel. Example:
```
{
  someoption.stuff.foo.bar.enabled = true;
  someoption.stuff.foo.baz.host = 2;
}
// equivalent to
{
  someoption.stuff.foo = {bar.enabled = true; baz.host = 2}
}
```

Merging then handles the cases of incompatible definitions:

```
nickel export <<< "{ a.b = 2; a.b = 3}"
error: Non mergeable terms
  ┌─ <stdin>:1:8
  │
1 │ {a.b = 2; a.b = 3}
  │        ^        ^ with this expression
  │        │         
  │        cannot merge this expression
```

## Tests
As tests are being reworked, this doesn't make sense to wast time to write them now just to rewrite them immediately after. Hence #84 stays open, with an item to remember to add some tests once the test suite has been upgraded.