### PR TITLE
Edit README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Nickel's salient traits are:
 - **Composable code**: the basic building blocks for computing are functions.
     They are first-class citizens, which can be passed around, called and
     composed.
-- **Composable data**: the basic building blocks for data blocks are records
+- **Composable data**: the basic building blocks for data are records
     (called *objects* in JSON). In Nickel, records can be merged at will,
     including associated metadata (documentation, default values, type
     contracts, etc).

--- a/README.md
+++ b/README.md
@@ -1,136 +1,119 @@
-Nickel - Cheap configuration language
-=====================================
+# Nickel
 
-Nickel is a lightweight configuration language. Its purpose is to automate the
-generation of static configuration files - think JSON, YAML, XML, or your
-favorite data representation language - that are then fed to another system. It
-is designed to have a simple, well-understood core: at its heart, it is JSON
-with functions. It adds other features on top of it to improve expressivity and
-modularity, but you can do just fine without using it.
+Nickel is the cheap configuration language.
 
-Nickel's important traits are:
+Its purpose is to automate the generation of static configuration files - think
+JSON, YAML, XML, or your favorite data representation language - that are then
+fed to another system. It is designed to have a simple, well-understood core: it
+is in essence JSON with functions.
 
-- **Lightweight**: Nickel aims at being embeddable into other projects. As
-    such, a simple and lightweight minimal interpreter should be reasonably
-    simple to implement.  The reference interpreter should also be easily
-    callable from various programming languages.
-- **Functional**: the basic building blocks are functions. They are first-class
-    citizens, which can be passed around, called and composed.
-- **Gradual typing**: static types improve code quality, serve as a
-    documentation and eliminate bugs early. On the one hand, code specific to a
-    particular configuration does not depend on external inputs and will always
-    be evaluated to the same value, thus any type error will show up at run time
-    anyway. Also, some JSON can be hard to type.  There, types are only a
-    burden.  On the other hand, reusable code - that is, *functions* - is
-    evaluated on potentially infinitely many different inputs, and is impossible
-    to test exhaustively: there, types are precious.  Nickel has types, but you
-    get to chose when you want it or not, and it handles safely the interaction
-    between the typed and the untyped world.
-- **Contracts**: complementary to the type system, contracts are a principled
-    approach to dynamic type checking. They are used internally by the
-    interpreter to insert guards at the boundary between typed and untyped
-    chunks.  Nickel makes them available to the programmer as well, to give them
-    the ability to enforce type assertions at runtime in a simple way.
-- **Merge system**: while the basic computational blocks are functions, the
-    basic data blocks are records (called objects in JSON). Nickel features a
-    merge operation which lets you combine together such records modularly, but
-    also to specify meta-data about the content of these records (documentation,
-    default values, type contracts, etc.), called *enriched values*.
+Nickel's salient traits are:
+
+- **Lightweight**: Nickel is easy to embed. An interpreter should be simple to
+    implement. The reference interpreter can be called from many programming
+    languages.
+- **Composable code**: the basic building blocks for computing are functions.
+    They are first-class citizens, which can be passed around, called and
+    composed.
+- **Composable data**: the basic building blocks for data blocks are records
+    (called *objects* in JSON). In Nickel, records can be merged at will,
+    including associated metadata (documentation, default values, type
+    contracts, etc).
+- **Typed only when it helps**: static types improve code quality, serve as
+    documentation and eliminate bugs early. But application-specific
+    self-contained code will always evaluate to the same value, so type errors
+    will show up at runtime anyway. Some JSON is hard to type. There, types are
+    only a burden. Whereas reusable code - that is, *functions* - is evaluated
+    on potentially infinitely many different inputs, and is impossible to test
+    exhaustively. There, types are precious. Nickel has types, but you get to
+    chose when you want it or not, and it handles safely the interaction between
+    the typed and the untyped world.
+- **Design by contract**: complementary to the type system, contracts are
+    a principled approach to checking assertions. The interpreter automatically
+    inserts assertions at the boundary between typed and untyped code. Nickel
+    lets users add arbitrary assertions of their own and easily understand why
+	when assertions fail.
 
 The motto guiding Nickel's design is:
 > Great defaults, design for extensibility
 
