### PR TITLE
shell: workaround locking in to default.nix

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,3 +1,10 @@
-(import (fetchTarball https://github.com/edolstra/flake-compat/archive/master.tar.gz) {
+let
+  inherit (default.inputs.nixos.lib) recurseIntoAttrs;
+
+  default = (import (fetchTarball https://github.com/edolstra/flake-compat/archive/master.tar.gz) {
   src = builtins.fetchGit ./.;
-}).defaultNix
+}).defaultNix;
+in
+builtins.mapAttrs (_: v: recurseIntoAttrs v) default.packages // {
+  shell = import ./shell.nix;
+}


### PR DESCRIPTION
When supplying the repository url to nix-shell:

    nix-shell https://github/tweag/nickel/archive/master.tar.gz

It does not attempt to load the shell.nix file contained in the tarball, instead only loading default.nix, which fails if it doesn't provide a viable shell.

I would expect the behavior to be consistent with launching from the base of a repository, namely, load shell.nix if it exists, default.nix otherwise.

(see https://github.com/divnix/devos/commit/e2172c84109751f4c457cd0914437656479c1296)