### PR TITLE
Change precedence of let and annotations

### DIFF
--- a/src/grammar.lalrpop
+++ b/src/grammar.lalrpop
@@ -15,7 +15,7 @@ use codespan::FileId;
 
 grammar<'input>(src_id: FileId);
 
-SpTerm<Rule>: RichTerm = <l: @L> <t: Rule> <r: @R> => t.with_pos(mk_pos(src_id, l, r));
+WithPos<Rule>: RichTerm = <l: @L> <t: Rule> <r: @R> => t.with_pos(mk_pos(src_id, l, r));
 
 TypeAnnot: MetaValue = ":" <l: @L> <ty: Types> <r: @R> => MetaValue {
     doc: None,
@@ -70,7 +70,7 @@ LeftOpLazy<Op, Current, Previous>: RichTerm =
     <t1: Current> <op: Op> <t2: Previous> => mk_app!(Term::Op1(op, t1), t2);
 
 pub Term: RichTerm = {
-    <t: SpTerm<RootTermNoLet>> <meta: Annot?> => {
+    <t: WithPos<RootTermNoLet>> <meta: Annot?> => {
         let pos = t.pos;
 
         if let Some(mut meta) = meta {
@@ -81,7 +81,7 @@ pub Term: RichTerm = {
             t
         }
     },
-    SpTerm<RootTermLet>,
+    WithPos<RootTermLet>,
 };
 
 pub ExtendedTerm: ExtendedTerm = {
@@ -102,7 +102,7 @@ pub ExtendedTerm: ExtendedTerm = {
 }
 
 RootTermMacro<RightRule>: RichTerm = {
-    <l: @L> "fun" <ps:Pattern+> "=>" <t: SpTerm<RightRule>> <r: @R> => {
+    <l: @L> "fun" <ps:Pattern+> "=>" <t: WithPos<RightRule>> <r: @R> => {
         let pos = mk_pos(src_id, l, r);
         ps.into_iter().rev().fold(t, |t, p| RichTerm {
             term: Box::new(Term::Fun(p, t)),
@@ -110,7 +110,7 @@ RootTermMacro<RightRule>: RichTerm = {
         })
     },
     "switch" "{" <cases: (switch_case ",")*> <last: switch_case?> "}" <exp:
-        SpTerm<RightRule>> => {
+        WithPos<RightRule>> => {
         let mut acc = HashMap::with_capacity(cases.len());
         let mut default = None;
 
@@ -131,13 +131,13 @@ RootTermMacro<RightRule>: RichTerm = {
             )
         )
     },
-    "if" <b:Term> "then" <t:Term> "else" <e:SpTerm<RightRule>> =>
+    "if" <b:Term> "then" <t:Term> "else" <e:WithPos<RightRule>> =>
         mk_app!(Term::Op1(UnaryOp::Ite(), b), t, e),
 };
 
 RootTermLet: RichTerm = {
     "let" <id:Ident> <meta1: Annot?> "=" <t1: Term> "in"
-        <t2:SpTerm<RootTermNoLet>> <meta2: Annot?> => {
+        <t2:WithPos<RootTermNoLet>> <meta2: Annot?> => {
         let pos1 = t1.pos;
         let t1 = if let Some(mut meta1) = meta1 {
             meta1.value = Some(t1);
@@ -159,7 +159,7 @@ RootTermLet: RichTerm = {
         mk_term::let_in(id, t1, t2)
     },
     "let" <id:Ident> <meta: Annot?> "=" <t1: Term> "in"
-        <t2:SpTerm<RootTermLet>> => {
+        <t2:WithPos<RootTermLet>> => {
         let pos = t1.pos;
         let t1 = if let Some(mut meta) = meta {
             meta.value = Some(t1);
@@ -177,26 +177,26 @@ RootTermLet: RichTerm = {
 RootTermNoLet: RichTerm = {
     RootTermMacro<RootTermNoLet>,
     "import" <s: Str> => RichTerm::from(Term::Import(OsString::from(s))),
-    SpTerm<InfixExpr>,
+    WithPos<InfixExpr>,
 };
 
 Applicative: RichTerm = {
-    <t1:SpTerm<Applicative>> <t2: RecordOperand> => mk_app!(t1, t2),
-    <op: UOp> <t: SpTerm<RecordOperand>> => mk_term::op1(op, t),
-    <op: BOpPre> <t1: SpTerm<RecordOperand>> <t2: SpTerm<Atom>> => mk_term::op2(op, t1, t2),
+    <t1:WithPos<Applicative>> <t2: RecordOperand> => mk_app!(t1, t2),
+    <op: UOp> <t: WithPos<RecordOperand>> => mk_term::op1(op, t),
+    <op: BOpPre> <t1: WithPos<RecordOperand>> <t2: WithPos<Atom>> => mk_term::op2(op, t1, t2),
     <RecordOperand>,
 };
 
 RecordOperand: RichTerm = {
-    SpTerm<Atom>,
-    SpTerm<RecordOperationChain>,
+    WithPos<Atom>,
+    WithPos<RecordOperationChain>,
 }
 
 RecordOperationChain: RichTerm = {
-    <t: SpTerm<RecordOperand>> "." <id: Ident> => mk_term::op1(UnaryOp::StaticAccess(id), t),
-    <t: SpTerm<RecordOperand>> "." <t_id: StrChunks> => mk_term::op2(BinaryOp::DynAccess(), t_id, t),
-    <t: SpTerm<RecordOperand>> "-$" <t_id: SpTerm<Atom>> => mk_term::op2(BinaryOp::DynRemove(), t_id, t),
-    <r: SpTerm<RecordOperand>> "$[" <id: Term> "=" <t: Term> "]" =>
+    <t: WithPos<RecordOperand>> "." <id: Ident> => mk_term::op1(UnaryOp::StaticAccess(id), t),
+    <t: WithPos<RecordOperand>> "." <t_id: StrChunks> => mk_term::op2(BinaryOp::DynAccess(), t_id, t),
+    <t: WithPos<RecordOperand>> "-$" <t_id: WithPos<Atom>> => mk_term::op2(BinaryOp::DynRemove(), t_id, t),
+    <r: WithPos<RecordOperand>> "$[" <id: Term> "=" <t: Term> "]" =>
         mk_app!(mk_term::op2(BinaryOp::DynExtend(), id, r), t),
 };
 
@@ -325,7 +325,7 @@ ChunkLiteral : String =
         })
     };
 
-ChunkExpr: StrChunk<RichTerm> = HashBrace <t: SpTerm<Term>> "}" => StrChunk::Expr(t, 0);
+ChunkExpr: StrChunk<RichTerm> = HashBrace <t: WithPos<Term>> "}" => StrChunk::Expr(t, 0);
 
 HashBrace = { "#{", "multstr #{" };
 
@@ -519,7 +519,7 @@ subType : Types = {
         Types(AbsType::List(ty))
     },
     <Ident> => Types(AbsType::Var(<>)),
-    "#" <SpTerm<Atom>> => Types(AbsType::Flat(<>)),
+    "#" <WithPos<Atom>> => Types(AbsType::Flat(<>)),
     "(" <Types> ")" => <>,
     "<" <rows:(<Ident> ",")*> <last: (<Ident>)?> <tail: ("|" <Ident>)?> ">" => {
         let ty = rows.into_iter()

--- a/src/grammar.lalrpop
+++ b/src/grammar.lalrpop
@@ -70,7 +70,7 @@ LeftOpLazy<Op, Current, Previous>: RichTerm =
     <t1: Current> <op: Op> <t2: Previous> => mk_app!(Term::Op1(op, t1), t2);
 
 pub Term: RichTerm = {
-    <t: SpTerm<RichTerm>> <meta: Annot?> => {
+    <t: SpTerm<RootTermNoLet>> <meta: Annot?> => {
         let pos = t.pos;
 
         if let Some(mut meta) = meta {
@@ -80,7 +80,8 @@ pub Term: RichTerm = {
         else {
             t
         }
-    }
+    },
+    SpTerm<RootTermLet>,
 };
 
 pub ExtendedTerm: ExtendedTerm = {
@@ -100,28 +101,16 @@ pub ExtendedTerm: ExtendedTerm = {
     Term => ExtendedTerm::RichTerm(<>),
 }
 
-RichTerm: RichTerm = {
-    <l: @L> "fun" <ps:Pattern+> "=>" <t: SpTerm<RichTerm>> <r: @R> => {
+RootTermMacro<RightRule>: RichTerm = {
+    <l: @L> "fun" <ps:Pattern+> "=>" <t: SpTerm<RightRule>> <r: @R> => {
         let pos = mk_pos(src_id, l, r);
         ps.into_iter().rev().fold(t, |t, p| RichTerm {
             term: Box::new(Term::Fun(p, t)),
             pos,
         })
     },
-    "let" <id:Ident> <meta: Annot?> "=" <t1: Term> "in" <t2:SpTerm<RichTerm>> => {
-        let pos = t1.pos;
-
-        let t1 = if let Some(mut meta) = meta {
-            meta.value = Some(t1);
-            RichTerm::new(Term::MetaValue(meta), pos)
-        }
-        else {
-            t1
-        };
-
-        mk_term::let_in(id, t1, t2)
-    },
-    "switch" "{" <cases: (switch_case ",")*> <last: switch_case?> "}" <exp: SpTerm<RichTerm>> => {
+    "switch" "{" <cases: (switch_case ",")*> <last: switch_case?> "}" <exp:
+        SpTerm<RightRule>> => {
         let mut acc = HashMap::with_capacity(cases.len());
         let mut default = None;
 
@@ -142,9 +131,52 @@ RichTerm: RichTerm = {
             )
         )
     },
-    "if" <b:Term> "then" <t:Term> "else" <e:SpTerm<RichTerm>> =>
+    "if" <b:Term> "then" <t:Term> "else" <e:SpTerm<RightRule>> =>
         mk_app!(Term::Op1(UnaryOp::Ite(), b), t, e),
-    "import" <s: StaticString> => RichTerm::from(Term::Import(OsString::from(s))),
+};
+
+RootTermLet: RichTerm = {
+    "let" <id:Ident> <meta1: Annot?> "=" <t1: Term> "in"
+        <t2:SpTerm<RootTermNoLet>> <meta2: Annot?> => {
+        let pos1 = t1.pos;
+        let t1 = if let Some(mut meta1) = meta1 {
+            meta1.value = Some(t1);
+            RichTerm::new(Term::MetaValue(meta1), pos1)
+        }
+        else {
+            t1
+        };
+
+        let pos2 = t2.pos;
+        let t2 = if let Some(mut meta2) = meta2 {
+            meta2.value = Some(t2);
+            RichTerm::new(Term::MetaValue(meta2), pos2)
+        }
+        else {
+            t2
+        };
+
+        mk_term::let_in(id, t1, t2)
+    },
+    "let" <id:Ident> <meta: Annot?> "=" <t1: Term> "in"
+        <t2:SpTerm<RootTermLet>> => {
+        let pos = t1.pos;
+        let t1 = if let Some(mut meta) = meta {
+            meta.value = Some(t1);
+            RichTerm::new(Term::MetaValue(meta), pos)
+        }
+        else {
+            t1
+        };
+
+        mk_term::let_in(id, t1, t2)
+    },
+    RootTermMacro<RootTermLet>,
+}
+
+RootTermNoLet: RichTerm = {
+    RootTermMacro<RootTermNoLet>,
+    "import" <s: Str> => RichTerm::from(Term::Import(OsString::from(s))),
     SpTerm<InfixExpr>,
 };
 
@@ -293,7 +325,7 @@ ChunkLiteral : String =
         })
     };
 
-ChunkExpr: StrChunk<RichTerm> = HashBrace <t: SpTerm<RichTerm>> "}" => StrChunk::Expr(t, 0);
+ChunkExpr: StrChunk<RichTerm> = HashBrace <t: SpTerm<Term>> "}" => StrChunk::Expr(t, 0);
 
 HashBrace = { "#{", "multstr #{" };
 

--- a/src/grammar.lalrpop
+++ b/src/grammar.lalrpop
@@ -69,20 +69,7 @@ LeftOp<Op, Current, Previous>: RichTerm =
 LeftOpLazy<Op, Current, Previous>: RichTerm =
     <t1: Current> <op: Op> <t2: Previous> => mk_app!(Term::Op1(op, t1), t2);
 
-pub Term: RichTerm = {
-    <t: WithPos<RootTermNoLet>> <meta: Annot?> => {
-        let pos = t.pos;
-
-        if let Some(mut meta) = meta {
-            meta.value = Some(t);
-            RichTerm::new(Term::MetaValue(meta), pos)
-        }
-        else {
-            t
-        }
-    },
-    WithPos<RootTermLet>,
-};
+pub Term: RichTerm = WithPos<RootTerm>;
 
 pub ExtendedTerm: ExtendedTerm = {
     "let" <id:Ident> <meta: Annot?> "=" <t: Term> => {
@@ -101,16 +88,29 @@ pub ExtendedTerm: ExtendedTerm = {
     Term => ExtendedTerm::RichTerm(<>),
 }
 
-RootTermMacro<RightRule>: RichTerm = {
-    <l: @L> "fun" <ps:Pattern+> "=>" <t: WithPos<RightRule>> <r: @R> => {
+RootTerm: RichTerm = {
+    "let" <id:Ident> <meta: Annot?> "=" <t1: Term> "in"
+        <t2: Term> => {
+        let pos = t1.pos;
+        let t1 = if let Some(mut meta) = meta {
+            meta.value = Some(t1);
+            RichTerm::new(Term::MetaValue(meta), pos)
+        }
+        else {
+            t1
+        };
+
+        mk_term::let_in(id, t1, t2)
+    },
+    <l: @L> "fun" <ps:Pattern+> "=>" <t: Term> <r: @R> => {
         let pos = mk_pos(src_id, l, r);
         ps.into_iter().rev().fold(t, |t, p| RichTerm {
             term: Box::new(Term::Fun(p, t)),
             pos,
         })
     },
-    "switch" "{" <cases: (switch_case ",")*> <last: switch_case?> "}" <exp:
-        WithPos<RightRule>> => {
+    "switch" "{" <cases: (switch_case ",")*> <last: switch_case?> "}"
+        <exp: Term> => {
         let mut acc = HashMap::with_capacity(cases.len());
         let mut default = None;
 
@@ -131,65 +131,40 @@ RootTermMacro<RightRule>: RichTerm = {
             )
         )
     },
-    "if" <b:Term> "then" <t:Term> "else" <e:WithPos<RightRule>> =>
-        mk_app!(Term::Op1(UnaryOp::Ite(), b), t, e),
+    "if" <cond: Term> "then" <t1: Term> "else" <t2: Term> =>
+        mk_app!(Term::Op1(UnaryOp::Ite(), cond), t1, t2),
+    AnnotatedTerm,
 };
 
-RootTermLet: RichTerm = {
-    "let" <id:Ident> <meta1: Annot?> "=" <t1: Term> "in"
-        <t2:WithPos<RootTermNoLet>> <meta2: Annot?> => {
-        let pos1 = t1.pos;
-        let t1 = if let Some(mut meta1) = meta1 {
-            meta1.value = Some(t1);
-            RichTerm::new(Term::MetaValue(meta1), pos1)
-        }
-        else {
-            t1
-        };
+AnnotatedTerm: RichTerm = {
+    <t: WithPos<Infix>> <meta: Annot?> => {
+        let pos = t.pos;
 
-        let pos2 = t2.pos;
-        let t2 = if let Some(mut meta2) = meta2 {
-            meta2.value = Some(t2);
-            RichTerm::new(Term::MetaValue(meta2), pos2)
-        }
-        else {
-            t2
-        };
-
-        mk_term::let_in(id, t1, t2)
-    },
-    "let" <id:Ident> <meta: Annot?> "=" <t1: Term> "in"
-        <t2:WithPos<RootTermLet>> => {
-        let pos = t1.pos;
-        let t1 = if let Some(mut meta) = meta {
-            meta.value = Some(t1);
+        if let Some(mut meta) = meta {
+            meta.value = Some(t);
             RichTerm::new(Term::MetaValue(meta), pos)
         }
         else {
-            t1
-        };
-
-        mk_term::let_in(id, t1, t2)
+            t
+        }
     },
-    RootTermMacro<RootTermLet>,
-}
+};
 
-RootTermNoLet: RichTerm = {
-    RootTermMacro<RootTermNoLet>,
+Infix: RichTerm = {
     "import" <s: Str> => RichTerm::from(Term::Import(OsString::from(s))),
-    WithPos<InfixExpr>,
+    InfixExpr,
 };
 
 Applicative: RichTerm = {
-    <t1:WithPos<Applicative>> <t2: RecordOperand> => mk_app!(t1, t2),
+    <t1:WithPos<Applicative>> <t2: WithPos<RecordOperand>> => mk_app!(t1, t2),
     <op: UOp> <t: WithPos<RecordOperand>> => mk_term::op1(op, t),
     <op: BOpPre> <t1: WithPos<RecordOperand>> <t2: WithPos<Atom>> => mk_term::op2(op, t1, t2),
-    <RecordOperand>,
+    RecordOperand,
 };
 
 RecordOperand: RichTerm = {
-    WithPos<Atom>,
-    WithPos<RecordOperationChain>,
+    Atom,
+    RecordOperationChain,
 }
 
 RecordOperationChain: RichTerm = {

--- a/src/grammar.lalrpop
+++ b/src/grammar.lalrpop
@@ -180,7 +180,7 @@ Atom: RichTerm = {
     "num literal" => RichTerm::from(Term::Num(<>)),
     "null" => RichTerm::from(Term::Null),
     Bool => RichTerm::from(Term::Bool(<>)),
-    <StrChunks>,
+    StrChunks,
     Ident => RichTerm::from(Term::Var(<>)),
     "`" <Ident> => RichTerm::from(Term::Enum(<>)),
     "{" <fields: (<RecordField> ",")*> <last: RecordField?> "}" => {

--- a/src/grammar.lalrpop
+++ b/src/grammar.lalrpop
@@ -151,7 +151,7 @@ AnnotatedTerm: RichTerm = {
 };
 
 Infix: RichTerm = {
-    "import" <s: Str> => RichTerm::from(Term::Import(OsString::from(s))),
+    "import" <s: StaticString> => RichTerm::from(Term::Import(OsString::from(s))),
     InfixExpr,
 };
 

--- a/tests/pass.rs
+++ b/tests/pass.rs
@@ -102,3 +102,8 @@ fn serialize() {
     check_file("serialize.ncl");
     check_file("serialize-package.ncl");
 }
+
+#[test]
+fn annot_parsing() {
+    check_file("annotations.ncl");
+}

--- a/tests/pass/annotations.ncl
+++ b/tests/pass/annotations.ncl
@@ -19,7 +19,8 @@ let Assert = fun l x => x || %blame% l in
   f true) &&
 
 // others_precedence
-((fun x => x | #Assert -> Dyn) true) &&
-(switch {Ok => true, Err => false} `Ok | #Assert) &&
+((fun x => x | #Assert) true) &&
+(let AssertOk = fun l t => if t == `Ok then t else %blame% l in
+  switch {Ok => true, Err => false} `Ok | #AssertOk) &&
 
 true

--- a/tests/pass/annotations.ncl
+++ b/tests/pass/annotations.ncl
@@ -1,0 +1,25 @@
+let Assert = fun l x => x || %blame% l in
+
+// left_annot_precedence
+(let dummy = null in
+  let LocalAssert = Assert in
+  true | #LocalAssert) &&
+
+(if false then
+    null
+  else
+    let dummy = null in
+    let LocalAssert = Assert in
+    true | #LocalAssert) &&
+
+(let f = fun x =>
+    let dummy = null in
+    let LocalAssert = Assert in
+    x | #LocalAssert in
+  f true) &&
+
+// others_precedence
+((fun x => x | #Assert -> Dyn) true) &&
+(switch {Ok => true, Err => false} `Ok | #Assert) &&
+
+true

--- a/tests/pass/contracts.ncl
+++ b/tests/pass/contracts.ncl
@@ -77,7 +77,7 @@ f `boo == 3) &&
 (({a = 1, b = "b", c = false} | {a: Num, b: Str | Dyn})
   == {a = 1, b = "b", c = false}
   | #Assert) &&
-((fun r => r.b | {a: Num | Dyn} -> Dyn) {a = 1, b = 2} == 2
+(((fun r => r.b) | {a: Num | Dyn} -> Dyn) {a = 1; b = 2} == 2
   | #Assert) &&
 
 

--- a/tests/pass/contracts.ncl
+++ b/tests/pass/contracts.ncl
@@ -77,7 +77,7 @@ f `boo == 3) &&
 (({a = 1, b = "b", c = false} | {a: Num, b: Str | Dyn})
   == {a = 1, b = "b", c = false}
   | #Assert) &&
-(((fun r => r.b) | {a: Num | Dyn} -> Dyn) {a = 1; b = 2} == 2
+(((fun r => r.b) | {a: Num | Dyn} -> Dyn) {a = 1, b = 2} == 2
   | #Assert) &&
 
 

--- a/tests/pass/typechecking.ncl
+++ b/tests/pass/typechecking.ncl
@@ -103,16 +103,16 @@ let typecheck = [
   [1, "2", false],
   //TODO: the type system may accept the following test at some point.
   //([1, "2", false] : List),
-  (["a", "b", "c"] : List Str),
-  ([1, 2, 3] : List Num),
-  (fun x => [x] : forall a. a -> List a),
+  ["a", "b", "c"] : List Str,
+  [1, 2, 3] : List Num,
+  (fun x => [x]) : forall a. a -> List a,
 
   // lists_ops
-  fun l => %tail% l : forall a. List a -> List a,
-  fun l => %head% l : forall a. List a -> a,
-  fun f l => %map% l f : forall a b. (a -> b) -> List a -> List b,
-  fun l1 => fun l2 => l1 @ l2 : forall a. List a -> List a -> List a,
-  fun i l => %elemAt% l i : forall a. Num -> List a -> a,
+  (fun l => %tail% l) : forall a. List a -> List a,
+  (fun l => %head% l) : forall a. List a -> a,
+  (fun f l => %map% l f) : forall a b. (a -> b) -> List a -> List b,
+  (fun l1 => fun l2 => l1 @ l2) : forall a. List a -> List a -> List a,
+  (fun i l => %elemAt% l i) : forall a. Num -> List a -> a,
 
   // recursive_records
   {a : Num = 1, b = a + 1} : {a : Num, b : Num},

--- a/tests/typecheck_fail.rs
+++ b/tests/typecheck_fail.rs
@@ -84,7 +84,9 @@ fn enum_simple() {
 
 #[test]
 fn enum_complex() {
-    assert_typecheck_fails!("fun x => switch {bla => 1, ble => 2, bli => 4} x : <bla, ble> -> Num");
+    assert_typecheck_fails!(
+        "(fun x => switch {bla => 1, ble => 2, bli => 4} x) : <bla, ble> -> Num"
+    );
     // TODO typecheck this, I'm not sure how to do it with row variables
     // LATER NOTE: this requires row subtyping, not easy
     assert_typecheck_fails!(


### PR DESCRIPTION
Depend on #317.

## The problem

Given the ML-style lets, Nickel programs or subprograms often have the following shape:

```
let id1 = val1 in
let id2 = val2 in
...
result
```

The result usually being a configuration, a common thing to do is to add a contract:

```
let Contract = { ... } in
// or let Contract = (import "contracts.ncl").SomeContract
let id = val in
...
result | #Contract
```

The problem is that currently, annotations (type or contract) bind more loosely than anything else. Thus, the following example is parsed as `(let Contract = { ... } in ...) | #Contract`, which fails at run-time because `Contract` is not in scope of the annotation. Even if one can just add parentheses `let ... in (result | #Contract)`, in our limited tests already, it comes often and is annoying. Parsing the original example directly as `let Contract = { .. } in ... in (result | #Contract)` would have exactly the same operational semantics, while bringing more things in scope, which sounds like a better way.

## Implementation

This is not totally trivial as it may first seem, because it introduces a kind of dangling else issue: `let id = val in exp` may or may not have a trailing annotation, and thus `let id = val in let id2 = val2 in exp | #Contract` is ambiguous, as well as other constructs that can have a let on the right, such as `fun x => let id = val in ... | #Contract`. LALRPOP precedence annotations are not powerful enough to solve this, but hopefully only a few top-level rule may have let on the right (`if-then-else`, `let`, `switch` and `fun`), and thanks to LALRPOP's macros, there isn't much code duplication in this PR.

## Consistency

This change may introduce some quirks:
 1. Type and contracts annotations are treated the same in the grammar. For type annotations, this change is semantically significant, as `let id = val in exp : Type` would previously typecheck `val`, while it doesn't when parsed as `let id = val in (exp : Type)`. However, one could argue that the fact that `let id = val in exp : Type` includes `val` in the statically typed block isn't a totally obvious choice either.
 2. Let bindings eagerly "eat" annotations, while other constructs don't: `(fun x => x | forall a. a -> a)` still parses as before and as expected, but if we add a let, `(fun x => let _ign = null in x | forall a. a -> a)` is parsed as `(fun x => (let ign_ = null in x | forall a. a -> a))`. This is different and will most probably fail when applied. This different treatment may be confusing.

For 1., we could parse differently type and contract annotations, but this sounds like introducing a new inconsistency.

For 2., different stances would be:
 - Only apply the proposed change to chained lets, that is `let id1 = val1 in .. let id2 = val2 in .. exp | #Contract`, but not if there's a different construct on the left, like `fun x => let id = .. in .. exp | #Contract`. There again, I'm not sure this really less confusing.
 - Treat all of `if-then-else`, `let`, `switch` and `fun` the same way. But that means `fun x => x : forall a. a -> a` now fails, because now `x` is typechecked `x` against `forall a. a -> a` instead of the whole function.