### PR TITLE
Allow chained record operations as arguments to applications

### DIFF
--- a/src/grammar.lalrpop
+++ b/src/grammar.lalrpop
@@ -161,11 +161,10 @@ RichTerm: RichTerm = {
 };
 
 Applicative: RichTerm = {
-    <t1:SpTerm<Applicative>> <t2: SpTerm<Atom>> => mk_app!(t1, t2),
-    <op: UOp> <t: SpTerm<Atom>> => mk_term::op1(op, t),
-    <op: BOpPre> <t1: SpTerm<Atom>> <t2: SpTerm<Atom>> => mk_term::op2(op, t1, t2),
-    SpTerm<RecordOperationChain>,
-    SpTerm<Atom>,
+    <t1:SpTerm<Applicative>> <t2: RecordOperand> => mk_app!(t1, t2),
+    <op: UOp> <t: SpTerm<RecordOperand>> => mk_term::op1(op, t),
+    <op: BOpPre> <t1: SpTerm<RecordOperand>> <t2: SpTerm<Atom>> => mk_term::op2(op, t1, t2),
+    <RecordOperand>,
 };
 
 RecordOperand: RichTerm = {


### PR DESCRIPTION
Currently, one need parentheses around record operations (e.g. field access) when used as an argument, such as in `lists.head ({a = ["head"]}.a)`. This limitation is not justified.

This PR allows chained record operations (an atom followed by a chain of field accesses, field removal, field extension e.g., which are already allowed as the function part of an application) as arguments without the need for parentheses: `lists.head {a = ["head"]}.a`.