### PR TITLE
Serialize numbers as integers whenever possible

### DIFF
--- a/src/term.rs
+++ b/src/term.rs
@@ -40,6 +40,7 @@ pub enum Term {
     /// A boolean value.
     Bool(bool),
     /// A floating-point value.
+    #[serde(serialize_with = "crate::serialize::serialize_num")]
     Num(f64),
     /// A literal string.
     Str(String),


### PR DESCRIPTION
Close #309. Apply option 1 proposed in the issue. The option 3. is actually useless, because integers greater than `u64::max` are serialized to JSON using an exponent notation anyway, which looks ok. In conclusion, this PR removes trailing `.0` for integers represented as float in the range `i64::MIN`/`u64::MAX`.