### PR TITLE
Add the substituter to flake.nix and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,9 +75,11 @@ abstractions or just feel ad hoc. Nickel buys you more for less.
 
 1. Start Nickel
    * with [flake-enabled](https://nixos.wiki/wiki/Flakes) Nix directly
-     with `nix run nickel` (which pulls it from the global flakes registry), or
-     with `nix run github:tweag/nickel` (which pulls it from the repo). You
-     pass in arguments with an extra `--` as in `nix run nickel -- repl`,
+     with `nix run nickel` (which pulls it from the global flakes
+     registry), or with `nix run github:tweag/nickel` (which pulls it
+     from the repo). You can use [our binary cache](https://nickel.cachix.org) to
+     prevent rebuilding a lot of packages. You pass in arguments with
+     an extra `--` as in `nix run nickel -- repl`,
    * with `./nickel`, after [building](#Build) this repo, depending on the
      location of the executable and passing in arguments directly,
    * or with `cargo run` after [building](#Build), passing in arguments with
@@ -126,7 +128,9 @@ for help about a specific subcommand.
      ```console
      $ nix-shell shell.nix
      ```
-     to be dropped in a shell, ready to build.
+     to be dropped in a shell, ready to build. You can use [our binary
+     cache](https://nickel.cachix.org) to prevent rebuilding a lot of
+     packages.
    - **Without Nix**: otherwise, follow [this guide][rust-guide] to install Rust
      and Cargo first.
 2. Build Nickel:

--- a/flake.nix
+++ b/flake.nix
@@ -6,6 +6,11 @@
   inputs.nixpkgs-mozilla.url = "github:nickel-lang/nixpkgs-mozilla/flake";
   inputs.import-cargo.url = "github:edolstra/import-cargo";
 
+  nixConfig = {
+    substituters = [ "https://nickel.cachix.org" ];
+    trusted-public-keys = [ "nickel.cachix.org-1:ABoCOGpTJbAum7U6c+04VbjvLxG9f0gJP5kYihRRdQs=" ];
+  };
+
   outputs = { self, nixpkgs, nixpkgs-wasm, nixpkgs-mozilla, import-cargo }:
     let
 


### PR DESCRIPTION
We already have a binary cache on cachix that has all the dependencies
cached. Why not tell people about it?

Adds the `nixConfig.substituters` (and `trusted-public-keys`) options
to `flake.nix`, so that newer Nix versions pick it up automatically,
provided the user has the necessary permissions or runs a single-user
store, and mentions the existance of the binary cache in the README
for those still using older Nix or not being a trusted user.

The public key is taken from https://nickel.cachix.org .
