### PR TITLE
Mention that `--format` also accepts `yaml, toml`

### DIFF
--- a/src/bin/nickel.rs
+++ b/src/bin/nickel.rs
@@ -28,7 +28,7 @@ struct Opt {
 enum Command {
     /// Export the result to a different format
     Export {
-        /// Available formats: `raw, json`. Default format: `json`.
+        /// Available formats: `raw, json, yaml, toml`. Default format: `json`.
         #[structopt(long)]
         format: Option<ExportFormat>,
         /// Output file. Standard output by default

--- a/src/serialize.rs
+++ b/src/serialize.rs
@@ -10,6 +10,7 @@ use std::io;
 use std::str::FromStr;
 
 /// Available export formats.
+// If you add or remove variants, remember to update the CLI docs in `src/bin/nickel.rs'
 #[derive(Copy, Clone, Eq, PartialEq, Debug)]
 pub enum ExportFormat {
     Raw,


### PR DESCRIPTION
Would you like me to add a comment right next to the definition of `ExportFormat` to remind whoever will edit it to also update this documentation line?

Thanks