### PR TITLE
Make it easier to build the project without using flakes

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,3 +1,4 @@
+{ fromGit ? true }:
 (import (fetchTarball https://github.com/edolstra/flake-compat/archive/master.tar.gz) {
-  src = builtins.fetchGit ./.;
+  src = if fromGit then builtins.fetchGit ./. else ./.;
 }).defaultNix


### PR DESCRIPTION
Make it possible to build it with `nix-build https://github.com/tweag/nickel/archive/master.tar.gz --arg fromGit false`
