### PR TITLE
Add valuesOf to records stdlib

### DIFF
--- a/src/grammar.lalrpop
+++ b/src/grammar.lalrpop
@@ -331,6 +331,7 @@ UOp: UnaryOp = {
     "tail" => UnaryOp::ListTail(),
     "length" => UnaryOp::ListLength(),
     "fieldsOf" => UnaryOp::FieldsOf(),
+    "valuesOf" => UnaryOp::ValuesOf(),
 };
 
 switch_case: SwitchCase = {
@@ -622,6 +623,7 @@ extern {
         "tail" => Token::Normal(NormalToken::Tail),
         "length" => Token::Normal(NormalToken::Length),
         "fieldsOf" => Token::Normal(NormalToken::FieldsOf),
+        "valuesOf" => Token::Normal(NormalToken::ValuesOf),
         "pow" => Token::Normal(NormalToken::Pow),
 
         "hasField" => Token::Normal(NormalToken::HasField),

--- a/src/parser/lexer.rs
+++ b/src/parser/lexer.rs
@@ -189,6 +189,8 @@ pub enum NormalToken<'input> {
     Length,
     #[token("%fieldsOf%")]
     FieldsOf,
+    #[token("%valuesOf%")]
+    ValuesOf,
     #[token("%pow%")]
     Pow,
 

--- a/src/term.rs
+++ b/src/term.rs
@@ -601,6 +601,8 @@ pub enum UnaryOp {
 
     /// Return the names of the fields of a record as a string list.
     FieldsOf(),
+    /// Return the values of the fields of a record as a list.
+    ValuesOf(),
 }
 
 /// Primitive binary operators

--- a/src/typecheck.rs
+++ b/src/typecheck.rs
@@ -1614,6 +1614,8 @@ pub fn get_uop_type(state: &mut State, op: &UnaryOp) -> Result<TypeWrapper, Type
             //mk_tyw_record!(; TypeWrapper::Ptr(new_var(state.table))),
             mk_typewrapper::list(AbsType::Str())
         ),
+        // Dyn -> List
+        UnaryOp::ValuesOf() => mk_tyw_arrow!(AbsType::Dyn(), mk_typewrapper::list(AbsType::Dyn())),
     })
 }
 

--- a/stdlib/records.ncl
+++ b/stdlib/records.ncl
@@ -2,8 +2,9 @@
   records = {
     map : forall a b. (Str -> a -> b) -> {_: a} -> {_: b} = fun f r => %recordMap% r f,
 
-    // TODO: change Dyn to { | Dyn} once the PR introducing open contracts lands
-    fieldsOf : Dyn -> List Str = fun r => %fieldsOf% r,
+    fieldsOf | { | Dyn} -> List Str = fun r => %fieldsOf% r,
+
+    valuesOf | { | Dyn} -> List  = fun r => %valuesOf% r,
 
     hasField : Str -> Dyn -> Bool = fun r field => %hasField% r field,
   }


### PR DESCRIPTION
Depend on #323. Partly address #254. Add `valuesOf` to the records stdlib, which returns a list of the content of the fields, ordered in the same way as `fieldsOf` (alphabetically by fields name).