### PR TITLE
Flip stdlib functions to accommodate use with the |> operator

### DIFF
--- a/examples/config-gcc/config-gcc.ncl
+++ b/examples/config-gcc/config-gcc.ncl
@@ -6,7 +6,7 @@ let GccFlag =
   fun label value =>
   if builtins.isStr value then
     if strings.length value > 0 &&
-      lists.any (fun x => x == strings.substring value 0 1) available then
+      lists.any (fun x => x == strings.substring 0 1 value) available then
       value
     else
       contracts.blameWith "unknown flag #{value}" label

--- a/examples/config-gcc/config-gcc.ncl
+++ b/examples/config-gcc/config-gcc.ncl
@@ -28,7 +28,7 @@ let Path =
   let pattern = m#"^(.+)/([^/]+)$"#m in
   fun label value =>
     if builtins.isStr value then
-      if strings.isMatch value pattern then
+      if strings.isMatch pattern value then
         value
       else
         contracts.blameWith "invalid path" label
@@ -37,7 +37,7 @@ let Path =
 
 let SharedObjectFile = fun label value =>
   if builtins.isStr value then
-    if strings.isMatch value m#"\.so$"#m then
+    if strings.isMatch m#"\.so$"#m value then
       value
     else
       contracts.blameWith "not an .so file" label

--- a/src/serialize.rs
+++ b/src/serialize.rs
@@ -342,7 +342,7 @@ mod tests {
             json!(["a", "bc", "def", "g"])
         );
         assert_json_eq!(
-            r#"lists.fold (fun elt acc => [[elt]] @ acc) [1, 2, 3, 4] []"#,
+            r#"lists.fold (fun elt acc => [[elt]] @ acc) [] [1, 2, 3, 4]"#,
             json!([[1], [2], [3], [4]])
         );
         assert_json_eq!("[\"a\", 1, false, `foo]", json!(["a", 1, false, "foo"]));

--- a/stdlib/builtins.ncl
+++ b/stdlib/builtins.ncl
@@ -28,7 +28,7 @@
       "#m
     = fun x => %isBool% x,
 
-    isStr : Dyn -> Bool 
+    isStr : Dyn -> Bool
     | doc m#"
       Checks if the given value is a string.
 
@@ -70,7 +70,7 @@
       "#m
     = fun x => %isList% x,
 
-    isRecord : Dyn -> Bool 
+    isRecord : Dyn -> Bool
     | doc m#"
       Checks if the given value is a record.
 

--- a/stdlib/contracts.ncl
+++ b/stdlib/contracts.ncl
@@ -92,6 +92,7 @@
         ```
         "#m
       = fun l => %blame% l,
+
     blameWith
       | doc m#"
         Raise blame with respect to a given label and a custom error message.
@@ -112,6 +113,7 @@
         ```
         "#m
       = fun msg l => %blame% (%tag% msg l),
+
     fromPred
       | doc m#"
         Generate a contract from a boolean predicate.
@@ -126,6 +128,7 @@
         ```
         "#m
       = fun pred l v => if pred v then v else %blame% l,
+
     tag
       | doc m#"
         Attach a tag, or a custom error message, to a label. If a tag was

--- a/stdlib/lists.ncl
+++ b/stdlib/lists.ncl
@@ -115,23 +115,23 @@
           let newAcc = f acc (%head% l) in
           %seq% newAcc (foldl f newAcc (%tail% l)),
 
-    fold : forall a b. (a -> b -> b) -> List a -> b -> b
+    fold : forall a b. (a -> b -> b) -> b -> List a -> b
       | doc m#"
         Fold a function over a list.
-        `fold f [x1, x2, ..., xn] init` results in `f x1 (f x2 (... (f xn init) ...))`.
+        `fold f init [x1, x2, ..., xn]` results in `f x1 (f x2 (... (f xn init) ...))`.
 
         For example:
         ```nickel
