### PR TITLE
Full annotations

### DIFF
--- a/src/grammar.lalrpop
+++ b/src/grammar.lalrpop
@@ -13,11 +13,17 @@ use super::lexer::{Token, NormalToken, StringToken, MultiStringToken, LexicalErr
 use std::collections::HashMap;
 use codespan::FileId;
 
-grammar<'input>(src_id: FileId, );
+grammar<'input>(src_id: FileId);
 
 SpTerm<Rule>: RichTerm = <l: @L> <t: Rule> <r: @R> => t.with_pos(mk_pos(src_id, l, r));
 
-TypeAnnot: (usize, Types, usize) = ":" <l: @L> <ty: Types> <r: @R> => (l, ty, r);
+TypeAnnot: MetaValue = ":" <l: @L> <ty: Types> <r: @R> => MetaValue {
+    doc: None,
+    types: Some(Contract {types: ty.clone(), label: mk_label(ty, src_id, l, r)}),
+    contracts: Vec::new(),
+    priority: Default::default(),
+    value: None,
+};
 
 MetaAnnotAtom: MetaValue = {
     "|" <l: @L> <ty: Types> <r: @R> => MetaValue {
@@ -45,6 +51,18 @@ MetaAnnotAtom: MetaValue = {
 
 MetaAnnot: MetaValue = <anns: MetaAnnotAtom+> => anns.into_iter().fold(MetaValue::new(), MetaValue::flatten);
 
+Annot: MetaValue = {
+    <TypeAnnot>,
+    <ty_ann: TypeAnnot?> <meta: MetaAnnot> => {
+        if let Some(ty_meta) = ty_ann {
+            MetaValue::flatten(ty_meta, meta)
+        }
+        else {
+            meta
+        }
+    }
+};
+
 LeftOp<Op, Current, Previous>: RichTerm =
     <t1: Current> <op: Op> <t2: Previous> => mk_term::op2(op, t1, t2);
 
@@ -52,78 +70,56 @@ LeftOpLazy<Op, Current, Previous>: RichTerm =
     <t1: Current> <op: Op> <t2: Previous> => mk_app!(Term::Op1(op, t1), t2);
 
 pub Term: RichTerm = {
-    SpTerm<RichTerm>,
-    SpTerm<TypedTerm>,
-    SpTerm<MetaTerm>,
+    <t: SpTerm<RichTerm>> <meta: Annot?> => {
+        let pos = t.pos;
+
+        if let Some(mut meta) = meta {
+            meta.value = Some(t);
+            RichTerm::new(Term::MetaValue(meta), pos)
+        }
+        else {
+            t
+        }
+    }
 };
 
 pub ExtendedTerm: ExtendedTerm = {
-    "let" <id:Ident> <ann: TypeAnnot?> "=" <t1: Term> => {
-        let t1 = if let Some((l, ty, r)) = ann {
-            let pos = t1.pos.clone();
-            RichTerm::new(Term::Promise(ty.clone(), mk_label(ty, src_id, l, r), t1), pos)
+    "let" <id:Ident> <meta: Annot?> "=" <t: Term> => {
+        let pos = t.pos;
+
+        let t = if let Some(mut meta) = meta {
+            meta.value = Some(t);
+            RichTerm::new(Term::MetaValue(meta), pos)
         }
         else {
-            t1
+            t
         };
 
-        ExtendedTerm::ToplevelLet(id, t1)
-    },
-    "let" <id:Ident> <meta: MetaAnnot> "=" <t1: Term> => {
-        //TODO: bump LALRPOP version to >= 0.18.0 which allows mutable x in
-        //actions and remove this
-        let mut meta = meta;
-        let pos = t1.pos.clone();
-        meta.value = Some(t1);
-
-        ExtendedTerm::ToplevelLet(id, RichTerm::new(Term::MetaValue(meta), pos))
+        ExtendedTerm::ToplevelLet(id, t)
     },
     Term => ExtendedTerm::RichTerm(<>),
 }
-
-TypedTerm: RichTerm = {
-    <t: SpTerm<RichTerm>> <ann: TypeAnnot> => {
-        let (l, ty, r) = ann;
-        RichTerm::from(Term::Promise(ty.clone(), mk_label(ty, src_id, l, r), t))
-    }
-};
-
-MetaTerm: RichTerm = {
-    <t: SpTerm<RichTerm>> <meta: MetaAnnot> => {
-        let pos = t.pos.clone();
-        //TODO: bump LALRPOP version to >= 0.18.0 which allows mutable x in
-        //actions and remove this
-        let mut meta = meta;
-        meta.value = Some(t);
-        RichTerm::new(Term::MetaValue(meta), pos)
-    }
-};
 
 RichTerm: RichTerm = {
     <l: @L> "fun" <ps:Pattern+> "=>" <t: SpTerm<RichTerm>> <r: @R> => {
         let pos = mk_pos(src_id, l, r);
         ps.into_iter().rev().fold(t, |t, p| RichTerm {
             term: Box::new(Term::Fun(p, t)),
-            pos: pos.clone()
+            pos,
         })
     },
-    "let" <id:Ident> <ann: TypeAnnot?> "=" <t1: Term> "in" <t2:SpTerm<RichTerm>> => {
-        let t1 = if let Some((l, ty, r)) = ann {
-            let pos = t1.pos.clone();
-            RichTerm::new(Term::Promise(ty.clone(), mk_label(ty, src_id, l, r), t1), pos)
+    "let" <id:Ident> <meta: Annot?> "=" <t1: Term> "in" <t2:SpTerm<RichTerm>> => {
+        let pos = t1.pos;
+
+        let t1 = if let Some(mut meta) = meta {
+            meta.value = Some(t1);
+            RichTerm::new(Term::MetaValue(meta), pos)
         }
         else {
             t1
         };
 
         mk_term::let_in(id, t1, t2)
-    },
-    "let" <id:Ident> <meta: MetaAnnot> "=" <t1: Term> "in" <t2:SpTerm<RichTerm>> => {
-        //TODO: bump LALRPOP version to >= 0.18.0 which allows mutable x in
-        //actions and remove this
-        let mut meta = meta;
-        meta.value = Some(t1);
-        mk_term::let_in(id, Term::MetaValue(meta), t2)
     },
     "switch" "{" <cases: (switch_case ",")*> <last: switch_case?> "}" <exp: SpTerm<RichTerm>> => {
         let mut acc = HashMap::with_capacity(cases.len());
@@ -192,14 +188,23 @@ Atom: RichTerm = {
 };
 
 RecordField: (FieldPathElem, RichTerm) = {
-    <path: FieldPath> <ann: TypeAnnot?> "=" <t: Term> => {
-        let t = if let Some((l, ty, r)) = ann {
-            let pos = t.pos.clone();
-            RichTerm::new(Term::Promise(ty.clone(), mk_label(ty, src_id, l, r), t), pos)
+    <path: FieldPath> <ty_ann: TypeAnnot?> "=" <t: Term> => {
+        let t = if let Some(mut meta) = ty_ann {
+            let pos = t.pos;
+            meta.value = Some(t);
+            RichTerm::new(Term::MetaValue(meta), pos)
         }
         else {
             t
         };
+
+        elaborate_field_path(path, t)
+    },
+    <path: FieldPath> <ty_ann: TypeAnnot> <meta: MetaAnnot> "=" <t: Term> => {
+        let pos = t.pos;
+        let mut meta = MetaValue::flatten(ty_ann, meta);
+        meta.value = Some(t);
+        let t = RichTerm::new(Term::MetaValue(meta), pos);
 
         elaborate_field_path(path, t)
     },

--- a/src/transformations.rs
+++ b/src/transformations.rs
@@ -226,9 +226,8 @@ pub mod apply_contracts {
     use super::{RichTerm, Term};
     use crate::mk_app;
 
-    /// If the top-level node of the AST is a meta-value, wrap the inner value inside generated
-    /// `Assume`s corresponding to the meta-value's contracts. Otherwise, return the term
-    /// unchanged.
+    /// If the top-level node of the AST is a meta-value, apply the meta-value's contracts to the
+    /// inner value.  Otherwise, return the term unchanged.
     pub fn transform_one(rt: RichTerm) -> RichTerm {
         let RichTerm { term, pos } = rt;
 

--- a/src/typecheck.rs
+++ b/src/typecheck.rs
@@ -682,10 +682,9 @@ fn type_check_(
         }) => {
             let tyw2 = to_typewrapper(ty2.clone());
 
-            let instantiated = instantiate_foralls(state, tyw2, ForallInst::Constant);
+            let instantiated = instantiate_foralls(state, tyw2.clone(), ForallInst::Constant);
 
-            unify(state, strict, ty, to_typewrapper(ty2.clone()))
-                .map_err(|err| err.into_typecheck_err(state, rt.pos))?;
+            unify(state, strict, ty, tyw2).map_err(|err| err.into_typecheck_err(state, rt.pos))?;
             type_check_(state, envs, true, t, instantiated)
         }
         // A metavalue with at least one contract is an assume. If there's several

--- a/tests/pass/contracts.ncl
+++ b/tests/pass/contracts.ncl
@@ -86,4 +86,11 @@ f `boo == 3) &&
 (([1, 2, 3] | List Num) == [1, 2, 3] | #Assert) &&
 ((["1", "2", "false"] | List Str) == ["1", "2", "false"] | #Assert) &&
 
+// full_annotations
+// Check that the contract introduced by the type annotation doesn't interact
+// with the `default` attribute
+(({foo : {bar: Bool} | default = {bar = false}} & {foo.bar = true}).foo.bar
+  | #Assert) &&
+
+
 true

--- a/tests/pass/typechecking.ncl
+++ b/tests/pass/typechecking.ncl
@@ -161,6 +161,9 @@ let typecheck = [
   // T` (for `T` a type or a type variable) to `List Dyn`.
   {foo = [1]} : {foo : List Num},
   (let y = [] in y) : forall a. List a,
+
+  // full_annotations
+  let x : Num | doc "some" | default = 1 in x + 1 : Num,
 ] in
 
 

--- a/tests/typecheck_fail.rs
+++ b/tests/typecheck_fail.rs
@@ -150,39 +150,43 @@ fn lists_operations() {
     );
 }
 
-#[test]
-fn imports() {
-    let mut resolver = SimpleResolver::new();
-    resolver.add_source(String::from("good"), String::from("1 + 1 : Num"));
-    resolver.add_source(String::from("bad"), String::from("false : Num"));
-    resolver.add_source(
-        String::from("proxy"),
-        String::from("let x = import \"bad\" in x"),
-    );
-
-    fn mk_import<R>(import: &str, resolver: &mut R) -> Result<RichTerm, ImportError>
-    where
-        R: ImportResolver,
-    {
-        transform(
-            mk_term::let_in("x", mk_term::import(import), mk_term::var("x")),
-            resolver,
-        )
-    };
-
-    type_check_in_env(
-        &mk_import("good", &mut resolver).unwrap(),
-        &Environment::new(),
-        &mut resolver,
-    )
-    .unwrap();
-    type_check_in_env(
-        &mk_import("proxy", &mut resolver).unwrap(),
-        &Environment::new(),
-        &mut resolver,
-    )
-    .unwrap_err();
-}
+// FIXME: these tests are boguous, because they transform the term before typechecking, which is
+// not the case in the actual evaluation pipeline. Currently, typechecking is done before program
+// transformation, and thus can't typecheck imported files, which is an issue that needs to be
+// solved before re-introducing these tests. See https://github.com/tweag/nickel/issues/316.
+// #[test]
+// fn imports() {
+//     let mut resolver = SimpleResolver::new();
+//     resolver.add_source(String::from("good"), String::from("1 + 1 : Num"));
+//     resolver.add_source(String::from("bad"), String::from("false : Num"));
+//     resolver.add_source(
+//         String::from("proxy"),
+//         String::from("let x = import \"bad\" in x"),
+//     );
+//
+//     fn mk_import<R>(import: &str, resolver: &mut R) -> Result<RichTerm, ImportError>
+//     where
+//         R: ImportResolver,
+//     {
+//         transform(
+//             mk_term::let_in("x", mk_term::import(import), mk_term::var("x")),
+//             resolver,
+//         )
+//     };
+//
+//     type_check_in_env(
+//         &mk_import("good", &mut resolver).unwrap(),
+//         &Environment::new(),
+//         &mut resolver,
+//     )
+//     .unwrap();
+//     type_check_in_env(
+//         &mk_import("proxy", &mut resolver).unwrap(),
+//         &Environment::new(),
+//         &mut resolver,
+//     )
+//     .unwrap_err();
+// }
 
 #[test]
 fn recursive_records() {


### PR DESCRIPTION
Depend on #315. Required for #254. Allow both type and meta annotations on the same term, as described in #314. If both a type annotation and a contract annotation is provided, the type annotation is used by the typechecker, while both contracts will be enforced at run-time.