### PR TITLE
[CI]Avoid nightly build to fail the whole workflow

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -24,6 +24,8 @@ jobs:
             system: x86_64-linux
           - os: macos-latest
             system: x86_64-darwin
+          - rust_channel: nightly
+            experimental: true
 
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
We are currently building on rust stable, beta and nightly in the CI. However the nightly build may break more often and for external reasons, making the whole job failing. It is currently the case of #355 , which CI is failing (and other jobs are cancelled) because it seems an external crate `crossbeam-epoch` fails to compile on nightly.

This PR marks building on nightly experimental so that its failure doesn't make the whole job fail anymore.