### PR TITLE
Adding strictness markers on top of stack

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -448,6 +448,10 @@ where
         } = clos;
         let term = *boxed_term;
 
+        if let Some(strict) = stack.pop_strictness_marker() {
+            enriched_strict = strict;
+        }
+
         clos = match term {
             Term::Var(x) => {
                 let mut thunk = env
@@ -475,6 +479,10 @@ where
                 thunk.into_closure()
             }
             Term::App(t1, t2) => {
+                if !enriched_strict {
+                    stack.push_strictness(enriched_strict);
+                }
+                enriched_strict = true;
                 stack.push_arg(
                     Closure {
                         body: t2,

--- a/tests/query.rs
+++ b/tests/query.rs
@@ -1,0 +1,50 @@
+use assert_matches::assert_matches;
+use nickel::program::Program;
+use nickel::term::{MetaValue, RichTerm, Term};
+
+#[test]
+pub fn test_query_metadata_basic() {
+    let mut program =
+        Program::new_from_source("(1+1) | doc \"Test basic\"".as_bytes(), "regr_tests").unwrap();
+    let result = program.query(None).unwrap();
+
+    assert_matches!(
+        result,
+        Term::MetaValue(MetaValue {
+            doc: Some(_),
+            value: Some(_),
+            ..
+        })
+    );
+    if let Term::MetaValue(meta) = result {
+        assert_eq!(meta.doc, Some(String::from("Test basic")));
+        assert_eq!(meta.value.unwrap().term, Box::new(Term::Num(2.0)));
+    } else {
+        panic!();
+    }
+}
+
+#[test]
+pub fn test_query_metadata_from_func() {
+    let mut program = Program::new_from_source(
+        "builtins.seq 2 ((3+1) | doc \"Test from func\")".as_bytes(),
+        "regr_tests",
+    )
+    .unwrap();
+    let result = program.query(None).unwrap();
+
+    assert_matches!(
+        result,
+        Term::MetaValue(MetaValue {
+            doc: Some(_),
+            value: Some(_),
+            ..
+        })
+    );
+    if let Term::MetaValue(meta) = result {
+        assert_eq!(meta.doc, Some(String::from("Test from func")));
+        assert_eq!(meta.value.unwrap().term, Box::new(Term::Num(4.0)));
+    } else {
+        panic!();
+    }
+}

--- a/tests/query.rs
+++ b/tests/query.rs
@@ -1,6 +1,5 @@
-use assert_matches::assert_matches;
 use nickel::program::Program;
-use nickel::term::{MetaValue, RichTerm, Term};
+use nickel::term::Term;
 
 #[test]
 pub fn test_query_metadata_basic() {
@@ -8,14 +7,6 @@ pub fn test_query_metadata_basic() {
         Program::new_from_source("(1+1) | doc \"Test basic\"".as_bytes(), "regr_tests").unwrap();
     let result = program.query(None).unwrap();
 
-    assert_matches!(
-        result,
-        Term::MetaValue(MetaValue {
-            doc: Some(_),
-            value: Some(_),
-            ..
-        })
-    );
     if let Term::MetaValue(meta) = result {
         assert_eq!(meta.doc, Some(String::from("Test basic")));
         assert_eq!(meta.value.unwrap().term, Box::new(Term::Num(2.0)));
@@ -33,14 +24,6 @@ pub fn test_query_metadata_from_func() {
     .unwrap();
     let result = program.query(None).unwrap();
 
-    assert_matches!(
-        result,
-        Term::MetaValue(MetaValue {
-            doc: Some(_),
-            value: Some(_),
-            ..
-        })
-    );
     if let Term::MetaValue(meta) = result {
         assert_eq!(meta.doc, Some(String::from("Test from func")));
         assert_eq!(meta.value.unwrap().term, Box::new(Term::Num(4.0)));


### PR DESCRIPTION
- Automatically apply strictness rule on evaluation loop if marker popped
- Ignore strictness markers while counting arguments
- Ignore strictness markers while popping things off the stack

Should fix issue #425 in a more systematic and generic way.