### PR TITLE
[Syntax]Pipe operator (reverse application)

### DIFF
--- a/src/grammar.lalrpop
+++ b/src/grammar.lalrpop
@@ -398,6 +398,8 @@ InfixExpr: RichTerm = {
     #[precedence(level="6")] #[assoc(side="left")]
     <t1: WithPos<InfixExpr>> "&" <t2: WithPos<InfixExpr>> =>
         mk_term::op2(BinaryOp::Merge(), t1, t2),
+    <t1: WithPos<InfixExpr>> "|>" <t2: WithPos<InfixExpr>> =>
+        mk_app!(t2, t1),
 
     #[precedence(level="7")] #[assoc(side="left")]
     <t1: WithPos<InfixExpr>> "<" <t2: WithPos<InfixExpr>> =>
@@ -576,6 +578,7 @@ extern {
         "fun" => Token::Normal(NormalToken::Fun),
         "import" => Token::Normal(NormalToken::Import),
         "|" => Token::Normal(NormalToken::Pipe),
+        "|>" => Token::Normal(NormalToken::RightPipe),
         "->" => Token::Normal(NormalToken::SimpleArrow),
         "=>" => Token::Normal(NormalToken::DoubleArrow),
         "#" => Token::Normal(NormalToken::Hash),

--- a/src/parser/lexer.rs
+++ b/src/parser/lexer.rs
@@ -130,6 +130,8 @@ pub enum NormalToken<'input> {
     Import,
     #[token("|")]
     Pipe,
+    #[token("|>")]
+    RightPipe,
     #[token("->")]
     SimpleArrow,
     #[token("=>")]

--- a/tests/pass/builtins.ncl
+++ b/tests/pass/builtins.ncl
@@ -19,4 +19,12 @@ let Assert = fun l x => x || %blame% l in
   let r = {a=(inj 1),b=(cat "a" "b")} in
   %deepSeq% r (r.a.b) == 3 | #Assert) &&
 
+([1,2,3]
+ |> lists.map (fun x => x + 1)
+ |> lists.filter (fun x => x > 2)
+ |> builtins.serialize `Json
+ |> builtins.deserialize `Json
+ == [3,4]
+ | #Assert) &&
+
 true


### PR DESCRIPTION
Close #455. Add a reverse application operator to nicely write a sequence of transformation as something like a Unix pipeline.

Usually you want this operator to not take precedence too much, to avoid parentheses around the initial expression such as `x * 2 |> nums.pow 2` and such that it can also serve as a Haskell's `$`, just reversed. I put it at a similar precedence level as in OCaml, where it takes higher precedence than boolean operators like `&&` and `||`. However Haskell's `$` and Elm `|>` take the lowest precedence of all operators, even than boolean ones. I'm not sure how much it matters: should `foo && bar |> stuff |> otherstuff` be interpreted as `foo && (bar |> stuff |> otherstuff)` or `(foo && bar) |> stuff |> otherstuff`? I don't have a strong opinion, although I arbitrarily prefer the first option, as is implemented in this PR.