### PR TITLE
Mark Cachix cache as __extra__-substitutor

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -7,8 +7,8 @@
   inputs.import-cargo.url = "github:edolstra/import-cargo";
 
   nixConfig = {
-    substituters = [ "https://nickel.cachix.org" ];
-    trusted-public-keys = [ "nickel.cachix.org-1:ABoCOGpTJbAum7U6c+04VbjvLxG9f0gJP5kYihRRdQs=" ];
+    extra-substituters = [ "https://nickel.cachix.org" ];
+    extra-trusted-public-keys = [ "nickel.cachix.org-1:ABoCOGpTJbAum7U6c+04VbjvLxG9f0gJP5kYihRRdQs=" ];
   };
 
   outputs = { self, nixpkgs, nixpkgs-wasm, nixpkgs-mozilla, import-cargo }:


### PR DESCRIPTION
Using `substitutors` in the flake file nix will override the local substitutor config, this may cause system packages cached by `cache.nixos.org` to be rebuilt unnecessarily. Using `entra-substitutors` should add to the local config instead.