### PR TITLE
Add test for serialization

### DIFF
--- a/tests/pass.rs
+++ b/tests/pass.rs
@@ -95,4 +95,5 @@ fn types() {
 #[test]
 fn serialize() {
     check_file("serialize.ncl");
+    check_file("serialize-package.ncl");
 }

--- a/tests/pass/serialize-package.ncl
+++ b/tests/pass/serialize-package.ncl
@@ -1,0 +1,64 @@
+let ctr = {
+  Derivation | doc "
+            A package natively specified in Nickel."
+          = {
+    name | doc "
+           The package name."
+         | Str;
+
+    buildInputs | doc "
+                  The list of inputs for this package, specified as a
+                  `NixPackage`."
+                | List #NixPackage;
+    // Many more missing
+  };
+
+  Shell = Derivation & {};
+
+  NixPackage | doc "
+               Interchange format representing a package only accessible on the
+               nix side. The nix interop code then translate this back to an
+               actual package.
+
+               # Example
+
+               ```
+               myPkg = {
+                 name  = \"myPkg\",
+                 buildInputs | List #NixPackage = [{package = \"hello\"}]\",
+               }
+               ```
+               This will give the following attribute sets once imported in Nix:
+               ```
+               {
+                 name = \"myPkg\",
+                 buildInputs = [nixpkgs.hello],
+               }
+               ```"
+             = {
+    package | Str
+            | doc "
+              The package name, given as a string. Dot-separated paths are not yet
+              supported";
+
+    input | Str
+          | doc "
+            The inputs where to fetch the package from. Must be a variable name
+            that is in scope on the Nix side."
+          | default = "nixpkgs";
+
+    _type | doc "
+            Used by the interop Nix code. Forced to a fixed value. Please
+            do not override."
+          = "package";
+  }
+} in
+builtins.serialize `Json (
+  {
+    name = "nickel";
+    buildInputs = [{package = "hello"}];
+  } | #(ctr.Shell)
+) == builtins.serialize `Json {
+  name = "nickel";
+  buildInputs = [{input = "nixpkgs"; package = "hello"; "_type" = "package"}];
+}


### PR DESCRIPTION
Depend on #314. When writing a nix shell in Nickel, some basic package definition failed to serialize correctly, due to merging not properly closurizing everything. Merging has been reworked quite a bit in #314, and the example works on the associated branch, so it seems to be fixed. This PR adds a regression test on top of #314 to make sure it stays this way.