### PR TITLE
[Overriding]Reversible thunks

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -190,10 +190,9 @@ impl ThunkData {
     pub fn into_closure(self) -> Closure {
         match self.inner {
             InnerThunkData::Standard(closure) => closure,
-            InnerThunkData::Reversible { orig, cached: None } => match Rc::try_unwrap(orig) {
-                Ok(inner) => inner,
-                Err(rc) => (*rc).clone(),
-            },
+            InnerThunkData::Reversible { orig, cached: None } => {
+                Rc::try_unwrap(orig).unwrap_or_else(|rc| (*rc).clone())
+            }
             InnerThunkData::Reversible {
                 cached: Some(cached),
                 ..

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -223,7 +223,7 @@ impl ThunkData {
 /// A thunk is a shared suspended computation. It is the primary device for the implementation of
 /// lazy evaluation.
 ///
-/// For the implementation of recursive merging, some thunks need to be revertible, in the sense
+/// For the implementation of recursive merging, some thunks need to be reversible, in the sense
 /// that we must be able to restore the original expression before update. Those are called
 /// reversible thunks. Most expressions don't need reversible thunks as their evaluation will
 /// always give the same result, but some others, such as the ones containing recursive references
@@ -248,7 +248,7 @@ impl Thunk {
         }
     }
 
-    /// Create a new revertible thunk.
+    /// Create a new reversible thunk.
     pub fn new_rev(closure: Closure, ident_kind: IdentKind) -> Self {
         Thunk {
             data: Rc::new(RefCell::new(ThunkData::new_rev(closure))),


### PR DESCRIPTION
Preparatory PR for the implementation of #330. Add support for reversible thunks, although they aren't put to use yet.

## Context

#330 requires a new device for evaluation. In this model, both recursive fields and merge expressions may be interpreted differently depending on the context. The simplest example is the one of overriding:

```
let r = { foo = bar + 1, bar | default = 0} in
r.foo + (r & {bar = 1}).foo
```

Here, the same original expression inside `foo` must be evaluated differently: as `1` in `r.foo`, but as `2` in `(r & {bar = 1}).foo`. The same thing happens with merging and custom merge functions: a sub expression `x1 & x2` may evaluate differently depending on a `| merge f` annotation being there in the same merge tree.

## A call-by-name semantics with caching

At first it doesn't seem obvious how to reconcile this with the usual call-by-need model based on thunks that are updated once in a destructive manner. Rather, we should understand our semantics as fundamentally call-by-name, be it for merge or recursive records. Then, the thunks are just an external caching (or memoization) mechanism for performance matter.

In the classical call-by-need setting, it just turns out that this caching mechanism is really simple: the cache is destructively updated once with the evaluated form of an expression, and never invalidated anymore. Morally, we are memoizing functions `unit -> a`.

In our setting, the fields of a recursive record (resp. merge expressions) can be seen rather as function `Self -> a` where `Self` represents the current, final record (resp. `MergeFun -> a`). Caching must thus be slightly more general.

## Reversible thunks

The proposed solution, as implemented in this PR, is to add a second type of thunks, called reversible thunks. Those not only cache a value, but also store the original expression, that can be restored even once updated. The `Thunk` type can either contain a standard thunk or a reversible thunk, such that all the code operating on thunks doesn't need to know about them and remains unchanged: we just add a `restore` capability, that either restores the original expression for reversible thunks, or is a simple `clone` for standard thunks. Reversible thunks will then have to be introduced explicitly for expressions that need to (record fields and merge expressions) and restored explicitly before operations that are known to potentially invalidate them (merging).