### PR TITLE
import relative to the source file path

### DIFF
--- a/src/cache.rs
+++ b/src/cache.rs
@@ -671,6 +671,8 @@ pub trait ImportResolver {
 
     /// Get a resolved import from the term cache.
     fn get(&self, file_id: FileId) -> Option<RichTerm>;
+
+    fn get_path(&self, file_id: FileId) -> &OsStr;
 }
 
 impl ImportResolver for Cache {
@@ -715,6 +717,10 @@ impl ImportResolver for Cache {
 
     fn insert(&mut self, file_id: FileId, term: RichTerm) {
         self.terms.insert(file_id, (term, EntryState::Transformed));
+    }
+
+    fn get_path(&self, file_id: FileId) -> &OsStr {
+        self.files.name(file_id)
     }
 }
 
@@ -761,6 +767,10 @@ pub mod resolvers {
         }
 
         fn get(&self, _file_id: FileId) -> Option<RichTerm> {
+            panic!("cache::resolvers: dummy resolver should not have been invoked");
+        }
+
+        fn get_path(&self, _: codespan::FileId) -> &std::ffi::OsStr {
             panic!("cache::resolvers: dummy resolver should not have been invoked");
         }
     }
@@ -838,6 +848,10 @@ pub mod resolvers {
                 .map(|opt| opt.as_ref())
                 .flatten()
                 .cloned()
+        }
+
+        fn get_path(&self, file_id: FileId) -> &OsStr {
+            self.files.name(file_id)
         }
     }
 }

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -770,7 +770,7 @@ pub mod resolvers {
             panic!("cache::resolvers: dummy resolver should not have been invoked");
         }
 
-        fn get_path(&self, _: codespan::FileId) -> &std::ffi::OsStr {
+        fn get_path(&self, _file_id: FileId) -> &OsStr {
             panic!("cache::resolvers: dummy resolver should not have been invoked");
         }
     }

--- a/src/transformations.rs
+++ b/src/transformations.rs
@@ -274,7 +274,11 @@ where
 {
     let mut stack = Vec::new();
 
-    let result = transform_pass(rt, resolver, &mut stack, None);
+    let source_file: Option<PathBuf> = rt.pos.into_opt().map(|x| {
+        let path = resolver.get_path(x.src_id);
+        PathBuf::from(path)
+    });
+    let result = transform_pass(rt, resolver, &mut stack, source_file);
 
     while let Some((t, file_id, parent)) = stack.pop() {
         let result = transform_pass(t, resolver, &mut stack, Some(parent))?;


### PR DESCRIPTION
resolves https://github.com/tweag/nickel/issues/337

adds the following:
- add `fn get_path(&self, file_id: FileId) -> &OsStr;` to the `ImportResolver` trait. this is the least friction way to expose this as far as I can tell
- in the first `transform_pass` of `transform`, use the path from the underlying source `FileId` of `RichTerm` as the parent path, if it exists. 

