### PR TITLE
Correctly parse `import "foo" bar`

### DIFF
--- a/src/grammar.lalrpop
+++ b/src/grammar.lalrpop
@@ -148,11 +148,11 @@ AnnotatedTerm: RichTerm = {
 };
 
 Infix: RichTerm = {
-    "import" <s: StaticString> => RichTerm::from(Term::Import(OsString::from(s))),
     InfixExpr,
 };
 
 Applicative: RichTerm = {
+    "import" <s: StaticString> => RichTerm::from(Term::Import(OsString::from(s))),
     <t1:WithPos<Applicative>> <t2: WithPos<RecordOperand>> => mk_app!(t1, t2),
     <op: UOp> <t: WithPos<RecordOperand>> => mk_term::op1(op, t),
     <op: BOpPre> <t1: WithPos<RecordOperand>> <t2: WithPos<Atom>> => mk_term::op2(op, t1, t2),

--- a/tests/pass.rs
+++ b/tests/pass.rs
@@ -107,3 +107,8 @@ fn serialize() {
 fn annot_parsing() {
     check_file("annotations.ncl");
 }
+
+#[test]
+fn importing() {
+    check_file("import.ncl");
+}

--- a/tests/pass/import.ncl
+++ b/tests/pass/import.ncl
@@ -1,0 +1,5 @@
+let Assert = fun l x => x || %blame% l in
+
+(import "imported.ncl" 3 == 3 | #Assert) &&
+
+true

--- a/tests/pass/imported.ncl
+++ b/tests/pass/imported.ncl
@@ -1,0 +1,3 @@
+// This isn’t really a test, mostly an auxiliary file used by `import.ncl`
+
+fun x => x


### PR DESCRIPTION
Fix #414

I’ve no idea whether the grammar change is actually sensible.
It does fix the issue and doesn’t obviously break anything else, but it’s definitely worth proof-reading
