### PR TITLE
[Fix]Upgrade nums stdlib to use the comma syntax

### DIFF
--- a/stdlib/nums.ncl
+++ b/stdlib/nums.ncl
@@ -7,7 +7,7 @@
         else
           %blame% (%tag% "not an integer" label)
       else
-        %blame% (%tag% "not a number" label);
+        %blame% (%tag% "not a number" label),
 
     Nat = fun label value =>
       if %isNum% value then
@@ -16,7 +16,7 @@
         else
           %blame% (%tag% "not a natural" label)
       else
-        %blame% (%tag% "not a number" label);
+        %blame% (%tag% "not a number" label),
 
     PosNat = fun label value =>
       if %isNum% value then
@@ -25,7 +25,7 @@
         else
           %blame% (%tag% "not positive integer" label)
       else
-        %blame% (%tag% "not a number" label);
+        %blame% (%tag% "not a number" label),
 
     NonZero = fun label value =>
       if %isNum% value then
@@ -34,31 +34,31 @@
         else
           %blame% (%tag% "non-zero" label)
       else
-        %blame% (%tag% "not a number" label);
+        %blame% (%tag% "not a number" label),
 
     isInt : Num -> Bool = fun x =>
-      %isNum% x && (x % 1 == 0);
+      %isNum% x && (x % 1 == 0),
 
     min : Num -> Num -> Num = fun x y =>
-      if x <= y then x else y;
+      if x <= y then x else y,
 
     max : Num -> Num -> Num = fun x y =>
-      if x >= y then x else y;
+      if x >= y then x else y,
 
     floor : Num -> Num = fun x =>
       if x >= 0 then x - (x % 1)
-      else x - 1 - (x % 1);
+      else x - 1 - (x % 1),
 
     abs : Num -> Num = fun x =>
-      if x < 0 then -x else x;
+      if x < 0 then -x else x,
 
     fract : Num -> Num = fun x =>
-      x % 1;
+      x % 1,
 
     trunc : Num -> Num = fun x =>
-      x - (x % 1);
+      x - (x % 1),
 
     pow : Num -> Num -> Num = fun x n =>
-      %pow% x n;
+      %pow% x n,
   }
 }


### PR DESCRIPTION
Tests are failing because #323 has been merged, but was written before the syntax change to commas introduced in #327, which has been merged before. This PR upgrades the nums stdlib to use the new comma syntax.