### PR TITLE
Fix dynamic fields not having access to recursive fields

### DIFF
--- a/src/cache.rs
+++ b/src/cache.rs
@@ -425,14 +425,15 @@ impl Cache {
                             std::mem::replace(interpolated, Vec::new())
                                 .into_iter()
                                 .map(|(id_t, t)| {
-                                    Ok((transformations::transform(id_t, self)?,
-                                       transformations::transform(t, self)?))
+                                    Ok((
+                                        transformations::transform(id_t, self)?,
+                                        transformations::transform(t, self)?,
+                                    ))
                                 })
                                 .collect();
 
                         *map = map_res?;
                         *interpolated = interpolated_res?;
-                        
                     }
                     _ => panic!("cache::transform_inner(): not a record"),
                 }

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -411,7 +411,7 @@ impl Cache {
                                 .collect();
                         *map = map_res?;
                     }
-                    Term::RecRecord(ref mut map, ref mut interpolated, _) => {
+                    Term::RecRecord(ref mut map, ref mut dyn_fields, _) => {
                         let map_res: Result<HashMap<Ident, RichTerm>, ImportError> =
                             std::mem::replace(map, HashMap::new())
                                 .into_iter()
@@ -421,8 +421,8 @@ impl Cache {
                                 })
                                 .collect();
 
-                        let interpolated_res: Result<Vec<(RichTerm, RichTerm)>, ImportError> =
-                            std::mem::replace(interpolated, Vec::new())
+                        let dyn_fields_res: Result<Vec<(RichTerm, RichTerm)>, ImportError> =
+                            std::mem::replace(dyn_fields, Vec::new())
                                 .into_iter()
                                 .map(|(id_t, t)| {
                                     Ok((
@@ -433,7 +433,7 @@ impl Cache {
                                 .collect();
 
                         *map = map_res?;
-                        *interpolated = interpolated_res?;
+                        *dyn_fields = dyn_fields_res?;
                     }
                     _ => panic!("cache::transform_inner(): not a record"),
                 }

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -391,7 +391,7 @@ impl Cache {
     /// # Preconditions
     ///
     /// - the entry must syntactically be a record (`Record` or `RecRecord`). Otherwise, this
-    /// function panic
+    /// function panics
     pub fn transform_inner(
         &mut self,
         file_id: FileId,
@@ -416,8 +416,7 @@ impl Cache {
                             std::mem::replace(map, HashMap::new())
                                 .into_iter()
                                 .map(|(id, t)| {
-                                    transformations::transform(t, self)
-                                        .map(|t_ok| (id.clone(), t_ok))
+                                    transformations::transform(t).map(|t_ok| (id.clone(), t_ok))
                                 })
                                 .collect();
 
@@ -426,8 +425,8 @@ impl Cache {
                                 .into_iter()
                                 .map(|(id_t, t)| {
                                     Ok((
-                                        transformations::transform(id_t, self)?,
-                                        transformations::transform(t, self)?,
+                                        transformations::transform(id_t)?,
+                                        transformations::transform(t)?,
                                     ))
                                 })
                                 .collect();

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -687,11 +687,15 @@ where
                             let RichTerm { term, pos } = t;
                             match *term {
                                 Term::Var(var_id) => {
-                                    let thunk = env.get_mut(&var_id).ok_or_else(|| {
+                                    let mut thunk = env.get(&var_id).ok_or_else(|| {
                                         EvalError::UnboundIdentifier(var_id.clone(), pos)
                                     })?;
 
-                                    thunk.borrow_mut().env.extend(rec_env.clone());
+                                    thunk.borrow_mut().env.extend(
+                                        rec_env
+                                            .iter_elems()
+                                            .map(|(id, thunk)| (id.clone(), thunk.clone())),
+                                    );
                                     Ok(Term::App(
                                         mk_term::op2(BinaryOp::DynExtend(), id_t, acc),
                                         mk_term::var(var_id).with_pos(pos),

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -621,8 +621,7 @@ where
                     env,
                 }
             }
-            // TODO: implement interpolated fields
-            Term::RecRecord(ts, interpolated, attrs) => {
+            Term::RecRecord(ts, dyn_fields, attrs) => {
                 // Thanks to the share normal form transformation, the content is either a constant or a
                 // variable.
                 let rec_env = ts.iter().try_fold::<_, _, Result<Environment, EvalError>>(
@@ -680,7 +679,7 @@ where
                 // `{stat1 = val1, ..., statn = valn} $[ exp1 = dyn_val1] ... $[ expn = dyn_valn ]`
                 // The `dyn_val` are given access to the recursive environment, but not the dynamic
                 // field names.
-                let extended = interpolated
+                let extended = dyn_fields
                     .into_iter()
                     .try_fold::<_, _, Result<RichTerm, EvalError>>(
                         static_part,
@@ -922,7 +921,7 @@ pub fn subst(rt: RichTerm, global_env: &Environment, env: &Environment) -> RichT
 
                 RichTerm::new(Term::Record(map, attrs), pos)
             }
-            Term::RecRecord(map, interpolated, attrs) => {
+            Term::RecRecord(map, dyn_fields, attrs) => {
                 let map = map
                     .into_iter()
                     .map(|(id, t)| {
@@ -933,7 +932,7 @@ pub fn subst(rt: RichTerm, global_env: &Environment, env: &Environment) -> RichT
                     })
                     .collect();
 
-                let interpolated = interpolated
+                let dyn_fields = dyn_fields
                     .into_iter()
                     .map(|(id_t, t)| {
                         (
@@ -943,7 +942,7 @@ pub fn subst(rt: RichTerm, global_env: &Environment, env: &Environment) -> RichT
                     })
                     .collect();
 
-                RichTerm::new(Term::RecRecord(map, interpolated, attrs), pos)
+                RichTerm::new(Term::RecRecord(map, dyn_fields, attrs), pos)
             }
             Term::List(ts) => {
                 let ts = ts

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -173,29 +173,43 @@ fn record_terms() {
             ]
             .into_iter()
             .collect(),
-            Default::default(),
+            Vec::new(),
+            Default::default()
         )
         .into()
     );
 
     assert_eq!(
         parse_without_pos("{ a = 1, \"#{123}\" = (if 4 then 5 else 6), d = 42}"),
-        mk_app!(
-            mk_term::op2(
-                BinaryOp::DynExtend(),
-                StrChunks(vec![StrChunk::expr(RichTerm::from(Num(123.)))]),
-                RecRecord(
-                    vec![
-                        (Ident::from("a"), Num(1.).into()),
-                        (Ident::from("d"), Num(42.).into()),
-                    ]
-                    .into_iter()
-                    .collect(),
-                    Default::default(),
-                )
-            ),
-            mk_app!(mk_term::op1(UnaryOp::Ite(), Num(4.)), Num(5.), Num(6.))
+        RecRecord(
+            vec![
+                (Ident::from("a"), Num(1.).into()),
+                (Ident::from("d"), Num(42.).into()),
+            ]
+            .into_iter()
+            .collect(),
+            vec![(
+                StrChunks(vec![StrChunk::expr(RichTerm::from(Num(123.)))]).into(),
+                mk_app!(mk_term::op1(UnaryOp::Ite(), Num(4.)), Num(5.), Num(6.))
+            )],
+            Default::default(),
         )
+        .into()
+    );
+
+    assert_eq!(
+        parse_without_pos("{ a = 1, \"\\\"#}#\" = 2}"),
+        RecRecord(
+            vec![
+                (Ident::from("a"), Num(1.).into()),
+                (Ident::from("\"#}#"), Num(2.).into()),
+            ]
+            .into_iter()
+            .collect(),
+            Vec::new(),
+            Default::default(),
+        )
+        .into()
     );
 }
 

--- a/src/parser/utils.rs
+++ b/src/parser/utils.rs
@@ -108,12 +108,7 @@ where
         (FieldPathElem::Expr(e), t) => dynamic_fields.push((e, t)),
     });
 
-    dynamic_fields
-        .into_iter()
-        .fold(Term::RecRecord(static_map, attrs), |rec, field| {
-            let (id_t, t) = field;
-            Term::App(mk_term::op2(BinaryOp::DynExtend(), id_t, rec), t)
-        })
+    Term::RecRecord(static_map, dynamic_fields, attrs)
 }
 
 /// Make a span from parser byte offsets.

--- a/src/repl/query_print.rs
+++ b/src/repl/query_print.rs
@@ -187,9 +187,16 @@ fn write_query_result_<R: QueryPrinter>(
     ) -> io::Result<()> {
         writeln!(out)?;
         match t {
-            Term::Record(map, _) | Term::RecRecord(map, _) if !map.is_empty() => {
+            Term::Record(map, _) if !map.is_empty() => {
                 let mut fields: Vec<_> = map.keys().collect();
                 fields.sort();
+                renderer.write_fields(out, fields.into_iter())
+            }
+            Term::RecRecord(map, dyn_fields, _) if !map.is_empty() => {
+                let mut fields: Vec<_> = map.keys().collect();
+                fields.sort();
+                let dynamic = Ident::from("<dynamic>");
+                fields.extend(dyn_fields.iter().map(|_| &dynamic));
                 renderer.write_fields(out, fields.into_iter())
             }
             Term::Record(..) | Term::RecRecord(..) => renderer.write_metadata(out, "value", "{}"),

--- a/src/repl/rustyline_frontend.rs
+++ b/src/repl/rustyline_frontend.rs
@@ -50,7 +50,14 @@ pub fn repl() -> Result<(), InitError> {
                 let cmd = line.chars().skip(1).collect::<String>().parse::<Command>();
                 let result = match cmd {
                     Ok(Command::Load(path)) => repl.load(&path).map(|term| match term.as_ref() {
-                        Term::Record(map, _) | Term::RecRecord(map, _) => {
+                        Term::Record(map, _) => {
+                             println!("Loaded {} symbol(s) in the environment.", map.len())
+                        }
+                        Term::RecRecord(map, dyn_fields, _) => {
+                            if !dyn_fields.is_empty() {
+                                println!("Warning: loading dynamic fields is currently not supported. {} symbols ignored", dyn_fields.len());
+                            }
+
                             println!("Loaded {} symbol(s) in the environment.", map.len())
                         }
                         _ => (),

--- a/src/term.rs
+++ b/src/term.rs
@@ -448,12 +448,18 @@ impl Term {
     /// Return a deep string representation of a term, used for printing in the REPL
     pub fn deep_repr(&self) -> String {
         match self {
-            Term::Record(fields, _) | Term::RecRecord(fields, _) => {
+            Term::Record(fields, _) | Term::RecRecord(fields, _, _) => {
                 let fields_str: Vec<String> = fields
                     .iter()
                     .map(|(ident, term)| format!("{} = {}", ident, term.as_ref().deep_repr()))
                     .collect();
-                format!("{{ {} }}", fields_str.join(", "))
+
+                let suffix = match self {
+                    Term::RecRecord(_, dyn_fields, _) if !dyn_fields.is_empty() => ", ..",
+                    _ => "",
+                };
+
+                format!("{{ {}{}}}", fields_str.join(", "), suffix)
             }
             Term::List(elements) => {
                 let elements_str: Vec<String> = elements

--- a/src/term.rs
+++ b/src/term.rs
@@ -307,9 +307,9 @@ impl Term {
             Record(ref mut static_map, _) => {
                 static_map.iter_mut().for_each(|(_, t)| func(t));
             }
-            RecRecord(ref mut static_map, ref mut interpolated, _) => {
+            RecRecord(ref mut static_map, ref mut dyn_fields, _) => {
                 static_map.iter_mut().for_each(|(_, t)| func(t));
-                interpolated.iter_mut().for_each(|(t1, t2)| {
+                dyn_fields.iter_mut().for_each(|(t1, t2)| {
                     func(t1);
                     func(t2);
                 });
@@ -1000,7 +1000,7 @@ impl RichTerm {
                     state,
                 )
             }
-            Term::RecRecord(map, interpolated, attrs) => {
+            Term::RecRecord(map, dyn_fields, attrs) => {
                 // The annotation on `map_res` uses Result's corresponding trait to convert from
                 // Iterator<Result> to a Result<Iterator>
                 let map_res: Result<HashMap<Ident, RichTerm>, E> = map
@@ -1008,13 +1008,13 @@ impl RichTerm {
                     // For the conversion to work, note that we need a Result<(Ident,RichTerm), E>
                     .map(|(id, t)| Ok((id, t.traverse(f, state)?)))
                     .collect();
-                let interpolated_res: Result<Vec<(RichTerm, RichTerm)>, E> = interpolated
+                let dyn_fields_res: Result<Vec<(RichTerm, RichTerm)>, E> = dyn_fields
                     .into_iter()
                     .map(|(id_t, t)| Ok((id_t.traverse(f, state)?, t.traverse(f, state)?)))
                     .collect();
                 f(
                     RichTerm {
-                        term: Box::new(Term::RecRecord(map_res?, interpolated_res?, attrs)),
+                        term: Box::new(Term::RecRecord(map_res?, dyn_fields_res?, attrs)),
                         pos,
                     },
                     state,

--- a/src/transformations.rs
+++ b/src/transformations.rs
@@ -102,7 +102,7 @@ pub mod share_normal_form {
 
                 let interpolated = interpolated
                     .into_iter()
-                    .map(|(id_t, t)|
+                    .map(|(id_t, t)| {
                         if !t.as_ref().is_constant() {
                             let fresh_var = fresh_var();
                             let pos_t = t.pos;
@@ -110,7 +110,8 @@ pub mod share_normal_form {
                             (id_t, RichTerm::new(Term::Var(fresh_var), pos_t))
                         } else {
                             (id_t, t)
-                        })
+                        }
+                    })
                     .collect();
 
                 with_bindings(Term::RecRecord(map, interpolated, attrs), bindings, pos)

--- a/src/transformations.rs
+++ b/src/transformations.rs
@@ -77,7 +77,7 @@ pub mod share_normal_form {
 
                 with_bindings(Term::Record(map, attrs), bindings, pos)
             }
-            Term::RecRecord(map, attrs) => {
+            Term::RecRecord(map, interpolated, attrs) => {
                 // When a recursive record is evaluated, all fields need to be turned to closures
                 // anyway (see the corresponding case in `eval::eval()`), which is what the share
                 // normal form transformation does. This is why the test is more lax here than for
@@ -100,7 +100,20 @@ pub mod share_normal_form {
                     })
                     .collect();
 
-                with_bindings(Term::RecRecord(map, attrs), bindings, pos)
+                let interpolated = interpolated
+                    .into_iter()
+                    .map(|(id_t, t)|
+                        if !t.as_ref().is_constant() {
+                            let fresh_var = fresh_var();
+                            let pos_t = t.pos;
+                            bindings.push((fresh_var.clone(), t));
+                            (id_t, RichTerm::new(Term::Var(fresh_var), pos_t))
+                        } else {
+                            (id_t, t)
+                        })
+                    .collect();
+
+                with_bindings(Term::RecRecord(map, interpolated, attrs), bindings, pos)
             }
             Term::List(ts) => {
                 let mut bindings = Vec::with_capacity(ts.len());

--- a/src/transformations.rs
+++ b/src/transformations.rs
@@ -77,7 +77,7 @@ pub mod share_normal_form {
 
                 with_bindings(Term::Record(map, attrs), bindings, pos)
             }
-            Term::RecRecord(map, interpolated, attrs) => {
+            Term::RecRecord(map, dyn_fields, attrs) => {
                 // When a recursive record is evaluated, all fields need to be turned to closures
                 // anyway (see the corresponding case in `eval::eval()`), which is what the share
                 // normal form transformation does. This is why the test is more lax here than for
@@ -100,7 +100,7 @@ pub mod share_normal_form {
                     })
                     .collect();
 
-                let interpolated = interpolated
+                let dyn_fields = dyn_fields
                     .into_iter()
                     .map(|(id_t, t)| {
                         if !t.as_ref().is_constant() {
@@ -114,7 +114,7 @@ pub mod share_normal_form {
                     })
                     .collect();
 
-                with_bindings(Term::RecRecord(map, interpolated, attrs), bindings, pos)
+                with_bindings(Term::RecRecord(map, dyn_fields, attrs), bindings, pos)
             }
             Term::List(ts) => {
                 let mut bindings = Vec::with_capacity(ts.len());

--- a/tests/pass/record-defs.ncl
+++ b/tests/pass/record-defs.ncl
@@ -29,7 +29,7 @@ let Assert = fun l x => x || %blame% l in
 ({foo.bar.baz = 1, bar.baz.foo = foo.bar.baz + 1}
   == {foo = {bar = {baz = 1}}, bar = {baz = {foo = 2}}}
   | #Assert) &&
-({foo.bar.baz = 1, bar.baz.foo = foo.bar.baz + 1}
+({foo."bar"."baz" = 1, "bar"."baz"."foo" = foo.bar."baz" + 1}
   == {foo = {bar = {baz = 1}}, bar = {baz = {foo = 2}}}
   | #Assert) &&
 

--- a/tests/pass/record-defs.ncl
+++ b/tests/pass/record-defs.ncl
@@ -29,6 +29,10 @@ let Assert = fun l x => x || %blame% l in
 ({foo.bar.baz = 1, bar.baz.foo = foo.bar.baz + 1}
   == {foo = {bar = {baz = 1}}, bar = {baz = {foo = 2}}}
   | #Assert) &&
+({foo.bar.baz = 1, bar.baz.foo = foo.bar.baz + 1}
+  == {foo = {bar = {baz = 1}}, bar = {baz = {foo = 2}}}
+  | #Assert) &&
+
 
 // piecewise_annotations
 ({foo.bar | default = 1, foo.baz = 2}
@@ -36,6 +40,11 @@ let Assert = fun l x => x || %blame% l in
   | #Assert) &&
 ({foo.bar | default = 1, foo.bar = 2} == {foo = {bar = 2}} | #Assert) &&
 ({foo.bar.baz | Bool = true}.foo.bar.baz | #Assert) &&
+
+// recursive_dynamic_fields
+(let x = "foo" in
+  {"#{x}" = bar, bar = 1} == {foo = 1, bar = 1} | #Assert) &&
+({"#foo"."#bar".baz = other + 1, other = 0}."#foo"."#bar".baz == 1) &&
 
 
 true

--- a/tests/pass/typechecking.ncl
+++ b/tests/pass/typechecking.ncl
@@ -167,6 +167,9 @@ let typecheck = [
 
   // Typed import
   import "typed-import.ncl" : Num,
+
+  // recursive_records_quoted
+  {"foo" = 1} : {foo : Num},
 ] in
 
 

--- a/tests/records_fail.rs
+++ b/tests/records_fail.rs
@@ -1,5 +1,5 @@
 use assert_matches::assert_matches;
-use nickel::error::{Error, EvalError};
+use nickel::error::{Error, EvalError, TypecheckError};
 
 mod common;
 use common::eval;
@@ -40,5 +40,13 @@ fn non_mergeable_piecewise() {
     assert_matches!(
         eval("({a.b = {}} & {a.b.c = []} & {a.b.c = {}}).a.b.c"),
         Err(Error::EvalError(EvalError::MergeIncompatibleArgs(..)))
+    );
+}
+
+#[test]
+fn dynamic_not_recursive() {
+    assert_matches!(
+        eval("let x = \"foo\" in {\"#{x}\" = 1, bar = foo}.bar"),
+        Err(Error::TypecheckError(TypecheckError::UnboundIdentifier(..)))
     );
 }

--- a/tests/typecheck_fail.rs
+++ b/tests/typecheck_fail.rs
@@ -262,3 +262,11 @@ fn shallow_type_inference() {
         Err(TypecheckError::TypeMismatch(..))
     );
 }
+
+#[test]
+fn dynamic_record_field() {
+    assert_matches!(
+        type_check_expr("let x = \"foo\" in {\"#{x}\" = 1} : {foo: Num}"),
+        Err(TypecheckError::TypeMismatch(..))
+    );
+}


### PR DESCRIPTION
Depend on #374. Fix #298.

Previously, the parser was elaborating a record with fields defined dynamically as a static record followed by a sequence of dynamic extension:

```
let x = "foo" in
let y = "bar" in
{ "#{x}" = 1, "#{y}" = 2, baz = 3}

// Rewritten at parsing time as
{baz = 3} $[ x = 1] $[ y = 2 ]
```

Where `$[ ]` is the dynamic extension operator. This causes #298: because dynamic fields are separated early from their original record, they don't have access to recursive fields like `baz`

This PR fixes the problem by changing the representation of recursive records to a set of static field and a set of dynamic fields. Doing so, the dynamic fields are kept together with their original record until the first evaluation of the `RecRecord` to a standard `Record`, and can thus have access to the other recursive fields.

## Recursive dynamic fields

Only field defined statically can be recursive, that is this PR doesn't support:

```
let x = "foo" in {"#{x}" = 0, bar = foo +1} //Error
```

Doing otherwise would require to pre-evaluate some terms before we can even typecheck, and would be dubious in any case, introducing a form of dynamic scoping.

## Typechecking

If a record has a dynamic field, then it is inferred to have a type of the form `{_ : _a}` for some unification variable `_a`, which is the only type that can handle statically unknown fields.