-There should be a standard, clear path for doing usual things. There should not
-be arbitrary restrictions which limit you this one day you need to go beyond
-usual to solve a hard specific problem.
+There should be a standard, clear path for common things. There should be no
+arbitrary restrictions that limit what you can do you the one day you need to go
+beyond.
 
 ## Use cases
 
-Nickel should fit any situation where you need to generate a complex
-configuration, be it for a software, a machine, a whole infrastructure, or a
+Nickel is a good fit is any situation where you need to generate a complex
+configuration, be it for a single app, a machine, whole infrastructure, or a
 build system.
 
 The motivating use cases are in particular:
 - The [Nix package manager](https://nixos.org/): Nix is a declarative package
-    manager using its own language for specifying packages. Nickel is inspired
-    in part by the Nix language, while trying to overcome some of its
-    limitations. It could be used instead of the Nix language.
-- (Cloud) infrastructure as code: infrastructure is becoming increasingly
-    complex, requiring a rigorous approach to deployment, modification and
-    configuration. This is where a declarative approach also shines, as adopted
-    by [Terraform](https://www.terraform.io/),
+    manager using its own language for specifying packages. Nickel is an
+    evolution of the Nix language, while trying to overcome some of its
+    limitations.
+- Infrastructure as code: infrastructure is becoming increasingly complex,
+    requiring a rigorous approach to deployment, modification and configuration.
+    This is where a declarative approach also shines, as adopted by
+    [Terraform](https://www.terraform.io/),
     [NixOps](https://github.com/NixOS/nixops) or
     [Kubernetes](https://kubernetes.io/), all requiring potentially complex
     generation of configuration.
-- Build systems: build systems are yet another piece of software
-    which needs to dynamically generate configuration, the dependency graph for
-    example. [Bazel](https://bazel.build/) rules may require a powerful
-    language.
+- Build systems: build systems (like [Bazel](https://bazel.build/)) need
+    a specification of the dependency graph.
 
-Several aforementioned projects have their own dedicated configuration language.
-See the Related project section for a partial comparison. In general, such
-specific languages may suffer from feature creep, lack of abstractions or just
-feel ad-hoc.  Some are also totally fine but have just made different design
-decisions and trade-offs.
+Most aforementioned projects have their own bespoke configuration language. See
+[Related projects and inspirations](#Related-projects-and-inspirations). In
+general, application-specific languages might suffer from feature creep, lack of
+abstractions or just feel ad hoc. Nickel buys you more for less.
 
 ## Getting started
 
 ### Build
 
-1. Clone the repository in a local folder:
-  ```
-  $ git clone git@github.com:tweag/nickel.git
-  $ cd nickel
-  nickel$
-  ```
+[rust-guide]: https://doc.rust-lang.org/cargo/getting-started/installation.html
 
-2. Install build dependencies:
-    - **With Nix**: If you have Nix installed, you can just type
-    ```
-    nickel$ nix-shell shell.nix
-    [nix-shell:/tmp/nickel]$
-    ```
-    to be dropped in a shell, ready to build.
-
-    - **Without Nix**: Otherwise, follow [this
-      guide](https://doc.rust-lang.org/cargo/getting-started/installation.html)
-      to install Rust and Cargo first.
-
-3. Build Nickel:
-  ```
-  nickel$ cargo build
-  ```
-  And voilà ! Generated files are placed in `target/debug`.
+1. Download build dependencies:
+   - **With Nix**: If you have [Nix](https://nixos.org/nix) installed:
+     ```
+     $ nix-shell shell.nix
+     ```
+	 to be dropped in a shell, ready to build.
+   - **Without Nix**: otherwise, follow [this guide][rust-guide] to install Rust
+     and Cargo first.
+2. Build Nickel:
+   ```
+   $ cargo build
+   ```
+   And voilà! Generated files are placed in `target/debug`.
 
 ### Run
 
 1. *(optional)* make a symbolic link to the executable:
   ```
-  nickel$ ln -S nickel target/debug/nickel
+  $ ln -S nickel target/debug/nickel
   ```
   Alternatively, you can use `cargo run` to launch nickel. To pass arguments to
   nickel using `cargo run`, use `--`:
   ```
-  nickel$ cargo run -- -f program.ncl
+  $ cargo run -- -f program.ncl
   ```
-
 2. Run your first program:
   ```
-  nickel$ ./nickel <<< 'let x = 2 in x + x'
+  $ ./nickel <<< 'let x = 2 in x + x'
   Typechecked: Ok(Types(Dyn))
   Done: Num(4.0)
   ```
   Or load it from a file:
   ```
-  nickel$ echo 'let s = "world" in "Hello, " ++ s' > program.ncl
-  nickel$ ./nickel -f program.ncl
+  $ echo 'let s = "world" in "Hello, " ++ s' > program.ncl
+  $ ./nickel -f program.ncl
   Typechecked: Ok(Types(Dyn))
   Done: Str("Hello, world")
   ```
-
 3. Start an REPL:
   ```
-  nickel$ ./nickel repl
+  $ ./nickel repl
   nickel> let x = 2 in x + x
   nickel> x
   4
@@ -138,10 +121,9 @@ decisions and trade-offs.
   nickel>
   ```
   Use `:help` for a list of available commands.
-
 4. Export your configuration to JSON, YAML or TOML:
   ```
-  nickel$ ./nickel export --format json <<< '{foo = "Hello, world!"}'
+  $ ./nickel export --format json <<< '{foo = "Hello, world!"}'
   {
     "foo": "Hello, world!"
   }
@@ -151,25 +133,28 @@ Use `nickel help` for a list of subcommands, and `nickel help <subcommand>`
 for help about a specific subcommand.
 
 ### Tests
+
 ```
-nickel$ cargo test
+$ cargo test
 ```
 
 ### Documentation
+
 1. Build the doc:
   ```
-  nickel$ cargo doc --no-deps
+  $ cargo doc --no-deps
   ```
-
 2. Open the file `target/doc/nickel/index.html` in your browser.
 
 ### Examples
+
 You can find examples in
 [`src/examples`](https://github.com/tweag/nickel/tree/master/src/examples). Note
 that as the syntax is not yet fixed, and some basic helpers are missing, they
 may seem a bit alien currently.
 
 ## Roadmap
+
 The design is settled and implemented for the most part, but the final syntax
 and others important practical aspects are still being debated. We aim to
 transition from an experimental stage to a minimum viable product stage.  The
@@ -182,8 +167,9 @@ next points to deal with are:
 - [Destructuring](https://github.com/tweag/nickel/issues/81)
 
 ## Related projects and inspirations
+
 - [Cue](https://cuelang.org/) is a configuration language with a focus on data
-    validation. It has an original constraint system backed by a solid theory
+    validation. It introduces a new constraint system backed by a solid theory
     which ensures strong guarantees about your code. It allows for very elegant
     schema specifications. In return, the cost to pay is to abandon functions
     and
@@ -209,14 +195,9 @@ next points to deal with are:
     describing your infrastructure. This is a different approach to the problem,
     with different trade-offs.
 - [Starlark](https://docs.bazel.build/versions/master/skylark/language.html) is
-   the language of [Bazel](https://bazel.build/), which is a dialect of
-   [Python](https://www.python.org/). It does not have types and recursion is
-   forbidden, making it not Turing-complete.
+    the language of [Bazel](https://bazel.build/), which is a dialect of
+    [Python](https://www.python.org/). It does not have types and recursion is
+    forbidden, making it not Turing-complete.
 
 See [RATIONALE.md](./RATIONALE.md) for the design rationale and a more detailed
 comparison with a selection of these languages.
-
-## License
-[MIT License](https://github.com/tweag/nickel/blob/master/LICENSE).
-
-Copyright (c) Tweag Holding and its affiliates.


### PR DESCRIPTION
Edit for conciseness and consistency. Remove `nickel$`, which is
a confusing and rare convention for shell commands (as opposed to just
`$`). Used more assertive language: better to say what we are than say
we will someday be something.

Changed the key features keywords to focus on user-relevant things,
like composability etc.