### PR TITLE
Remove assume from the AST, improve contract error reporting

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -875,7 +875,10 @@ impl ToDiagnostic<FileId> for EvalError {
                     // point to the builtin implementation contract like `func` or `record`, so
                     // there's no good reason to show it. Note than even in that case, the
                     // information contained in the argument thunk can still be useful.
-                    if contract_id.map(|ctrs_id| arg_pos.src_id != ctrs_id).unwrap_or(true)  {
+                    if contract_id
+                        .map(|ctrs_id| arg_pos.src_id != ctrs_id)
+                        .unwrap_or(true)
+                    {
                         labels.push(primary(&arg_pos).with_message("applied to this expression"));
                     }
                 }

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -575,7 +575,7 @@ where
                     }
                 }
             },
-            Term::Promise(ty, mut l, t) | Term::Assume(ty, mut l, t) => {
+            Term::Promise(ty, mut l, t) => {
                 l.arg_pos = t.pos;
                 let thunk = Thunk::new(
                     Closure {
@@ -839,11 +839,6 @@ pub fn subst(rt: RichTerm, global_env: &Environment, env: &Environment) -> RichT
                 let t = subst_(t, global_env, env, bound);
 
                 RichTerm::new(Term::Promise(ty, l, t), pos)
-            }
-            Term::Assume(ty, l, t) => {
-                let t = subst_(t, global_env, env, bound);
-
-                RichTerm::new(Term::Assume(ty, l, t), pos)
             }
             Term::Wrapped(i, t) => {
                 let t = subst_(t, global_env, env, bound);

--- a/src/grammar.lalrpop
+++ b/src/grammar.lalrpop
@@ -311,7 +311,6 @@ UOp: UnaryOp = {
     "isList" => UnaryOp::IsList(),
     "isRecord" => UnaryOp::IsRecord(),
     "blame" => UnaryOp::Blame(),
-    "assume" => UnaryOp::Assume(),
     "chngPol" => UnaryOp::ChangePolarity(),
     "polarity" => UnaryOp::Pol(),
     "goDom" => UnaryOp::GoDom(),
@@ -447,6 +446,7 @@ BOpPre: BinaryOp = {
     "hash" => BinaryOp::Hash(),
     "serialize" => BinaryOp::Serialize(),
     "deserialize" => BinaryOp::Deserialize(),
+    "assume" => BinaryOp::Assume(),
 }
 
 Types: Types = {

--- a/src/grammar.lalrpop
+++ b/src/grammar.lalrpop
@@ -446,7 +446,6 @@ BOpPre: BinaryOp = {
     "hash" => BinaryOp::Hash(),
     "serialize" => BinaryOp::Serialize(),
     "deserialize" => BinaryOp::Deserialize(),
-    "assume" => BinaryOp::Assume(),
 }
 
 Types: Types = {
@@ -595,7 +594,6 @@ extern {
         "List" => Token::Normal(NormalToken::List),
 
         "tag" => Token::Normal(NormalToken::Tag),
-        "assume" => Token::Normal(NormalToken::Assume),
         "isNum" => Token::Normal(NormalToken::IsNum),
         "isBool" => Token::Normal(NormalToken::IsBool),
         "isStr" => Token::Normal(NormalToken::IsStr),

--- a/src/grammar.lalrpop
+++ b/src/grammar.lalrpop
@@ -311,7 +311,7 @@ UOp: UnaryOp = {
     "isList" => UnaryOp::IsList(),
     "isRecord" => UnaryOp::IsRecord(),
     "blame" => UnaryOp::Blame(),
-    "applyContract" => UnaryOp::ApplyContract(),
+    "assume" => UnaryOp::Assume(),
     "chngPol" => UnaryOp::ChangePolarity(),
     "polarity" => UnaryOp::Pol(),
     "goDom" => UnaryOp::GoDom(),
@@ -595,7 +595,7 @@ extern {
         "List" => Token::Normal(NormalToken::List),
 
         "tag" => Token::Normal(NormalToken::Tag),
-        "applyContract" => Token::Normal(NormalToken::ApplyContract),
+        "assume" => Token::Normal(NormalToken::Assume),
         "isNum" => Token::Normal(NormalToken::IsNum),
         "isBool" => Token::Normal(NormalToken::IsBool),
         "isStr" => Token::Normal(NormalToken::IsStr),

--- a/src/merge.rs
+++ b/src/merge.rs
@@ -54,7 +54,7 @@
 use crate::error::EvalError;
 use crate::eval::{Closure, Environment};
 use crate::position::TermPos;
-use crate::term::{BinaryOp, Contract, MetaValue, RichTerm, Term};
+use crate::term::{BinaryOp, Contract, MetaValue, RichTerm, Term, make as mk_term};
 use crate::transformations::Closurizable;
 use std::collections::HashMap;
 
@@ -362,7 +362,7 @@ fn cross_apply_contracts<'a>(
     let result = it2
         .fold(t1, |acc, ctr| {
             let ty_closure = ctr.types.clone().closurize(&mut env1_local, env2.clone());
-            RichTerm::new(Term::Assume(ty_closure, ctr.label.clone(), acc), pos)
+            mk_term::assume(ty_closure, ctr.label.clone(), acc).with_pos(pos)
         })
         .closurize(&mut env, env1_local);
 

--- a/src/merge.rs
+++ b/src/merge.rs
@@ -54,7 +54,7 @@
 use crate::error::EvalError;
 use crate::eval::{Closure, Environment};
 use crate::position::TermPos;
-use crate::term::{BinaryOp, Contract, MetaValue, RichTerm, Term, make as mk_term};
+use crate::term::{make as mk_term, BinaryOp, Contract, MetaValue, RichTerm, Term};
 use crate::transformations::Closurizable;
 use std::collections::HashMap;
 

--- a/src/operation.rs
+++ b/src/operation.rs
@@ -241,34 +241,6 @@ fn process_unary_operation(
                 ))
             }
         }
-        UnaryOp::Assume() => {
-            match *t {
-                Term::Fun(..) => Ok(Closure {
-                    body: RichTerm { term: t, pos },
-                    env,
-                }),
-                Term::Record(..) => {
-                    let mut new_env = Environment::new();
-                    let closurized = RichTerm { term: t, pos }.closurize(&mut new_env, env);
-
-                    // Convert the record to the function `fun l x => contract & x`.
-                    let body = mk_fun!(
-                        "l",
-                        "x",
-                        mk_term::op2(BinaryOp::Merge(), closurized, mk_term::var("x"))
-                    )
-                    .with_pos(pos.into_inherited());
-
-                    Ok(Closure { body, env: new_env })
-                }
-                _ => Err(EvalError::TypeError(
-                    String::from("Function or record"),
-                    String::from("contract application"),
-                    arg_pos,
-                    RichTerm { term: t, pos },
-                )),
-            }
-        }
         UnaryOp::Embed(_id) => {
             if let en @ Term::Enum(_) = *t {
                 Ok(Closure::atomic_closure(RichTerm::new(en, pos_op_inh)))
@@ -904,6 +876,56 @@ fn process_binary_operation(
                         pos: pos1,
                     },
                 ))
+            }
+        }
+        BinaryOp::Assume() => {
+            if let Term::Lbl(mut l) = *t2 {
+                // Track the contract argument for better error reporting, and push back the label
+                // on the stack, so that it becomes the first argument of the contract.
+                let thunk = stack.track_arg().ok_or_else(|| EvalError::NotEnoughArgs(3, String::from("assume"), pos_op))?;
+                l.arg_pos = thunk.borrow().body.pos;
+                l.arg_thunk = Some(thunk);
+
+                stack.push_arg(
+                    Closure::atomic_closure(Term::Lbl(l).into()),
+                    pos2.into_inherited(),
+                );
+
+              match *t1 {
+                Term::Fun(..) => {
+                    Ok(Closure {
+                        body: RichTerm { term: t1, pos: pos1 },
+                        env: env1,
+                    })
+                }
+                Term::Record(..) => {
+                    let mut new_env = Environment::new();
+                    let closurized = RichTerm { term: t1, pos: pos1 }.closurize(&mut new_env, env1);
+
+                    // Convert the record to the function `fun l x => contract & x`.
+                    let body = mk_fun!(
+                        "l",
+                        "x",
+                        mk_term::op2(BinaryOp::Merge(), closurized, mk_term::var("x"))
+                    )
+                    .with_pos(pos1.into_inherited());
+
+                    Ok(Closure { body, env: new_env })
+                }
+                _ => Err(EvalError::TypeError(
+                    String::from("Function or record"),
+                    String::from("contract application, 1st argument"),
+                    fst_pos,
+                    RichTerm { term: t1, pos: pos1 },
+                )),
+              }
+            }
+            else {
+                Err(EvalError::TypeError(
+                    String::from("Label"),
+                    String::from("contract application, 2nd argument"),
+                    snd_pos,
+                    RichTerm { term: t2, pos: pos2}))
             }
         }
         BinaryOp::Unwrap() => {

--- a/src/operation.rs
+++ b/src/operation.rs
@@ -241,7 +241,7 @@ fn process_unary_operation(
                 ))
             }
         }
-        UnaryOp::ApplyContract() => {
+        UnaryOp::Assume() => {
             match *t {
                 Term::Fun(..) => Ok(Closure {
                     body: RichTerm { term: t, pos },

--- a/src/operation.rs
+++ b/src/operation.rs
@@ -901,9 +901,13 @@ fn process_binary_operation(
                         },
                         env: env1,
                     }),
-                   Term::Record(..) => {
+                    Term::Record(..) => {
                         let mut new_env = Environment::new();
-                        let closurized = RichTerm { term: t1, pos: pos1 }.closurize(&mut new_env, env1);
+                        let closurized = RichTerm {
+                            term: t1,
+                            pos: pos1,
+                        }
+                        .closurize(&mut new_env, env1);
 
                         // Convert the record to the function `fun l x => contract & x`.
                         let body = mk_fun!(
@@ -914,7 +918,7 @@ fn process_binary_operation(
                         .with_pos(pos1.into_inherited());
 
                         Ok(Closure { body, env: new_env })
-                    }    
+                    }
                     _ => Err(EvalError::TypeError(
                         String::from("Function or Record"),
                         String::from("assume, 1st argument"),

--- a/src/parser/lexer.rs
+++ b/src/parser/lexer.rs
@@ -170,8 +170,6 @@ pub enum NormalToken<'input> {
     GoField,
     #[token("%goList%")]
     GoList,
-    #[token("%assume%")]
-    Assume,
 
     #[token("%wrap%")]
     Wrap,

--- a/src/parser/lexer.rs
+++ b/src/parser/lexer.rs
@@ -170,8 +170,8 @@ pub enum NormalToken<'input> {
     GoField,
     #[token("%goList%")]
     GoList,
-    #[token("%applyCtr%")]
-    ApplyContract,
+    #[token("%assume%")]
+    Assume,
 
     #[token("%wrap%")]
     Wrap,

--- a/src/stack.rs
+++ b/src/stack.rs
@@ -267,9 +267,7 @@ impl Stack {
     /// corresponding thunk, or `None` if the top element wasn't an argument.
     pub fn track_arg(&mut self) -> Option<Thunk> {
         match self.0.last_mut() {
-            Some(Marker::TrackedArg(thunk, _)) => {
-                Some(thunk.clone())
-            }
+            Some(Marker::TrackedArg(thunk, _)) => Some(thunk.clone()),
             Some(Marker::Arg(..)) => {
                 let (closure, pos) = self.pop_arg().unwrap();
                 let thunk = Thunk::new(closure, IdentKind::Lam());

--- a/src/stack.rs
+++ b/src/stack.rs
@@ -262,6 +262,23 @@ impl Stack {
     pub fn clear_eqs(&mut self) {
         while self.pop_eq().is_some() {}
     }
+
+    /// Turning the top element of the stack into a tracked arg if it was not already. Returns the
+    /// corresponding thunk, or `None` if the top element wasn't an argument.
+    pub fn track_arg(&mut self) -> Option<Thunk> {
+        match self.0.last_mut() {
+            Some(Marker::TrackedArg(thunk, _)) => {
+                Some(thunk.clone())
+            }
+            Some(Marker::Arg(..)) => {
+                let (closure, pos) = self.pop_arg().unwrap();
+                let thunk = Thunk::new(closure, IdentKind::Lam());
+                self.push_tracked_arg(thunk.clone(), pos);
+                Some(thunk)
+            }
+            _ => None,
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/term.rs
+++ b/src/term.rs
@@ -518,14 +518,6 @@ pub enum UnaryOp {
 
     /// Raise a blame, which stops the execution and prints an error according to the label argument.
     Blame(),
-    /// An assume.
-    ///
-    /// Apply a contract to a label and a value. The label and the value are stored on the stack,
-    /// unevaluated, while the contract is the strict argument to this operator.  This operator
-    /// additionally marks the location of the tested value for better error reporting. It also
-    /// accepts contracts as records, which are translated to a merge operation instead of function
-    /// application.
-    Assume(),
 
     /// Typecast an enum to a larger enum type.
     ///
@@ -636,6 +628,14 @@ pub enum BinaryOp {
     GreaterThan(),
     /// Greater than or equal comparison operator.
     GreaterOrEq(),
+    /// An assume.
+    ///
+    /// Apply a contract to a label and a value. The label and the value are stored on the stack,
+    /// unevaluated, while the contract is the strict argument to this operator.  This operator
+    /// additionally marks the location of the tested value for better error reporting. It also
+    /// accepts contracts as records, which are translated to a merge operation instead of function
+    /// application.
+    Assume(),
     /// Unwrap a tagged term.
     ///
     /// See `Wrap` in [`UnaryOp`](enum.UnaryOp.html).
@@ -1081,8 +1081,14 @@ pub mod make {
         Term::Op2(op, t1.into(), t2.into()).into()
     }
 
-    pub fn assume<T>(types: Types, l: Label, t: T) -> RichTerm where T: Into<RichTerm> {
-        mk_app!(op1(UnaryOp::Assume(), types.contract()), Term::Lbl(l), t.into()) 
+    pub fn assume<T>(types: Types, l: Label, t: T) -> RichTerm
+    where
+        T: Into<RichTerm>,
+    {
+        mk_app!(
+            op2(BinaryOp::Assume(), types.contract(), Term::Lbl(l)),
+            t.into()
+        )
     }
 
     pub fn string<S>(s: S) -> RichTerm

--- a/src/term.rs
+++ b/src/term.rs
@@ -518,6 +518,12 @@ pub enum UnaryOp {
 
     /// Raise a blame, which stops the execution and prints an error according to the label argument.
     Blame(),
+    /// Convert a flat contract, specified as an expression like `#SomeContract`, to a function of
+    /// two arguments (a label and the value to be tested) suitable to be passed to [`Assume`]().
+    /// This operator's purpose is to accept more terms than just functions as a contract: it is
+    /// the identity on functions, but it also accepts contracts as records, which are translated
+    /// to a function that performs a merge operation with its argument.
+    ToCtrFun(),
 
     /// Typecast an enum to a larger enum type.
     ///
@@ -632,9 +638,7 @@ pub enum BinaryOp {
     ///
     /// Apply a contract to a label and a value. The label and the value are stored on the stack,
     /// unevaluated, while the contract is the strict argument to this operator.  This operator
-    /// additionally marks the location of the tested value for better error reporting. It also
-    /// accepts contracts as records, which are translated to a merge operation instead of function
-    /// application.
+    /// additionally marks the location of the tested value for better error reporting.
     Assume(),
     /// Unwrap a tagged term.
     ///

--- a/src/term.rs
+++ b/src/term.rs
@@ -518,7 +518,7 @@ pub enum UnaryOp {
 
     /// Raise a blame, which stops the execution and prints an error according to the label argument.
     Blame(),
-    
+
     /// Typecast an enum to a larger enum type.
     ///
     /// `Embed` is used to upcast enums. For example, if a value `x` has enum type `a | b`, then

--- a/src/term.rs
+++ b/src/term.rs
@@ -518,13 +518,7 @@ pub enum UnaryOp {
 
     /// Raise a blame, which stops the execution and prints an error according to the label argument.
     Blame(),
-    /// Convert a flat contract, specified as an expression like `#SomeContract`, to a function of
-    /// two arguments (a label and the value to be tested) suitable to be passed to [`Assume`]().
-    /// This operator's purpose is to accept more terms than just functions as a contract: it is
-    /// the identity on functions, but it also accepts contracts as records, which are translated
-    /// to a function that performs a merge operation with its argument.
-    ToCtrFun(),
-
+    
     /// Typecast an enum to a larger enum type.
     ///
     /// `Embed` is used to upcast enums. For example, if a value `x` has enum type `a | b`, then
@@ -636,9 +630,11 @@ pub enum BinaryOp {
     GreaterOrEq(),
     /// An assume.
     ///
-    /// Apply a contract to a label and a value. The label and the value are stored on the stack,
-    /// unevaluated, while the contract is the strict argument to this operator.  This operator
-    /// additionally marks the location of the tested value for better error reporting.
+    /// Apply a contract to a label and a value. The value is is stored on the stack unevaluated,
+    /// while the contract and the label are the strict arguments to this operator. Assume also
+    /// accepts contracts as records, that are translates to a function that performs a merge
+    /// operation with its argument. Finally, this operator marks the location of the contract
+    /// argument for better error reporting.
     Assume(),
     /// Unwrap a tagged term.
     ///

--- a/src/transformations.rs
+++ b/src/transformations.rs
@@ -224,6 +224,7 @@ pub mod import_resolution {
 /// value is unwrapped.
 pub mod apply_contracts {
     use super::{RichTerm, Term};
+    use crate::term::make as mk_term;
 
     /// If the top-level node of the AST is a meta-value, wrap the inner value inside generated
     /// `Assume`s corresponding to the meta-value's contracts. Otherwise, return the term
@@ -236,7 +237,7 @@ pub mod apply_contracts {
                 let inner = meta.types.iter().chain(meta.contracts.iter()).fold(
                     meta.value.take().unwrap(),
                     |acc, ctr| {
-                        RichTerm::new(Term::Assume(ctr.types.clone(), ctr.label.clone(), acc), pos)
+                        mk_term::assume(ctr.types.clone(), ctr.label.clone(), acc).with_pos(pos)
                     },
                 );
 

--- a/src/transformations.rs
+++ b/src/transformations.rs
@@ -224,7 +224,7 @@ pub mod import_resolution {
 /// value is unwrapped.
 pub mod apply_contracts {
     use super::{RichTerm, Term};
-    use crate::term::make as mk_term;
+    use crate::mk_app;
 
     /// If the top-level node of the AST is a meta-value, wrap the inner value inside generated
     /// `Assume`s corresponding to the meta-value's contracts. Otherwise, return the term
@@ -237,7 +237,12 @@ pub mod apply_contracts {
                 let inner = meta.types.iter().chain(meta.contracts.iter()).fold(
                     meta.value.take().unwrap(),
                     |acc, ctr| {
-                        mk_term::assume(ctr.types.clone(), ctr.label.clone(), acc).with_pos(pos)
+                        mk_app!(
+                            ctr.types.clone().contract(),
+                            Term::Lbl(ctr.label.clone()),
+                            acc
+                        )
+                        .with_pos(pos)
                     },
                 );
 
@@ -317,7 +322,7 @@ where
 }
 
 /// Generate a new fresh variable which do not clash with user-defined variables.
-fn fresh_var() -> Ident {
+pub fn fresh_var() -> Ident {
     Ident(format!("%{}", FreshVarCounter::next()))
 }
 

--- a/src/typecheck.rs
+++ b/src/typecheck.rs
@@ -814,7 +814,7 @@ pub fn apparent_type(t: &Term, envs: Option<&Envs>) -> ApparentType {
     match t {
         Term::Promise(ty, _, _)
         | Term::MetaValue(MetaValue {
-            types: Some(Contract {types: ty, ..}),
+            types: Some(Contract { types: ty, .. }),
             ..
         }) => ApparentType::Annotated(ty.clone()),
         // For metavalues, if there's no type annotation, choose the first contract appearing.
@@ -1528,6 +1528,8 @@ pub fn get_uop_type(state: &mut State, op: &UnaryOp) -> Result<TypeWrapper, Type
         }
         // Bool -> Bool
         UnaryOp::BoolNot() => mk_tyw_arrow!(AbsType::Bool(), AbsType::Bool()),
+        // This should not happen, as ToCtrFun() is only produced during evaluation.
+        UnaryOp::ToCtrFun() => panic!("cannot typecheck ToCtrFun()"),
         // forall a. Dyn -> a
         UnaryOp::Blame() => {
             let res = TypeWrapper::Ptr(new_var(state.table));

--- a/src/typecheck.rs
+++ b/src/typecheck.rs
@@ -1528,8 +1528,6 @@ pub fn get_uop_type(state: &mut State, op: &UnaryOp) -> Result<TypeWrapper, Type
         }
         // Bool -> Bool
         UnaryOp::BoolNot() => mk_tyw_arrow!(AbsType::Bool(), AbsType::Bool()),
-        // This should not happen, as ToCtrFun() is only produced during evaluation.
-        UnaryOp::ToCtrFun() => panic!("cannot typecheck ToCtrFun()"),
         // forall a. Dyn -> a
         UnaryOp::Blame() => {
             let res = TypeWrapper::Ptr(new_var(state.table));

--- a/src/typecheck.rs
+++ b/src/typecheck.rs
@@ -1534,8 +1534,6 @@ pub fn get_uop_type(state: &mut State, op: &UnaryOp) -> Result<TypeWrapper, Type
 
             mk_tyw_arrow!(AbsType::Dyn(), res)
         }
-        // This should not happen, as `ApplyContract()` is only produced during evaluation.
-        UnaryOp::Assume() => panic!("cannot typecheck ApplyContract()"),
         // Dyn -> Bool
         UnaryOp::Pol() => mk_tyw_arrow!(AbsType::Dyn(), AbsType::Bool()),
         // forall rows. < | rows> -> <id | rows>
@@ -1632,6 +1630,8 @@ pub fn get_bop_type(state: &mut State, op: &BinaryOp) -> Result<TypeWrapper, Typ
         // Str -> Str -> Str
         BinaryOp::PlusStr() => mk_tyw_arrow!(AbsType::Str(), AbsType::Str(), AbsType::Str()),
         // Sym -> Dyn -> Dyn -> Dyn
+        // This should not happen, as `ApplyContract()` is only produced during evaluation.
+        BinaryOp::Assume() => panic!("cannot typecheck assume"),
         BinaryOp::Unwrap() => mk_tyw_arrow!(
             AbsType::Sym(),
             AbsType::Dyn(),

--- a/src/typecheck.rs
+++ b/src/typecheck.rs
@@ -673,42 +673,26 @@ fn type_check_(
             type_check_(state, envs.clone(), strict, e, src1)?;
             type_check_(state, envs, strict, t, src2)
         }
-        Term::Promise(ty2, _, t) => {
-            let tyw2 = to_typewrapper(ty2.clone());
-
-            let instantiated = instantiate_foralls(state, tyw2, ForallInst::Constant);
-
-            unify(state, strict, ty, to_typewrapper(ty2.clone()))
-                .map_err(|err| err.into_typecheck_err(state, rt.pos))?;
-            type_check_(state, envs, true, t, instantiated)
-        }
-        Term::Assume(ty2, _, t) => {
-            unify(state, strict, ty, to_typewrapper(ty2.clone()))
-                .map_err(|err| err.into_typecheck_err(state, rt.pos))?;
-            let new_ty = TypeWrapper::Ptr(new_var(state.table));
-            type_check_(state, envs, false, t, new_ty)
-        }
-        Term::Sym(_) => unify(state, strict, ty, mk_typewrapper::sym())
-            .map_err(|err| err.into_typecheck_err(state, rt.pos)),
-        Term::Wrapped(_, t) => type_check_(state, envs, strict, t, ty),
+        Term::Promise(ty2, _, t)
         // A non-empty metavalue with a type annotation is a promise.
-        Term::MetaValue(MetaValue {
+        | Term::MetaValue(MetaValue {
             types: Some(Contract { types: ty2, .. }),
             value: Some(t),
             ..
         }) => {
             let tyw2 = to_typewrapper(ty2.clone());
+
             let instantiated = instantiate_foralls(state, tyw2, ForallInst::Constant);
 
             unify(state, strict, ty, to_typewrapper(ty2.clone()))
                 .map_err(|err| err.into_typecheck_err(state, rt.pos))?;
             type_check_(state, envs, true, t, instantiated)
         }
-        // A non-empty metavalue with at least one contract is an assume. If there's several
+        // A metavalue with at least one contract is an assume. If there's several
         // contracts, we arbitrarily chose the first one as the type annotation.
         Term::MetaValue(MetaValue {
             contracts,
-            value: Some(t),
+            value,
             ..
         }) if !contracts.is_empty() => {
             let ctr = contracts.get(0).unwrap();
@@ -716,13 +700,30 @@ fn type_check_(
 
             unify(state, strict, ty, to_typewrapper(ty2.clone()))
                 .map_err(|err| err.into_typecheck_err(state, rt.pos))?;
-            type_check_(state, envs, false, t, mk_typewrapper::dynamic())
+
+            // if there's an inner value, we have to recursively typecheck it, but in non strict
+            // mode.
+            if let Some(t) = value {
+                type_check_(state, envs, false, t, mk_typewrapper::dynamic())
+            }
+            else {
+                Ok(())
+            }
         }
-        // A metavalue without a type or contract annotation is typechecked in the same way as its inner value
+        Term::Sym(_) => unify(state, strict, ty, mk_typewrapper::sym())
+            .map_err(|err| err.into_typecheck_err(state, rt.pos)),
+        Term::Wrapped(_, t) => type_check_(state, envs, strict, t, ty),
+        // A non-empty metavalue without a type or contract annotation is typechecked in the same way as its inner value
         Term::MetaValue(MetaValue { value: Some(t), .. }) => {
             type_check_(state, envs, strict, t, ty)
         }
-        Term::MetaValue(_) => Ok(()),
+        // A metavalue without a body nor a type annotation is a record field without definition.
+        // This should probably be non representable in the syntax, as it doesn't really make
+        // sense. In any case, we infer it to be of type `Dyn` for now.
+        Term::MetaValue(_) => {
+             unify(state, strict, ty, mk_typewrapper::dynamic())
+                .map_err(|err| err.into_typecheck_err(state, rt.pos))
+        },
         Term::Import(_) => unify(state, strict, ty, mk_typewrapper::dynamic())
             .map_err(|err| err.into_typecheck_err(state, rt.pos)),
         Term::ResolvedImport(file_id) => {
@@ -811,12 +812,12 @@ impl Into<TypeWrapper> for ApparentType {
 ///   the future, such as `Dyn -> Dyn` for functions, `{ | Dyn}` for records, and so on).
 pub fn apparent_type(t: &Term, envs: Option<&Envs>) -> ApparentType {
     match t {
-        Term::Assume(ty, _, _) | Term::Promise(ty, _, _) => ApparentType::Annotated(ty.clone()),
-        // For metavalues, chose first the type annotation if any, or the first contract appearing.
-        Term::MetaValue(MetaValue {
-            types: Some(ty_ctr),
+        Term::Promise(ty, _, _)
+        | Term::MetaValue(MetaValue {
+            types: Some(Contract {types: ty, ..}),
             ..
-        }) => ApparentType::Annotated(ty_ctr.types.clone()),
+        }) => ApparentType::Annotated(ty.clone()),
+        // For metavalues, if there's no type annotation, choose the first contract appearing.
         Term::MetaValue(MetaValue { contracts, .. }) if !contracts.is_empty() => {
             ApparentType::Annotated(contracts.get(0).unwrap().types.clone())
         }
@@ -1534,7 +1535,7 @@ pub fn get_uop_type(state: &mut State, op: &UnaryOp) -> Result<TypeWrapper, Type
             mk_tyw_arrow!(AbsType::Dyn(), res)
         }
         // This should not happen, as `ApplyContract()` is only produced during evaluation.
-        UnaryOp::ApplyContract() => panic!("cannot typecheck ApplyContract()"),
+        UnaryOp::Assume() => panic!("cannot typecheck ApplyContract()"),
         // Dyn -> Bool
         UnaryOp::Pol() => mk_tyw_arrow!(AbsType::Dyn(), AbsType::Bool()),
         // forall rows. < | rows> -> <id | rows>

--- a/src/types.rs
+++ b/src/types.rs
@@ -53,7 +53,7 @@
 //! untyped parts.
 use crate::identifier::Ident;
 use crate::term::make as mk_term;
-use crate::term::{RichTerm, Term, UnaryOp};
+use crate::term::{RichTerm, Term, UnaryOp, BinaryOp};
 use crate::{mk_app, mk_fun};
 use std::collections::HashMap;
 use std::fmt;
@@ -186,7 +186,7 @@ impl Types {
             AbsType::Bool() => contracts::bool(),
             AbsType::Str() => contracts::string(),
             //TODO: optimization: have a specialized contract for `List Dyn`, to avoid mapping an
-            //always succesful contract on each element.
+            //always successful contract on each element.
             AbsType::List(ref ty) => mk_app!(contracts::list(), ty.contract_open(h, pol, sy)),
             AbsType::Sym() => panic!("Are you trying to check a Sym at runtime?"),
             AbsType::Arrow(ref s, ref t) => mk_app!(
@@ -195,7 +195,10 @@ impl Types {
                 t.contract_open(h, pol, sy)
             ),
             AbsType::Flat(ref t) => {
-                mk_term::op1(UnaryOp::Assume(), t.clone()).with_pos(t.pos)
+                // The assume primive op being strict in its first argument, we need to map the
+                // contract 
+                mk_fun!("l", mk_term::op2(BinaryOp::Assume(), t.clone(), mk_term::var("l")))
+                //mk_term::op1(UnaryOp::Assume(), t.clone()).with_pos(t.pos)
             }
             AbsType::Var(ref i) => {
                 let (rt, _) = h

--- a/src/types.rs
+++ b/src/types.rs
@@ -195,13 +195,7 @@ impl Types {
                 s.contract_open(h.clone(), !pol, sy),
                 t.contract_open(h, pol, sy)
             ),
-            AbsType::Flat(ref t) => {
-                // As contracts may be specified either as function or records, we apply the ToCtrFun
-                // operator, specifically to generate a uniform function of the label and the value to be
-                // tested.
-                let pos = t.pos;
-                mk_term::op1(UnaryOp::ToCtrFun(), t.clone()).with_pos(pos.into_inherited())
-            }
+            AbsType::Flat(ref t) => t.clone(),
             AbsType::Var(ref i) => {
                 let (rt, _) = h
                     .get(i)
@@ -295,10 +289,10 @@ impl Types {
             }
         };
 
-        // To track the argument to contracts, we need to wrap the function contracts as an
-        // `Assume`. Since `Assume` is strict in the label and need to be fully applied, we need
-        // to wrap this assume back as a standard function, that is to form:
-        // `fun l val => %assume% ctr l val`
+        // To track the argument to contracts and support contracts as record, we need to wrap the
+        // function contracts as an `Assume`. Since `Assume` is strict in the label and need to be
+        // fully applied, we need to wrap the whole expression back as a standard function, that is
+        // to form: `fun l val => %assume% ctr l val`
         let var_l = fresh_var();
         let var_val = fresh_var();
         let pos = ctr.pos;

--- a/src/types.rs
+++ b/src/types.rs
@@ -53,7 +53,7 @@
 //! untyped parts.
 use crate::identifier::Ident;
 use crate::term::make as mk_term;
-use crate::term::{RichTerm, Term, UnaryOp, BinaryOp};
+use crate::term::{BinaryOp, RichTerm, Term, UnaryOp};
 use crate::{mk_app, mk_fun};
 use std::collections::HashMap;
 use std::fmt;
@@ -180,7 +180,7 @@ impl Types {
     ) -> RichTerm {
         use crate::stdlib::contracts;
 
-        let ctr = match self.0 {
+        match self.0 {
             AbsType::Dyn() => contracts::dynamic(),
             AbsType::Num() => contracts::num(),
             AbsType::Bool() => contracts::bool(),
@@ -189,19 +189,17 @@ impl Types {
             //always successful contract on each element.
             AbsType::List(ref ty) => mk_app!(contracts::list(), ty.contract_open(h, pol, sy)),
             AbsType::Sym() => panic!("Are you trying to check a Sym at runtime?"),
-            AbsType::Arrow(ref s, ref t) => {
-                let res = mk_app!(
+            AbsType::Arrow(ref s, ref t) => mk_app!(
                 contracts::func(),
                 s.contract_open(h.clone(), !pol, sy),
                 t.contract_open(h, pol, sy)
-            );
-                println!("Resulting contract: {:#?}", res);
-                res
-            }
+            ),
             AbsType::Flat(ref t) => {
-                // The assume primive op being strict in the label, we need to map the contract in
-                // a function first.
-                mk_fun!("l", mk_term::op2(BinaryOp::Assume(), t.clone(), mk_term::var("l")))
+                // As contracts may be specified either as function or records, we apply the ToCtrFun
+                // operator, specifically to generate a uniform function of the label and the value to be
+                // tested.
+                let pos = t.pos;
+                mk_term::op1(UnaryOp::ToCtrFun(), t.clone()).with_pos(pos.into_inherited())
             }
             AbsType::Var(ref i) => {
                 let (rt, _) = h
@@ -294,12 +292,7 @@ impl Types {
             AbsType::DynRecord(ref ty) => {
                 mk_app!(contracts::dyn_record(), ty.contract_open(h, pol, sy))
             }
-        };
-
-        // The assume primive op being strict in the label, we need to map contracts as a lazy
-        // function.
-        let pos = ctr.pos;
-        mk_fun!("l", mk_term::op2(BinaryOp::Assume(), ctr, mk_term::var("l"))).with_pos(pos.into_inherited())
+        }
     }
 
     /// Find a binding in a record row type. Return `None` if there is no such binding, if the type

--- a/src/types.rs
+++ b/src/types.rs
@@ -195,7 +195,7 @@ impl Types {
                 t.contract_open(h, pol, sy)
             ),
             AbsType::Flat(ref t) => {
-                mk_term::op1(UnaryOp::ApplyContract(), t.clone()).with_pos(t.pos)
+                mk_term::op1(UnaryOp::Assume(), t.clone()).with_pos(t.pos)
             }
             AbsType::Var(ref i) => {
                 let (rt, _) = h


### PR DESCRIPTION
Depend on #314. Following #314, `Assume` as a standalone AST node isn't useful anymore, as it can be implemented in terms of existing operations. This PR removes the `Assume` node, now implemented by the `ApplyContract` operator.

`ApplyContract` is also splitt in two more atomic operators, one named `Assume` that is in charge of filling the label with required information and track the contract argument, while `ToCtrFn` is a wrapper that in charge of converting contracts as record to vanilla contract functions.

As a reward, tracked arguments introduced in #302, that were basically restricted to flat contracts, now works with composed (sub)contracts (records, lists, and functions): in the following example, although the contract is higher-order, the error pinpoints the value of ground type actually causing the problem, which was not the case previously.

```
nickel> let Nat = fun l x =>
  if (builtins.isNum x && x % 1 == 0 && x >= 0) then
    x
  else
    contracts.blame l
nickel> let f | ((#Nat -> #Nat) -> #Nat) -> #Nat =
  fun ev => ev (fun x => x + 0.5)
nickel> f (fun f => f 10)

error: Blame error: contract broken by a function.
  ┌─ :1:11
  │
1 │ ((#Nat -> #Nat) -> #Nat) -> #Nat
  │           ---- expected return type of a sub-function passed as an argument of an inner call
  │
  ┌─ repl-input-6:2:26
  │
2 │   fun ev => ev (fun x => x + 0.5)
  │                          ------- evaluated to this expression
  │
  ┌─ <unkown> (generated by evaluation):1:1
  │
1 │ 10.5
  │ ---- evaluated to this value
  │
[...]
```