### PR TITLE
Recursive overriding

### DIFF
--- a/lsp/nls/src/linearization.rs
+++ b/lsp/nls/src/linearization.rs
@@ -373,7 +373,7 @@ impl Linearizer<BuildingResource, (UnifTable, HashMap<usize, Ident>)> for Analys
 
         let id = id_gen.get();
         match term {
-            Term::Let(ident, _, _) | Term::Fun(ident, _) => {
+            Term::Let(ident, _, _, _) | Term::Fun(ident, _) => {
                 self.env
                     .insert(ident.to_owned(), lin.state.resource.linearization.len());
                 lin.push(LinearizationItem {

--- a/lsp/nls/src/linearization.rs
+++ b/lsp/nls/src/linearization.rs
@@ -373,7 +373,7 @@ impl Linearizer<BuildingResource, (UnifTable, HashMap<usize, Ident>)> for Analys
 
         let id = id_gen.get();
         match term {
-            Term::Let(ident, _, _) | Term::Fun(ident, _) => {
+            Term::Let(ident, _, _) | Term::LetRev(ident, _, _) | Term::Fun(ident, _) => {
                 self.env
                     .insert(ident.to_owned(), lin.state.resource.linearization.len());
                 lin.push(LinearizationItem {

--- a/lsp/nls/src/linearization.rs
+++ b/lsp/nls/src/linearization.rs
@@ -385,7 +385,7 @@ impl Linearizer<BuildingResource, (UnifTable, HashMap<usize, Ident>)> for Analys
                     meta: self.meta.take(),
                 });
             }
-            Term::Var(ident) => {
+            Term::Var(ident) | Term::VarRev(ident) => {
                 let root_id = id_gen.get_and_advance();
 
                 debug!(

--- a/lsp/nls/src/linearization.rs
+++ b/lsp/nls/src/linearization.rs
@@ -373,7 +373,7 @@ impl Linearizer<BuildingResource, (UnifTable, HashMap<usize, Ident>)> for Analys
 
         let id = id_gen.get();
         match term {
-            Term::Let(ident, _, _) | Term::LetRev(ident, _, _) | Term::Fun(ident, _) => {
+            Term::Let(ident, _, _) | Term::Fun(ident, _) => {
                 self.env
                     .insert(ident.to_owned(), lin.state.resource.linearization.len());
                 lin.push(LinearizationItem {
@@ -385,7 +385,7 @@ impl Linearizer<BuildingResource, (UnifTable, HashMap<usize, Ident>)> for Analys
                     meta: self.meta.take(),
                 });
             }
-            Term::Var(ident) | Term::VarRev(ident) => {
+            Term::Var(ident) => {
                 let root_id = id_gen.get_and_advance();
 
                 debug!(
@@ -442,12 +442,10 @@ impl Linearizer<BuildingResource, (UnifTable, HashMap<usize, Ident>)> for Analys
                 self.record_fields =
                     Some((id + 1, field_names.into_iter().enumerate().rev().collect()));
             }
-
             Term::Op1(UnaryOp::StaticAccess(ident), _) => {
                 let x = self.access.get_or_insert(Vec::with_capacity(1));
                 x.push(ident.to_owned())
             }
-
             Term::MetaValue(meta) => {
                 // Notice 1: No push to lin
                 // Notice 2: we discard the encoded value as anything we
@@ -485,7 +483,6 @@ impl Linearizer<BuildingResource, (UnifTable, HashMap<usize, Ident>)> for Analys
                     })
                 }
             }
-
             other => {
                 debug!("Add wildcard item: {:?}", other);
 

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -763,7 +763,7 @@ where
         }
 
         clos = match term {
-            Term::Var(x) => {
+            Term::Var(x) | Term::VarRev(x) => {
                 let mut thunk = env
                     .get(&x)
                     .or_else(|| global_env.get(&x))
@@ -939,7 +939,7 @@ where
                 let rec_env = ts.iter().try_fold::<_, _, Result<Environment, EvalError>>(
                     Environment::new(),
                     |mut rec_env, (id, rt)| match rt.as_ref() {
-                        Term::Var(ref var_id) => {
+                        Term::Var(ref var_id) | Term::VarRev(ref var_id) => {
                             let thunk = env.get(var_id).ok_or_else(|| {
                                 EvalError::UnboundIdentifier(var_id.clone(), rt.pos)
                             })?;
@@ -963,7 +963,7 @@ where
                 let new_ts = ts.into_iter().map(|(id, rt)| {
                     let RichTerm { term, pos } = rt;
                     match *term {
-                        Term::Var(var_id) => {
+                        var @ Term::Var(var_id) | var @ Term::VarRev(var_id) => {
                             // We already checked for unbound identifier in the previous fold,
                             // so function should always succeed
                             let mut thunk = env.get(&var_id).unwrap();
@@ -975,6 +975,7 @@ where
                             (
                                 id,
                                 RichTerm {
+                                    //TODO WE SHOULD PUT THE RIGHT THING
                                     term: Box::new(Term::Var(var_id)),
                                     pos,
                                 },
@@ -998,7 +999,7 @@ where
                         |acc, (id_t, t)| {
                             let RichTerm { term, pos } = t;
                             match *term {
-                                Term::Var(var_id) => {
+                                Term::Var(var_id) | Term::VarRev(var_id) => {
                                     let mut thunk = env.get(&var_id).ok_or_else(|| {
                                         EvalError::UnboundIdentifier(var_id.clone(), pos)
                                     })?;

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -203,16 +203,13 @@ impl ThunkData {
     /// this case, `restore()` is the same as `clone()`.
     pub fn restore(&self) -> Self {
         match self.inner {
-            InnerThunkData::Standard(ref closure) => ThunkData {
-                inner: InnerThunkData::Standard(closure.clone()),
-                state: self.state,
-            },
+            InnerThunkData::Standard(_) => self.clone(),
             InnerThunkData::Reversible { ref orig, .. } => ThunkData {
                 inner: InnerThunkData::Reversible {
                     orig: Rc::clone(orig),
                     cached: Rc::clone(orig),
                 },
-                state: self.state,
+                state: ThunkState::Suspended,
             },
         }
     }

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -812,6 +812,14 @@ where
                 env.insert(x, Thunk::new(closure, IdentKind::Let));
                 Closure { body: t, env }
             }
+            Term::LetRev(x, s, t) => {
+                let closure = Closure {
+                    body: s,
+                    env: env.clone(),
+                };
+                env.insert(x, Thunk::new_rev(closure, IdentKind::Let));
+                Closure { body: t, env }
+            }
             Term::Switch(exp, cases, default) => {
                 let has_default = default.is_some();
 
@@ -1167,6 +1175,12 @@ pub fn subst(rt: RichTerm, global_env: &Environment, env: &Environment) -> RichT
                 RichTerm::new(Term::Let(id, t1, t2), pos)
             }
             p @ Term::LetPattern(..) => panic!("Pattern {:?} has not been transformed before evaluation", p),
+            Term::LetRev(id, t1, t2) => {
+                let t1 = subst_(t1, global_env, env, Cow::Borrowed(bound.as_ref()));
+                let t2 = subst_(t2, global_env, env, bound);
+
+                RichTerm::new(Term::LetRev(id, t1, t2), pos)
+            }
             Term::App(t1, t2) => {
                 let t1 = subst_(t1, global_env, env, Cow::Borrowed(bound.as_ref()));
                 let t2 = subst_(t2, global_env, env, bound);

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -763,7 +763,7 @@ where
         }
 
         clos = match term {
-            Term::Var(x) | Term::VarRev(x) => {
+            Term::Var(x) => {
                 let mut thunk = env
                     .get(&x)
                     .or_else(|| global_env.get(&x))
@@ -939,7 +939,7 @@ where
                 let rec_env = ts.iter().try_fold::<_, _, Result<Environment, EvalError>>(
                     Environment::new(),
                     |mut rec_env, (id, rt)| match rt.as_ref() {
-                        Term::Var(ref var_id) | Term::VarRev(ref var_id) => {
+                        Term::Var(ref var_id) => {
                             let thunk = env.get(var_id).ok_or_else(|| {
                                 EvalError::UnboundIdentifier(var_id.clone(), rt.pos)
                             })?;
@@ -963,7 +963,7 @@ where
                 let new_ts = ts.into_iter().map(|(id, rt)| {
                     let RichTerm { term, pos } = rt;
                     match *term {
-                        var @ Term::Var(var_id) | var @ Term::VarRev(var_id) => {
+                        Term::Var(var_id) => {
                             // We already checked for unbound identifier in the previous fold,
                             // so function should always succeed
                             let mut thunk = env.get(&var_id).unwrap();
@@ -975,7 +975,6 @@ where
                             (
                                 id,
                                 RichTerm {
-                                    //TODO WE SHOULD PUT THE RIGHT THING
                                     term: Box::new(Term::Var(var_id)),
                                     pos,
                                 },
@@ -999,7 +998,7 @@ where
                         |acc, (id_t, t)| {
                             let RichTerm { term, pos } = t;
                             match *term {
-                                Term::Var(var_id) | Term::VarRev(var_id) => {
+                                Term::Var(var_id) => {
                                     let mut thunk = env.get(&var_id).ok_or_else(|| {
                                         EvalError::UnboundIdentifier(var_id.clone(), pos)
                                     })?;

--- a/src/identifier.rs
+++ b/src/identifier.rs
@@ -11,6 +11,8 @@ pub struct Ident {
     pub pos: TermPos,
 }
 
+pub const UNIQUE_PREFIX: char = '%';
+
 impl PartialOrd for Ident {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
         self.label.partial_cmp(&other.label)
@@ -64,5 +66,11 @@ impl Into<String> for Ident {
 impl Ident {
     pub fn is_generated(&self) -> bool {
         self.label.starts_with('%')
+    }
+}
+
+impl Ident {
+    pub fn is_unique(&self) -> bool {
+        self.0.starts_with(UNIQUE_PREFIX)
     }
 }

--- a/src/identifier.rs
+++ b/src/identifier.rs
@@ -11,7 +11,9 @@ pub struct Ident {
     pub pos: TermPos,
 }
 
-pub const UNIQUE_PREFIX: char = '%';
+/// Special character used for generating fresh identifiers. It must be syntactically impossible to
+/// use to write in a standard Nickel program, to avoid name clashes.
+pub const GEN_PREFIX: char = '%';
 
 impl PartialOrd for Ident {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
@@ -70,7 +72,7 @@ impl Ident {
 }
 
 impl Ident {
-    pub fn is_unique(&self) -> bool {
-        self.0.starts_with(UNIQUE_PREFIX)
+    pub fn is_generated(&self) -> bool {
+        self.0.starts_with(GEN_PREFIX)
     }
 }

--- a/src/identifier.rs
+++ b/src/identifier.rs
@@ -67,12 +67,6 @@ impl Into<String> for Ident {
 
 impl Ident {
     pub fn is_generated(&self) -> bool {
-        self.label.starts_with('%')
-    }
-}
-
-impl Ident {
-    pub fn is_generated(&self) -> bool {
-        self.0.starts_with(GEN_PREFIX)
+        self.label.starts_with(GEN_PREFIX)
     }
 }

--- a/src/merge.rs
+++ b/src/merge.rs
@@ -52,7 +52,7 @@
 //! - *Contract check*: merging a `Contract` or a `ContractDefault` with a simple value `t`
 //! evaluates to a contract check, that is an `Assume(..., t)`
 use crate::error::EvalError;
-use crate::eval::{CallStack, Closure, Environment, IdentKind, Thunk};
+use crate::eval::{CallStack, Closure, Environment};
 use crate::label::Label;
 use crate::position::TermPos;
 use crate::term::{make as mk_term, BinaryOp, Contract, MetaValue, RecordAttrs, RichTerm, Term};
@@ -438,14 +438,14 @@ fn rev_thunks<'a, I: Iterator<Item = &'a mut RichTerm>>(map: I, env: &mut Enviro
 
     for rt in map {
         if let Term::Var(id) = rt.as_ref() {
-            // This create a fresh variable which is bound to a reversed copy of the original thunk
-            let reversed = env.get(&id).unwrap().restore();
+            // This create a fresh variable which is bound to a reverted copy of the original thunk
+            let reverted = env.get(&id).unwrap().revert();
             let fresh_id = fresh_var();
-            env.insert(fresh_id.clone(), reversed);
+            env.insert(fresh_id.clone(), reverted);
             *rt.term = Term::Var(fresh_id);
         }
         // Otherwise, if it is not a variable after the share normal form transformations, it
-        // should be a constant and we don't need to reverse anything
+        // should be a constant and we don't need to revert anything
     }
 }
 

--- a/src/term.rs
+++ b/src/term.rs
@@ -63,12 +63,10 @@ pub enum Term {
 
     /// A let binding.
     #[serde(skip)]
-    Let(Ident, RichTerm, RichTerm),
+    Let(Ident, RichTerm, RichTerm, BindingType),
+    /// A destructuring let-binding.
     #[serde(skip)]
     LetPattern(Option<Ident>, Destruct, RichTerm, RichTerm),
-    /// A revertible let binding.
-    #[serde(skip)]
-    LetRev(Ident, RichTerm, RichTerm),
     /// An application.
     #[serde(skip)]
     App(RichTerm, RichTerm),
@@ -155,6 +153,21 @@ pub enum Term {
 impl From<MetaValue> for Term {
     fn from(m: MetaValue) -> Self {
         Term::MetaValue(m)
+    }
+}
+
+/// Type of let-binding. This only affects run-time behavior. Revertible bindings introduce
+/// revertible thunks at evaluation, which are devices used for the implementation of recursive
+/// records merging. See the [`merge`] and [`eval`] modules for more details.
+#[derive(Debug, Eq, PartialEq, Copy, Clone)]
+pub enum BindingType {
+    Normal,
+    Revertible,
+}
+
+impl Default for BindingType {
+    fn default() -> Self {
+        BindingType::Normal
     }
 }
 
@@ -336,9 +349,8 @@ impl Term {
                     });
                 meta.value.iter_mut().for_each(func);
             }
-            Let(_, ref mut t1, ref mut t2)
+            Let(_, ref mut t1, ref mut t2, _)
             | LetPattern(_, _, ref mut t1, ref mut t2)
-            | LetRev(_, ref mut t1, ref mut t2)
             | App(ref mut t1, ref mut t2)
             | Op2(_, ref mut t1, ref mut t2) => {
                 func(t1);
@@ -374,9 +386,8 @@ impl Term {
             Term::Sym(_) => Some("Sym"),
             Term::Wrapped(_, _) => Some("Wrapped"),
             Term::MetaValue(_) => Some("Metavalue"),
-            Term::Let(_, _, _)
-            | Term::LetPattern(_, _, _, _)
-            | Term::LetRev(_, _, _)
+            Term::Let(..)
+            | Term::LetPattern(..)
             | Term::App(_, _)
             | Term::Var(_)
             | Term::Switch(..)
@@ -451,9 +462,8 @@ impl Term {
             }
             Term::Var(id) => id.to_string(),
             Term::ParseError => String::from("<parse error>"),
-            Term::Let(_, _, _)
-            | Term::LetPattern(_, _, _, _)
-            | Term::LetRev(_, _, _)
+            Term::Let(..)
+            | Term::LetPattern(..)
             | Term::App(_, _)
             | Term::Switch(..)
             | Term::Op1(_, _)
@@ -504,9 +514,8 @@ impl Term {
             | Term::Record(..)
             | Term::List(_)
             | Term::Sym(_) => true,
-            Term::Let(_, _, _)
-            | Term::LetPattern(_, _, _, _)
-            | Term::LetRev(_, _, _)
+            Term::Let(..)
+            | Term::LetPattern(..)
             | Term::App(_, _)
             | Term::Var(_)
             | Term::Switch(..)
@@ -541,9 +550,8 @@ impl Term {
             | Term::Lbl(_)
             | Term::Enum(_)
             | Term::Sym(_) => true,
-            Term::Let(_, _, _)
-            | Term::LetPattern(_, _, _, _)
-            | Term::LetRev(_, _, _)
+            Term::Let(..)
+            | Term::LetPattern(..)
             | Term::Record(..)
             | Term::List(_)
             | Term::Fun(_, _)
@@ -929,11 +937,11 @@ impl RichTerm {
                     pos,
                 }
             }
-            Term::Let(id, t1, t2) => {
+            Term::Let(id, t1, t2, btype) => {
                 let t1 = t1.traverse(f, state, method)?;
                 let t2 = t2.traverse(f, state, method)?;
                 RichTerm {
-                    term: Box::new(Term::Let(id, t1, t2)),
+                    term: Box::new(Term::Let(id, t1, t2, btype)),
                     pos,
                 }
             }
@@ -942,14 +950,6 @@ impl RichTerm {
                 let t2 = t2.traverse(f, state, method)?;
                 RichTerm {
                     term: Box::new(Term::LetPattern(id, pat, t1, t2)),
-                    pos,
-                }
-            }
-            Term::LetRev(id, t1, t2) => {
-                let t1 = t1.traverse(f, state, method)?;
-                let t2 = t2.traverse(f, state, method)?;
-                RichTerm {
-                    term: Box::new(Term::LetRev(id, t1, t2)),
                     pos,
                 }
             }
@@ -1241,7 +1241,7 @@ pub mod make {
         T2: Into<RichTerm>,
         I: Into<Ident>,
     {
-        Term::Let(id.into(), t1.into(), t2.into()).into()
+        Term::Let(id.into(), t1.into(), t2.into(), BindingType::Normal).into()
     }
 
     pub fn let_pat<I, D, T1, T2>(id: Option<I>, pat: D, t1: T1, t2: T2) -> RichTerm

--- a/src/term.rs
+++ b/src/term.rs
@@ -66,7 +66,7 @@ pub enum Term {
     Let(Ident, RichTerm, RichTerm),
     #[serde(skip)]
     LetPattern(Option<Ident>, Destruct, RichTerm, RichTerm),
-    /// A reversible let binding.
+    /// A revertible let binding.
     #[serde(skip)]
     LetRev(Ident, RichTerm, RichTerm),
     /// An application.

--- a/src/term.rs
+++ b/src/term.rs
@@ -66,6 +66,9 @@ pub enum Term {
     Let(Ident, RichTerm, RichTerm),
     #[serde(skip)]
     LetPattern(Option<Ident>, Destruct, RichTerm, RichTerm),
+    /// A reversible let binding.
+    #[serde(skip)]
+    LetRev(Ident, RichTerm, RichTerm),
     /// An application.
     #[serde(skip)]
     App(RichTerm, RichTerm),
@@ -335,6 +338,7 @@ impl Term {
             }
             Let(_, ref mut t1, ref mut t2)
             | LetPattern(_, _, ref mut t1, ref mut t2)
+            | LetRev(_, ref mut t1, ref mut t2)
             | App(ref mut t1, ref mut t2)
             | Op2(_, ref mut t1, ref mut t2) => {
                 func(t1);
@@ -372,6 +376,7 @@ impl Term {
             Term::MetaValue(_) => Some("Metavalue"),
             Term::Let(_, _, _)
             | Term::LetPattern(_, _, _, _)
+            | Term::LetRev(_, _, _)
             | Term::App(_, _)
             | Term::Var(_)
             | Term::Switch(..)
@@ -448,6 +453,7 @@ impl Term {
             Term::ParseError => String::from("<parse error>"),
             Term::Let(_, _, _)
             | Term::LetPattern(_, _, _, _)
+            | Term::LetRev(_, _, _)
             | Term::App(_, _)
             | Term::Switch(..)
             | Term::Op1(_, _)
@@ -500,6 +506,7 @@ impl Term {
             | Term::Sym(_) => true,
             Term::Let(_, _, _)
             | Term::LetPattern(_, _, _, _)
+            | Term::LetRev(_, _, _)
             | Term::App(_, _)
             | Term::Var(_)
             | Term::Switch(..)
@@ -536,6 +543,7 @@ impl Term {
             | Term::Sym(_) => true,
             Term::Let(_, _, _)
             | Term::LetPattern(_, _, _, _)
+            | Term::LetRev(_, _, _)
             | Term::Record(..)
             | Term::List(_)
             | Term::Fun(_, _)
@@ -934,6 +942,14 @@ impl RichTerm {
                 let t2 = t2.traverse(f, state, method)?;
                 RichTerm {
                     term: Box::new(Term::LetPattern(id, pat, t1, t2)),
+                    pos,
+                }
+            }
+            Term::LetRev(id, t1, t2) => {
+                let t1 = t1.traverse(f, state, method)?;
+                let t2 = t2.traverse(f, state, method)?;
+                RichTerm {
+                    term: Box::new(Term::LetRev(id, t1, t2)),
                     pos,
                 }
             }

--- a/src/term.rs
+++ b/src/term.rs
@@ -75,6 +75,9 @@ pub enum Term {
     /// A variable.
     #[serde(skip)]
     Var(Ident),
+    /// The original expression of a variable.
+    #[serde(skip)]
+    VarRev(Ident),
 
     /// An enum variant.
     Enum(Ident),
@@ -155,6 +158,12 @@ pub enum Term {
 impl From<MetaValue> for Term {
     fn from(m: MetaValue) -> Self {
         Term::MetaValue(m)
+    }
+}
+
+impl Default for Term {
+    fn default() -> Self {
+        Term::Null
     }
 }
 
@@ -322,8 +331,8 @@ impl Term {
                     func(t2);
                 });
             }
-            Bool(_) | Num(_) | Str(_) | Lbl(_) | Var(_) | Sym(_) | Enum(_) | Import(_)
-            | ResolvedImport(_) => {}
+            Bool(_) | Num(_) | Str(_) | Lbl(_) | Var(_) | VarRev(_) | Sym(_) | Enum(_)
+            | Import(_) | ResolvedImport(_) => {}
             Fun(_, ref mut t) | Op1(_, ref mut t) | Wrapped(_, ref mut t) => {
                 func(t);
             }
@@ -379,6 +388,7 @@ impl Term {
             | Term::LetRev(_, _, _)
             | Term::App(_, _)
             | Term::Var(_)
+            | Term::VarRev(_)
             | Term::Switch(..)
             | Term::Op1(_, _)
             | Term::Op2(_, _, _)
@@ -449,7 +459,7 @@ impl Term {
 
                 format!("<{}{}={}>", content, value_label, value)
             }
-            Term::Var(id) => id.to_string(),
+            Term::Var(id) | Term::VarRev(id) => id.to_string(),
             Term::ParseError => String::from("<parse error>"),
             Term::Let(_, _, _)
             | Term::LetPattern(_, _, _, _)
@@ -509,6 +519,7 @@ impl Term {
             | Term::LetRev(_, _, _)
             | Term::App(_, _)
             | Term::Var(_)
+            | Term::VarRev(_)
             | Term::Switch(..)
             | Term::Op1(_, _)
             | Term::Op2(_, _, _)
@@ -550,6 +561,7 @@ impl Term {
             | Term::App(_, _)
             | Term::Switch(..)
             | Term::Var(_)
+            | Term::VarRev(_)
             | Term::Op1(_, _)
             | Term::Op2(_, _, _)
             | Term::OpN(..)
@@ -916,6 +928,7 @@ impl RichTerm {
             | v @ Term::Lbl(_)
             | v @ Term::Sym(_)
             | v @ Term::Var(_)
+            | v @ Term::VarRev(_)
             | v @ Term::Enum(_)
             | v @ Term::Import(_)
             | v @ Term::ResolvedImport(_) => RichTerm {

--- a/src/term.rs
+++ b/src/term.rs
@@ -158,12 +158,6 @@ impl From<MetaValue> for Term {
     }
 }
 
-impl Default for Term {
-    fn default() -> Self {
-        Term::Null
-    }
-}
-
 #[derive(Debug, Default, Eq, PartialEq, Copy, Clone)]
 pub struct RecordAttrs {
     pub open: bool,

--- a/src/term.rs
+++ b/src/term.rs
@@ -75,9 +75,6 @@ pub enum Term {
     /// A variable.
     #[serde(skip)]
     Var(Ident),
-    /// The original expression of a variable.
-    #[serde(skip)]
-    VarRev(Ident),
 
     /// An enum variant.
     Enum(Ident),
@@ -331,8 +328,8 @@ impl Term {
                     func(t2);
                 });
             }
-            Bool(_) | Num(_) | Str(_) | Lbl(_) | Var(_) | VarRev(_) | Sym(_) | Enum(_)
-            | Import(_) | ResolvedImport(_) => {}
+            Bool(_) | Num(_) | Str(_) | Lbl(_) | Var(_) | Sym(_) | Enum(_) | Import(_)
+            | ResolvedImport(_) => {}
             Fun(_, ref mut t) | Op1(_, ref mut t) | Wrapped(_, ref mut t) => {
                 func(t);
             }
@@ -388,7 +385,6 @@ impl Term {
             | Term::LetRev(_, _, _)
             | Term::App(_, _)
             | Term::Var(_)
-            | Term::VarRev(_)
             | Term::Switch(..)
             | Term::Op1(_, _)
             | Term::Op2(_, _, _)
@@ -459,7 +455,7 @@ impl Term {
 
                 format!("<{}{}={}>", content, value_label, value)
             }
-            Term::Var(id) | Term::VarRev(id) => id.to_string(),
+            Term::Var(id) => id.to_string(),
             Term::ParseError => String::from("<parse error>"),
             Term::Let(_, _, _)
             | Term::LetPattern(_, _, _, _)
@@ -519,7 +515,6 @@ impl Term {
             | Term::LetRev(_, _, _)
             | Term::App(_, _)
             | Term::Var(_)
-            | Term::VarRev(_)
             | Term::Switch(..)
             | Term::Op1(_, _)
             | Term::Op2(_, _, _)
@@ -561,7 +556,6 @@ impl Term {
             | Term::App(_, _)
             | Term::Switch(..)
             | Term::Var(_)
-            | Term::VarRev(_)
             | Term::Op1(_, _)
             | Term::Op2(_, _, _)
             | Term::OpN(..)
@@ -928,7 +922,6 @@ impl RichTerm {
             | v @ Term::Lbl(_)
             | v @ Term::Sym(_)
             | v @ Term::Var(_)
-            | v @ Term::VarRev(_)
             | v @ Term::Enum(_)
             | v @ Term::Import(_)
             | v @ Term::ResolvedImport(_) => RichTerm {

--- a/src/transformations.rs
+++ b/src/transformations.rs
@@ -501,7 +501,9 @@ where
 
 /// Generate a new fresh variable which do not clash with user-defined variables.
 pub fn fresh_var() -> Ident {
-    format!("%{}", FreshVarCounter::next()).into()
+    use crate::identifier::UNIQUE_PREFIX;
+
+    format!("{}{}", UNIQUE_PREFIX, FreshVarCounter::next()).into()
 }
 
 /// Structures which can be packed together with their environment as a closure.
@@ -521,15 +523,31 @@ impl Closurizable for RichTerm {
     /// Generate a fresh variable, bind it to the corresponding closure `(t,with_env)` in `env`,
     /// and return this variable as a fresh term.
     fn closurize(self, env: &mut Environment, with_env: Environment) -> RichTerm {
-        let var = fresh_var();
-        let pos = self.pos;
-        let closure = Closure {
-            body: self,
-            env: with_env,
+        // If the term is already a variable with a unique name (that is, introduced by the share
+        // normal form transformation), we don't have to create an useless intermediate variable
+        // and thunks. We just transfer the original thunk to the new environment.  This is not
+        // only an optimization: this is relied upon by recursive record merging to guarantee
+        // correctness. Change carefully.
+        let reuse_binding = match self.as_ref() {
+            Term::Var(id) if id.is_unique() => with_env.get(&id).map(|t| (id.clone(), t)),
+            _ => None,
         };
-        env.insert(var.clone(), Thunk::new(closure, IdentKind::Record));
 
-        RichTerm::new(Term::Var(var), pos.into_inherited())
+        if let Some((id, thunk)) = reuse_binding {
+            // Because the id is unique, this won't shadow anything
+            env.insert(id, thunk);
+            self
+        } else {
+            let var = fresh_var();
+            let pos = self.pos;
+            let closure = Closure {
+                body: self,
+                env: with_env,
+            };
+            env.insert(var.clone(), Thunk::new(closure, IdentKind::Record));
+
+            RichTerm::new(Term::Var(var), pos.into_inherited())
+        }
     }
 }
 

--- a/src/transformations.rs
+++ b/src/transformations.rs
@@ -553,7 +553,7 @@ impl Closurizable for RichTerm {
         let thunk = match self.as_ref() {
             Term::Var(id) if id.is_generated() => with_env.get(&id).expect(&format!(
                 "Internal error(closurize) : generated identifier {} not found in the environment",
-                id.is_generated()
+                id
             )),
             _ => {
                 let closure = Closure {

--- a/src/transformations.rs
+++ b/src/transformations.rs
@@ -237,7 +237,7 @@ pub mod share_normal_form {
                     .collect();
 
                 // Recursive records are the reason why we need reversible thunks, since when
-                // merged, we may have to revert back to the fields to their original expression.
+                // merged, we may have to revert the fields back to their original expression.
                 with_bindings(
                     Term::RecRecord(map, dyn_fields, attrs),
                     bindings,
@@ -524,7 +524,7 @@ impl Closurizable for RichTerm {
     /// and return this variable as a fresh term.
     fn closurize(self, env: &mut Environment, with_env: Environment) -> RichTerm {
         // If the term is already a generated variable (that is, introduced by the share normal
-        // form transformation), we don't have to create an useless intermediate closure. We just
+        // form transformation), we don't have to create a useless intermediate closure. We just
         // transfer the original thunk to the new environment. This is not only an optimization:
         // this is relied upon by recursive record merging when computing the fixpoint. Change
         // carefully.

--- a/src/transformations.rs
+++ b/src/transformations.rs
@@ -33,8 +33,7 @@ pub mod desugar_destructuring {
     use super::{Ident, RichTerm, Term};
     use crate::destruct::{Destruct, Match};
     use crate::term::make::{op1, op2};
-    use crate::term::MetaValue;
-    use crate::term::{BinaryOp::DynRemove, UnaryOp::StaticAccess};
+    use crate::term::{BinaryOp::DynRemove, BindingType, MetaValue, UnaryOp::StaticAccess};
 
     /// Wrap the desugarized term in a meta value containing the "Record contract" needed to check
     /// the pattern exaustivity and also fill the default values (`?` operator) if not presents in the record.
@@ -73,6 +72,7 @@ pub mod desugar_destructuring {
                     x.clone(),
                     t_,
                     destruct_term(x.clone(), &pat, bind_open_field(x, &pat, body)),
+                    BindingType::Normal,
                 ),
                 pos,
             )
@@ -101,6 +101,7 @@ pub mod desugar_destructuring {
                 }
             }),
             body,
+            BindingType::Normal,
         )
         .into()
     }
@@ -116,6 +117,7 @@ pub mod desugar_destructuring {
                         id.clone(),
                         op1(StaticAccess(id.clone()), Term::Var(x.clone())),
                         t,
+                        BindingType::Normal,
                     ),
                     pos,
                 ),
@@ -558,7 +560,7 @@ impl Closurizable for RichTerm {
                     body: self,
                     env: with_env,
                 };
-                Thunk::new(closure, IdentKind::Record())
+                Thunk::new(closure, IdentKind::Record)
             }
         };
 

--- a/src/transformations.rs
+++ b/src/transformations.rs
@@ -236,13 +236,13 @@ pub mod share_normal_form {
                     })
                     .collect();
 
-                // Recursive records are the reason why we need reversible thunks, since when
+                // Recursive records are the reason why we need revertible thunks, since when
                 // merged, we may have to revert the fields back to their original expression.
                 with_bindings(
                     Term::RecRecord(map, dyn_fields, attrs),
                     bindings,
                     pos,
-                    BindingType::Reversible,
+                    BindingType::Revertible,
                 )
             }
             Term::List(ts) => {
@@ -303,7 +303,7 @@ pub mod share_normal_form {
     /// Type of let-binding to introduce during the share normal form pass.
     enum BindingType {
         Normal,
-        Reversible,
+        Revertible,
     }
 
     impl Default for BindingType {
@@ -330,7 +330,7 @@ pub mod share_normal_form {
             },
             |acc, (id, t)| match btype {
                 BindingType::Normal => RichTerm::new(Term::Let(id, t, acc), pos),
-                BindingType::Reversible => RichTerm::new(Term::LetRev(id, t, acc), pos),
+                BindingType::Revertible => RichTerm::new(Term::LetRev(id, t, acc), pos),
             },
         )
     }

--- a/src/typecheck/mod.rs
+++ b/src/typecheck/mod.rs
@@ -628,7 +628,7 @@ fn type_check_<S, E>(
             unify(state, strict, ty, mk_typewrapper::dynamic())
                 .map_err(|err| err.into_typecheck_err(state, rt.pos))
         }
-        Term::Let(x, re, rt) | Term::LetRev(x, re, rt) => {
+        Term::Let(x, re, rt, _) => {
             let ty_let = binding_type(re.as_ref(), &envs, state.table, strict);
             linearizer.retype_ident(lin, x, ty_let.clone());
             type_check_(

--- a/src/typecheck/mod.rs
+++ b/src/typecheck/mod.rs
@@ -628,7 +628,7 @@ fn type_check_<S, E>(
             unify(state, strict, ty, mk_typewrapper::dynamic())
                 .map_err(|err| err.into_typecheck_err(state, rt.pos))
         }
-        Term::Let(x, re, rt) => {
+        Term::Let(x, re, rt) | Term::LetRev(x, re, rt) => {
             let ty_let = binding_type(re.as_ref(), &envs, state.table, strict);
             linearizer.retype_ident(lin, x, ty_let.clone());
             type_check_(

--- a/src/typecheck/mod.rs
+++ b/src/typecheck/mod.rs
@@ -742,7 +742,7 @@ fn type_check_<S, E>(
             unify(state, strict, ty, res).map_err(|err| err.into_typecheck_err(state, rt.pos))?;
             type_check_(state, envs, lin, linearizer, strict, exp, mk_tyw_enum!(row))
         }
-        Term::Var(x) | Term::VarRev(x) => {
+        Term::Var(x) => {
             let x_ty = envs
                 .get(x)
                 .ok_or_else(|| TypecheckError::UnboundIdentifier(x.clone(), *pos))?;

--- a/src/typecheck/mod.rs
+++ b/src/typecheck/mod.rs
@@ -742,7 +742,7 @@ fn type_check_<S, E>(
             unify(state, strict, ty, res).map_err(|err| err.into_typecheck_err(state, rt.pos))?;
             type_check_(state, envs, lin, linearizer, strict, exp, mk_tyw_enum!(row))
         }
-        Term::Var(x) => {
+        Term::Var(x) | Term::VarRev(x) => {
             let x_ty = envs
                 .get(x)
                 .ok_or_else(|| TypecheckError::UnboundIdentifier(x.clone(), *pos))?;

--- a/tests/pass.rs
+++ b/tests/pass.rs
@@ -112,3 +112,8 @@ fn annot_parsing() {
 fn importing() {
     check_file("import.ncl");
 }
+
+#[test]
+fn overriding() {
+    check_file("overriding.ncl");
+}

--- a/tests/pass/overriding.ncl
+++ b/tests/pass/overriding.ncl
@@ -62,5 +62,13 @@ let Assert = contracts.from_predicate functions.id in
   |> builtins.deep_seq base
   |> builtins.deep_seq ext1
   |> builtins.deep_seq ext2,
+
+  // Test that the evaluation of a recursive record patches the right
+  // environment in some edge cases (when fields only contains a variable)
+  let foo = 1 in
+  let y = foo in
+  {bar = y, foo = 2}.bar == 1,
+  ({foo | default = 1, bar = foo} & {foo = 2}).bar == 2,
+  ({foo | default = 1, bar = foo, baz = bar} & {foo = 2}).baz == 2,
 ]
 |> lists.foldl (fun next acc => (next | #Assert) && acc) true

--- a/tests/pass/overriding.ncl
+++ b/tests/pass/overriding.ncl
@@ -1,0 +1,66 @@
+let Assert = contracts.fromPred functions.id in
+
+[
+  {foo | default = 1} & {foo = 2} == {foo = 2},
+  {foo = 1 + 1, bar = foo + 1} == {foo = 2, bar = 3},
+
+  let r = {foo | default = 1 + 1, bar = foo + 1} in
+  builtins.deepSeq (r & {foo = 3}) r == {foo = 2, bar = 3},
+
+  let r = {foo | default = 1 + 1, bar = foo + 1} in
+  (r & {foo = 3}) == {foo = 3, bar = 4},
+
+  let r = {foo | default = 1 + 1, bar = foo + 1} in
+  builtins.deepSeq r (r & {foo = 3}) == {foo = 3, bar = 4},
+
+  let ext = 0 + 1 in
+  let r = {
+    foo | default = 1 + 1,
+    a = let inner = 0 in foo + ext + inner,
+    b = let inner = 1 in a + ext + inner,
+    c = let inner = 2 in b + ext + inner,
+  } in
+  builtins.deepSeq (r & {foo = 1 - 1}) r
+    == {foo = 2, a = 3, b = 5, c = 8},
+
+  let ext = 0 + 1 in
+  let r = {
+    foo | default = 1 + 1,
+    a = let inner = 0 in foo + ext + inner,
+    b = let inner = 1 in a + ext + inner,
+    c = let inner = 2 in b + ext + inner,
+  } in
+  builtins.deepSeq r (r & {foo = 1 - 1})
+    == {foo = 0, a = 1, b = 3, c = 6},
+
+  let nested = {
+    foo.bar.baz | default = 0,
+    some.nested = {
+      stuff = foo.bar.baz + 1,
+      other = stuff + 1,
+    },
+  } in
+  builtins.deepSeq (nested & {foo.bar.baz = 1}) nested
+    == {foo.bar.baz = 0, some.nested.stuff = 1, some.nested.other = 2},
+
+  let nested = {
+    foo.bar.baz | default = 0,
+    some.nested = {
+      stuff = foo.bar.baz + 1,
+      other = stuff + 1,
+    },
+  } in
+  builtins.deepSeq nested (nested & {foo.bar.baz = 1})
+    == {foo.bar.baz = 1, some.nested.stuff = 2, some.nested.other = 3},
+
+  let base = {foo | default = "a", bar = foo ++ "b"} in
+  let ext1 = base & {foo = "1"} in
+  let ext2 = base & {foo = "A"} in
+  (base.bar == "ab"
+  && ext1.bar == "1b"
+  && ext2.bar == "Ab")
+  |> builtins.deepSeq base
+  |> builtins.deepSeq ext1
+  |> builtins.deepSeq ext2,
+]
+|> lists.foldl (fun next acc => (next | #Assert) && acc) true

--- a/tests/pass/overriding.ncl
+++ b/tests/pass/overriding.ncl
@@ -1,17 +1,17 @@
-let Assert = contracts.fromPred functions.id in
+let Assert = contracts.from_predicate functions.id in
 
 [
   {foo | default = 1} & {foo = 2} == {foo = 2},
   {foo = 1 + 1, bar = foo + 1} == {foo = 2, bar = 3},
 
   let r = {foo | default = 1 + 1, bar = foo + 1} in
-  builtins.deepSeq (r & {foo = 3}) r == {foo = 2, bar = 3},
+  builtins.deep_seq (r & {foo = 3}) r == {foo = 2, bar = 3},
 
   let r = {foo | default = 1 + 1, bar = foo + 1} in
   (r & {foo = 3}) == {foo = 3, bar = 4},
 
   let r = {foo | default = 1 + 1, bar = foo + 1} in
-  builtins.deepSeq r (r & {foo = 3}) == {foo = 3, bar = 4},
+  builtins.deep_seq r (r & {foo = 3}) == {foo = 3, bar = 4},
 
   let ext = 0 + 1 in
   let r = {
@@ -20,7 +20,7 @@ let Assert = contracts.fromPred functions.id in
     b = let inner = 1 in a + ext + inner,
     c = let inner = 2 in b + ext + inner,
   } in
-  builtins.deepSeq (r & {foo = 1 - 1}) r
+  builtins.deep_seq (r & {foo = 1 - 1}) r
     == {foo = 2, a = 3, b = 5, c = 8},
 
   let ext = 0 + 1 in
@@ -30,7 +30,7 @@ let Assert = contracts.fromPred functions.id in
     b = let inner = 1 in a + ext + inner,
     c = let inner = 2 in b + ext + inner,
   } in
-  builtins.deepSeq r (r & {foo = 1 - 1})
+  builtins.deep_seq r (r & {foo = 1 - 1})
     == {foo = 0, a = 1, b = 3, c = 6},
 
   let nested = {
@@ -40,7 +40,7 @@ let Assert = contracts.fromPred functions.id in
       other = stuff + 1,
     },
   } in
-  builtins.deepSeq (nested & {foo.bar.baz = 1}) nested
+  builtins.deep_seq (nested & {foo.bar.baz = 1}) nested
     == {foo.bar.baz = 0, some.nested.stuff = 1, some.nested.other = 2},
 
   let nested = {
@@ -50,7 +50,7 @@ let Assert = contracts.fromPred functions.id in
       other = stuff + 1,
     },
   } in
-  builtins.deepSeq nested (nested & {foo.bar.baz = 1})
+  builtins.deep_seq nested (nested & {foo.bar.baz = 1})
     == {foo.bar.baz = 1, some.nested.stuff = 2, some.nested.other = 3},
 
   let base = {foo | default = "a", bar = foo ++ "b"} in
@@ -59,8 +59,8 @@ let Assert = contracts.fromPred functions.id in
   (base.bar == "ab"
   && ext1.bar == "1b"
   && ext2.bar == "Ab")
-  |> builtins.deepSeq base
-  |> builtins.deepSeq ext1
-  |> builtins.deepSeq ext2,
+  |> builtins.deep_seq base
+  |> builtins.deep_seq ext1
+  |> builtins.deep_seq ext2,
 ]
 |> lists.foldl (fun next acc => (next | #Assert) && acc) true


### PR DESCRIPTION
Implement the recursive overriding of records, as detailed in #330 and along the lines of #103. This doesn't add merge priorities, merge functions, etc., but just implement the call-by-name semantics when merging recursive records:

```
({foo | default = 0, bar = foo + 1} & {foo = 2}).bar // Equals 3 after this PR
```

## Overview

This PR implements the following changes:
1. Add a `LetRev` node to the AST. `LetRev` acts as a normal `Let`, excepted that it allocates a revertible thunk when evaluated. The share normal form pass generates those `LetRev` instead of normal `Let` precisely for the fields of recursive records.

    To be honest, it's becoming clear at this point that we need to have at least two different ASTs, one straight out of the parser, and one for runtime, as those "syntax-only" and "runtime-only" constructs start to accumulate in the current single AST. However, it is out of scope for this issue. Also, `LetRev` is not so bad as for anything else but evaluation, it is strictly equivalent to a `Let`, so most changes are mechanical.
2. When merging two records, revert all the thunks inside the fields of the operands before performing the usual recursive merging. Once done, `merge` returns a `RecRecord` instead of a standard `Record`, such that when evaluated, the abstract machine builds a fresh recursive environment again (tying the knot).
3. Incidentally, I had to implement a simple optimization for `colsurize` that has been on the plate for a long time. It avoids dumbly generating nested closures when unnecessary. It is required for overriding as the indirections introduced by those nested closures mess with the creation of the recursive environment of `RecRecord`s generated by `merge`.
