### PR TITLE
Use Closure and type definition environment during typechecking to check unbound types

### DIFF
--- a/lsp/nls/src/cache.rs
+++ b/lsp/nls/src/cache.rs
@@ -14,7 +14,7 @@ pub trait CacheExt {
     fn typecheck_with_analysis(
         &mut self,
         file_id: FileId,
-        global_env: &typecheck::Environment,
+        global_env: &typecheck::GlobalEnvironment,
         lin_cache: &mut HashMap<FileId, Completed>,
     ) -> Result<CacheOp<()>, CacheError<TypecheckError>>;
 }
@@ -34,7 +34,7 @@ impl CacheExt for Cache {
     fn typecheck_with_analysis<'a>(
         &mut self,
         file_id: FileId,
-        global_env: &typecheck::Environment,
+        global_env: &typecheck::GlobalEnvironment,
         lin_cache: &mut HashMap<FileId, Completed>,
     ) -> Result<CacheOp<()>, CacheError<TypecheckError>> {
         if !self.terms_mut().contains_key(&file_id) {

--- a/lsp/nls/src/server.rs
+++ b/lsp/nls/src/server.rs
@@ -17,7 +17,7 @@ use lsp_types::{
 };
 
 use nickel::cache::Cache;
-use nickel::typecheck::{linearization::Completed, Environment};
+use nickel::typecheck::{linearization::Completed, GlobalEnvironment};
 
 use crate::{
     requests::{completion, goto, hover, symbols},
@@ -28,7 +28,7 @@ pub struct Server {
     pub connection: Connection,
     pub cache: Cache,
     pub lin_cache: HashMap<FileId, Completed>,
-    pub global_env: Environment,
+    pub global_env: GlobalEnvironment,
 }
 
 impl Server {

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -77,14 +77,14 @@ pub struct GlobalEnv {
     /// The typing environment, counterpart of the eval environment for typechecking. Entries are
     /// [`TypeWrapper`](../typecheck/enum.TypeWrapper.html) for the ease of interacting with the
     /// typechecker, but there are not any unification variable in it.
-    pub type_env: typecheck::Environment,
+    pub type_env: typecheck::GlobalEnvironment,
 }
 
 impl GlobalEnv {
     pub fn new() -> Self {
         GlobalEnv {
             eval_env: eval::Environment::new(),
-            type_env: typecheck::Environment::new(),
+            type_env: typecheck::GlobalEnvironment::new(),
         }
     }
 }
@@ -406,7 +406,7 @@ impl Cache {
     pub fn typecheck(
         &mut self,
         file_id: FileId,
-        global_env: &typecheck::Environment,
+        global_env: &typecheck::GlobalEnvironment,
     ) -> Result<CacheOp<()>, CacheError<TypecheckError>> {
         match self.terms.get(&file_id) {
             Some(CachedTerm { state, .. }) if *state >= EntryState::Typechecked => {
@@ -598,7 +598,7 @@ impl Cache {
     pub fn prepare(
         &mut self,
         file_id: FileId,
-        global_env: &typecheck::Environment,
+        global_env: &typecheck::GlobalEnvironment,
     ) -> Result<CacheOp<()>, Error> {
         let mut result = CacheOp::Cached(());
 
@@ -643,7 +643,7 @@ impl Cache {
     pub fn prepare_nocache(
         &mut self,
         file_id: FileId,
-        global_env: &typecheck::Environment,
+        global_env: &typecheck::GlobalEnvironment,
     ) -> Result<(RichTerm, Vec<FileId>), Error> {
         let (term, errs) = self.parse_nocache(file_id)?;
         if errs.no_errors() {
@@ -814,7 +814,7 @@ impl Cache {
 
     /// Generate a global typing environment from the list of `file_ids` corresponding to the standard
     /// library parts.
-    pub fn mk_types_env(&self) -> Result<typecheck::Environment, CacheError<Void>> {
+    pub fn mk_types_env(&self) -> Result<typecheck::GlobalEnvironment, CacheError<Void>> {
         let stdlib_terms_vec =
             self.stdlib_ids
                 .as_ref()
@@ -828,7 +828,7 @@ impl Cache {
                         })
                         .collect())
                 })?;
-        Ok(typecheck::Envs::mk_global(stdlib_terms_vec).unwrap())
+        Ok(typecheck::mk_global(stdlib_terms_vec).unwrap())
     }
 
     /// Generate a global evaluation environment from the list of `file_ids` corresponding to the standard

--- a/src/error.rs
+++ b/src/error.rs
@@ -438,9 +438,6 @@ impl ParseError {
                 InternalParseError::Lexical(LexicalError::InvalidAsciiEscapeCode(location)) => {
                     ParseError::InvalidAsciiEscapeCode(mk_span(file_id, location, location + 2))
                 }
-                InternalParseError::UnboundTypeVariables(idents, span) => {
-                    ParseError::UnboundTypeVariables(idents, span)
-                }
             },
         }
     }

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -1018,7 +1018,7 @@ where
                 }
             }
             // Unwrapping of enriched terms
-            Term::MetaValue(mut meta) if enriched_strict => {
+            Term::MetaValue(meta) if enriched_strict => {
                 if meta.value.is_some() {
                     /* Since we are forcing a metavalue, we are morally evaluating `force t` rather
                      * than `t` iteself.  Updating a thunk after having performed this forcing may

--- a/src/grammar.lalrpop
+++ b/src/grammar.lalrpop
@@ -21,9 +21,8 @@ use crate::types::{Types, AbsType};
 grammar<'input, 'err>(src_id: FileId, errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParseError>>);
 
 WithPos<Rule>: RichTerm = <l: @L> <t: Rule> <r: @R> => t.with_pos(mk_pos(src_id, l, r));
-CheckUnbound<Rule>: Types = <l: @L> <t: Rule> <r: @R> =>? check_unbound(&t, mk_span(src_id, l, r)).map_err(|e| lalrpop_util::ParseError::User{error: e}).and(Ok(t));
 
-TypeAnnot: MetaValue = ":" <l: @L> <ty_res: CheckUnbound<Types>> <r: @R> => MetaValue {
+TypeAnnot: MetaValue = ":" <l: @L> <ty_res: Types> <r: @R> => MetaValue {
     doc: None,
     types: Some(Contract {types: ty_res.clone(), label: mk_label(ty_res, src_id, l, r)}),
     contracts: Vec::new(),
@@ -32,7 +31,7 @@ TypeAnnot: MetaValue = ":" <l: @L> <ty_res: CheckUnbound<Types>> <r: @R> => Meta
 };
 
 MetaAnnotAtom: MetaValue = {
-    "|" <l: @L> <ty_res: CheckUnbound<Types>> <r: @R> => MetaValue {
+    "|" <l: @L> <ty_res: Types> <r: @R> => MetaValue {
         doc: None,
         types: None,
         contracts: vec![Contract {types: ty_res.clone(), label: mk_label(ty_res, src_id, l, r)}],

--- a/src/parser/error.rs
+++ b/src/parser/error.rs
@@ -1,6 +1,3 @@
-use crate::identifier::Ident;
-use crate::position::RawSpan;
-
 #[derive(Clone, PartialEq, Debug)]
 pub enum LexicalError {
     /// A closing brace '}' does not match an opening brace '{'.
@@ -17,6 +14,4 @@ pub enum LexicalError {
 pub enum ParseError {
     /// A specific lexical error
     Lexical(LexicalError),
-    /// Unbound type variable(s)
-    UnboundTypeVariables(Vec<Ident>, RawSpan),
 }

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -373,30 +373,3 @@ fn line_comments() {
         parse_without_pos("{field = foo}")
     );
 }
-
-#[test]
-fn unbound_type_variables() {
-    // should fail, "a" is unbound
-    assert_matches!(
-        parse("1 | a"),
-        Err(ParseError::UnboundTypeVariables(unbound_vars, _)) if (unbound_vars.contains(&Ident::from("a")) && unbound_vars.len() == 1)
-    );
-
-    // should fail, "d" is unbound
-    assert_matches!(
-        parse("null: forall a b c. a -> (b -> List c) -> {foo : List {_ : d}, bar: b | Dyn}"),
-        Err(ParseError::UnboundTypeVariables(unbound_vars, _)) if (unbound_vars.contains(&Ident::from("d")) && unbound_vars.len() == 1)
-    );
-
-    // should fail, "e" is unbound
-    assert_matches!(
-        parse("null: forall a b c. a -> (b -> List c) -> {foo : List {_ : a}, bar: b | e}"),
-        Err(ParseError::UnboundTypeVariables(unbound_vars, _)) if (unbound_vars.contains(&Ident::from("e")) && unbound_vars.len() == 1)
-    );
-
-    // should fail, "a" is unbound
-    assert_matches!(
-        parse("null: a -> (forall a. a -> a)"),
-        Err(ParseError::UnboundTypeVariables(unbound_vars, _)) if (unbound_vars.contains(&Ident::from("a")) && unbound_vars.len() == 1)
-    );
-}

--- a/src/repl/mod.rs
+++ b/src/repl/mod.rs
@@ -75,7 +75,7 @@ pub struct REPLImpl {
     env: GlobalEnv,
     /// The initial type environment, without the toplevel declarations made inside the REPL. Used
     /// to typecheck imports in a fresh environment.
-    init_type_env: typecheck::Environment,
+    init_type_env: typecheck::GlobalEnvironment,
 }
 
 impl REPLImpl {
@@ -85,7 +85,7 @@ impl REPLImpl {
             cache: Cache::new(),
             parser: grammar::ExtendedTermParser::new(),
             env: GlobalEnv::new(),
-            init_type_env: typecheck::Environment::new(),
+            init_type_env: typecheck::GlobalEnvironment::new(),
         }
     }
 
@@ -229,7 +229,8 @@ impl REPL for REPLImpl {
 
         Ok(typecheck::apparent_type(
             term.as_ref(),
-            Some(&typecheck::Envs::from_global(&self.env.type_env)),
+            Some((&typecheck::Envs::new(), &self.init_type_env)),
+            //&typecheck::Envs::from_global(&self.env.type_env)),
         )
         .into())
     }

--- a/tests/typecheck_fail.rs
+++ b/tests/typecheck_fail.rs
@@ -4,11 +4,11 @@ use nickel::cache::resolvers::DummyResolver;
 use nickel::error::TypecheckError;
 use nickel::parser::{grammar, lexer};
 use nickel::term::RichTerm;
-use nickel::typecheck::{type_check_in_env, Environment};
+use nickel::typecheck::{type_check_in_env, GlobalEnvironment};
 use nickel::types::Types;
 
 fn type_check(rt: &RichTerm) -> Result<Types, TypecheckError> {
-    type_check_in_env(rt, &Environment::new(), &mut DummyResolver {})
+    type_check_in_env(rt, &GlobalEnvironment::new(), &mut DummyResolver {})
 }
 
 fn type_check_expr(s: impl std::string::ToString) -> Result<Types, TypecheckError> {


### PR DESCRIPTION
Add a `typedef` field to the typechecker environment, that will check if a variable  is defined in the environment before raising an error.
Also removes anything related to types in the `parser`

Useful for future fix of PR #464 
Can be also used for future modifications related to #202 