### PR TITLE
Only typecheck the stdlib during tests

### DIFF
--- a/src/cache.rs
+++ b/src/cache.rs
@@ -550,8 +550,7 @@ impl Cache {
         Ok(CacheOp::Done(()))
     }
 
-    /// Typecheck the standard library. This function may be dropped once the standard library is
-    /// stable.
+    /// Typecheck the standard library. Currently only used in the test suite.
     pub fn typecheck_stdlib(&mut self) -> Result<CacheOp<()>, CacheError<TypecheckError>> {
         // We have a small bootstraping problem: to typecheck the global environment, we already
         // need a global evaluation environment, since stdlib parts may reference each other). But
@@ -578,21 +577,10 @@ impl Cache {
         }
     }
 
-    /// Load, parse, typecheck and apply program transformations to the standard library.
+    /// Load, parse, and apply program transformations to the standard library. Do not typecheck
+    /// for performance reason: this is done in the test suite.
     pub fn prepare_stdlib(&mut self) -> Result<(), Error> {
-        // We have a small bootstraping problem: to typecheck the global environment, we already
-        // need a global evaluation environment, because stdlib parts may be mutually recursive.
-        // But typechecking is performed before program transformations, so this environment is not
-        // the final one. We have to create a temporary global environment just for typechecking,
-        // which is dropped right after. However:
-        // 1. The stdlib is meant to stay relatively light.
-        // 2. Typechecking the standard library ought to occur only during development. Ideally, we
-        //    should only typecheck it at every update, not at every execution.
         self.load_stdlib()?;
-        self.typecheck_stdlib().map_err(|cache_err| {
-            cache_err
-                .unwrap_error("cache::prepare_stdlib(): expected standard library to be parsed")
-        })?;
         self.stdlib_ids
             .as_ref()
             .cloned()

--- a/src/program.rs
+++ b/src/program.rs
@@ -109,7 +109,6 @@ impl Program {
     pub fn typecheck(&mut self) -> Result<(), Error> {
         self.cache.parse(self.main_id)?;
         self.cache.load_stdlib()?;
-        self.cache.typecheck_stdlib().map_err(|err| err.unwrap_error("program::typecheck(): stdlib has been loaded but was not found in cache on typechecking"))?;
         let global_env = self.cache.mk_global_env().expect("program::typecheck(): stdlib has been loaded but was not found in cache on mk_global_env()");
         self.cache
             .typecheck(self.main_id, &global_env)

--- a/tests/stdlib_typecheck.rs
+++ b/tests/stdlib_typecheck.rs
@@ -1,0 +1,9 @@
+use assert_matches::assert_matches;
+use nickel::cache::Cache;
+
+#[test]
+fn stdlib_typecheck() {
+    let mut cache = Cache::new();
+    assert_matches!(cache.load_stdlib(), Ok(_));
+    assert_matches!(cache.typecheck_stdlib(), Ok(_));
+}


### PR DESCRIPTION
Currently, the stdlib is typechecked at each invocation of `nickel`. This is overkill, because even the stdlib is not stabilized yet, it is included at compile time in the interpreter and thus shouldn't need to be rechecked each time.

This PR disables the typechecking of the stdlib during normal execution, and move the check to the test suite.