### PR TITLE
[Stdlib] Add blameWith and fromPred

### DIFF
--- a/examples/config-gcc/config-gcc.ncl
+++ b/examples/config-gcc/config-gcc.ncl
@@ -9,19 +9,20 @@ let GccFlag =
       lists.any (fun x => x == strings.substring value 0 1) available then
       value
     else
-      contracts.blame (contracts.tag "unknown flag #{value}" label)
+      contracts.blameWith "unknown flag #{value}" label
   else if builtins.isRecord value then
     if records.hasField "flag" value && records.hasField "arg" value then
       if lists.any (fun x => x == value.flag) available then
         //Normalize the tag to a string
         value.flag ++ value.arg
       else
-        contracts.blame (contracts.tag "unknown flag #{value.flag}")
+        contracts.blameWith "unknown flag #{value.flag}" label
     else
-      contracts.blame (contracts.tag "bad record structure: missing field
-        `flag` or `arg`" label)
+      contracts.blameWith
+        "bad record structure: missing field `flag` or `arg`"
+        label
   else
-    contracts.blame (contracts.tag "expected record or string") in
+    contracts.blameWith "expected record or string" label in
 
 let Path =
   let pattern = m#"^(.+)/([^/]+)$"#m in
@@ -30,18 +31,18 @@ let Path =
       if strings.isMatch value pattern then
         value
       else
-        contracts.blame (contracts.tag "invalid path" label)
+        contracts.blameWith "invalid path" label
     else
-      contracts.blame (contracts.tag "not a string" label) in
+      contracts.blameWith "not a string" label in
 
 let SharedObjectFile = fun label value =>
   if builtins.isStr value then
     if strings.isMatch value m#"\.so$"#m then
       value
     else
-      contracts.blame (contracts.tag "not an .so file" label)
+      contracts.blameWith "not an .so file" label
   else
-    contracts.blame (contracts.tag "not a string" label) in
+    contracts.blameWith "not a string" label in
 
 let OptLevel = fun label value =>
   if value == 0 || value == 1 || value == 2 then

--- a/examples/record-contract/record-contract.ncl
+++ b/examples/record-contract/record-contract.ncl
@@ -1,23 +1,18 @@
 // An illustrative (thus incomplete and maybe incorrect) contract example for a
 // Kubernetes configuration.
 
-let Port | doc "A contract for a port number" =
-  fun label value =>
-    if builtins.isNum value &&
-      value % 1 == 0 &&
-      value >= 0 &&
-      value <= 65535
-    then
-      value
-    else
-      contracts.blame label in
+let Port | doc "A contract for a port number" = contracts.fromPred (fun value =>
+  builtins.isNum value &&
+  value % 1 == 0 &&
+  value >= 0 &&
+  value <= 65535) in
 
 let PortElt
   | doc "A contract for a port element of a Kubernetes configuration"
   = {
-  name | Str,
-  containerPort | #Port,
-} in
+    name | Str,
+    containerPort | #Port,
+  } in
 
 let Container = {
   name | Str,

--- a/examples/simple-contracts/README.md
+++ b/examples/simple-contracts/README.md
@@ -9,6 +9,11 @@ The second one, `simple-contract-div.ncl`, defines simple contracts on numbers
 and illustrates the application of several contracts to one value. It is
 expected to fail, to demonstrate basic error-reporting for contracts.
 
+For illustrative purpose, those contracts are written as plain custom contracts:
+functions `Lbl -> Dyn -> Dyn`. However, they are just boolean predicates here.
+In this case, you should rather write them more succintly as predicates `Dyn ->
+Bool` and use `contracts.fromPred` to obtain the corresponding contracts.
+
 ## Run
 
 ```

--- a/examples/simple-contracts/simple-contract-bool.ncl
+++ b/examples/simple-contracts/simple-contract-bool.ncl
@@ -1,4 +1,6 @@
 // Example of simple custom contract, parametrized by a first argument.
+// In practice, for this kind of simple predicate, one should rather use
+// `contracts.fromPred`
 let EqualsTo = fun referenceValue label value =>
   if referenceValue == value then
     value 

--- a/stdlib/contracts.ncl
+++ b/stdlib/contracts.ncl
@@ -107,7 +107,7 @@
         ```nickel
         let IsZero = fun label value =>
           if value == 0 then value
-          else contracts.blame label in
+          else contracts.blameWith "Not zero" label in
         0 | #IsZero
         ```
         "#m

--- a/stdlib/contracts.ncl
+++ b/stdlib/contracts.ncl
@@ -73,7 +73,80 @@
       else %blame% (%tag% "extra field `#{%head% (%fieldsOf% t)}`" l),
 
   contracts = {
-    blame = fun l => %blame% l,
-    tag = fun msg l => %tag% msg l,
+    blame
+      | doc m#"
+        Raise blame for a given label.
+
+        Type: `forall a. Lbl -> a`
+        (for technical reasons, this element isn't actually statically typed)
+
+        Blame is the mechanism to signal contract violiation in Nickel. It ends
+        the program execution and print a detailed report thanks to the
+        information tracked inside the label.
+
+        For example:
+        ```nickel
+        IsZero = fun label value =>
+          if value == 0 then value
+          else contracts.blame label
+        ```
+        "#m
+      = fun l => %blame% l,
+    blameWith
+      | doc m#"
+        Raise blame with respect to a given label and a custom error message.
+
+        Type: `forall a. Str -> Lbl -> a`
+        (for technical reasons, this element isn't actually statically typed)
+
+        Same as `blame`, but take an additional custom error message that will be
+        displayed as part of the blame error. `blameWith msg l` is equivalent to
+        `blame (tag msg l)
+
+        For example:
+        ```nickel
+        let IsZero = fun label value =>
+          if value == 0 then value
+          else contracts.blame label in
+        0 | #IsZero
+        ```
+        "#m
+      = fun msg l => %blame% (%tag% msg l),
+    fromPred
+      | doc m#"
+        Generate a contract from a boolean predicate.
+
+        Type: `(Dyn -> Bool) -> (Lbl -> Dyn -> Dyn)`
+        (for technical reasons, this element isn't actually statically typed)
+
+        For example:
+        ```
+        let IsZero = contracts.fromPred (fun x => x == 0) in
+        0 | #IsZero
+        ```
+        "#m
+      = fun pred l v => if pred v then v else %blame% l,
+    tag
+      | doc m#"
+        Attach a tag, or a custom error message, to a label. If a tag was
+        previously set, it is erased.
+
+        Type: `Str -> Lbl -> Lbl`
+        (for technical reasons, this element isn't actually statically typed)
+
+        For example:
+        ```
+        let ContractNum = contracts.fromPred (fun x => x > 0 && x < 50) in
+        Contract = fun label value =>
+          if builtins.isNum value then
+            ContractNum
+              (contracts.tag "num subcontract failed! (out of bound)" label)
+              value
+          else
+            value in
+        5 | #Contract
+        ```
+        "#m
+      = fun msg l => %tag% msg l,
   },
 }


### PR DESCRIPTION
This PR adds two functions to the contracts stdlib, adds missing documentation for the remaining ones, and updates the examples accordingly.

## blameWith

The current way to trigger a contract violation with an error is to compose the `blame` function and the `tag` function, which is unncessarily verbose: `contracts.blame (contracts.tag "invalid FizzBuzz number" label)`. This PR adds a `blameWith : Str -> Lbl -> a` function to write `contracts.blameWith "invalid FizzBuzz number" label` instead.

## fromPred 

Independently, we also add the `fromPred : (Dyn -> Bool) -> (Lbl -> Dyn -> Dyn)` function, that turns a boolean predicate into a contract. Currently, one has to write irrelevant boilerplate (the part about returning value and blaming in case of error):

```
let IsZero = fun label value =>
  if value == 0 then value
  else contracts.blame label in
//...
```

With `fromPred`, this becomes:

```
let IsZero = contracts.fromPred (fun value => value == 0) in
```