### PR TITLE
Fix broken links to examples in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ $ cargo test
 ### Examples
 
 You can find examples in
-[`src/examples`](https://github.com/tweag/nickel/tree/master/src/examples). Note
+[`examples`](./examples). Note
 that as the syntax is not yet fixed, and some basic helpers are missing, they
 may seem a bit alien currently.
 


### PR DESCRIPTION
The examples subdirectory of this repo was moved around at some point, so the link in README.md now dangles.

This PR fixes that and also makes the link relative so it works correctly in e.g. downstream forks (I assume this would be fine since the README already uses a relative link to refer to `RATIONALE.md`).