### PR TITLE
Update and simplify flakes-based GH workflow

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -41,7 +41,7 @@ jobs:
         fetch-depth: 0
 
     - name: Installing Nix
-      uses: cachix/install-nix-action@v14
+      uses: cachix/install-nix-action@v14.1
       with:
         nix_path: nixpkgs=channel:nixos-unstable
         extra_nix_config: |

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -41,22 +41,14 @@ jobs:
         fetch-depth: 0
 
     - name: Installing Nix
-      uses: cachix/install-nix-action@v12
+      uses: cachix/install-nix-action@v14
       with:
         nix_path: nixpkgs=channel:nixos-unstable
+        extra_nix_config: |
+          experimental-features = nix-command flakes
 
-    - name: Adding `unstable` Nix channel
-      run: |
-        nix-channel --add https://nixos.org/channels/nixpkgs-unstable
-        nix-channel --update
-
-    - name: Installing nixFlakes
-      run: |
-        nix-env -iA nixpkgs.nixFlakes
-        echo 'experimental-features = nix-command flakes' | sudo tee -a /etc/nix/nix.conf
-        echo "$HOME/.nix-profile/bin" >> $GITHUB_PATH
-
-    - uses: cachix/cachix-action@v8
+    - name: Setup Cachix
+      uses: cachix/cachix-action@v10
       with:
         name: nickel
         authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'

--- a/.github/workflows/daily_update_rust_channel.yml
+++ b/.github/workflows/daily_update_rust_channel.yml
@@ -27,22 +27,14 @@ jobs:
         fetch-depth: 0
 
     - name: Installing Nix
-      uses: cachix/install-nix-action@v12
+      uses: cachix/install-nix-action@v14
       with:
         nix_path: nixpkgs=channel:nixos-unstable
+        extra_nix_config: |
+          experimental-features = nix-command flakes
 
-    - name: Add `unstable` Nix channel
-      run: |
-        nix-channel --add https://nixos.org/channels/nixpkgs-unstable
-        nix-channel --update
-
-    - name: Installing nixFlakes
-      run: |
-        nix-env -iA nixpkgs.nixFlakes
-        echo 'experimental-features = nix-command flakes' | sudo tee -a /etc/nix/nix.conf
-        echo "$HOME/.nix-profile/bin" >> $GITHUB_PATH
-
-    - uses: cachix/cachix-action@v8
+    - name: Setup Cachix
+      uses: cachix/cachix-action@v10
       with:
         name: nickel
         authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'

--- a/.github/workflows/daily_update_rust_channel.yml
+++ b/.github/workflows/daily_update_rust_channel.yml
@@ -27,7 +27,7 @@ jobs:
         fetch-depth: 0
 
     - name: Installing Nix
-      uses: cachix/install-nix-action@v14
+      uses: cachix/install-nix-action@v14.1
       with:
         nix_path: nixpkgs=channel:nixos-unstable
         extra_nix_config: |

--- a/.github/workflows/makam-specifications.yml
+++ b/.github/workflows/makam-specifications.yml
@@ -20,22 +20,14 @@ jobs:
         fetch-depth: 0
 
     - name: Installing Nix
-      uses: cachix/install-nix-action@v12
+      uses: cachix/install-nix-action@v14
       with:
         nix_path: nixpkgs=channel:nixos-unstable
+        extra_nix_config: |
+          experimental-features = nix-command flakes
 
-    - name: Add `unstable` Nix channel
-      run: |
-        nix-channel --add https://nixos.org/channels/nixpkgs-unstable
-        nix-channel --update
-
-    - name: Installing nixFlakes
-      run: |
-        nix-env -iA nixpkgs.nixFlakes
-        echo 'experimental-features = nix-command flakes' | sudo tee -a /etc/nix/nix.conf
-        echo "$HOME/.nix-profile/bin" >> $GITHUB_PATH
-
-    - uses: cachix/cachix-action@v8
+    - name: Setup Cachix
+      uses: cachix/cachix-action@v10
       with:
         name: nickel
         authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'

--- a/.github/workflows/makam-specifications.yml
+++ b/.github/workflows/makam-specifications.yml
@@ -20,7 +20,7 @@ jobs:
         fetch-depth: 0
 
     - name: Installing Nix
-      uses: cachix/install-nix-action@v14
+      uses: cachix/install-nix-action@v14.1
       with:
         nix_path: nixpkgs=channel:nixos-unstable
         extra_nix_config: |

--- a/.github/workflows/update-wasm-repl.yml
+++ b/.github/workflows/update-wasm-repl.yml
@@ -20,20 +20,14 @@ jobs:
         fetch-depth: 0
 
     - name: Installing Nix
-      uses: cachix/install-nix-action@v12
+      uses: cachix/install-nix-action@v14
       with:
         nix_path: nixpkgs=channel:nixos-unstable
+        extra_nix_config: |
+          experimental-features = nix-command flakes
 
-    - name: Add `unstable` Nix channel
-      run: |
-        nix-channel --add https://nixos.org/channels/nixpkgs-unstable
-        nix-channel --update
-    - name: Installing nixFlakes
-      run: |
-        nix-env -iA nixpkgs.nixFlakes
-        echo 'experimental-features = nix-command flakes' | sudo tee -a /etc/nix/nix.conf
-        echo "$HOME/.nix-profile/bin" >> $GITHUB_PATH
-    - uses: cachix/cachix-action@v8
+    - name: Setup Cachix
+      uses: cachix/cachix-action@v10
       with:
         name: nickel
         authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'

--- a/.github/workflows/update-wasm-repl.yml
+++ b/.github/workflows/update-wasm-repl.yml
@@ -20,7 +20,7 @@ jobs:
         fetch-depth: 0
 
     - name: Installing Nix
-      uses: cachix/install-nix-action@v14
+      uses: cachix/install-nix-action@v14.1
       with:
         nix_path: nixpkgs=channel:nixos-unstable
         extra_nix_config: |

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -15,22 +15,14 @@ jobs:
           node-version: 14
 
       - name: Installing Nix
-        uses: cachix/install-nix-action@v12
+        uses: cachix/install-nix-action@v14
         with:
           nix_path: nixpkgs=channel:nixos-unstable
+          extra_nix_config: |
+            experimental-features = nix-command flakes
 
-      - name: Add `unstable` Nix channel
-        run: |
-          nix-channel --add https://nixos.org/channels/nixpkgs-unstable
-          nix-channel --update
-
-      - name: Installing nixFlakes
-        run: |
-          nix-env -iA nixpkgs.nixFlakes
-          echo 'experimental-features = nix-command flakes' | sudo tee -a /etc/nix/nix.conf
-          echo "$HOME/.nix-profile/bin" >> $GITHUB_PATH
-
-      - uses: cachix/cachix-action@v8
+      - name: Setup Cachix
+        uses: cachix/cachix-action@v10
         with:
           name: nickel
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -15,7 +15,7 @@ jobs:
           node-version: 14
 
       - name: Installing Nix
-        uses: cachix/install-nix-action@v14
+        uses: cachix/install-nix-action@v14.1
         with:
           nix_path: nixpkgs=channel:nixos-unstable
           extra_nix_config: |


### PR DESCRIPTION
The MacOS CI is failing repetitively on the install nix action. This PR tries to fix this by bumping the version of the nix install and the cachix action. Also, now that flakes are in stable nix (although as an experimental feature), this PR gets rid of the bootstraping of a flake-enabled nix version, which makes action code simpler.