### PR TITLE
save repl history not only  on interupt but  also when using `:exit` …

### DIFF
--- a/src/repl/rustyline_frontend.rs
+++ b/src/repl/rustyline_frontend.rs
@@ -90,7 +90,7 @@ pub fn repl(histfile: PathBuf) -> Result<(), InitError> {
                     }
                     Ok(Command::Exit) => {
                         println!("{}", Style::new().bold().paint("Exiting"));
-                        return Ok(());
+                        break Ok(());
                     }
                     Err(err) => Err(Error::from(err)),
                 };


### PR DESCRIPTION
…command