### PR TITLE
Implement std::fmt::Display for Marker and OperationCont for debug printing

### DIFF
--- a/src/operation.rs
+++ b/src/operation.rs
@@ -42,7 +42,7 @@ enum EqResult {
 }
 
 /// An operation continuation as stored on the stack.
-#[derive(Debug, PartialEq)]
+#[derive(PartialEq)]
 pub enum OperationCont {
     Op1(
         /* unary operation */ UnaryOp,
@@ -71,6 +71,17 @@ pub enum OperationCont {
                               of arguments yet to be evaluated */
         prev_enriched_strict: bool,
     },
+}
+
+impl std::fmt::Debug for OperationCont {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            OperationCont::Op1(op, _, _) => write!(f, "Op1 {:?}", op),
+            OperationCont::Op2First(op, _, _, _) => write!(f, "Op2First {:?}", op),
+            OperationCont::Op2Second(op, _, _, _, _) => write!(f, "Op2Second {:?}", op),
+            OperationCont::OpN { op, .. } => write!(f, "OpN {:?}", op),
+        }
+    }
 }
 
 /// Process to the next step of the evaluation of an operation.

--- a/src/stack.rs
+++ b/src/stack.rs
@@ -7,7 +7,6 @@ use crate::position::TermPos;
 use crate::term::{RichTerm, StrChunk};
 
 /// An element of the stack.
-#[derive(Debug)]
 pub enum Marker {
     /// An equality to test.
     ///
@@ -47,6 +46,21 @@ pub enum Marker {
         Environment, /* the common environment of chunks */
     ),
     Strictness(bool),
+}
+
+impl std::fmt::Debug for Marker {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Marker::Eq(_, _) => write!(f, "Eq"),
+            Marker::Arg(_, _) => write!(f, "Arg"),
+            Marker::TrackedArg(_, _) => write!(f, "TrackedArg"),
+            Marker::Thunk(_) => write!(f, "Thunk"),
+            Marker::Cont(op, sz, _) => write!(f, "Cont {:?} (callstack size {})", op, sz),
+            Marker::StrChunk(_) => write!(f, "StrChunk"),
+            Marker::StrAcc(_, _, _) => write!(f, "StrAcc"),
+            Marker::Strictness(s) => write!(f, "Strictness = {}", s),
+        }
+    }
 }
 
 impl Marker {

--- a/src/stack.rs
+++ b/src/stack.rs
@@ -94,7 +94,6 @@ impl Marker {
 }
 
 /// The evaluation stack.
-#[derive(Debug)]
 pub struct Stack(Vec<Marker>);
 
 impl IntoIterator for Stack {
@@ -310,6 +309,16 @@ impl Stack {
             }
             _ => None,
         }
+    }
+}
+
+impl std::fmt::Debug for Stack {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "--- STACK ---")?;
+        for marker in self.0.iter().rev() {
+            write!(f, "| {:?}", marker)?;
+        }
+        write!(f, "---  END  ---")
     }
 }
 


### PR DESCRIPTION
It occured severall times that I have Stack overflows errors when trying to print some variables to debug something and it happens that this variable contains everything from the stdlib for example.

To get around this, I implemented the `std::fmt::Display` trait on some elements to be able to still see the maximum informations about them, without dumping the whole memory into the console.
I think it could be much more extended than Marker and OperationCont, and I can continue to implement the trait on other elements if needed.
Thought it could be good to have a quick and easy text representation of elements inside the machine

Example using `stack.display()` in the `continuate_operation` function:
```
--- STACK ---
| Cont Op2First Plus (callstack size 1)
| Thunk
| Cont Op1 DeepSeq (callstack size 0)
| Arg
---  END  ---
--- STACK ---
| Cont Op2First Plus (callstack size 1)
| Thunk
| Cont Op1 DeepSeq (callstack size 0)
| Arg
---  END  ---
--- STACK ---
| Thunk
| Cont Op1 DeepSeq (callstack size 0)
| Arg
---  END  ---
```