-          fold (fun e acc => acc @ [e]) [ 1, 2, 3 ] [] =>
+          fold (fun e acc => acc @ [e]) [] [ 1, 2, 3 ] =>
             ((([] @ [3]) @ [2]) @ [1]) =>
             [ 3, 2, 1 ]
         ```
         "#m
-      = fun f l fst =>
+      = fun f fst l =>
         if %length% l == 0 then
           fst
         else
-          f (%head% l) (fold f (%tail% l) fst),
+          f (%head% l) (fold f fst (%tail% l)),
 
     cons : forall a. a -> List a -> List a
       | doc m#"
@@ -179,7 +179,7 @@
             [1, 2, 3, 4]
         ```
         "#m
-      = fun l => fold (fun l acc => l @ acc) l [],
+      = fun l => fold (fun l acc => l @ acc) [] l,
 
     all : forall a. (a -> Bool) -> List a -> Bool
       | doc m#"
@@ -193,7 +193,7 @@
             false
         ```
         "#m
-      = fun pred l => fold (fun x acc => if pred x then acc else false) l true,
+      = fun pred l => fold (fun x acc => if pred x then acc else false) true l,
 
     any : forall a. (a -> Bool) -> List a -> Bool
       | doc m#"
@@ -207,7 +207,7 @@
             false
         ```
         "#m
-      = fun pred l => fold (fun x acc => if pred x then true else acc) l false,
+      = fun pred l => fold (fun x acc => if pred x then true else acc) false l,
 
     elem : Dyn -> List -> Bool
       | doc m#"

--- a/stdlib/lists.ncl
+++ b/stdlib/lists.ncl
@@ -115,7 +115,7 @@
           let newAcc = f acc (%head% l) in
           %seq% newAcc (foldl f newAcc (%tail% l)),
 
-    fold : forall a b. (a -> b -> b) -> List a -> b -> b 
+    fold : forall a b. (a -> b -> b) -> List a -> b -> b
       | doc m#"
         Fold a function over a list.
         `fold f [x1, x2, ..., xn] init` results in `f x1 (f x2 (... (f xn init) ...))`.

--- a/stdlib/lists.ncl
+++ b/stdlib/lists.ncl
@@ -70,7 +70,7 @@
         "#m
       = fun f l => %map% l f,
 
-    elemAt : forall a. List a -> Num -> a
+    elemAt : forall a. Num -> List a -> a
       | doc m#"
         Retrieves the n'th element from a list (0-indexed).
 
@@ -80,7 +80,7 @@
             "three"
         ```
         "#m
-      = fun l n => %elemAt% l n,
+      = fun n l => %elemAt% l n,
 
     concat : forall a. List a -> List a -> List a
       | doc m#"

--- a/stdlib/records.ncl
+++ b/stdlib/records.ncl
@@ -47,6 +47,6 @@
         hasField "one" { one = 1, two = 2 } =>
           true
       "#m
-    = fun r field => %hasField% r field,
+    = fun field r => %hasField% field r,
   }
 }

--- a/stdlib/strings.ncl
+++ b/stdlib/strings.ncl
@@ -276,17 +276,17 @@
 
     replaceRegex: Str -> Str -> Str -> Str
     | doc m#"
-      `replaceRegex str regex repl` replaces every match of `regex` in `str` with `repl`.
+      `replaceRegex regex repl str` replaces every match of `regex` in `str` with `repl`.
 
       For example:
       ```nickel
-        replaceRegex "Hello!" "l+." "j" =>
+        replaceRegex "l+." "j" "Hello!" =>
           "Hej!"
-        replaceRegex "This 37 is a number." "\\d+" "\"a\" is not" =>
-          "This "a" is not a number."
+        replaceRegex "\\d+" "\"a\" is not" "This 37 is a number." =>
+          "This \"a\" is not a number."
       ```
       "#m
-    = fun s pattern replace =>
+    = fun pattern replace s =>
        %strReplaceRegex% s pattern replace,
 
     isMatch : Str -> Str -> Bool

--- a/stdlib/strings.ncl
+++ b/stdlib/strings.ncl
@@ -261,17 +261,17 @@
 
     replace: Str -> Str -> Str -> Str
     | doc m#"
-      `replace str sub repl` replaces every occurence of `sub` in `str` with `repl`.
+      `replace sub repl str` replaces every occurence of `sub` in `str` with `repl`.
 
       For example:
       ```nickel
