### PR TITLE
[Language Server] Simple document symbols

### DIFF
--- a/lsp/nls/src/main.rs
+++ b/lsp/nls/src/main.rs
@@ -9,6 +9,7 @@ mod linearization;
 mod requests;
 mod server;
 use server::Server;
+mod term;
 
 fn main() -> Result<()> {
     env_logger::init();

--- a/lsp/nls/src/requests/mod.rs
+++ b/lsp/nls/src/requests/mod.rs
@@ -1,4 +1,5 @@
 pub mod completion;
 pub mod goto;
 pub mod hover;
+pub mod symbols;
 mod utils;

--- a/lsp/nls/src/requests/symbols.rs
+++ b/lsp/nls/src/requests/symbols.rs
@@ -1,0 +1,54 @@
+use crate::term::TermPosExt;
+use lsp_server::{RequestId, Response, ResponseError};
+use lsp_types::{DocumentSymbol, DocumentSymbolParams, SymbolKind};
+use serde_json::Value;
+
+use crate::server::Server;
+
+pub fn handle_document_symbols(
+    params: DocumentSymbolParams,
+    id: RequestId,
+    server: &mut Server,
+) -> Result<(), ResponseError> {
+    let file_id = server
+        .cache
+        .id_of(params.text_document.uri.to_string())
+        .unwrap();
+
+    if let Some(completed) = server.lin_cache.get(&file_id) {
+        let symbols = completed
+            .lin
+            .iter()
+            .filter_map(|item| match &item.kind {
+                nickel::typecheck::linearization::TermKind::Declaration(name, _) => {
+                    let range = item
+                        .pos
+                        .try_to_range()
+                        .or_else(|| Some((file_id.clone(), (0usize..0usize))))
+                        .map(|(file_id, range)| {
+                            codespan_lsp::byte_span_to_range(server.cache.files(), file_id, range)
+                                .unwrap()
+                        })
+                        .unwrap();
+                    Some(DocumentSymbol {
+                        name: name.to_owned(),
+                        detail: Some(format!("{}", item.ty)),
+                        kind: SymbolKind::Variable,
+                        tags: None,
+                        range,
+                        selection_range: range,
+                        children: None,
+                        deprecated: None,
+                    })
+                }
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+
+        server.reply(Response::new_ok(id, symbols));
+    } else {
+        server.reply(Response::new_ok(id, Value::Null));
+    }
+
+    Ok(())
+}

--- a/lsp/nls/src/server.rs
+++ b/lsp/nls/src/server.rs
@@ -19,7 +19,10 @@ use lsp_types::{
 use nickel::typecheck::linearization::Completed;
 use nickel::{cache::Cache, environment::Environment, eval::Thunk, identifier::Ident};
 
-use crate::requests::{completion, goto, hover};
+use crate::{
+    diagnostic::LocationCompat,
+    requests::{completion, goto, hover, symbols},
+};
 
 pub struct Server {
     pub connection: Connection,

--- a/lsp/nls/src/server.rs
+++ b/lsp/nls/src/server.rs
@@ -11,8 +11,8 @@ use lsp_types::{
     notification::{DidChangeTextDocument, DidOpenTextDocument},
     request::{Request as RequestTrait, *},
     CompletionOptions, CompletionParams, DidChangeTextDocumentParams, DidOpenTextDocumentParams,
-    GotoDefinitionParams, HoverOptions, HoverParams, HoverProviderCapability, OneOf,
-    ReferenceParams, ServerCapabilities, TextDocumentSyncCapability, TextDocumentSyncKind,
+    DocumentSymbolParams, GotoDefinitionParams, HoverOptions, HoverParams, HoverProviderCapability,
+    OneOf, ReferenceParams, ServerCapabilities, TextDocumentSyncCapability, TextDocumentSyncKind,
     TextDocumentSyncOptions, WorkDoneProgressOptions,
 };
 
@@ -52,6 +52,7 @@ impl Server {
                 trigger_characters: Some(vec![]),
                 ..Default::default()
             }),
+            document_symbol_provider: Some(OneOf::Left(true)),
             ..ServerCapabilities::default()
         }
     }
@@ -173,6 +174,12 @@ impl Server {
                 debug!("handle completion");
                 let params: CompletionParams = serde_json::from_value(req.params).unwrap();
                 completion::handle_completion(params, req.id.clone(), self)
+            }
+
+            DocumentSymbolRequest::METHOD => {
+                debug!("handle completion");
+                let params: DocumentSymbolParams = serde_json::from_value(req.params).unwrap();
+                symbols::handle_document_symbols(params, req.id.clone(), self)
             }
 
             _ => Ok(()),

--- a/lsp/nls/src/term.rs
+++ b/lsp/nls/src/term.rs
@@ -1,0 +1,20 @@
+use std::ops::Range;
+
+use codespan::FileId;
+use nickel::position::{RawSpan, TermPos};
+
+pub trait TermPosExt {
+    fn try_to_range(&self) -> Option<(FileId, Range<usize>)>;
+}
+
+impl TermPosExt for TermPos {
+    fn try_to_range(&self) -> Option<(FileId, Range<usize>)> {
+        match self {
+            TermPos::Inherited(RawSpan { src_id, start, end })
+            | TermPos::Original(RawSpan { src_id, start, end }) => {
+                Some((src_id.clone(), (start.0 as usize..end.0 as usize)))
+            }
+            TermPos::None => None,
+        }
+    }
+}


### PR DESCRIPTION
The current linearization contains all variables defined in the document.
This PR makes use of that and exposes those definitions as document symbols.

- currently the whole scope of the let binding is highlighted
- we do not distinguish between types or record fields yet

(in VS-Code the document symbols can be opened with `cmd/ctrl+shift+o`)