### PR TITLE
Fix `lists.reverse`

### DIFF
--- a/stdlib/lists.ncl
+++ b/stdlib/lists.ncl
@@ -155,7 +155,7 @@
             [ 3, 2, 1 ]
         ```
         "#m
-      = fun l => foldl (fun acc e => acc @ [e]) [] l,
+      = fun l => foldl (fun acc e => [e] @ acc) [] l,
 
     filter : forall a. (a -> Bool) -> List a -> List a
       | doc m#"


### PR DESCRIPTION
Right now, it doesn't do anything :)

```
reverse [ 1, 2, 3 ]
== f ( f ( f [] 1 ) 2 ) 3
== (([] @ [1]) @ [2]) @ [3]
```