### PR TITLE
Fix looping typechecking of cyclic imports

### DIFF
--- a/src/cache.rs
+++ b/src/cache.rs
@@ -88,11 +88,23 @@ pub struct NameIdEntry {
 }
 
 /// The state of an entry of the term cache.
+///
+/// # Imports
+///
+/// Usually, when we apply a procedure to an entry (typechecking, transformation, ...), we also
+/// process all of its transitive imports. However, note that the state is guaranteed to be correct
+/// only for the entry, and not necessarily for its transitive imports. Under normal conditions, if
+/// the state of an entry is `Typechecked`, then all of its transitive imports should also be at
+/// least in the state `Typechecked`. This is not true if an import fails to typecheck, leaving the
+/// entry `Typechecked` while the import stays as `Parsed`.
+///
+/// Thus, the state (e.g. `Typechecked`) only guarantees in general that the corresponding
+/// procedure have been successfully applied to the entry, not to all of its transitive imports.
 #[derive(Eq, PartialEq, Ord, PartialOrd, Debug, Copy, Clone)]
 pub enum EntryState {
     /// The term have just been parsed.
     Parsed,
-    /// The term has been parsed and the imports resolved
+    /// The term has been parsed and the imports resolved.
     ImportsResolved,
     /// The term have been parsed and typechecked.
     Typechecked,

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -463,10 +463,12 @@ impl Cache {
             Some(_) => {
                 let (t, _) = self.terms.remove(&file_id).unwrap();
                 let (t, pending) = transformations::resolve_imports(t, self)?;
+                self.terms.insert(file_id, (t, EntryState::ImportsResolved));
+
                 for id in pending {
                     self.resolve_imports(id)?;
                 }
-                self.terms.insert(file_id, (t, EntryState::ImportsResolved));
+
                 Ok(CacheOp::Done(()))
             }
             None => Err(CacheError::NotParsed),

--- a/src/transformations.rs
+++ b/src/transformations.rs
@@ -265,9 +265,9 @@ struct ImportsResolutionState<'a, R> {
 /// If needed, either do it yourself using pending imports returned by
 /// [`resolve_imports`](../fn.resolve_imports.html)
 /// or use the [`Cache`](../../cache/struct.Cache.html)
-pub fn transform(rt: RichTerm) -> Result<RichTerm, ImportError> {
+pub fn transform(rt: RichTerm) -> RichTerm {
     rt.traverse(
-        &mut |rt: RichTerm, _| -> Result<RichTerm, ImportError> {
+        &mut |rt: RichTerm, _| -> Result<RichTerm, ()> {
             // We need to do contract generation before wrapping stuff in variables
             let rt = apply_contracts::transform_one(rt);
             let rt = share_normal_form::transform_one(rt);
@@ -275,6 +275,7 @@ pub fn transform(rt: RichTerm) -> Result<RichTerm, ImportError> {
         },
         &mut (),
     )
+    .unwrap()
 }
 
 /// import resolution.

--- a/src/typecheck/mod.rs
+++ b/src/typecheck/mod.rs
@@ -810,14 +810,14 @@ fn type_check_<S, E>(
         },
         Term::Import(_) => unify(state, strict, ty, mk_typewrapper::dynamic())
             .map_err(|err| err.into_typecheck_err(state, rt.pos)),
-        // We typecheck the import in a fresh typing environment, and then use its apparent type
-        // for checking. 
+        // We use the apparent type of the import for checking. This function doesn't recursively
+        // typecheck imports: this is the responsibility of the caller.
         Term::ResolvedImport(file_id) => {
             let t = state
                 .resolver
                 .get(*file_id)
                 .expect("Internal error: resolved import not found ({:?}) during typechecking.");
-            let _ = type_check_in_env(&t, envs.global, state.resolver)?;
+            // let _ = type_check_in_env(&t, envs.global, state.resolver)?;
             let ty_import : TypeWrapper = apparent_type(t.as_ref(), Some(&Envs::from_envs(&envs))).into();
             unify(state, strict, ty, ty_import).map_err(|err| err.into_typecheck_err(state, rt.pos))
         }

--- a/src/typecheck/mod.rs
+++ b/src/typecheck/mod.rs
@@ -820,7 +820,6 @@ fn type_check_<S, E>(
                 .resolver
                 .get(*file_id)
                 .expect("Internal error: resolved import not found ({:?}) during typechecking.");
-            // let _ = type_check_in_env(&t, envs.global, state.resolver)?;
             let ty_import : TypeWrapper = apparent_type(t.as_ref(), Some(&Envs::from_envs(&envs))).into();
             unify(state, strict, ty, ty_import).map_err(|err| err.into_typecheck_err(state, rt.pos))
         }

--- a/src/typecheck/mod.rs
+++ b/src/typecheck/mod.rs
@@ -449,6 +449,9 @@ pub struct State<'a> {
 ///
 /// Return the inferred type in case of success. This is just a wrapper that calls
 /// [`type_check_`](fn.type_check_.html) with a fresh unification variable as goal.
+///
+/// Note that this function doesn't recursively typecheck imports (anymore), but just the current
+/// file. It however still needs the resolver to get the apparent type of imports.
 pub fn type_check<L>(
     t: &RichTerm,
     global_eval_env: &eval::Environment,

--- a/tests/imports.rs
+++ b/tests/imports.rs
@@ -1,6 +1,7 @@
 use assert_matches::assert_matches;
 use nickel::error::{Error, EvalError, TypecheckError};
 use nickel::program::Program;
+use nickel::term::Term;
 use std::io::BufReader;
 use std::path::PathBuf;
 
@@ -15,7 +16,6 @@ fn mk_import(file: &str) -> String {
 
 #[test]
 fn nested() {
-    use nickel::term::Term;
     let mut prog = Program::new_from_source(
         BufReader::new(mk_import("nested.ncl").as_bytes()),
         "should_be = 3",
@@ -26,7 +26,6 @@ fn nested() {
 
 #[test]
 fn root_path() {
-    use nickel::term::Term;
     let mut prog = Program::new_from_source(
         BufReader::new(mk_import("root_path.ncl").as_bytes()),
         "should_be = 44",
@@ -37,7 +36,6 @@ fn root_path() {
 
 #[test]
 fn multi_imports() {
-    use nickel::term::Term;
     let mut prog = Program::new_from_source(
         BufReader::new(mk_import("multi_imports.ncl").as_bytes()),
         "should_be = 5",
@@ -102,19 +100,12 @@ fn serialize() {
     assert_eq!(prog.eval(), Ok(Term::Bool(true)));
 }
 
-// TODO produce a stack overflow
-//#[test]
-//fn circular_imports_fail() {
-//    let mut prog = Program::new_from_source(
-//        BufReader::new(mk_import("cycle.ncl").as_bytes()),
-//        "should_fail",
-//    )
-//    .unwrap();
-//    prog.eval()
-//        .map_err(|e| match e {
-//            Error::TypecheckError(TypecheckError::TypeMismatch(..)) => Ok(()),
-//            r => Err(r),
-//        })
-//        .unwrap_err()
-//        .unwrap();
-//}
+#[test]
+fn circular_imports_fail() {
+    let mut prog = Program::new_from_source(
+        BufReader::new(mk_import("cycle.ncl").as_bytes()),
+        "should_fail",
+    )
+    .unwrap();
+    assert_matches!(prog.eval(), Ok(Term::RecRecord(..)) | Ok(Term::Record(..)));
+}

--- a/tests/imports/cycle.ncl
+++ b/tests/imports/cycle.ncl
@@ -1,2 +1,1 @@
-
 let x = import "cycle_b.ncl" in {a = 1, b = x.a}

--- a/tests/imports/cycle_b.ncl
+++ b/tests/imports/cycle_b.ncl
@@ -1,2 +1,1 @@
-
 let x = import "cycle.ncl" in {a = x.a}


### PR DESCRIPTION
Fix #409.

Do not make `type_check` functions transitively typecheck imports anymore. They now just peek at the toplevel node of the imports to see the apparent type, in order to be able to decide the type of an expression `import "foo.ncl"`, but they restrain from recursing inside `foo.ncl`.

It is now the responsibility of the caller (in practice, the cache) to call `type_check` on transitive imports of a source file, and the cache is able to see the imports it has already processed, which eliminates the loop.

Did small code cleaning on the way (such as removing the `Result` from `transform`'s return type, as now that transform does not perform import resolution, it isn't fallible anymore).