### PR TITLE
Restore the :print command in the repl

### DIFF
--- a/src/repl/command.rs
+++ b/src/repl/command.rs
@@ -49,6 +49,7 @@ impl FromStr for CommandType {
             "load" | "l" => Ok(Load),
             "typecheck" | "tc" => Ok(Typecheck),
             "query" | "q" => Ok(Query),
+            "print" | "p" => Ok(Print),
             "help" | "?" | "h" => Ok(Help),
             "exit" | "e" => Ok(Exit),
             _ => Err(UnknownCommandError {}),


### PR DESCRIPTION
Accidentally removed by https://github.com/tweag/nickel/commit/a9d5255fdb15e914a40d3a55822d4c4e1d7a28c8

~~(note that I wrote this PR using the github online editor and didn’t test anything so far)~~ I’ve tested it locally, and it seems to work all-right