### PR TITLE
[Fix]Make MergeContract operator strict in its arguments

### DIFF
--- a/src/term.rs
+++ b/src/term.rs
@@ -810,7 +810,6 @@ impl NAryOp {
 
     pub fn is_strict(&self) -> bool {
         match self {
-            NAryOp::MergeContract() => false,
             _ => true,
         }
     }

--- a/tests/pass/contracts.ncl
+++ b/tests/pass/contracts.ncl
@@ -101,7 +101,7 @@ f `boo == 3) &&
   | #Assert) &&
 
 // nested_metavalues
-// Regression test for #420
+// Regression test for #402
 (let myContract = { x | Str } in
 {
   foo | #myContract | default = { x = "From foo" },

--- a/tests/pass/contracts.ncl
+++ b/tests/pass/contracts.ncl
@@ -100,4 +100,12 @@ f `boo == 3) &&
 (({foo : {bar: Bool} | default = {bar = false}} & {foo.bar = true}).foo.bar
   | #Assert) &&
 
+// nested_metavalues
+// Regression test for #420
+(let myContract = { x | Str } in
+{
+  foo | #myContract | default = { x = "From foo" },
+  bar | #{..} | default = foo
+} == { foo.x = "From foo", bar.x = "From foo"} | #Assert) &&
+
 true


### PR DESCRIPTION
Fix #402.

When using merge for the application of a record contract, we should ignore top-level meta-data such as a default priority which can otherwise cause inner default values of the tested value to be silently dropped (see #402 for an example). That is, when merge is used for a contract-as-a-record application, it must be strict in its arguments with respect to metavalues.