### PR TITLE
Show type information in queries

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -41,6 +41,8 @@ enum Command {
         doc: bool,
         #[structopt(long)]
         contract: bool,
+        #[structopt(long = "type")]
+        types: bool,
         #[structopt(long)]
         default: bool,
         #[structopt(long)]
@@ -79,17 +81,19 @@ fn main() {
                 path,
                 doc,
                 contract,
+                types,
                 default,
                 value,
             }) => {
                 program.query(path).map(|term| {
                     // Print a default selection of attributes if no option is specified
-                    let attrs = if !doc && !contract && !default && !value {
+                    let attrs = if !doc && !contract && !types && !default && !value {
                         repl::query_print::Attributes::default()
                     } else {
                         repl::query_print::Attributes {
                             doc,
                             contract,
+                            types,
                             default,
                             value,
                         }

--- a/src/repl/query_print.rs
+++ b/src/repl/query_print.rs
@@ -214,7 +214,11 @@ fn write_query_result_<R: QueryPrinter>(
             }
 
             if selected_attrs.types && meta.types.is_some() {
-                renderer.print_metadata("type", &meta.types.as_ref().unwrap().types.to_string());
+                renderer.write_metadata(
+                    out,
+                    "type",
+                    &meta.types.as_ref().unwrap().types.to_string(),
+                )?;
                 found = true;
             }
 

--- a/src/repl/query_print.rs
+++ b/src/repl/query_print.rs
@@ -134,6 +134,7 @@ impl QueryPrinter for MarkdownRenderer {
 pub struct Attributes {
     pub doc: bool,
     pub contract: bool,
+    pub types: bool,
     pub default: bool,
     pub value: bool,
 }
@@ -144,6 +145,7 @@ impl Default for Attributes {
         Attributes {
             doc: true,
             contract: true,
+            types: true,
             default: true,
             value: true,
         }
@@ -198,7 +200,7 @@ fn write_query_result_<R: QueryPrinter>(
     match term {
         Term::MetaValue(meta) => {
             let mut found = false;
-            if !meta.contracts.is_empty() && selected_attrs.contract {
+            if selected_attrs.contract && !meta.contracts.is_empty()  {
                 let ctrs: Vec<String> = meta
                     .contracts
                     .iter()
@@ -208,6 +210,12 @@ fn write_query_result_<R: QueryPrinter>(
                     .map(|ctr| ctr.label.types.to_string())
                     .collect();
                 renderer.write_metadata(out, "contract", &ctrs.join(","))?;
+                found = true;
+            }
+
+            if selected_attrs.types && meta.types.is_some() {
+                renderer
+                    .print_metadata("type", &meta.types.as_ref().unwrap().types.to_string());
                 found = true;
             }
 

--- a/src/repl/query_print.rs
+++ b/src/repl/query_print.rs
@@ -200,7 +200,7 @@ fn write_query_result_<R: QueryPrinter>(
     match term {
         Term::MetaValue(meta) => {
             let mut found = false;
-            if selected_attrs.contract && !meta.contracts.is_empty()  {
+            if selected_attrs.contract && !meta.contracts.is_empty() {
                 let ctrs: Vec<String> = meta
                     .contracts
                     .iter()
@@ -214,8 +214,7 @@ fn write_query_result_<R: QueryPrinter>(
             }
 
             if selected_attrs.types && meta.types.is_some() {
-                renderer
-                    .print_metadata("type", &meta.types.as_ref().unwrap().types.to_string());
+                renderer.print_metadata("type", &meta.types.as_ref().unwrap().types.to_string());
                 found = true;
             }
 


### PR DESCRIPTION
Fix #368. Include type annotations in the result of a metadata query.