-        replace "abcdef" "cd" "   " =>
+        replace "cd" "   " "abcdef" =>
           "ab   ef"
-        replace "abcdef" "" "A" =>
+        replace "" "A" "abcdef" =>
           "AaAbAcAdAeAfA"
       ```
       "#m
-    = fun s pattern replace =>
+    = fun pattern replace s =>
        %strReplace% s pattern replace,
 
     replaceRegex: Str -> Str -> Str -> Str

--- a/stdlib/strings.ncl
+++ b/stdlib/strings.ncl
@@ -305,18 +305,18 @@
 
     match : Str -> Str -> {match: Str, index: Num, groups: List Str}
     | doc m#"
-      `match str regex` matches `str` given `regex`. Results in the part of `str` that matched, the index of the
+      `match regex str` matches `str` given `regex`. Results in the part of `str` that matched, the index of the
       first character that was part of the match in `str`, and a lists of all capture groups if any.
 
       For example:
       ```nickel
-        match "5 apples, 6 pears and 0 grapes" "^(\\d).*(\\d).*(\\d).*$" =>
+        match "^(\\d).*(\\d).*(\\d).*$" "5 apples, 6 pears and 0 grapes" =>
           { match = "5 apples, 6 pears and 0 grapes", index = 0, groups = [ "5", "6", "0" ] }
-        match "01234" "3" =>
+        match "3" "01234" =>
           { match = "3", index = 3, groups = [ ] }
       ```
       "#m
-    = fun s regex => %strMatch% s regex,
+    = fun regex s => %strMatch% s regex,
 
     length : Str -> Num
     | doc m#"

--- a/stdlib/strings.ncl
+++ b/stdlib/strings.ncl
@@ -143,13 +143,13 @@
 
       For example:
       ```nickel
-      split "1,2,3" "," =>
+      split "," "1,2,3" =>
         [ "1", "2", "3" ]
-      split "1,2,3" "." =>
+      split "." "1,2,3" =>
         [ "1,2,3" ]
       ```
       "#m
-    = fun s sep => %strSplit% s sep,
+    = fun sep s => %strSplit% s sep,
 
     trim : Str -> Str
     | doc m#"

--- a/stdlib/strings.ncl
+++ b/stdlib/strings.ncl
@@ -121,17 +121,17 @@
         %blame% (%tag% "not a string" l),
 
     // using a contract instead of type for now because of https://github.com/tweag/nickel/issues/226
-    join | List Str -> Str -> Str
+    join | Str -> List Str -> Str
     | doc m#"
       Joins a list of strings given a seperator.
 
       For example:
       ```nickel
-        join [ "Hello", "World!" ] ", " =>
+        join ", " [ "Hello", "World!" ] =>
           "Hello, World!"
       ```
       "#m
-    = fun l sep =>
+    = fun sep l =>
       if %length% l == 0 then
         ""
       else

--- a/stdlib/strings.ncl
+++ b/stdlib/strings.ncl
@@ -245,19 +245,19 @@
 
     contains: Str -> Str -> Bool
     | doc m#"
-      Checks if the second string is part of the first string.
+      Checks if the first string is part of the second string.
 
       For example:
       ```nickel
-        contains "abcdef" "cde" =>
+        contains "cde" "abcdef" =>
           true
-        contains "abcdef" "" =>
+        contains "" "abcdef" =>
           true
-        contains "abcdef" "ghj" =>
+        contains "ghj" "abcdef" =>
           false
       ```
       "#m
-    = fun s subs => %strContains% s subs,
+    = fun subs s => %strContains% s subs,
 
     replace: Str -> Str -> Str -> Str
     | doc m#"

--- a/stdlib/strings.ncl
+++ b/stdlib/strings.ncl
@@ -332,21 +332,21 @@
       "#m
     = fun s => %strLength% s,
 
-    substring: Str -> Num -> Num -> Str
+    substring: Num -> Num -> Str -> Str
     | doc m#"
       Takes a slice from the string. Errors if either index is out of range.
 
       For example:
       ```nickel
