### PR TITLE
[CI] Only check formatting on stable channel

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -70,7 +70,7 @@
         else
           [];
 
-      buildNickel = { system, isShell ? false, channel ? "stable" }:
+      buildNickel = { system, isShell ? false, channel ? "stable", checkFmt ?  false }:
         let
           pkgs = mkPkgs {inherit system;};
 
@@ -106,8 +106,10 @@
           checkPhase =
             ''
               cargo test --release --frozen --offline
-              cargo fmt --all -- --check
-            '';
+            '' + (if checkFmt then ''
+
+                cargo fmt --all -- --check
+              '' else "");
 
           installPhase =
             ''
@@ -225,8 +227,8 @@
           '';
         };
 
-      buildDevShell = { system, channel ? "stable" }: 
-      let 
+      buildDevShell = { system, channel ? "stable" }:
+      let
         pkgs = mkPkgs { inherit system; };
         nickel = buildNickel { inherit system; isShell = true; };
         rust = (mkRust pkgs channel).rust.override({
@@ -239,7 +241,7 @@
             [ $RESULT != 0 ] && echo "Please run \`cargo fmt\` before"
             exit $RESULT
           '';
-        
+
         installGitHooks = hookTypes:
           let mkHook = type: hooks: {
             hook = pkgs.writeShellScript type
@@ -268,7 +270,7 @@
           '';
           in
 
-          pkgs.writeShellScriptBin "install-git-hooks" 
+          pkgs.writeShellScriptBin "install-git-hooks"
           ''
 
             if [[ ! -d .git ]] || [[ ! -f flake.nix ]]; then
@@ -282,14 +284,14 @@
             fi
 
             mkdir -p ./.git/hooks
-            
+
             ${pkgs.lib.concatStringsSep "\n" (pkgs.lib.mapAttrsToList (type: hooks: installHookScript (mkHook type hooks)) hookTypes )}
 
             echo "Installed git hooks: $INSTALLED_GIT_HOOKS"
             printf "%s\n" "''${INSTALLED_GIT_HOOKS[@]}" > .git/hooks/nix-installed-hooks
           '';
-        
-        uninstallGitHooks = pkgs.writeShellScriptBin "uninstall-git-hooks" 
+
+        uninstallGitHooks = pkgs.writeShellScriptBin "uninstall-git-hooks"
           ''
           if [[ ! -e "$PWD/.git/hooks/nix-installed-hooks" ]]; then
             echo "Error: could find list of installed hooks."
@@ -332,8 +334,9 @@
         } //
         (builtins.listToAttrs
           (map (channel:
+            let checkFmt = channel == "stable"; in
             { name = "nickel-against-${channel}-rust-channel";
-              value = buildNickel { inherit system channel; };
+              value = buildNickel { inherit system channel checkFmt; };
             }
           )
           (builtins.attrNames RUST_CHANNELS))


### PR DESCRIPTION
The CI is checking nickel against all channels, and it checks in particular formatting. But we just had a case where beta and stable had different and incompatible `cargo fmt` outputs, making it impossible to please the CI.

This PR disables formatting check on all rust channels but stable.