### PR TITLE
Remove Term::Promise from the project

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -613,28 +613,6 @@ where
                     }
                 }
             },
-            Term::Promise(ty, mut l, t) => {
-                l.arg_pos = t.pos;
-                let thunk = Thunk::new(
-                    Closure {
-                        body: t,
-                        env: env.clone(),
-                    },
-                    IdentKind::Lam(),
-                );
-                l.arg_thunk = Some(thunk.clone());
-
-                stack.push_tracked_arg(thunk, pos.into_inherited());
-                stack.push_arg(
-                    Closure::atomic_closure(Term::Lbl(l).into()),
-                    pos.into_inherited(),
-                );
-
-                Closure {
-                    body: ty.contract(),
-                    env,
-                }
-            }
             Term::RecRecord(ts, dyn_fields, attrs) => {
                 // Thanks to the share normal form transformation, the content is either a constant or a
                 // variable.
@@ -916,11 +894,6 @@ pub fn subst(rt: RichTerm, global_env: &Environment, env: &Environment) -> RichT
                     .collect();
 
                 RichTerm::new(Term::OpN(op, ts), pos)
-            }
-            Term::Promise(ty, l, t) => {
-                let t = subst_(t, global_env, env, bound);
-
-                RichTerm::new(Term::Promise(ty, l, t), pos)
             }
             Term::Wrapped(i, t) => {
                 let t = subst_(t, global_env, env, bound);

--- a/src/term.rs
+++ b/src/term.rs
@@ -105,12 +105,6 @@ pub enum Term {
     #[serde(skip)]
     OpN(NAryOp, Vec<RichTerm>),
 
-    /// A promise.
-    ///
-    /// Represent a subterm which is to be statically typechecked.
-    #[serde(skip)]
-    Promise(Types, Label, RichTerm),
-
     /// A symbol.
     ///
     /// A unique tag corresponding to a type variable. See `Wrapped` below.
@@ -318,10 +312,7 @@ impl Term {
             }
             Bool(_) | Num(_) | Str(_) | Lbl(_) | Var(_) | Sym(_) | Enum(_) | Import(_)
             | ResolvedImport(_) => {}
-            Fun(_, ref mut t)
-            | Op1(_, ref mut t)
-            | Promise(_, _, ref mut t)
-            | Wrapped(_, ref mut t) => {
+            Fun(_, ref mut t) | Op1(_, ref mut t) | Wrapped(_, ref mut t) => {
                 func(t);
             }
             MetaValue(ref mut meta) => {
@@ -376,7 +367,6 @@ impl Term {
             | Term::Op1(_, _)
             | Term::Op2(_, _, _)
             | Term::OpN(..)
-            | Term::Promise(_, _, _)
             | Term::Import(_)
             | Term::ResolvedImport(_)
             | Term::StrChunks(_)
@@ -443,7 +433,6 @@ impl Term {
             | Term::Op1(_, _)
             | Term::Op2(_, _, _)
             | Term::OpN(..)
-            | Term::Promise(_, _, _)
             | Term::Import(_)
             | Term::ResolvedImport(_) => String::from("<unevaluated>"),
         }
@@ -496,7 +485,6 @@ impl Term {
             | Term::Op1(_, _)
             | Term::Op2(_, _, _)
             | Term::OpN(..)
-            | Term::Promise(_, _, _)
             | Term::Wrapped(_, _)
             | Term::MetaValue(_)
             | Term::Import(_)
@@ -535,7 +523,6 @@ impl Term {
             | Term::Op1(_, _)
             | Term::Op2(_, _, _)
             | Term::OpN(..)
-            | Term::Promise(_, _, _)
             | Term::Wrapped(_, _)
             | Term::MetaValue(_)
             | Term::Import(_)
@@ -966,13 +953,6 @@ impl RichTerm {
                     .collect();
                 RichTerm {
                     term: Box::new(Term::OpN(op, ts_res?)),
-                    pos,
-                }
-            }
-            Term::Promise(ty, l, t) => {
-                let t = t.traverse(f, state, method)?;
-                RichTerm {
-                    term: Box::new(Term::Promise(ty, l, t)),
                     pos,
                 }
             }


### PR DESCRIPTION
After discussion with @yannham it seams that `Term::Promise` is a relic from past development that can be removed safely from the code.
I simply removed all its appearances in the code and everything still works perfectly.
However some commentaries are still mentioning it, and they should be rephrased.