### PR TITLE
Fix lsp not parsed panic

### DIFF
--- a/lsp/nls/src/requests/completion.rs
+++ b/lsp/nls/src/requests/completion.rs
@@ -1,13 +1,17 @@
 use codespan::ByteIndex;
 use codespan_lsp::position_to_byte_index;
 use log::debug;
-use lsp_server::{RequestId, Response};
+use lsp_server::{RequestId, Response, ResponseError};
 use lsp_types::{CompletionItem, CompletionParams};
 use serde_json::Value;
 
 use crate::{requests::utils::find_linearization_index, server::Server};
 
-pub fn handle_completion(params: CompletionParams, id: RequestId, server: &mut Server) {
+pub fn handle_completion(
+    params: CompletionParams,
+    id: RequestId,
+    server: &mut Server,
+) -> Result<(), ResponseError> {
     let file_id = server
         .cache
         .id_of(params.text_document_position.text_document.uri.as_str())
@@ -21,13 +25,13 @@ pub fn handle_completion(params: CompletionParams, id: RequestId, server: &mut S
     .unwrap();
 
     let locator = (file_id, ByteIndex(start as u32));
-    let linearization = server.lin_cache.get(&file_id).unwrap();
+    let linearization = server.lin_cache_get(&file_id)?;
 
     let index = find_linearization_index(&linearization.lin, locator);
 
     if index == None {
         server.reply(Response::new_ok(id, Value::Null));
-        return;
+        return Ok(());
     }
 
     let item = linearization.lin[index.unwrap()].to_owned();
@@ -49,4 +53,5 @@ pub fn handle_completion(params: CompletionParams, id: RequestId, server: &mut S
     server.reply(Response::new_ok(id, in_scope));
 
     debug!("found closest item: {:?}", item);
+    Ok(())
 }

--- a/lsp/nls/src/requests/hover.rs
+++ b/lsp/nls/src/requests/hover.rs
@@ -1,7 +1,7 @@
 use codespan::ByteIndex;
 use codespan_lsp::position_to_byte_index;
 use log::debug;
-use lsp_server::{ErrorCode, RequestId, Response, ResponseError};
+use lsp_server::{RequestId, Response, ResponseError};
 use lsp_types::{Hover, HoverContents, HoverParams, LanguageString, MarkedString, Range};
 use nickel::position::TermPos;
 use serde_json::Value;
@@ -36,15 +36,7 @@ pub fn handle(
     debug!("start of hovered item: ByteIndex({})", start);
 
     let locator = (file_id, ByteIndex(start as u32));
-    let linearization = &server
-        .lin_cache
-        .get(&file_id)
-        .ok_or_else(|| ResponseError {
-            data: None,
-            message: "File has not yet been parsed or cached.".to_owned(),
-            code: ErrorCode::ParseError as i32,
-        })?
-        .lin;
+    let linearization = &server.lin_cache_get(&file_id)?.lin;
 
     let index = find_linearization_index(linearization, locator);
 

--- a/lsp/nls/src/requests/hover.rs
+++ b/lsp/nls/src/requests/hover.rs
@@ -1,7 +1,7 @@
 use codespan::ByteIndex;
 use codespan_lsp::position_to_byte_index;
 use log::debug;
-use lsp_server::{RequestId, Response};
+use lsp_server::{ErrorCode, RequestId, Response, ResponseError};
 use lsp_types::{Hover, HoverContents, HoverParams, LanguageString, MarkedString, Range};
 use nickel::position::TermPos;
 use serde_json::Value;
@@ -10,7 +10,11 @@ use crate::{
     diagnostic::LocationCompat, requests::utils::find_linearization_index, server::Server,
 };
 
-pub fn handle(params: HoverParams, id: RequestId, server: &mut Server) {
+pub fn handle(
+    params: HoverParams,
+    id: RequestId,
+    server: &mut Server,
+) -> Result<(), ResponseError> {
     let file_id = server
         .cache
         .id_of(
@@ -32,13 +36,21 @@ pub fn handle(params: HoverParams, id: RequestId, server: &mut Server) {
     debug!("start of hovered item: ByteIndex({})", start);
 
     let locator = (file_id, ByteIndex(start as u32));
-    let linearization = &server.lin_cache.get(&file_id).unwrap().lin;
+    let linearization = &server
+        .lin_cache
+        .get(&file_id)
+        .ok_or_else(|| ResponseError {
+            data: None,
+            message: "File has not yet been parsed or cached.".to_owned(),
+            code: ErrorCode::ParseError as i32,
+        })?
+        .lin;
 
     let index = find_linearization_index(linearization, locator);
 
     if index == None {
         server.reply(Response::new_ok(id, Value::Null));
-        return;
+        return Ok(());
     }
 
     let item = linearization[index.unwrap()].to_owned();
@@ -68,5 +80,6 @@ pub fn handle(params: HoverParams, id: RequestId, server: &mut Server) {
 
             range,
         },
-    ))
+    ));
+    Ok(())
 }


### PR DESCRIPTION
The lsp server no longer panics if the client makes a request before a file has been parsed.
This used to happen if a file had a syntax error in it.