### PR TITLE
[CI]Do not fail the workflow because of nightly

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -28,6 +28,8 @@ jobs:
             experimental: true
 
     runs-on: ${{ matrix.os }}
+    # The `== true` makes it work wether experimental has been defined or not.
+    continue-on-error: ${{ matrix.experimental == true }}
 
     steps:
 


### PR DESCRIPTION
#356 seems to be insufficient. The CI still fails when building with Rust nightly fails.