### PR TITLE
[Fix]Fix tests, implement clippy's suggestion

### DIFF
--- a/src/cache.rs
+++ b/src/cache.rs
@@ -29,7 +29,7 @@ pub enum InputFormat {
 }
 
 impl InputFormat {
-    fn from_path_buf(path_buf: &PathBuf) -> Option<InputFormat> {
+    fn from_path_buf(path_buf: &Path) -> Option<InputFormat> {
         match path_buf.extension().and_then(OsStr::to_str) {
             Some("ncl") => Some(InputFormat::Nickel),
             Some("json") => Some(InputFormat::Json),

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -1126,7 +1126,7 @@ mod tests {
                 mk_term::let_in(var, mk_term::import(import), body),
                 resolver,
             )
-        };
+        }
 
         // let x = import "does_not_exist" in x
         match mk_import("x", "does_not_exist", mk_term::var("x"), &mut resolver).unwrap_err() {

--- a/src/operation.rs
+++ b/src/operation.rs
@@ -527,11 +527,7 @@ fn process_unary_operation(
             /// evaluation of the argument on the top of the stack.
             ///
             /// Requires its first argument to be non-empty.
-            fn seq_terms<I>(
-                mut terms: I,
-                env: Environment,
-                pos_op_inh: TermPos,
-            ) -> Result<Closure, EvalError>
+            fn seq_terms<I>(mut terms: I, env: Environment, pos_op_inh: TermPos) -> Closure
             where
                 I: Iterator<Item = RichTerm>,
             {
@@ -543,15 +539,15 @@ fn process_unary_operation(
                     |acc, t| mk_app!(mk_term::op1(UnaryOp::DeepSeq(), t), acc).with_pos(pos_op_inh),
                 );
 
-                Ok(Closure { body, env })
-            };
+                Closure { body, env }
+            }
 
             match *t {
                 Term::Record(map) if !map.is_empty() => {
                     let terms = map.into_iter().map(|(_, t)| t);
-                    seq_terms(terms, env, pos_op)
+                    Ok(seq_terms(terms, env, pos_op))
                 }
-                Term::List(ts) if !ts.is_empty() => seq_terms(ts.into_iter(), env, pos_op),
+                Term::List(ts) if !ts.is_empty() => Ok(seq_terms(ts.into_iter(), env, pos_op)),
                 _ => {
                     if let Some((next, ..)) = stack.pop_arg() {
                         Ok(next)

--- a/src/typecheck.rs
+++ b/src/typecheck.rs
@@ -773,9 +773,9 @@ pub enum ApparentType {
     Approximated(Types),
 }
 
-impl Into<Types> for ApparentType {
-    fn into(self) -> Types {
-        match self {
+impl From<ApparentType> for Types {
+    fn from(at: ApparentType) -> Self {
+        match at {
             ApparentType::Annotated(ty)
             | ApparentType::Inferred(ty)
             | ApparentType::Approximated(ty) => ty,
@@ -784,9 +784,9 @@ impl Into<Types> for ApparentType {
     }
 }
 
-impl Into<TypeWrapper> for ApparentType {
-    fn into(self) -> TypeWrapper {
-        match self {
+impl From<ApparentType> for TypeWrapper {
+    fn from(at: ApparentType) -> TypeWrapper {
+        match at {
             ApparentType::Annotated(ty)
             | ApparentType::Inferred(ty)
             | ApparentType::Approximated(ty) => to_typewrapper(ty),

--- a/tests/pass/serialize-package.ncl
+++ b/tests/pass/serialize-package.ncl
@@ -4,16 +4,16 @@ let ctr = {
           = {
     name | doc "
            The package name."
-         | Str;
+         | Str,
 
     buildInputs | doc "
                   The list of inputs for this package, specified as a
                   `NixPackage`."
-                | List #NixPackage;
+                | List #NixPackage,
     // Many more missing
-  };
+  },
 
-  Shell = Derivation & {};
+  Shell = Derivation & {},
 
   NixPackage | doc "
                Interchange format representing a package only accessible on the
@@ -39,26 +39,26 @@ let ctr = {
     package | Str
             | doc "
               The package name, given as a string. Dot-separated paths are not yet
-              supported";
+              supported",
 
     input | Str
           | doc "
             The inputs where to fetch the package from. Must be a variable name
             that is in scope on the Nix side."
-          | default = "nixpkgs";
+          | default = "nixpkgs",
 
     _type | doc "
             Used by the interop Nix code. Forced to a fixed value. Please
             do not override."
-          = "package";
+          = "package",
   }
 } in
 builtins.serialize `Json (
   {
-    name = "nickel";
-    buildInputs = [{package = "hello"}];
+    name = "nickel",
+    buildInputs = [{package = "hello"}],
   } | #(ctr.Shell)
 ) == builtins.serialize `Json {
-  name = "nickel";
-  buildInputs = [{input = "nixpkgs"; package = "hello"; "_type" = "package"}];
+  name = "nickel",
+  buildInputs = [{input = "nixpkgs", package = "hello", "_type" = "package"}],
 }

--- a/tests/typecheck_fail.rs
+++ b/tests/typecheck_fail.rs
@@ -1,14 +1,9 @@
 use assert_matches::assert_matches;
 use codespan::Files;
-use nickel::cache::{
-    resolvers::{DummyResolver, SimpleResolver},
-    ImportResolver,
-};
-use nickel::error::{ImportError, TypecheckError};
+use nickel::cache::resolvers::DummyResolver;
+use nickel::error::TypecheckError;
 use nickel::parser::{grammar, lexer};
-use nickel::term::make as mk_term;
 use nickel::term::RichTerm;
-use nickel::transformations::transform;
 use nickel::typecheck::{type_check_in_env, Environment};
 use nickel::types::Types;
 


### PR DESCRIPTION
Once again, a lot of pending PRs have been merged, causing some syntax errors in tests. This PR fixes the test `serialize-package` by updating the syntax, and implement `clippy`'s suggestions.