### PR TITLE
do not do anymore recursive transformations in transformations.rs (im…

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -1157,7 +1157,7 @@ mod tests {
             resolve_imports(
                 mk_term::let_in(var, mk_term::import(import), body),
                 resolver,
-            )
+            ).map(|(t,pending)| t)
         }
 
         // let x = import "does_not_exist" in x

--- a/src/program.rs
+++ b/src/program.rs
@@ -77,10 +77,8 @@ impl Program {
             .cache
             .mk_global_env()
             .expect("program::prepare_eval(): expected event to be ready");
-        Ok((
-            self.cache.prepare_nocache(self.main_id, &global_env)?,
-            global_env,
-        ))
+        self.cache.prepare(self.main_id, &global_env)?;
+        Ok((self.cache.get(self.main_id).unwrap(), global_env))
     }
 
     /// Parse if necessary, typecheck and then evaluate the program.

--- a/src/repl/mod.rs
+++ b/src/repl/mod.rs
@@ -118,13 +118,13 @@ impl REPLImpl {
             .map_err(|err| ParseError::from_lalrpop(err, file_id))?
         {
             ExtendedTerm::RichTerm(t) => {
-                let t = transformations::resolve_imports(t, &mut self.cache)?;
+                let (t,pending) = transformations::resolve_imports(t, &mut self.cache)?;
                 typecheck::type_check_in_env(&t, &self.type_env, &self.cache)?;
                 let t = transformations::transform(t)?;
                 Ok(eval_function(t, &self.eval_env, &mut self.cache)?.into())
             }
             ExtendedTerm::ToplevelLet(id, t) => {
-                let t = transformations::resolve_imports(t, &mut self.cache)?;
+                let (t,pending) = transformations::resolve_imports(t, &mut self.cache)?;
                 typecheck::type_check_in_env(&t, &self.type_env, &self.cache)?;
                 typecheck::Envs::env_add(&mut self.type_env, id.clone(), &t);
 

--- a/tests/typecheck_fail.rs
+++ b/tests/typecheck_fail.rs
@@ -166,10 +166,11 @@ fn imports() {
     where
         R: ImportResolver,
     {
-        resolve_imports(
+        let (t,pending) = resolve_imports(
             mk_term::let_in("x", mk_term::import(import), mk_term::var("x")),
             resolver,
-        )
+        )?;
+        Ok(t)
     }
 
     type_check_in_env(


### PR DESCRIPTION
…ports and transformations)

rewrite cache to do itself the recurtion
now the transformations::resolve _imports return the richterm and a list of pending imports (previously the stack used to resolve imports