-        substring "abcdef" 3 5 =>
+        substring 3 5 "abcdef" =>
           "de"
-        substring "abcdef" 3 10 =>
+        substring 3 10 "abcdef" =>
           error
-        substring "abcdef" (-3) 4 =>
+        substring (-3) 4 "abcdef" =>
           error
       ```
       "#m
-    = fun s start end => %strSubstr% s start end,
+    = fun start end s => %strSubstr% s start end,
 
     fromNum | Num -> Str
     | doc m#"

--- a/stdlib/strings.ncl
+++ b/stdlib/strings.ncl
@@ -291,17 +291,17 @@
 
     isMatch : Str -> Str -> Bool
     | doc m#"
-      `isMatch str regex` checks if `str` matches `regex`.
+      `isMatch regex str` checks if `str` matches `regex`.
 
       For example:
       ```nickel
-        isMatch "123" "^\\d+$" =>
+        isMatch "^\\d+$" "123" =>
           true
-        isMatch "123" "\\d{4}" =>
+        isMatch "\\d{4}" "123" =>
           false
       ```
       "#m
-    = fun s regex => %strIsMatch% s regex,
+    = fun regex s => %strIsMatch% s regex,
 
     match : Str -> Str -> {match: Str, index: Num, groups: List Str}
     | doc m#"

--- a/tests/pass/lists.ncl
+++ b/tests/pass/lists.ncl
@@ -1,8 +1,8 @@
 let Assert = fun l x => x || %blame% l in
 
 // accesses
-(lists.elemAt [1,2,3] 1 == 2 | #Assert) &&
-(lists.elemAt (lists.map (fun x => x + 1) [1,2,3]) 1 == 3 | #Assert) &&
+(lists.elemAt 1 [1,2,3] == 2 | #Assert) &&
+(lists.elemAt 1 (lists.map (fun x => x + 1) [1,2,3]) == 3 | #Assert) &&
 
 // length
 (lists.length [] == 0 | #Assert) &&

--- a/tests/stdlib_lists_fail.rs
+++ b/tests/stdlib_lists_fail.rs
@@ -28,11 +28,11 @@ fn elem_at() {
     );
 
     assert_matches!(
-        eval("lists.elemAt {} 0"),
+        eval("lists.elemAt 0 {} 0"),
         Err(Error::EvalError(EvalError::BlameError(..)))
     );
     assert_matches!(
-        eval("lists.elemAt [] \"a\""),
+        eval("lists.elemAt \"a\" []"),
         Err(Error::EvalError(EvalError::BlameError(..)))
     );
 }

--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -20,7 +20,7 @@ const codeExample = `let conf = {
 
 let SemanticVersion = fun label value =>
   let pattern = "^\\\\d{1,2}\\\\.\\\\d{1,2}(\\\\.\\\\d{1,2})?$" in
-  if strings.isMatch value pattern then
+  if strings.isMatch pattern value then
     value
   else
     let msg = "invalid version number" in


### PR DESCRIPTION
This is influenced by how Elm designed their standard library: https://package.elm-lang.org/packages/elm/core/latest/

These remain untouched for now:
```
lists.ncl
85:    concat : forall a. List a -> List a -> List a
nums.ncl
186:    pow : Num -> Num -> Num
```

If we compare with Elm:
- `lists.concat` is called `Array.append` and has the same order (there is a `Array.concat` is that is equal to Nickel's `lists.flatten`).
- `nums.pow` is flipped and is named `powBy`.

I've left those two out because they involve changing the name of a function, which I decided not to do until further discussion. Following Elm's method might work out, we could flip them and rename them to `lists.appendWith`, `nums.powBy`. We may add a `lists.prependWith` for symmetry.

Note that these changes may have considerable consequences on the "flavor" of the language in the long run.
It might be valid to change the documentation examples to better demonstrate usage with `|>`, especially in cases where the call site looks better than normal application