### PR TITLE
Contracts as records and blame error reporting

### DIFF
--- a/src/grammar.lalrpop
+++ b/src/grammar.lalrpop
@@ -16,13 +16,7 @@ use codespan::FileId;
 
 grammar<'input>(src_id: FileId, );
 
-SpTerm<Rule>: RichTerm =
-    <l: @L> <t: Rule> <r: @R> => match t {
-        RichTerm {term: t, pos: _} => RichTerm {
-            term: t,
-            pos: mk_pos(src_id, l, r)
-        }
-    };
+SpTerm<Rule>: RichTerm = <l: @L> <t: Rule> <r: @R> => t.with_pos(mk_pos(src_id, l, r));
 
 TypeAnnot: (usize, Types, usize) = ":" <l: @L> <ty: Types> <r: @R> => (l, ty, r);
 
@@ -372,6 +366,7 @@ UOp: UnaryOp = {
     "isList" => UnaryOp::IsList(),
     "isRecord" => UnaryOp::IsRecord(),
     "blame" => UnaryOp::Blame(),
+    "applyContract" => UnaryOp::ApplyContract(),
     "chngPol" => UnaryOp::ChangePolarity(),
     "polarity" => UnaryOp::Pol(),
     "goDom" => UnaryOp::GoDom(),
@@ -655,6 +650,7 @@ extern {
         "List" => Token::Normal(NormalToken::List),
 
         "tag" => Token::Normal(NormalToken::Tag),
+        "applyContract" => Token::Normal(NormalToken::ApplyContract),
         "Assume(" => Token::Normal(NormalToken::Assume),
         "Promise(" => Token::Normal(NormalToken::Promise),
         "Default(" => Token::Normal(NormalToken::Deflt),

--- a/src/label.rs
+++ b/src/label.rs
@@ -2,7 +2,8 @@
 //!
 //! A label is a value holding metadata relative to contract checking. It gives the user useful
 //! information about the context of a contract failure.
-use crate::position::RawSpan;
+use crate::eval::Thunk;
+use crate::position::{RawSpan, TermPos};
 use crate::types::{AbsType, Types};
 use codespan::Files;
 
@@ -236,6 +237,10 @@ pub struct Label {
     pub tag: String,
     /// The position of the original contract.
     pub span: RawSpan,
+    /// The thunk corresponding to the value being checked. Set at run-time by the interpreter.
+    pub arg_thunk: Option<Thunk>,
+    /// The original position of the value being checked. Set at run-time by the interpreter.
+    pub arg_pos: TermPos,
     /// The polarity, used for higher-order contracts, that specifies if the current contract is
     /// on the environment (ex, the argument of a function) or on the term.
     pub polarity: bool,
@@ -254,6 +259,8 @@ impl Label {
                 start: 0.into(),
                 end: 1.into(),
             },
+            arg_thunk: None,
+            arg_pos: TermPos::None,
             polarity: false,
             path: Vec::new(),
         }

--- a/src/operation.rs
+++ b/src/operation.rs
@@ -257,7 +257,7 @@ fn process_unary_operation(
                         "x",
                         mk_term::op2(BinaryOp::Merge(), closurized, mk_term::var("x"))
                     )
-                    .with_pos(pos);
+                    .with_pos(pos.into_inherited());
 
                     Ok(Closure { body, env: new_env })
                 }

--- a/src/operation.rs
+++ b/src/operation.rs
@@ -79,7 +79,7 @@ pub fn continuate_operation(
     call_stack.truncate(cs_len);
     match cont {
         OperationCont::Op1(u_op, arg_pos, prev_strict) => {
-            let result = process_unary_operation(u_op, clos, arg_pos, stack, pos);
+            let result = process_unary_operation(u_op, clos, arg_pos, stack, call_stack, pos);
             *enriched_strict = prev_strict;
             result
         }
@@ -110,6 +110,7 @@ fn process_unary_operation(
     clos: Closure,
     arg_pos: TermPos,
     stack: &mut Stack,
+    call_stack: &mut CallStack,
     pos_op: TermPos,
 ) -> Result<Closure, EvalError> {
     let Closure {
@@ -122,8 +123,8 @@ fn process_unary_operation(
         UnaryOp::Ite() => {
             if let Term::Bool(b) = *t {
                 if stack.count_args() >= 2 {
-                    let (fst, _) = stack.pop_arg().expect("Condition already checked.");
-                    let (snd, _) = stack.pop_arg().expect("Condition already checked.");
+                    let (fst, ..) = stack.pop_arg().expect("Condition already checked.");
+                    let (snd, ..) = stack.pop_arg().expect("Condition already checked.");
 
                     Ok(if b { fst } else { snd })
                 } else {
@@ -165,7 +166,7 @@ fn process_unary_operation(
         UnaryOp::BoolAnd() =>
         // The syntax should not allow partially applied boolean operators.
         {
-            if let Some((next, _)) = stack.pop_arg() {
+            if let Some((next, ..)) = stack.pop_arg() {
                 match *t {
                     Term::Bool(true) => Ok(next),
                     // FIXME: this does not check that the second argument is actually a boolean.
@@ -188,7 +189,7 @@ fn process_unary_operation(
             }
         }
         UnaryOp::BoolOr() => {
-            if let Some((next, _)) = stack.pop_arg() {
+            if let Some((next, ..)) = stack.pop_arg() {
                 match *t {
                     b @ Term::Bool(true) => {
                         Ok(Closure::atomic_closure(RichTerm::new(b, pos_op_inh)))
@@ -226,8 +227,11 @@ fn process_unary_operation(
             }
         }
         UnaryOp::Blame() => {
-            if let Term::Lbl(l) = *t {
-                Err(EvalError::BlameError(l, None))
+            if let Term::Lbl(label) = *t {
+                Err(EvalError::BlameError(
+                    label,
+                    std::mem::replace(call_stack, Vec::new()),
+                ))
             } else {
                 Err(EvalError::TypeError(
                     String::from("Label"),
@@ -235,6 +239,34 @@ fn process_unary_operation(
                     arg_pos,
                     RichTerm { term: t, pos },
                 ))
+            }
+        }
+        UnaryOp::ApplyContract() => {
+            match *t {
+                Term::Fun(..) => Ok(Closure {
+                    body: RichTerm { term: t, pos },
+                    env,
+                }),
+                Term::Record(..) => {
+                    let mut new_env = Environment::new();
+                    let closurized = RichTerm { term: t, pos }.closurize(&mut new_env, env);
+
+                    // Convert the record to the function `fun l x => contract & x`.
+                    let body = mk_fun!(
+                        "l",
+                        "x",
+                        mk_term::op2(BinaryOp::Merge(), closurized, mk_term::var("x"))
+                    )
+                    .with_pos(pos);
+
+                    Ok(Closure { body, env: new_env })
+                }
+                _ => Err(EvalError::TypeError(
+                    String::from("Function or record"),
+                    String::from("contract application"),
+                    arg_pos,
+                    RichTerm { term: t, pos },
+                )),
             }
         }
         UnaryOp::Embed(_id) => {
@@ -250,12 +282,12 @@ fn process_unary_operation(
             }
         }
         UnaryOp::Switch(has_default) => {
-            let (cases_closure, _) = stack.pop_arg().expect("missing arg for switch");
+            let (cases_closure, ..) = stack.pop_arg().expect("missing arg for switch");
             let default = if has_default {
                 Some(
                     stack
                         .pop_arg()
-                        .map(|(clos, _)| clos)
+                        .map(|(clos, ..)| clos)
                         .expect("missing default case for switch"),
                 )
             } else {
@@ -441,7 +473,7 @@ fn process_unary_operation(
             }
         }
         UnaryOp::ListMap() => {
-            let (f, _) = stack
+            let (f, ..) = stack
                 .pop_arg()
                 .ok_or_else(|| EvalError::NotEnoughArgs(2, String::from("map"), pos_op))?;
 
@@ -474,7 +506,7 @@ fn process_unary_operation(
             }
         }
         UnaryOp::RecordMap() => {
-            let (f, _) = stack
+            let (f, ..) = stack
                 .pop_arg()
                 .ok_or_else(|| EvalError::NotEnoughArgs(2, String::from("recordMap"), pos_op))?;
 
@@ -512,7 +544,7 @@ fn process_unary_operation(
         }
         UnaryOp::Seq() => {
             if stack.count_args() >= 1 {
-                let (next, _) = stack.pop_arg().expect("Condition already checked.");
+                let (next, ..) = stack.pop_arg().expect("Condition already checked.");
                 Ok(next)
             } else {
                 Err(EvalError::NotEnoughArgs(2, String::from("seq"), pos_op))
@@ -549,8 +581,7 @@ fn process_unary_operation(
                 }
                 Term::List(ts) if !ts.is_empty() => seq_terms(ts.into_iter(), env, pos_op),
                 _ => {
-                    if stack.count_args() >= 1 {
-                        let (next, _) = stack.pop_arg().expect("Condition already checked.");
+                    if let Some((next, ..)) = stack.pop_arg() {
                         Ok(next)
                     } else {
                         Err(EvalError::NotEnoughArgs(2, String::from("deepSeq"), pos_op))
@@ -1137,6 +1168,7 @@ fn process_binary_operation(
                 ))
             }
         }
+
         BinaryOp::DynAccess() => {
             if let Term::Str(id) = *t1 {
                 if let Term::Record(mut static_map) = *t2 {

--- a/src/parser/lexer.rs
+++ b/src/parser/lexer.rs
@@ -183,6 +183,8 @@ pub enum NormalToken<'input> {
     GoField,
     #[token("%goList%")]
     GoList,
+    #[token("%applyCtr%")]
+    ApplyContract,
 
     #[token("%wrap%")]
     Wrap,

--- a/src/parser/utils.rs
+++ b/src/parser/utils.rs
@@ -125,6 +125,8 @@ pub fn mk_label(types: Types, src_id: FileId, l: usize, r: usize) -> Label {
         types,
         tag: String::new(),
         span: mk_span(src_id, l, r),
+        arg_thunk: None,
+        arg_pos: TermPos::None,
         polarity: true,
         path: Vec::new(),
     }

--- a/src/term.rs
+++ b/src/term.rs
@@ -477,6 +477,13 @@ pub enum UnaryOp {
 
     /// Raise a blame, which stops the execution and prints an error according to the label argument.
     Blame(),
+    /// Apply a contract to a label and a value. The label and the value are stored on the stack, unevaluated.
+    ///
+    /// Operationally equivalent to the standard application for contracts given as functions, this
+    /// operator additionally marks the location of the tested value for better error reporting. It
+    /// also accepts contracts as records, which are translated to a merge operation instead of
+    /// function application.
+    ApplyContract(),
 
     /// Typecast an enum to a larger enum type.
     ///
@@ -659,7 +666,7 @@ impl RichTerm {
             .apply_to_rich_terms(|rt: &mut Self| rt.clean_pos());
     }
 
-    /// Set the position, and return the updated term.
+    /// Set the position and return the term updated.
     pub fn with_pos(mut self, pos: TermPos) -> Self {
         self.pos = pos;
         self

--- a/src/transformations.rs
+++ b/src/transformations.rs
@@ -66,8 +66,9 @@ pub mod share_normal_form {
                     .map(|(id, t)| {
                         if should_share(&t.term) {
                             let fresh_var = fresh_var();
+                            let pos_t = t.pos;
                             bindings.push((fresh_var.clone(), t));
-                            (id, RichTerm::new(Term::Var(fresh_var), pos))
+                            (id, RichTerm::new(Term::Var(fresh_var), pos_t))
                         } else {
                             (id, t)
                         }
@@ -90,8 +91,9 @@ pub mod share_normal_form {
                     .map(|(id, t)| {
                         if !t.as_ref().is_constant() {
                             let fresh_var = fresh_var();
+                            let pos_t = t.pos;
                             bindings.push((fresh_var.clone(), t));
-                            (id, RichTerm::new(Term::Var(fresh_var), pos))
+                            (id, RichTerm::new(Term::Var(fresh_var), pos_t))
                         } else {
                             (id, t)
                         }
@@ -108,8 +110,9 @@ pub mod share_normal_form {
                     .map(|t| {
                         if should_share(&t.term) {
                             let fresh_var = fresh_var();
+                            let pos_t = t.pos;
                             bindings.push((fresh_var.clone(), t));
-                            RichTerm::new(Term::Var(fresh_var), pos)
+                            RichTerm::new(Term::Var(fresh_var), pos_t)
                         } else {
                             t
                         }
@@ -123,7 +126,7 @@ pub mod share_normal_form {
                     let fresh_var = fresh_var();
                     let t = meta.value.take().unwrap();
                     meta.value
-                        .replace(RichTerm::new(Term::Var(fresh_var.clone()), pos));
+                        .replace(RichTerm::new(Term::Var(fresh_var.clone()), t.pos));
                     let inner = RichTerm::new(Term::MetaValue(meta), pos);
                     RichTerm::new(Term::Let(fresh_var, t, inner), pos)
                 } else {

--- a/src/typecheck.rs
+++ b/src/typecheck.rs
@@ -1519,6 +1519,8 @@ pub fn get_uop_type(state: &mut State, op: &UnaryOp) -> Result<TypeWrapper, Type
 
             mk_tyw_arrow!(AbsType::Dyn(), res)
         }
+        // This should not happen, as `ApplyContract()` is only produced during evaluation.
+        UnaryOp::ApplyContract() => panic!("cannot typecheck ApplyContract()"),
         // Dyn -> Bool
         UnaryOp::Pol() => mk_tyw_arrow!(AbsType::Dyn(), AbsType::Bool()),
         // forall rows. < | rows> -> <id | rows>

--- a/src/types.rs
+++ b/src/types.rs
@@ -194,7 +194,9 @@ impl Types {
                 s.contract_open(h.clone(), !pol, sy),
                 t.contract_open(h, pol, sy)
             ),
-            AbsType::Flat(ref t) => t.clone(),
+            AbsType::Flat(ref t) => {
+                mk_term::op1(UnaryOp::ApplyContract(), t.clone()).with_pos(t.pos)
+            }
             AbsType::Var(ref i) => {
                 let (rt, _) = h
                     .get(i)


### PR DESCRIPTION
Close #293 and #294. Depend on #301.

## Contracts as records
In order to support contracts specified as record using the pipe syntax, an `Assume` can't just evaluate to standard application. This PR introduces a new primitive operator, to which `Assume` reduces to, that evaluates the contract and then either evaluate to standard application if the contract is a function, or wrap it as `fun l t => t & contract` if the contract is a record.

## Report the offending value in blame errors
For error reporting purpose, a label can now include the position of the original expression a contract is applied to, and a pointer to the corresponding thunk of this argument. These data are set dynamically when evaluating an `Assume`. The argument is pushed on a stack with a specific flag, such that the corresponding evaluation of the contract body will then use the thunk shared with the label instead of creating a separate one. Then, if a blame error occurs, the error reporting code has access to the evaluated expression at the time the blame was raised.

Here is an example of a nested blame error, implying records, lists, and an indirection via a function call to `check` before this PR:
```
nickel> let toCtr = fun ctrct => fun l val => val & ctrct in
let Ctr = {
  x | List #(toCtr {y | Num});
  z | Str | default = "a"} in
let val = {x = [
  {y = 1},
  {y = ("a" ++ "b" ++ "c")}
]} in
let check = fun x => (x | #(toCtr Ctr)) in
builtins.deepSeq (check val) 1

error: Blame error: contract broken by a value.
  ┌─ :1:1
  │
1 │ Num
  │ --- expected type
  │
  ┌─ repl-input-7:2:34
  │
2 │ let Ctr = {x | List #(toCtr {y | Num}); z | Str | default = "a"} in
  │                                  ^^^ bound here
```

And the same version after this PR, using directly contracts as records:
```
nickel> let Ctr = {
  x | List #{y | Num};
  z | Str | default = "a"} in
let val = {x = [
  {y = 1},
  {y = ("a" ++ "b" ++ "c")}
]} in
let check = fun x => (x | #Ctr) in
builtins.deepSeq (check val) 1

error: Blame error: contract broken by a value.
  ┌─ :1:1
  │
1 │ Num
  │ --- expected type
  │
  ┌─ repl-input-0:2:31
  │
2 │ let val = {x = [{y = 1}, {y = ("a" ++ "b" ++ "c")}]} in
  │                               ^^^^^^^^^^^^^^^^^^^ applied to this expression
  │
  ┌─ <unkown> (generated by evaluation):1:1
  │
1 │ "abc"
  │ ----- evaluated to this value

note:
  ┌─ repl-input-0:1:27
  │
1 │ let Ctr = {x | List #{y | Num}; z | Str | default = "a"} in
  │                           ^^^ bound here
```

## Limits
This argument information doesn't propagate well to subcontracts, when using either higher-order contracts (but in that case the printed call stack should give some relevant information) or record types. In these cases, the reported value is the top contract (either the function or the whole root record) instead of the argument to the faulty sub-contract.

However, note that there is no hard blocker to improve on this in the future: it's just not implemented in this PR.