### PR TITLE
Implement User-defined types with TypeAliasEnv to store recurrent type definitions

### DIFF
--- a/examples/user-defined-types/user-defined-types.ncl
+++ b/examples/user-defined-types/user-defined-types.ncl
@@ -1,0 +1,34 @@
+typealias Type1 = { foo: Num, bar: Str } in
+typealias Type2 = { rec: Type1, foobool: Bool } in
+typealias Type3 = { recrec: Type2, rec: Type1, foo: Num } in
+
+typealias FctType = forall a b. (a -> b) -> List a -> List b in
+
+let maptest : forall a b. (a -> b) -> List a -> List b = fun f l => %map% l f in
+//let map1 : FctType = fun f l => %map% l f in
+//let map2 : FctType = fun f l => %map% l f in
+
+let f = fun x => x in
+
+{
+    mylist0 = maptest (fun z => z*4) [4, 6],
+//    mylist1 = map1 (fun x => x*2) [3, 5],
+//    mylist2 = map2 (fun y => y*5) [5, 10],
+
+//    outofscope_type = (typealias foo = Num in (f (0 : foo)) : foo) + (f 5),
+
+    data : Type3 = {
+        recrec = {
+            rec = {
+                foo = 3,
+                bar = "recrec",
+            },
+            foobool = false,
+        },
+        rec = {
+            foo = 5,
+            bar = "rec",
+        },
+        foo = 42,
+    },
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -418,9 +418,6 @@ impl ParseError {
                 InternalParseError::Lexical(LexicalError::InvalidAsciiEscapeCode(location)) => {
                     ParseError::InvalidAsciiEscapeCode(mk_span(file_id, location, location + 2))
                 }
-                InternalParseError::UnboundTypeVariables(idents, span) => {
-                    ParseError::UnboundTypeVariables(idents, span)
-                }
             },
         }
     }

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -614,26 +614,7 @@ where
                 }
             },
             Term::Promise(ty, mut l, t) => {
-                l.arg_pos = t.pos;
-                let thunk = Thunk::new(
-                    Closure {
-                        body: t,
-                        env: env.clone(),
-                    },
-                    IdentKind::Lam(),
-                );
-                l.arg_thunk = Some(thunk.clone());
-
-                stack.push_tracked_arg(thunk, pos.into_inherited());
-                stack.push_arg(
-                    Closure::atomic_closure(Term::Lbl(l).into()),
-                    pos.into_inherited(),
-                );
-
-                Closure {
-                    body: ty.contract(),
-                    env,
-                }
+                unreachable!();
             }
             Term::RecRecord(ts, dyn_fields, attrs) => {
                 // Thanks to the share normal form transformation, the content is either a constant or a

--- a/src/grammar.lalrpop
+++ b/src/grammar.lalrpop
@@ -7,7 +7,7 @@ use lalrpop_util::ErrorRecovery;
 
 use super::ExtendedTerm;
 use super::utils::{StringKind, mk_pos, mk_label, mk_span, strip_indent, SwitchCase,
-    FieldPathElem, strip_indent_doc, build_record, elaborate_field_path, check_unbound,
+    FieldPathElem, strip_indent_doc, build_record, elaborate_field_path,
     ChunkLiteralPart, RecordLastField};
 use super::lexer::{Token, NormalToken, StringToken, MultiStringToken};
 
@@ -22,9 +22,8 @@ use crate::types::{Types, AbsType};
 grammar<'input, 'err>(src_id: FileId, errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParseError>>);
 
 WithPos<Rule>: RichTerm = <l: @L> <t: Rule> <r: @R> => t.with_pos(mk_pos(src_id, l, r));
-CheckUnbound<Rule>: Types = <l: @L> <t: Rule> <r: @R> =>? check_unbound(&t, mk_span(src_id, l, r)).map_err(|e| lalrpop_util::ParseError::User{error: e}).and(Ok(t));
 
-TypeAnnot: MetaValue = ":" <l: @L> <ty_res: CheckUnbound<Types>> <r: @R> => MetaValue {
+TypeAnnot: MetaValue = ":" <l: @L> <ty_res: Types> <r: @R> => MetaValue {
     doc: None,
     types: Some(Contract {types: ty_res.clone(), label: mk_label(ty_res, src_id, l, r)}),
     contracts: Vec::new(),
@@ -33,7 +32,7 @@ TypeAnnot: MetaValue = ":" <l: @L> <ty_res: CheckUnbound<Types>> <r: @R> => Meta
 };
 
 MetaAnnotAtom: MetaValue = {
-    "|" <l: @L> <ty_res: CheckUnbound<Types>> <r: @R> => MetaValue {
+    "|" <l: @L> <ty_res: Types> <r: @R> => MetaValue {
         doc: None,
         types: None,
         contracts: vec![Contract {types: ty_res.clone(), label: mk_label(ty_res, src_id, l, r)}],

--- a/src/grammar.lalrpop
+++ b/src/grammar.lalrpop
@@ -88,6 +88,10 @@ pub ExtendedTerm: ExtendedTerm = {
 }
 
 RootTerm: RichTerm = {
+    "typealias" <id:Ident> "=" <ty: Types> "in" <rest: Term> => {
+        mk_term::let_in(id.clone(), Term::TypeAlias(id, ty), rest)
+    },
+
     "let" <id:Ident> <meta: Annot?> "=" <t1: Term> "in"
         <t2: Term> => {
         let t1 = if let Some(mut meta) = meta {
@@ -540,6 +544,7 @@ extern {
         "multstr literal" => Token::MultiStr(MultiStringToken::Literal(<&'input str>)),
         "num literal" => Token::Normal(NormalToken::NumLiteral(<f64>)),
 
+        "typealias" => Token::Normal(NormalToken::TypeDef),
         "if" => Token::Normal(NormalToken::If),
         "then" => Token::Normal(NormalToken::Then),
         "else" => Token::Normal(NormalToken::Else),

--- a/src/parser/error.rs
+++ b/src/parser/error.rs
@@ -17,6 +17,4 @@ pub enum LexicalError {
 pub enum ParseError {
     /// A specific lexical error
     Lexical(LexicalError),
-    /// Unbound type variable(s)
-    UnboundTypeVariables(Vec<Ident>, RawSpan),
 }

--- a/src/parser/lexer.rs
+++ b/src/parser/lexer.rs
@@ -56,6 +56,8 @@ pub enum NormalToken<'input> {
     #[token("List")]
     List,
 
+    #[token("typealias")]
+    TypeDef,
     #[token("if")]
     If,
     #[token("then")]

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -369,30 +369,3 @@ fn line_comments() {
         parse_without_pos("{field = foo}")
     );
 }
-
-#[test]
-fn unbound_type_variables() {
-    // should fail, "a" is unbound
-    assert_matches!(
-        parse("1 | a"),
-        Err(ParseError::UnboundTypeVariables(unbound_vars, _)) if (unbound_vars.contains(&Ident("a".into())) && unbound_vars.len() == 1)
-    );
-
-    // should fail, "d" is unbound
-    assert_matches!(
-        parse("null: forall a b c. a -> (b -> List c) -> {foo : List {_ : d}, bar: b | Dyn}"),
-        Err(ParseError::UnboundTypeVariables(unbound_vars, _)) if (unbound_vars.contains(&Ident("d".into())) && unbound_vars.len() == 1)
-    );
-
-    // should fail, "e" is unbound
-    assert_matches!(
-        parse("null: forall a b c. a -> (b -> List c) -> {foo : List {_ : a}, bar: b | e}"),
-        Err(ParseError::UnboundTypeVariables(unbound_vars, _)) if (unbound_vars.contains(&Ident("e".into())) && unbound_vars.len() == 1)
-    );
-
-    // should fail, "a" is unbound
-    assert_matches!(
-        parse("null: a -> (forall a. a -> a)"),
-        Err(ParseError::UnboundTypeVariables(unbound_vars, _)) if (unbound_vars.contains(&Ident("a".into())) && unbound_vars.len() == 1)
-    );
-}

--- a/src/parser/utils.rs
+++ b/src/parser/utils.rs
@@ -7,10 +7,9 @@ use crate::identifier::Ident;
 /// A few helpers to generate position spans and labels easily during parsing
 use crate::label::Label;
 use crate::mk_app;
-use crate::parser::error::ParseError;
 use crate::position::{RawSpan, TermPos};
 use crate::term::{make as mk_term, BinaryOp, RecordAttrs, RichTerm, StrChunk, Term};
-use crate::types::{AbsType, Types};
+use crate::types::Types;
 
 /// Distinguish between the standard string separators `"`/`"` and the multi-line string separators
 /// `m#"`/`"#m` in the parser.
@@ -394,65 +393,4 @@ pub fn strip_indent_doc(doc: String) -> String {
         })
         .next()
         .expect("expected non-empty chunks after indentation of documentation")
-}
-
-/// Recursively checks for unbound type variables in a type
-pub fn check_unbound(types: &Types, span: RawSpan) -> Result<(), ParseError> {
-    // heavy lifting function, recurses into a type expression and returns a set of unbound vars
-    fn find_unbound_vars(types: &Types, unbound_set: &mut HashSet<Ident>) {
-        match &types.0 {
-            AbsType::Var(ident) => {
-                unbound_set.insert(ident.clone());
-            }
-            AbsType::Forall(ident, ty) => {
-                // forall needs a "scoped" set for the variables in its nodes
-                let mut forall_unbound_vars = HashSet::new();
-                find_unbound_vars(&ty, &mut forall_unbound_vars);
-
-                forall_unbound_vars.remove(ident);
-
-                // once the forall vars are recursed into and analyzed, the parent set and
-                // the forall set are merged
-                unbound_set.extend(forall_unbound_vars);
-            }
-            AbsType::Arrow(s, t) => {
-                find_unbound_vars(&s, unbound_set);
-                find_unbound_vars(&t, unbound_set);
-            }
-            AbsType::DynRecord(ty)
-            | AbsType::StaticRecord(ty)
-            | AbsType::List(ty)
-            | AbsType::Enum(ty) => {
-                find_unbound_vars(&ty, unbound_set);
-            }
-            AbsType::RowExtend(_, opt_ty, ty) => {
-                if let Some(ty) = opt_ty {
-                    find_unbound_vars(&ty, unbound_set);
-                }
-
-                find_unbound_vars(&ty, unbound_set);
-            }
-            AbsType::Dyn()
-            | AbsType::Bool()
-            | AbsType::Num()
-            | AbsType::Str()
-            | AbsType::Sym()
-            | AbsType::Flat(_)
-            | AbsType::RowEmpty() => {}
-        }
-    }
-
-    let mut unbound_set: HashSet<Ident> = HashSet::new();
-
-    // recurse into type and find unbound type vars
-    find_unbound_vars(&types, &mut unbound_set);
-
-    if !unbound_set.is_empty() {
-        return Err(ParseError::UnboundTypeVariables(
-            unbound_set.into_iter().collect(),
-            span,
-        ));
-    }
-
-    Ok(())
 }

--- a/src/term.rs
+++ b/src/term.rs
@@ -43,6 +43,9 @@ pub enum Term {
     Num(f64),
     /// A literal string.
     Str(String),
+
+    #[serde(skip)]
+    TypeAlias(Ident, Types),
     /// A string containing interpolated expressions, represented as a list of either literals or
     /// expressions.
     ///
@@ -317,7 +320,7 @@ impl Term {
                 });
             }
             Bool(_) | Num(_) | Str(_) | Lbl(_) | Var(_) | Sym(_) | Enum(_) | Import(_)
-            | ResolvedImport(_) => {}
+            | TypeAlias(..) | ResolvedImport(_) => {}
             Fun(_, ref mut t)
             | Op1(_, ref mut t)
             | Promise(_, _, ref mut t)
@@ -379,6 +382,7 @@ impl Term {
             | Term::Promise(_, _, _)
             | Term::Import(_)
             | Term::ResolvedImport(_)
+            | Term::TypeAlias(..)
             | Term::StrChunks(_)
             | Term::ParseError => None,
         }
@@ -405,6 +409,7 @@ impl Term {
 
                 format!("\"{}\"", chunks_str.join(""))
             }
+            Term::TypeAlias(Ident(id), _) => format!("<typealias {}>", id),
             Term::Fun(_, _) => String::from("<func>"),
             Term::Lbl(_) => String::from("<label>"),
             Term::Enum(Ident(s)) => format!("`{}", s),
@@ -502,6 +507,7 @@ impl Term {
             | Term::Import(_)
             | Term::ResolvedImport(_)
             | Term::StrChunks(_)
+            | Term::TypeAlias(..)
             | Term::RecRecord(..)
             | Term::ParseError => false,
         }
@@ -541,6 +547,7 @@ impl Term {
             | Term::Import(_)
             | Term::ResolvedImport(_)
             | Term::StrChunks(_)
+            | Term::TypeAlias(..)
             | Term::RecRecord(..)
             | Term::ParseError => false,
         }
@@ -898,6 +905,7 @@ impl RichTerm {
             | v @ Term::Var(_)
             | v @ Term::Enum(_)
             | v @ Term::Import(_)
+            | v @ Term::TypeAlias(..)
             | v @ Term::ResolvedImport(_) => RichTerm {
                 term: Box::new(v),
                 pos,


### PR DESCRIPTION
Implement user-defined types definition using a new syntax `let type ... in ...`.
Uses a TypeAliasEnv to store user-defined types and replace the `ident` given with the definition stored when performing typchecking and transformation.

The changes looks big because it adds an environment in places where they weren't before, but to keep it simple:
- If we encounter a `Term::TypeAlias(ident, type)`, we store the `type` in the environment with key `ident`
- Later on the process (typecheck or transform), if we encounter the type definition `ident`, we fetch the `type` from the environment and perform the operations on it instead.

Quick Nickel code to test it out:
```
let type recType = { foo: Num } in
let type mapType = forall a b. (a -> b) -> List a -> List b in 

let mylib = {
    mymap : mapType = fun f l => %map% l f,
    mymap_standard : forall a b. (a -> b) -> List a -> List b = fun f l => %map% l f,
    recTest1 : recType = { foo = 4 },
    recTest2 : recType = { foo = 5 },
} in 

{
    test = mylib.mymap (fun x => x * 2) [2, 4, 6, 8, 10, 12],
    test_standard = mylib.mymap_standard (fun x => x * 2) [2, 4, 6, 8, 10, 12],

    testrec1 = mylib.recTest1,
    testrec2 = mylib.recTest2,
}
```
Everything should work well, and inducing an error like `recTest2 : recType = { foo = 5, bar = false},` should return a typechecking error with the corresponding hints as if the type alias was written by hand.

Feature request #422 
