### PR TITLE
Do not require parenthesis for applying contracts stored in records 

### DIFF
--- a/examples/record-contract/record-contract.ncl
+++ b/examples/record-contract/record-contract.ncl
@@ -38,7 +38,7 @@ let KubernetesConfig = {
   },
 
   spec = {
-    replicas | #(nums.PosNat)
+    replicas | #nums.PosNat
              | doc "The number of replicas"
              | default = 1,
 

--- a/src/grammar.lalrpop
+++ b/src/grammar.lalrpop
@@ -482,7 +482,7 @@ subType : Types = {
         Types(AbsType::List(ty))
     },
     <Ident> => Types(AbsType::Var(<>)),
-    "#" <WithPos<Atom>> => Types(AbsType::Flat(<>)),
+    "#" <WithPos<RecordOperand>> => Types(AbsType::Flat(<>)),
     "(" <Types> ")",
     "<" <rows:(<Ident> ",")*> <last: (<Ident>)?> <tail: ("|" <Ident>)?> ">" => {
         let ty = rows.into_iter()

--- a/tests/pass/serialize-package.ncl
+++ b/tests/pass/serialize-package.ncl
@@ -57,7 +57,7 @@ builtins.serialize `Json (
   {
     name = "nickel",
     buildInputs = [{package = "hello"}],
-  } | #(ctr.Shell)
+  } | #ctr.Shell
 ) == builtins.serialize `Json {
   name = "nickel",
   buildInputs = [{input = "nixpkgs", package = "hello", "_type" = "package"}],


### PR DESCRIPTION
Records are used as modules to regroup functions, values and contracts (as e.g. stdlib modules `strings`, `lists`, and so on). Hence we often use a record field as a contract, but anything else than an atom (variable and constants) currently requires parentheses, that is we have to write `let list | #(lists.NonEmpty) = [1, 2]`.

This is neither aesthetically pleasant nor justified, so this PR allows any record operation sequence (basically any sequence of field access like `foo.bar.baz`) to appear as a custom contract after a `#` without parentheses. We can now write `let list | #lists.NonEmpty = [1, 2]`.