### PR TITLE
[Fix]Primitive operators typing errors

### DIFF
--- a/src/typecheck.rs
+++ b/src/typecheck.rs
@@ -1772,10 +1772,10 @@ pub fn get_bop_type(
             mk_typewrapper::str(),
             mk_typewrapper::dynamic(),
         ),
-        BinaryOp::Pow() => mk_tyw_arrow!(
+        BinaryOp::Pow() => (
             mk_typewrapper::num(),
             mk_typewrapper::num(),
-            mk_typewrapper::num()
+            mk_typewrapper::num(),
         ),
     })
 }

--- a/src/typecheck.rs
+++ b/src/typecheck.rs
@@ -652,26 +652,19 @@ fn type_check_(
             }
         }
         Term::Op1(op, t) => {
-            let ty_op = get_uop_type(state, op)?;
+            let (ty_arg, ty_res) = get_uop_type(state, op)?;
 
-            let src = TypeWrapper::Ptr(new_var(state.table));
-            let arr = mk_tyw_arrow!(src.clone(), ty);
-
-            unify(state, strict, arr, ty_op)
+            unify(state, strict, ty, ty_res)
                 .map_err(|err| err.into_typecheck_err(state, rt.pos))?;
-            type_check_(state, envs.clone(), strict, t, src)
+            type_check_(state, envs.clone(), strict, t, ty_arg)
         }
