### PR TITLE
[CI]Disable the netlify bot comments to reduce spam

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -31,8 +31,8 @@ jobs:
           publish-dir: './website/public'
           github-token: ${{ secrets.GITHUB_TOKEN }}
           deploy-message: 'Deploy from GitHub Actions'
-          enable-pull-request-comment: true
+          enable-pull-request-comment: false
           enable-commit-comment: false
-          enable-commit-status: false
+          enable-commit-status: true
           overwrites-pull-request-comment: false
         if: github.repository == 'tweag/nickel'

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -32,7 +32,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           deploy-message: 'Deploy from GitHub Actions'
           enable-pull-request-comment: true
-          enable-commit-comment: true
-          enable-commit-status: true
+          enable-commit-comment: false
+          enable-commit-status: false
           overwrites-pull-request-comment: false
         if: github.repository == 'tweag/nickel'


### PR DESCRIPTION
Currently the netlify deploy action sends two new notifications each time a commit is pushed to a pull request, which is spamming quite a bit. This PR disables this features and only keep the "details" link next the action as a way to preview the website.

In the future we could even only trigger the action if some flags like `[Website]` is present in the name of the PR or alike, as most PRs won't affect the website's code.