### PR TITLE
Refactoring operation continuation with Strictness markers on stack

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -527,18 +527,19 @@ where
                 }
             }
             Term::Op1(op, t) => {
-                let prev_strict = enriched_strict;
+                if !enriched_strict {
+                    stack.push_strictness(enriched_strict);
+                }
                 enriched_strict = true;
-                stack.push_op_cont(
-                    OperationCont::Op1(op, t.pos, prev_strict),
-                    call_stack.len(),
-                    pos,
-                );
+                stack.push_op_cont(OperationCont::Op1(op, t.pos), call_stack.len(), pos);
                 Closure { body: t, env }
             }
             Term::Op2(op, fst, snd) => {
-                let prev_strict = enriched_strict;
-                enriched_strict = op.is_strict();
+                let strict_op = op.is_strict();
+                if enriched_strict != strict_op {
+                    stack.push_strictness(enriched_strict);
+                }
+                enriched_strict = strict_op;
                 stack.push_op_cont(
                     OperationCont::Op2First(
                         op,
@@ -547,7 +548,6 @@ where
                             env: env.clone(),
                         },
                         fst.pos,
-                        prev_strict,
                     ),
                     call_stack.len(),
                     pos,
@@ -555,8 +555,11 @@ where
                 Closure { body: fst, env }
             }
             Term::OpN(op, mut args) => {
-                let prev_strict = enriched_strict;
-                enriched_strict = op.is_strict();
+                let strict_op = op.is_strict();
+                if enriched_strict != strict_op {
+                    stack.push_strictness(enriched_strict);
+                }
+                enriched_strict = strict_op;
 
                 // Arguments are passed as a stack to the operation continuation, so we reverse the
                 // original list.
@@ -579,7 +582,6 @@ where
                         evaluated: Vec::with_capacity(pending.len() + 1),
                         pending,
                         current_pos: fst.pos,
-                        prev_enriched_strict: prev_strict,
                     },
                     call_stack.len(),
                     pos,
@@ -788,7 +790,7 @@ where
                     update_thunks(&mut stack, &clos);
                     clos
                 } else {
-                    continuate_operation(clos, &mut stack, &mut call_stack, &mut enriched_strict)?
+                    continuate_operation(clos, &mut stack, &mut call_stack)?
                 }
             }
             // Function call

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -600,6 +600,10 @@ where
                         StrChunk::Expr(e, indent) => (e, indent),
                     };
 
+                    if !enriched_strict {
+                        stack.push_strictness(enriched_strict);
+                    }
+                    enriched_strict = true;
                     stack.push_str_chunks(chunks.into_iter());
                     stack.push_str_acc(String::new(), indent, env.clone());
 

--- a/src/operation.rs
+++ b/src/operation.rs
@@ -72,9 +72,9 @@ pub enum OperationCont {
 impl std::fmt::Debug for OperationCont {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            OperationCont::Op1(op, _, _) => write!(f, "Op1 {:?}", op),
-            OperationCont::Op2First(op, _, _, _) => write!(f, "Op2First {:?}", op),
-            OperationCont::Op2Second(op, _, _, _, _) => write!(f, "Op2Second {:?}", op),
+            OperationCont::Op1(op, _) => write!(f, "Op1 {:?}", op),
+            OperationCont::Op2First(op, _, _) => write!(f, "Op2First {:?}", op),
+            OperationCont::Op2Second(op, _, _, _) => write!(f, "Op2Second {:?}", op),
             OperationCont::OpN { op, .. } => write!(f, "OpN {:?}", op),
         }
     }
@@ -88,7 +88,7 @@ impl std::fmt::Debug for OperationCont {
 pub fn continuate_operation(
     mut clos: Closure,
     stack: &mut Stack,
-    call_stack: &mut CallStack
+    call_stack: &mut CallStack,
 ) -> Result<Closure, EvalError> {
     let (cont, cs_len, pos) = stack.pop_op_cont().expect("Condition already checked");
     call_stack.truncate(cs_len);
@@ -2322,7 +2322,6 @@ mod tests {
 
         stack.push_op_cont(cont, 0, TermPos::None);
         let mut call_stack = CallStack::new();
-        let mut strict = true;
 
         clos = continuate_operation(clos, &mut stack, &mut call_stack).unwrap();
 
@@ -2354,7 +2353,6 @@ mod tests {
         let mut stack = Stack::new();
         stack.push_op_cont(cont, 0, TermPos::None);
         let mut call_stack = CallStack::new();
-        let mut strict = true;
 
         clos = continuate_operation(clos, &mut stack, &mut call_stack).unwrap();
 
@@ -2403,7 +2401,6 @@ mod tests {
         let mut stack = Stack::new();
         stack.push_op_cont(cont, 0, TermPos::None);
         let mut call_stack = CallStack::new();
-        let mut strict = false;
 
         clos = continuate_operation(clos, &mut stack, &mut call_stack).unwrap();
 

--- a/src/stack.rs
+++ b/src/stack.rs
@@ -346,7 +346,7 @@ mod tests {
     }
 
     fn some_cont() -> OperationCont {
-        OperationCont::Op1(UnaryOp::IsNum(), TermPos::None, true)
+        OperationCont::Op1(UnaryOp::IsNum(), TermPos::None)
     }
 
     fn some_arg_marker() -> Marker {


### PR DESCRIPTION
Using strictness markers to save and restore strictness during operation continuations.
Continuation from #433, allows to take care of operation continuation without saving a `prev_strictness` value in the `OperationCont` variants.