### PR TITLE
Fix issue #425 - Querying MetaValues from returned objects

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -717,7 +717,7 @@ where
                 }
             }
             // Unwrapping of enriched terms
-            Term::MetaValue(meta) if enriched_strict => {
+            Term::MetaValue(meta) if enriched_strict || (stack.count_args() > 0) => {
                 if meta.value.is_some() {
                     /* Since we are forcing a metavalue, we are morally evaluating `force t` rather
                      * than `t` iteself.  Updating a thunk after having performed this forcing may


### PR DESCRIPTION
Continuating term evaluation as long as there are arguments in the stack.
Only return metadata once every arguments are taken into account.
This way `nickel query <<< 'builtins.seq 2 ((1+3) | doc "test")'` returns a value of `4` and `test` as a documentation, and `nickel query <<< 'lists.length'` returns the expected  documentation.

I need some external tests & reviews as I didn't cover the real use cases.
Fixes for the issue #425 