-        Term::Op2(op, e, t) => {
-            let ty_op = get_bop_type(state, op)?;
+        Term::Op2(op, t1, t2) => {
+            let (ty_arg1, ty_arg2, ty_res) = get_bop_type(state, op)?;
 
-            let src1 = TypeWrapper::Ptr(new_var(state.table));
-            let src2 = TypeWrapper::Ptr(new_var(state.table));
-            let arr = mk_tyw_arrow!(src1.clone(), src2.clone(), ty);
-
-            unify(state, strict, arr, ty_op)
+            unify(state, strict, ty, ty_res)
                 .map_err(|err| err.into_typecheck_err(state, rt.pos))?;
-            type_check_(state, envs.clone(), strict, e, src1)?;
-            type_check_(state, envs, strict, t, src2)
+            type_check_(state, envs.clone(), strict, t1, ty_arg1)?;
+            type_check_(state, envs, strict, t2, ty_arg2)
         }
         Term::OpN(op, args) => {
             let (tys_op, ty_ret) = get_nop_type(state, op)?;
@@ -1513,17 +1506,18 @@ fn instantiate_foralls(state: &mut State, mut ty: TypeWrapper, inst: ForallInst)
 }
 
 /// Type of unary operations.
-pub fn get_uop_type(state: &mut State, op: &UnaryOp) -> Result<TypeWrapper, TypecheckError> {
+pub fn get_uop_type(
+    state: &mut State,
+    op: &UnaryOp,
+) -> Result<(TypeWrapper, TypeWrapper), TypecheckError> {
     Ok(match op {
         // forall a. bool -> a -> a -> a
         UnaryOp::Ite() => {
             let branches = TypeWrapper::Ptr(new_var(state.table));
 
-            mk_tyw_arrow!(
-                AbsType::Bool(),
-                branches.clone(),
-                branches.clone(),
-                branches
+            (
+                mk_typewrapper::bool(),
+                mk_tyw_arrow!(branches.clone(), branches.clone(), branches),
             )
         }
         // forall a. a -> Bool
@@ -1534,44 +1528,47 @@ pub fn get_uop_type(state: &mut State, op: &UnaryOp) -> Result<TypeWrapper, Type
         | UnaryOp::IsList()
         | UnaryOp::IsRecord() => {
             let inp = TypeWrapper::Ptr(new_var(state.table));
-
-            mk_tyw_arrow!(inp, AbsType::Bool())
+            (inp, mk_typewrapper::bool())
         }
         // Bool -> Bool -> Bool
-        UnaryOp::BoolAnd() | UnaryOp::BoolOr() => {
-            mk_tyw_arrow!(AbsType::Bool(), AbsType::Bool(), AbsType::Bool())
-        }
+        UnaryOp::BoolAnd() | UnaryOp::BoolOr() => (
+            mk_typewrapper::bool(),
+            mk_tyw_arrow!(AbsType::Bool(), AbsType::Bool()),
+        ),
         // Bool -> Bool
-        UnaryOp::BoolNot() => mk_tyw_arrow!(AbsType::Bool(), AbsType::Bool()),
+        UnaryOp::BoolNot() => (mk_typewrapper::bool(), mk_typewrapper::bool()),
         // forall a. Dyn -> a
         UnaryOp::Blame() => {
             let res = TypeWrapper::Ptr(new_var(state.table));
 
-            mk_tyw_arrow!(AbsType::Dyn(), res)
+            (mk_typewrapper::dynamic(), res)
         }
         // Dyn -> Bool
-        UnaryOp::Pol() => mk_tyw_arrow!(AbsType::Dyn(), AbsType::Bool()),
+        UnaryOp::Pol() => (mk_typewrapper::dynamic(), mk_typewrapper::bool()),
         // forall rows. < | rows> -> <id | rows>
         UnaryOp::Embed(id) => {
             let row = TypeWrapper::Ptr(new_var(state.table));
             // Constraining a freshly created variable should never fail.
             constraint(state, row.clone(), id.clone()).unwrap();
-            mk_tyw_arrow!(mk_tyw_enum!(row.clone()), mk_tyw_enum!(id.clone(), row))
+            (mk_tyw_enum!(row.clone()), mk_tyw_enum!(id.clone(), row))
         }
         // This should not happen, as Switch() is only produced during evaluation.
         UnaryOp::Switch(_) => panic!("cannot typecheck Switch()"),
         // Dyn -> Dyn
         UnaryOp::ChangePolarity() | UnaryOp::GoDom() | UnaryOp::GoCodom() | UnaryOp::GoList() => {
-            mk_tyw_arrow!(AbsType::Dyn(), AbsType::Dyn())
+            (mk_typewrapper::dynamic(), mk_typewrapper::dynamic())
         }
         // Sym -> Dyn -> Dyn
-        UnaryOp::Wrap() => mk_tyw_arrow!(AbsType::Sym(), AbsType::Dyn(), AbsType::Dyn()),
+        UnaryOp::Wrap() => (
+            mk_typewrapper::sym(),
+            mk_tyw_arrow!(AbsType::Dyn(), AbsType::Dyn()),
+        ),
         // forall rows a. { id: a | rows} -> a
         UnaryOp::StaticAccess(id) => {
             let row = TypeWrapper::Ptr(new_var(state.table));
             let res = TypeWrapper::Ptr(new_var(state.table));
 
-            mk_tyw_arrow!(mk_tyw_record!((id.clone(), res.clone()); row), res)
+            (mk_tyw_record!((id.clone(), res.clone()); row), res)
         }
         // forall a b. List a -> (a -> b) -> List b
         UnaryOp::ListMap() => {
@@ -1579,7 +1576,10 @@ pub fn get_uop_type(state: &mut State, op: &UnaryOp) -> Result<TypeWrapper, Type
             let b = TypeWrapper::Ptr(new_var(state.table));
 
             let f_type = mk_tyw_arrow!(a.clone(), b.clone());
-            mk_tyw_arrow!(mk_typewrapper::list(a), f_type, mk_typewrapper::list(b))
+            (
+                mk_typewrapper::list(a),
+                mk_tyw_arrow!(f_type, mk_typewrapper::list(b)),
+            )
         }
         // forall a b. { _ : a} -> (Str -> a -> b) -> { _ : b }
         UnaryOp::RecordMap() => {
@@ -1590,10 +1590,9 @@ pub fn get_uop_type(state: &mut State, op: &UnaryOp) -> Result<TypeWrapper, Type
             let b = TypeWrapper::Ptr(new_var(state.table));
 
             let f_type = mk_tyw_arrow!(AbsType::Str(), a.clone(), b.clone());
-            mk_tyw_arrow!(
+            (
                 mk_typewrapper::dyn_record(a),
-                f_type,
-                mk_typewrapper::dyn_record(b)
+                mk_tyw_arrow!(f_type, mk_typewrapper::dyn_record(b)),
             )
         }
         // forall a b. a -> b -> b
@@ -1601,117 +1600,153 @@ pub fn get_uop_type(state: &mut State, op: &UnaryOp) -> Result<TypeWrapper, Type
             let fst = TypeWrapper::Ptr(new_var(state.table));
             let snd = TypeWrapper::Ptr(new_var(state.table));
 
-            mk_tyw_arrow!(fst, snd.clone(), snd)
+            (fst, mk_tyw_arrow!(snd.clone(), snd))
         }
         // forall a. List a -> a
         UnaryOp::ListHead() => {
             let ty_elt = TypeWrapper::Ptr(new_var(state.table));
-            mk_tyw_arrow!(mk_typewrapper::list(ty_elt.clone()), ty_elt)
+            (mk_typewrapper::list(ty_elt.clone()), ty_elt)
         }
         // forall a. List a -> List a
         UnaryOp::ListTail() => {
             let ty_elt = TypeWrapper::Ptr(new_var(state.table));
-            mk_tyw_arrow!(
+            (
                 mk_typewrapper::list(ty_elt.clone()),
-                mk_typewrapper::list(ty_elt)
+                mk_typewrapper::list(ty_elt),
             )
         }
         // forall a. List a -> Num
         UnaryOp::ListLength() => {
             let ty_elt = TypeWrapper::Ptr(new_var(state.table));
-            mk_tyw_arrow!(mk_typewrapper::list(ty_elt), AbsType::Num())
+            (mk_typewrapper::list(ty_elt), mk_typewrapper::num())
         }
         // This should not happen, as ChunksConcat() is only produced during evaluation.
         UnaryOp::ChunksConcat() => panic!("cannot type ChunksConcat()"),
         // BEFORE: forall rows. { rows } -> List
         // Dyn -> List Str
-        UnaryOp::FieldsOf() => mk_tyw_arrow!(
-            AbsType::Dyn(),
+        UnaryOp::FieldsOf() => (
+            mk_typewrapper::dynamic(),
             //mk_tyw_record!(; TypeWrapper::Ptr(new_var(state.table))),
-            mk_typewrapper::list(AbsType::Str())
+            mk_typewrapper::list(AbsType::Str()),
         ),
     })
 }
 
 /// Type of a binary operation.
-pub fn get_bop_type(state: &mut State, op: &BinaryOp) -> Result<TypeWrapper, TypecheckError> {
+pub fn get_bop_type(
+    state: &mut State,
+    op: &BinaryOp,
+) -> Result<(TypeWrapper, TypeWrapper, TypeWrapper), TypecheckError> {
     Ok(match op {
         // Num -> Num -> Num
         BinaryOp::Plus()
         | BinaryOp::Sub()
         | BinaryOp::Mult()
         | BinaryOp::Div()
-        | BinaryOp::Modulo() => mk_tyw_arrow!(AbsType::Num(), AbsType::Num(), AbsType::Num()),
+        | BinaryOp::Modulo() => (
+            mk_typewrapper::num(),
+            mk_typewrapper::num(),
+            mk_typewrapper::num(),
+        ),
         // Str -> Str -> Str
-        BinaryOp::PlusStr() => mk_tyw_arrow!(AbsType::Str(), AbsType::Str(), AbsType::Str()),
+        BinaryOp::PlusStr() => (
+            mk_typewrapper::str(),
+            mk_typewrapper::str(),
+            mk_typewrapper::str(),
+        ),
         // Sym -> Dyn -> Dyn -> Dyn
         // This should not happen, as `ApplyContract()` is only produced during evaluation.
         BinaryOp::Assume() => panic!("cannot typecheck assume"),
-        BinaryOp::Unwrap() => mk_tyw_arrow!(
-            AbsType::Sym(),
-            AbsType::Dyn(),
-            AbsType::Dyn(),
-            AbsType::Dyn()
+        BinaryOp::Unwrap() => (
+            mk_typewrapper::sym(),
+            mk_typewrapper::dynamic(),
+            mk_tyw_arrow!(AbsType::Dyn(), AbsType::Dyn()),
         ),
         // Str -> Dyn -> Dyn
-        BinaryOp::Tag() => mk_tyw_arrow!(AbsType::Str(), AbsType::Dyn(), AbsType::Dyn()),
+        BinaryOp::Tag() => (
+            mk_typewrapper::str(),
+            mk_typewrapper::dynamic(),
+            mk_typewrapper::dynamic(),
+        ),
         // forall a b. a -> b -> Bool
-        BinaryOp::Eq() => mk_tyw_arrow!(
+        BinaryOp::Eq() => (
             TypeWrapper::Ptr(new_var(state.table)),
             TypeWrapper::Ptr(new_var(state.table)),
-            AbsType::Bool()
+            mk_typewrapper::bool(),
         ),
         // Num -> Num -> Bool
         BinaryOp::LessThan()
         | BinaryOp::LessOrEq()
         | BinaryOp::GreaterThan()
-        | BinaryOp::GreaterOrEq() => mk_tyw_arrow!(AbsType::Num(), AbsType::Num(), AbsType::Bool()),
+        | BinaryOp::GreaterOrEq() => (
+            mk_typewrapper::num(),
+            mk_typewrapper::num(),
+            mk_typewrapper::bool(),
+        ),
         // Str -> Dyn -> Dyn
-        BinaryOp::GoField() => mk_tyw_arrow!(AbsType::Str(), AbsType::Dyn(), AbsType::Dyn()),
+        BinaryOp::GoField() => (
+            mk_typewrapper::str(),
+            mk_typewrapper::dynamic(),
+            mk_typewrapper::dynamic(),
+        ),
         // forall a. Str -> { _ : a} -> a
         BinaryOp::DynAccess() => {
             let res = TypeWrapper::Ptr(new_var(state.table));
 
-            mk_tyw_arrow!(AbsType::Str(), mk_typewrapper::dyn_record(res.clone()), res)
+            (
+                mk_typewrapper::str(),
+                mk_typewrapper::dyn_record(res.clone()),
+                res,
+            )
         }
         // forall a. Str -> { _ : a } -> a -> { _ : a }
         BinaryOp::DynExtend() => {
             let res = TypeWrapper::Ptr(new_var(state.table));
-
-            mk_tyw_arrow!(
-                AbsType::Str(),
+            (
+                mk_typewrapper::str(),
                 mk_typewrapper::dyn_record(res.clone()),
-                res.clone(),
-                mk_typewrapper::dyn_record(res)
+                mk_tyw_arrow!(res.clone(), mk_typewrapper::dyn_record(res)),
             )
         }
         // forall a. Str -> { _ : a } -> { _ : a}
         BinaryOp::DynRemove() => {
             let res = TypeWrapper::Ptr(new_var(state.table));
 
-            mk_tyw_arrow!(
-                AbsType::Str(),
+            (
+                mk_typewrapper::str(),
                 mk_typewrapper::dyn_record(res.clone()),
-                mk_typewrapper::dyn_record(res)
+                mk_typewrapper::dyn_record(res),
             )
         }
         // Str -> Dyn -> Bool
-        BinaryOp::HasField() => mk_tyw_arrow!(AbsType::Str(), AbsType::Dyn(), AbsType::Bool()),
+        BinaryOp::HasField() => (
+            mk_typewrapper::str(),
+            mk_typewrapper::dynamic(),
+            mk_typewrapper::bool(),
+        ),
         // forall a. List a -> List a -> List a
         BinaryOp::ListConcat() => {
             let ty_elt = TypeWrapper::Ptr(new_var(state.table));
             let ty_list = mk_typewrapper::list(ty_elt);
-            mk_tyw_arrow!(ty_list.clone(), ty_list.clone(), ty_list)
+            (ty_list.clone(), ty_list.clone(), ty_list)
         }
         // forall a. List a -> Num -> a
         BinaryOp::ListElemAt() => {
             let ty_elt = TypeWrapper::Ptr(new_var(state.table));
-            mk_tyw_arrow!(mk_typewrapper::list(ty_elt.clone()), AbsType::Num(), ty_elt)
+            (
+                mk_typewrapper::list(ty_elt.clone()),
+                mk_typewrapper::num(),
+                ty_elt,
+            )
         }
         // Dyn -> Dyn -> Dyn
-        BinaryOp::Merge() => mk_tyw_arrow!(AbsType::Dyn(), AbsType::Dyn(), AbsType::Dyn()),
+        BinaryOp::Merge() => (
+            mk_typewrapper::dynamic(),
+            mk_typewrapper::dynamic(),
+            mk_typewrapper::dynamic(),
+        ),
         // <Md5, Sha1, Sha256, Sha512> -> Str -> Str
-        BinaryOp::Hash() => mk_tyw_arrow!(
+        BinaryOp::Hash() => (
             mk_tyw_enum!(
                 "Md5",
                 "Sha1",
@@ -1720,22 +1755,22 @@ pub fn get_bop_type(state: &mut State, op: &BinaryOp) -> Result<TypeWrapper, Typ
                 mk_typewrapper::row_empty()
             ),
             mk_typewrapper::str(),
-            mk_typewrapper::str()
+            mk_typewrapper::str(),
         ),
         // forall a. <Json, Yaml, Toml> -> a -> Str
         BinaryOp::Serialize() => {
             let ty_input = TypeWrapper::Ptr(new_var(state.table));
-            mk_tyw_arrow!(
+            (
                 mk_tyw_enum!("Json", "Yaml", "Toml", mk_typewrapper::row_empty()),
                 ty_input,
-                mk_typewrapper::str()
+                mk_typewrapper::str(),
             )
         }
         // <Json, Yaml, Toml> -> Str -> Dyn
-        BinaryOp::Deserialize() => mk_tyw_arrow!(
+        BinaryOp::Deserialize() => (
             mk_tyw_enum!("Json", "Yaml", "Toml", mk_typewrapper::row_empty()),
             mk_typewrapper::str(),
-            mk_typewrapper::dynamic()
+            mk_typewrapper::dynamic(),
         ),
         BinaryOp::Pow() => mk_tyw_arrow!(
             mk_typewrapper::num(),


### PR DESCRIPTION
Fix #320. Depend on #319. The type of primitive operators was internally passed as an arrow `TypeArg -> TypeArg -> TypeResult`, causing unification errors on the return type to mysteriously report about a function type. It is now passed as tuples, and directly unified with the corresponding components. This also gets rid of a few unification steps and unification variable creations.