### PR TITLE
[Refactor]Improve metavalue representation and handling

### DIFF
--- a/src/cache.rs
+++ b/src/cache.rs
@@ -800,12 +800,14 @@ pub mod resolvers {
             let file_id = self
                 .file_cache
                 .get(path.to_string_lossy().as_ref())
-                .map(|id| id.clone())
-                .ok_or(ImportError::IOError(
-                    path.to_string_lossy().into_owned(),
-                    String::from("Import not found by the mockup resolver."),
-                    *pos,
-                ))?;
+                .copied()
+                .ok_or_else(|| {
+                    ImportError::IOError(
+                        path.to_string_lossy().into_owned(),
+                        String::from("Import not found by the mockup resolver."),
+                        *pos,
+                    )
+                })?;
 
             if self.term_cache.contains_key(&file_id) {
                 Ok((ResolvedTerm::FromCache(), file_id))

--- a/src/error.rs
+++ b/src/error.rs
@@ -897,10 +897,7 @@ impl ToDiagnostic<FileId> for EvalError {
                             // Do not show the same thing twice: if arg_pos and val_pos are the same,
                             // the first label "applied to this value" is sufficient.
                             (TermPos::Original(ref val_pos), Some(arg_pos), _)
-                                if val_pos == arg_pos =>
-                            {
-                                ()
-                            }
+                                if val_pos == arg_pos => {}
                             (TermPos::Original(ref val_pos), ..) => labels.push(
                                 secondary(val_pos).with_message("evaluated to this expression"),
                             ),

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -93,7 +93,7 @@ use crate::mk_app;
 use crate::operation::{continuate_operation, OperationCont};
 use crate::position::TermPos;
 use crate::stack::Stack;
-use crate::term::{make as mk_term, MetaValue, RichTerm, StrChunk, Term, UnaryOp};
+use crate::term::{make as mk_term, Contract, MetaValue, RichTerm, StrChunk, Term, UnaryOp};
 use std::cell::{Ref, RefCell, RefMut};
 use std::collections::HashMap;
 use std::rc::{Rc, Weak};
@@ -670,21 +670,16 @@ where
                     update_thunks(&mut stack, &update_closure);
 
                     let Closure {
-                        body:
-                            RichTerm {
-                                term: meta_box,
-                                pos: _,
-                            },
+                        body: RichTerm { term, .. },
                         env,
                     } = update_closure;
 
-                    let t = match *meta_box {
-                        Term::MetaValue(MetaValue {contract: Some((ty, lbl)), value: Some(t), ..}) =>
-                            Term::Assume(ty, lbl, t).into(),
-                        Term::MetaValue(MetaValue {value: Some(t), ..}) => t,
-                        _ => panic!("eval::eval(): previous match enforced that a metavalue has an underlying value, but matched something else")
-                    };
-                    Closure { body: t, env }
+                    match *term {
+                        Term::MetaValue(MetaValue {
+                            value: Some(inner), ..
+                        }) => Closure { body: inner, env },
+                        _ => unreachable!(),
+                    }
                 }
                 // TODO: improve error message using some positions
                 else {
@@ -904,8 +899,28 @@ pub fn subst(rt: RichTerm, global_env: &Environment, env: &Environment) -> RichT
                 RichTerm::new(Term::StrChunks(chunks), pos)
             }
             Term::MetaValue(meta) => {
-                let contract = meta.contract.map(|(ty, lbl)| {
-                    let ty = match ty {
+                // let contracts = meta.contracts.clone();
+                // let types = meta.types.clone();
+                let contracts: Vec<_> = meta
+                    .contracts
+                    .into_iter()
+                    .map(|ctr| {
+                        let types = match ctr.types {
+                            Types(AbsType::Flat(t)) => Types(AbsType::Flat(subst_(
+                                t,
+                                global_env,
+                                env,
+                                Cow::Borrowed(bound.as_ref()),
+                            ))),
+                            ty => ty,
+                        };
+
+                        Contract { types, ..ctr }
+                    })
+                    .collect();
+
+                let types = meta.types.map(|ctr| {
+                    let types = match ctr.types {
                         Types(AbsType::Flat(t)) => Types(AbsType::Flat(subst_(
                             t,
                             global_env,
@@ -915,14 +930,15 @@ pub fn subst(rt: RichTerm, global_env: &Environment, env: &Environment) -> RichT
                         ty => ty,
                     };
 
-                    (ty, lbl)
+                    Contract { types, ..ctr }
                 });
 
                 let value = meta.value.map(|t| subst_(t, global_env, env, bound));
 
                 let meta = MetaValue {
                     doc: meta.doc,
-                    contract,
+                    types,
+                    contracts,
                     priority: meta.priority,
                     value,
                 };
@@ -943,8 +959,7 @@ mod tests {
     use crate::label::Label;
     use crate::parser::{grammar, lexer};
     use crate::term::make as mk_term;
-    use crate::term::StrChunk;
-    use crate::term::{BinaryOp, UnaryOp};
+    use crate::term::{BinaryOp, Contract, StrChunk, UnaryOp};
     use crate::transformations::transform;
     use crate::{mk_app, mk_fun};
     use codespan::Files;

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -899,8 +899,6 @@ pub fn subst(rt: RichTerm, global_env: &Environment, env: &Environment) -> RichT
                 RichTerm::new(Term::StrChunks(chunks), pos)
             }
             Term::MetaValue(meta) => {
-                // let contracts = meta.contracts.clone();
-                // let types = meta.types.clone();
                 let contracts: Vec<_> = meta
                     .contracts
                     .into_iter()
@@ -959,7 +957,7 @@ mod tests {
     use crate::label::Label;
     use crate::parser::{grammar, lexer};
     use crate::term::make as mk_term;
-    use crate::term::{BinaryOp, Contract, StrChunk, UnaryOp};
+    use crate::term::{BinaryOp, StrChunk, UnaryOp};
     use crate::transformations::transform;
     use crate::{mk_app, mk_fun};
     use codespan::Files;

--- a/src/grammar.lalrpop
+++ b/src/grammar.lalrpop
@@ -1,6 +1,6 @@
 use crate::identifier::Ident;
 use crate::term::{BinaryOp, RichTerm, Term, UnaryOp, StrChunk, MetaValue,
-    MergePriority};
+    MergePriority, Contract};
 use crate::term::make as mk_term;
 use crate::mk_app;
 use crate::types::{Types, AbsType};
@@ -11,7 +11,6 @@ use super::utils::{StringKind, mk_pos, mk_label, strip_indent, SwitchCase,
 use std::ffi::OsString;
 use super::lexer::{Token, NormalToken, StringToken, MultiStringToken, LexicalError};
 use std::collections::HashMap;
-use std::cmp::min;
 use codespan::FileId;
 
 grammar<'input>(src_id: FileId, );
@@ -23,35 +22,28 @@ TypeAnnot: (usize, Types, usize) = ":" <l: @L> <ty: Types> <r: @R> => (l, ty, r)
 MetaAnnotAtom: MetaValue = {
     "|" <l: @L> <ty: Types> <r: @R> => MetaValue {
         doc: None,
-        contract: Some((ty.clone(), mk_label(ty, src_id, l, r))),
+        types: None,
+        contracts: vec![Contract {types: ty.clone(), label: mk_label(ty, src_id, l, r)}],
         priority: Default::default(),
         value: None,
     },
     "|" "default" => MetaValue {
         doc: None,
-        contract: None,
+        types: None,
+        contracts: Vec::new(),
         priority: MergePriority::Default,
         value: None,
     },
     "|" "doc" <s: Str> => MetaValue {
         doc: Some(strip_indent_doc(s)),
-        contract: None,
+        types: None,
+        contracts: Vec::new(),
         priority: Default::default(),
         value: None,
     },
 };
 
-MetaAnnot: MetaValue =
-    <anns: MetaAnnotAtom+> => {
-        anns.into_iter().fold(MetaValue::new(), |acc, meta| {
-            MetaValue {
-                doc: meta.doc.or(acc.doc),
-                contract: meta.contract.or(acc.contract),
-                priority: min(acc.priority, meta.priority),
-                value: meta.value.or(acc.value),
-            }
-        })
-    };
+MetaAnnot: MetaValue = <anns: MetaAnnotAtom+> => anns.into_iter().fold(MetaValue::new(), MetaValue::flatten);
 
 LeftOp<Op, Current, Previous>: RichTerm =
     <t1: Current> <op: Op> <t2: Previous> => mk_term::op2(op, t1, t2);

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -530,7 +530,6 @@ pub mod rustyline_frontend {
 /// Rendering of the results of a metadata query.
 pub mod query_print {
     use crate::identifier::Ident;
-    use crate::label::Label;
     use crate::term::{MergePriority, MetaValue, Term};
 
     /// A query printer. The implementation may differ depending on the activation of markdown
@@ -695,12 +694,14 @@ pub mod query_print {
         match term {
             Term::MetaValue(meta) => {
                 let mut found = false;
-                match &meta.contract {
-                    Some((_, Label { types, .. })) if selected_attrs.contract => {
-                        renderer.print_metadata("contract", &format!("{}", types));
-                        found = true;
-                    }
-                    _ => (),
+                if !meta.contracts.is_empty() && selected_attrs.contract {
+                    let ctrs: Vec<String> = meta
+                        .contracts
+                        .iter()
+                        .map(|ctr| ctr.types.to_string())
+                        .collect();
+                    renderer.print_metadata("contract", &ctrs.join(","));
+                    found = true;
                 }
 
                 match &meta {

--- a/src/serialize.rs
+++ b/src/serialize.rs
@@ -74,7 +74,7 @@ where
         }
     }
 
-    return n.serialize(serializer);
+    n.serialize(serializer)
 }
 
 /// Serializer for metavalues.

--- a/src/serialize.rs
+++ b/src/serialize.rs
@@ -83,7 +83,6 @@ where
     S: Serializer,
 {
     if let Some(ref t) = meta.value {
-        println!("Serializing {:p}", meta);
         t.serialize(serializer)
     } else {
         // This error should not happen if the input term is validated before serialization

--- a/src/serialize.rs
+++ b/src/serialize.rs
@@ -83,6 +83,7 @@ where
     S: Serializer,
 {
     if let Some(ref t) = meta.value {
+        println!("Serializing {:p}", meta);
         t.serialize(serializer)
     } else {
         // This error should not happen if the input term is validated before serialization

--- a/src/term.rs
+++ b/src/term.rs
@@ -164,9 +164,16 @@ impl Default for MergePriority {
 }
 
 #[derive(Debug, PartialEq, Clone)]
+pub struct Contract {
+    pub types: Types,
+    pub label: Label,
+}
+
+#[derive(Debug, PartialEq, Clone)]
 pub struct MetaValue {
     pub doc: Option<String>,
-    pub contract: Option<(Types, Label)>,
+    pub types: Option<Contract>,
+    pub contracts: Vec<Contract>,
     pub priority: MergePriority,
     pub value: Option<RichTerm>,
 }
@@ -175,7 +182,8 @@ impl From<RichTerm> for MetaValue {
     fn from(rt: RichTerm) -> Self {
         MetaValue {
             doc: None,
-            contract: None,
+            types: None,
+            contracts: Vec::new(),
             priority: Default::default(),
             value: Some(rt),
         }
@@ -186,9 +194,34 @@ impl MetaValue {
     pub fn new() -> Self {
         MetaValue {
             doc: None,
-            contract: None,
+            types: None,
+            contracts: Vec::new(),
             priority: Default::default(),
             value: None,
+        }
+    }
+
+    pub fn flatten(outer: MetaValue, inner: MetaValue) -> MetaValue {
+        // Keep the outermost value for non-mergeable information, such as documentation, type annotation,
+        // and so on, which is the one that is accessible from the outside anyway (by queries, by the typechecker, and
+        // so on).
+        // Keep the inner value
+        let MetaValue {
+            doc,
+            types,
+            mut contracts,
+            priority,
+            value: _,
+        } = outer;
+
+        contracts.extend(inner.contracts.into_iter());
+
+        MetaValue {
+            doc: doc.or(inner.doc),
+            types: types.or(inner.types),
+            contracts,
+            priority: std::cmp::min(priority, inner.priority),
+            value: inner.value,
         }
     }
 }
@@ -250,9 +283,9 @@ impl Term {
                 func(t);
             }
             MetaValue(ref mut meta) => {
-                meta.contract
+                meta.contracts
                     .iter_mut()
-                    .for_each(|(ref mut ty, _)| match ty.0 {
+                    .for_each(|Contract { types, .. }| match types.0 {
                         AbsType::Flat(ref mut rt) => func(rt),
                         _ => (),
                     });
@@ -342,7 +375,7 @@ impl Term {
                 if meta.doc.is_some() {
                     content.push_str("doc,");
                 }
-                if meta.contract.is_some() {
+                if !meta.contracts.is_empty() {
                     content.push_str("contract,");
                 }
 
@@ -867,14 +900,27 @@ impl RichTerm {
                 )
             }
             Term::MetaValue(meta) => {
-                let contract = meta
-                    .contract
-                    .map(|(ty, lbl)| {
-                        let ty = match ty {
+                let contracts: Result<Vec<Contract>, _> = meta
+                    .contracts
+                    .into_iter()
+                    .map(|ctr| {
+                        let types = match ctr.types {
                             Types(AbsType::Flat(t)) => Types(AbsType::Flat(t.traverse(f, state)?)),
                             ty => ty,
                         };
-                        Ok((ty, lbl))
+                        Ok(Contract { types, ..ctr })
+                    })
+                    .collect();
+                let contracts = contracts?;
+
+                let types = meta
+                    .types
+                    .map(|ctr| {
+                        let types = match ctr.types {
+                            Types(AbsType::Flat(t)) => Types(AbsType::Flat(t.traverse(f, state)?)),
+                            ty => ty,
+                        };
+                        Ok(Contract { types, ..ctr })
                     })
                     // Transpose from Option<Result> to Result<Option>. There is a `transpose`
                     // method in Rust, but it has currently not made it to the stable version yet
@@ -887,7 +933,8 @@ impl RichTerm {
 
                 let meta = MetaValue {
                     doc: meta.doc,
-                    contract,
+                    types,
+                    contracts,
                     priority: meta.priority,
                     value,
                 };

--- a/src/transformations.rs
+++ b/src/transformations.rs
@@ -214,9 +214,20 @@ pub mod import_resolution {
     }
 }
 
+/// During the evaluation, we the following invariant is enforced: any contract (be it the type
+/// annotation, or the contracts) contained in a `MetaValue` must have been applied to the inner
+/// value of this metavalue. This invariant is false just after parsing, as there's merely no
+/// direct `Assume` in the output AST. This transformation makes it true after program
+/// transformations by generating corresponding assume.
+///
+/// It must be run before `share_normal_form` to avoid rechecking contracts each time the inner
+/// value is unwrapped.
 pub mod apply_contracts {
     use super::{RichTerm, Term};
 
+    /// If the top-level node of the AST is a meta-value, wrap the inner value inside generated
+    /// `Assume`s corresponding to the meta-value's contracts. Otherwise, return the term
+    /// unchanged.
     pub fn transform_one(rt: RichTerm) -> RichTerm {
         let RichTerm { term, pos } = rt;
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -416,10 +416,9 @@ mod test {
         let rt = TermParser::new().parse(id, Lexer::new(&wrapper)).unwrap();
 
         match *rt.term {
-            Term::MetaValue(MetaValue {
-                contract: Some((ty, _)),
-                ..
-            }) => ty,
+            Term::MetaValue(MetaValue { mut contracts, .. }) if contracts.len() == 1 => {
+                contracts.remove(0).types
+            }
             _ => panic!("types::test::parse_type(): expected contract"),
         }
     }


### PR DESCRIPTION
While addressing #254, it appeared that having both a type and a metadata annotation on the same binding is currently not allowed by the parser, while this is something fundamental for library functions, e.g:

```
someFunc : Num -> Num
         | doc "
           Increase its argument by one."  
         = fun x => x + 1;
// ..
```

A question that arises is how to desugar this: should we have the `Promise` (type annotation) inside and the metavalue outside, or the other way around? While one of the two is manageable (the other has more serious issues), both introduce some quirks about typechecking and discoverability of metavalues (often boiling down to the outer construct hiding or affecting the behavior of the inner one). In the end it felt more natural to allow type annotations to also be part of a metavalue, and store all these information as one flat metadata. 

This PR started as the implementation of this, and doing so, simplified a bit the representation of multiple contracts.

## Contracts application

It also unveiled inefficiencies in the way metavalue's contracts are enforced. Each time a value with metadata containing a contract is accessed, `eval()` generates a new contract application when projecting it. This means that if a record field with a contract annotation is accessed `n` times, the same contract is applied to the same value `n` times, instead of just once, which is not great.

One solution is to lazily apply these contracts when the metavalue is requested and remember which have been applied at any point in time, but this introduces state in the AST. Another solution is to ensure that all the contracts of a metavalue are eagerly applied before its first evaluation (applied in the sense of generating the corresponding applications, not actually forcing the evaluation), and to maintain this invariant during evaluation. This is actually already what the `merge` implementation was doing: the only missing bit was to make sure this invariant is true at the beginning of the evaluation, which is done thanks to a simple pass during program transformation. With this, we can get rid of the additional contract application introduced by `eval()`.

## Content of the PR
To sum, this PR:

- add a field corresponding to type annotations to metavalues, in order to represent both metadata and type annotations on the same element
- instead of having a single contract field and accumulating contracts through merging by generating unreadable composed custom contracts along the way, accumulate multiple contracts in a vector of contracts instead, which preserves more information for e.g. query.
- avoid re-applying the same contract to the same value multiple times by maintaining the following run-time invariant: any contract contained in a `MetaValue` must have been applied to the inner term of this metavalue.