### PR TITLE
Add support for n-ary operators

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -555,6 +555,31 @@ where
                 );
                 Closure { body: fst, env }
             }
+            Term::OpN(op, mut args) => {
+                let prev_strict = enriched_strict;
+                enriched_strict = op.is_strict();
+
+                args.reverse();
+                let fst = args
+                    .pop()
+                    .ok_or_else(|| EvalError::NotEnoughArgs(op.arity(), op.to_string(), pos))?;
+
+                let pending: Vec<Closure> = args
+                    .into_iter()
+                    .map(|t| Closure {
+                        body: t,
+                        env: env.clone(),
+                    })
+                    .collect();
+
+                stack.push_op_cont(
+                    OperationCont::opn(op, pending, fst.pos, prev_strict),
+                    call_stack.len(),
+                    pos,
+                );
+
+                Closure { body: fst, env }
+            }
             Term::StrChunks(mut chunks) => match chunks.pop() {
                 None => Closure {
                     body: Term::Str(String::new()).into(),
@@ -834,6 +859,14 @@ pub fn subst(rt: RichTerm, global_env: &Environment, env: &Environment) -> RichT
                 let t2 = subst_(t2, global_env, env, bound);
 
                 RichTerm::new(Term::Op2(op, t1, t2), pos)
+            }
+            Term::OpN(op, ts) => {
+                let ts = ts
+                    .into_iter()
+                    .map(|t| subst_(t, global_env, env, Cow::Borrowed(bound.as_ref())))
+                    .collect();
+
+                RichTerm::new(Term::OpN(op, ts), pos)
             }
             Term::Promise(ty, l, t) => {
                 let t = subst_(t, global_env, env, bound);

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -559,6 +559,8 @@ where
                 let prev_strict = enriched_strict;
                 enriched_strict = op.is_strict();
 
+                // Arguments are passed as a stack to the operation continuation, so we reverse the
+                // original list.
                 args.reverse();
                 let fst = args
                     .pop()
@@ -573,7 +575,13 @@ where
                     .collect();
 
                 stack.push_op_cont(
-                    OperationCont::opn(op, pending, fst.pos, prev_strict),
+                    OperationCont::OpN {
+                        op,
+                        evaluated: Vec::with_capacity(pending.len() + 1),
+                        pending,
+                        current_pos: fst.pos,
+                        prev_enriched_strict: prev_strict,
+                    },
                     call_stack.len(),
                     pos,
                 );

--- a/src/operation.rs
+++ b/src/operation.rs
@@ -66,28 +66,10 @@ pub enum OperationCont {
         op: NAryOp,                         /* the n-ary operation */
         evaluated: Vec<(Closure, TermPos)>, /* evaluated arguments and their original position */
         current_pos: TermPos, /* original position of the argument being currently evaluated */
-        pending: Vec<Closure>, /* pending arguments yet to be evaluated */
+        pending: Vec<Closure>, /* a stack (meaning the order of arguments is to be reversed)
+                              of arguments yet to be evaluated */
         prev_enriched_strict: bool,
     },
-}
-
-impl OperationCont {
-    pub fn opn(
-        op: NAryOp,
-        args: Vec<Closure>,
-        fst_pos: TermPos,
-        prev_enriched_strict: bool,
-    ) -> OperationCont {
-        let arity = args.len();
-
-        OperationCont::OpN {
-            op,
-            evaluated: Vec::with_capacity(arity),
-            current_pos: fst_pos,
-            pending: args,
-            prev_enriched_strict,
-        }
-    }
 }
 
 /// Process to the next step of the evaluation of an operation.


### PR DESCRIPTION
While addressing #254, it turned out some builtin string operations require corresponding primitive operations with more than 2 arguments. This PR keeps the existing unary and binary operator nodes, as they make up for the majority of primitive operations, but add a generic n-ary operator node for arity greater than 2.