### PR TITLE
Github action - stablize daily update of rust channels

### DIFF
--- a/.github/workflows/daily_update_rust_channel.yml
+++ b/.github/workflows/daily_update_rust_channel.yml
@@ -7,6 +7,8 @@ jobs:
   update-rust-channels:
 
     strategy:
+      # Run in sequence to prevent `git push` overlaps
+      max-parallel: 1
       matrix:
         rust_channel:
         - stable


### PR DESCRIPTION
The git-auto-commit action (https://github.com/stefanzweifel/git-auto-commit-action) used for pushing changes to master branch is deliberately not supporting runs in build matrices - which means, ocasional conflicts may appear (see: [example](https://github.com/tweag/nickel/actions/runs/1164778938))

For example, if both stable and beta rust channels need to be updated and both of their respective workflows are executed in parallel, the first one to reach git-auto-commit step wins - the other one fails with error (describing discrepancy between checked-out branch and master).

This change forces build-matrix workflows to run in sequence, preventing such issues from taking place - should more efficient approach be needed, this would have to change.