### PR TITLE
Add curried operator syntax

### DIFF
--- a/src/grammar.lalrpop
+++ b/src/grammar.lalrpop
@@ -371,32 +371,67 @@ switch_case: SwitchCase = {
     "_" "=>" <t: Term> => SwitchCase::Default(<>),
 }
 
+InfixBOp2: BinaryOp = {
+    "++" => BinaryOp::StrConcat(),
+    "@" => BinaryOp::ListConcat(),
+}
+
+InfixBOp3: BinaryOp = {
+    "*" => BinaryOp::Mult(),
+    "/" => BinaryOp::Div(),
+    "%" => BinaryOp::Modulo(),
+}
+
+InfixBOp4: BinaryOp = {
+    "+" => BinaryOp::Plus(),
+    "-" => BinaryOp::Sub(),
+}
+
+InfixUOp5: UnaryOp = {
+    "!" => UnaryOp::BoolNot(),
+}
+
+InfixBOp6: BinaryOp = {
+    "&" => BinaryOp::Merge(),
+}
+
+InfixBOp7: BinaryOp = {
+    "<" => BinaryOp::LessThan(),
+    "<=" => BinaryOp::LessOrEq(),
+    ">" => BinaryOp::GreaterThan(),
+    ">=" => BinaryOp::GreaterOrEq(),
+}
+
+InfixBOp8: BinaryOp = {
+    "==" => BinaryOp::Eq(),
+}
+
+InfixLazyBOp9: UnaryOp = {
+    "&&" => UnaryOp::BoolAnd(),
+}
+
+InfixLazyBOp10: UnaryOp = {
+    "||" => UnaryOp::BoolOr(),
+}
+
+InfixBOp: BinaryOp = {
+    InfixBOp2,
+    InfixBOp3,
+    InfixBOp4,
+    InfixBOp6,
+    InfixBOp7,
+    InfixBOp8,
+}
+
+InfixLazyBOp: UnaryOp = {
+    InfixUOp5,
+    InfixLazyBOp9,
+    InfixLazyBOp10,
+}
+
 InfixOp: InfixOp = {
-    "++" => InfixOp::Binary(BinaryOp::StrConcat()),
-    "@" => InfixOp::Binary(BinaryOp::ListConcat()),
-
-    "*" => InfixOp::Binary(BinaryOp::Mult()),
-    "/" => InfixOp::Binary(BinaryOp::Div()),
-    "%" => InfixOp::Binary(BinaryOp::Modulo()),
-
-    "+" => InfixOp::Binary(BinaryOp::Plus()),
-    "-" => InfixOp::Binary(BinaryOp::Sub()),
-
-    "!" => InfixOp::Unary(UnaryOp::BoolNot()),
-
-    "&" => InfixOp::Binary(BinaryOp::Merge()),
-
-    "<" => InfixOp::Binary(BinaryOp::LessThan()),
-    "<=" => InfixOp::Binary(BinaryOp::LessOrEq()),
-    ">" => InfixOp::Binary(BinaryOp::GreaterThan()),
-    ">=" => InfixOp::Binary(BinaryOp::GreaterOrEq()),
-
-    "==" => InfixOp::Binary(BinaryOp::Eq()),
-    "!=" => InfixOp::Unary(UnaryOp::BoolNot()),
-
-    "&&" => InfixOp::Unary(UnaryOp::BoolAnd()),
-
-    "||" => InfixOp::Unary(UnaryOp::BoolOr()),
+    <InfixBOp> => <>.into(),
+    <InfixLazyBOp> => <>.into(),
 }
 
 CurriedOp: RichTerm = {
@@ -406,68 +441,65 @@ CurriedOp: RichTerm = {
             mk_app!(mk_term::var("x2"), mk_term::var("x1"))
             .with_pos(mk_pos(src_id, l, r))
         ),
+    <l: @L> "!=" <r: @R> =>
+        mk_fun!("x1", "x2",
+            mk_term::op1(
+                UnaryOp::BoolNot(),
+                Term::Op2(BinaryOp::Eq(),
+                    mk_term::var("x2"),
+                    mk_term::var("x1")
+                )
+            )
+            .with_pos(mk_pos(src_id, l, r))
+        ),
 }
+
+InfixUOpApp<UOp, Expr>: RichTerm =
+  <op: UOp> <t: WithPos<Expr>> => mk_term::op1(op, t);
+
+InfixBOpApp<BOp, LExpr, RExpr>: RichTerm =
+  <t1: WithPos<LExpr>> <op: BOp> <t2: WithPos<RExpr>> => mk_term::op2(op, t1, t2);
+
+InfixLazyBOpApp<UOp, LExpr, RExpr>: RichTerm =
+  <t1: WithPos<LExpr>> <op: UOp> <t2: WithPos<RExpr>> =>
+    mk_app!(mk_term::op1(op, t1), t2);
 
 InfixExpr: RichTerm = {
     #[precedence(level="0")]
     Applicative,
 
     #[precedence(level="1")]
-    "-" <WithPos<InfixExpr>> =>
-        mk_term::op2(BinaryOp::Sub(), Term::Num(0.0), <>),
+    "-" <WithPos<InfixExpr>> => mk_term::op2(BinaryOp::Sub(), Term::Num(0.0), <>),
 
     #[precedence(level="2")] #[assoc(side="left")]
-    <t1: WithPos<InfixExpr>> "++" <t2: WithPos<InfixExpr>> =>
-        mk_term::op2(BinaryOp::StrConcat(), t1, t2),
-    <t1: WithPos<InfixExpr>> "@" <t2: WithPos<InfixExpr>> =>
-        mk_term::op2(BinaryOp::ListConcat(), t1, t2),
+    InfixBOpApp<InfixBOp2, InfixExpr, InfixExpr>,
 
     #[precedence(level="3")] #[assoc(side="left")]
-    <t1: WithPos<InfixExpr>> "*" <t2: WithPos<InfixExpr>> =>
-        mk_term::op2(BinaryOp::Mult(), t1, t2),
-    <t1: WithPos<InfixExpr>> "/" <t2: WithPos<InfixExpr>> =>
-        mk_term::op2(BinaryOp::Div(), t1, t2),
-    <t1: WithPos<InfixExpr>> "%" <t2: WithPos<InfixExpr>> =>
-        mk_term::op2(BinaryOp::Modulo(), t1, t2),
+    InfixBOpApp<InfixBOp3, InfixExpr, InfixExpr>,
 
     #[precedence(level="4")] #[assoc(side="left")]
-    <t1: WithPos<InfixExpr>> "+" <t2: WithPos<InfixExpr>> =>
-        mk_term::op2(BinaryOp::Plus(), t1, t2),
-    <t1: WithPos<InfixExpr>> "-" <t2: WithPos<InfixExpr>> =>
-        mk_term::op2(BinaryOp::Sub(), t1, t2),
+    InfixBOpApp<InfixBOp4, InfixExpr, InfixExpr>,
 
     #[precedence(level="5")]
-    "!" <WithPos<InfixExpr>> => mk_term::op1(UnaryOp::BoolNot(), <>),
+    InfixUOpApp<InfixUOp5, InfixExpr>,
 
     #[precedence(level="6")] #[assoc(side="left")]
-    <t1: WithPos<InfixExpr>> "&" <t2: WithPos<InfixExpr>> =>
-        mk_term::op2(BinaryOp::Merge(), t1, t2),
-    <t1: WithPos<InfixExpr>> "|>" <t2: WithPos<InfixExpr>> =>
-        mk_app!(t2, t1),
+    InfixBOpApp<InfixBOp6, InfixExpr, InfixExpr>,
+    <t1: WithPos<InfixExpr>> "|>" <t2: WithPos<InfixExpr>> => mk_app!(t2, t1),
 
     #[precedence(level="7")] #[assoc(side="left")]
-    <t1: WithPos<InfixExpr>> "<" <t2: WithPos<InfixExpr>> =>
-        mk_term::op2(BinaryOp::LessThan(), t1, t2),
-    <t1: WithPos<InfixExpr>> "<=" <t2: WithPos<InfixExpr>> =>
-        mk_term::op2(BinaryOp::LessOrEq(), t1, t2),
-    <t1: WithPos<InfixExpr>> ">" <t2: WithPos<InfixExpr>> =>
-        mk_term::op2(BinaryOp::GreaterThan(), t1, t2),
-    <t1: WithPos<InfixExpr>> ">=" <t2: WithPos<InfixExpr>> =>
-        mk_term::op2(BinaryOp::GreaterOrEq(), t1, t2),
+    InfixBOpApp<InfixBOp7, InfixExpr, InfixExpr>,
 
     #[precedence(level="8")] #[assoc(side="left")]
-    <t1: WithPos<InfixExpr>> "==" <t2: WithPos<InfixExpr>> =>
-        mk_term::op2(BinaryOp::Eq(), t1, t2),
+    InfixBOpApp<InfixBOp8, InfixExpr, InfixExpr>,
     <t1: WithPos<InfixExpr>> "!=" <t2: WithPos<InfixExpr>> =>
         mk_term::op1(UnaryOp::BoolNot(), Term::Op2(BinaryOp::Eq(), t1, t2)),
 
     #[precedence(level="9")] #[assoc(side="left")]
-    <t1: WithPos<InfixExpr>> "&&" <t2: WithPos<InfixExpr>> =>
-        mk_app!(mk_term::op1(UnaryOp::BoolAnd(), t1), t2),
+    InfixLazyBOpApp<InfixLazyBOp9, InfixExpr, InfixExpr>,
 
     #[precedence(level="10")] #[assoc(side="left")]
-    <t1: WithPos<InfixExpr>> "||" <t2: WithPos<InfixExpr>> =>
-        mk_app!(mk_term::op1(UnaryOp::BoolOr(), t1), t2),
+    InfixLazyBOpApp<InfixLazyBOp10, InfixExpr, InfixExpr>,
 }
 
 BOpPre: BinaryOp = {

--- a/src/grammar.lalrpop
+++ b/src/grammar.lalrpop
@@ -6,12 +6,10 @@ use codespan::FileId;
 use lalrpop_util::ErrorRecovery;
 
 use super::ExtendedTerm;
-use super::utils::{StringKind, mk_pos, mk_label, mk_span, strip_indent, SwitchCase,
-    FieldPathElem, strip_indent_doc, build_record, elaborate_field_path, check_unbound,
-    ChunkLiteralPart, RecordLastField};
+use super::utils::*;
 use super::lexer::{Token, NormalToken, StringToken, MultiStringToken};
 
-use crate::{mk_app, mk_opn};
+use crate::{mk_app, mk_opn, mk_fun};
 use crate::identifier::Ident;
 use crate::parser::error::ParseError;
 use crate::term::{BinaryOp, RichTerm, Term, UnaryOp, StrChunk, MetaValue,
@@ -177,6 +175,7 @@ RecordOperationChain: RichTerm = {
 };
 
 Atom: RichTerm = {
+    "(" <CurriedOp> ")",
     "(" <Term> ")",
     "num literal" => RichTerm::from(Term::Num(<>)),
     "null" => RichTerm::from(Term::Null),
@@ -370,6 +369,43 @@ UOp: UnaryOp = {
 switch_case: SwitchCase = {
     "`" <id: EnumTag> "=>" <t: Term> => SwitchCase::Normal(id, t),
     "_" "=>" <t: Term> => SwitchCase::Default(<>),
+}
+
+InfixOp: InfixOp = {
+    "++" => InfixOp::Binary(BinaryOp::StrConcat()),
+    "@" => InfixOp::Binary(BinaryOp::ListConcat()),
+
+    "*" => InfixOp::Binary(BinaryOp::Mult()),
+    "/" => InfixOp::Binary(BinaryOp::Div()),
+    "%" => InfixOp::Binary(BinaryOp::Modulo()),
+
+    "+" => InfixOp::Binary(BinaryOp::Plus()),
+    "-" => InfixOp::Binary(BinaryOp::Sub()),
+
+    "!" => InfixOp::Unary(UnaryOp::BoolNot()),
+
+    "&" => InfixOp::Binary(BinaryOp::Merge()),
+
+    "<" => InfixOp::Binary(BinaryOp::LessThan()),
+    "<=" => InfixOp::Binary(BinaryOp::LessOrEq()),
+    ">" => InfixOp::Binary(BinaryOp::GreaterThan()),
+    ">=" => InfixOp::Binary(BinaryOp::GreaterOrEq()),
+
+    "==" => InfixOp::Binary(BinaryOp::Eq()),
+    "!=" => InfixOp::Unary(UnaryOp::BoolNot()),
+
+    "&&" => InfixOp::Unary(UnaryOp::BoolAnd()),
+
+    "||" => InfixOp::Unary(UnaryOp::BoolOr()),
+}
+
+CurriedOp: RichTerm = {
+    <l: @L> <op: InfixOp> <r: @R> => op.eta_expand(mk_pos(src_id, l, r)),
+    <l: @L> "|>" <r: @R> =>
+        mk_fun!("x1", "x2",
+            mk_app!(mk_term::var("x2"), mk_term::var("x1"))
+            .with_pos(mk_pos(src_id, l, r))
+        ),
 }
 
 InfixExpr: RichTerm = {

--- a/src/grammar.lalrpop
+++ b/src/grammar.lalrpop
@@ -423,7 +423,7 @@ InfixBOp: BinaryOp = {
     InfixBOp8,
 }
 
-InfixLazyBOp: UnaryOp = {
+InfixUOpOrLazyBOp: UnaryOp = {
     InfixUOp5,
     InfixLazyBOp9,
     InfixLazyBOp10,
@@ -431,7 +431,7 @@ InfixLazyBOp: UnaryOp = {
 
 InfixOp: InfixOp = {
     <InfixBOp> => <>.into(),
-    <InfixLazyBOp> => <>.into(),
+    <InfixUOpOrLazyBOp> => <>.into(),
 }
 
 CurriedOp: RichTerm = {

--- a/src/parser/utils.rs
+++ b/src/parser/utils.rs
@@ -12,7 +12,7 @@ use crate::{
     mk_app, mk_fun,
     parser::error::ParseError,
     position::{RawSpan, TermPos},
-    term::{make as mk_term, BinaryOp, NAryOp, RecordAttrs, RichTerm, StrChunk, Term, UnaryOp},
+    term::{make as mk_term, BinaryOp, RecordAttrs, RichTerm, StrChunk, Term, UnaryOp},
     types::{AbsType, Types},
 };
 
@@ -64,7 +64,6 @@ pub enum RecordLastField {
 pub enum InfixOp {
     Unary(UnaryOp),
     Binary(BinaryOp),
-    NAry(NAryOp),
 }
 
 impl InfixOp {
@@ -80,13 +79,6 @@ impl InfixOp {
                 "x2",
                 mk_term::op2(op, mk_term::var("x1"), mk_term::var("x2")).with_pos(pos)
             ),
-            InfixOp::NAry(op) => {
-                let var_names = (1..=op.arity()).map(|i| format!("x{}", i));
-                let args: Vec<_> = var_names.clone().map(mk_term::var).collect();
-                var_names.rfold(mk_term::opn(op, args).with_pos(pos), |term, var| {
-                    mk_fun!(var, term)
-                })
-            }
         }
     }
 }

--- a/src/parser/utils.rs
+++ b/src/parser/utils.rs
@@ -1,17 +1,20 @@
+//! Various helpers and companion code for the parser are put here to keep the grammar definition
+//! uncluttered.
 use std::collections::hash_map::Entry;
 use std::collections::{HashMap, HashSet};
 use std::fmt::Debug;
 
 use codespan::FileId;
 
-use crate::identifier::Ident;
-/// A few helpers to generate position spans and labels easily during parsing
-use crate::label::Label;
-use crate::mk_app;
-use crate::parser::error::ParseError;
-use crate::position::{RawSpan, TermPos};
-use crate::term::{make as mk_term, BinaryOp, RecordAttrs, RichTerm, StrChunk, Term};
-use crate::types::{AbsType, Types};
+use crate::{
+    identifier::Ident,
+    label::Label,
+    mk_app, mk_fun,
+    parser::error::ParseError,
+    position::{RawSpan, TermPos},
+    term::{make as mk_term, BinaryOp, NAryOp, RecordAttrs, RichTerm, StrChunk, Term, UnaryOp},
+    types::{AbsType, Types},
+};
 
 /// Distinguish between the standard string separators `"`/`"` and the multi-line string separators
 /// `m#"`/`"#m` in the parser.
@@ -55,6 +58,37 @@ pub enum ChunkLiteralPart<'input> {
 pub enum RecordLastField {
     Field((FieldPathElem, RichTerm)),
     Ellipsis,
+}
+
+/// An infix operator that is not applied. Used for the curried operator syntax (e.g `(==)`)
+pub enum InfixOp {
+    Unary(UnaryOp),
+    Binary(BinaryOp),
+    NAry(NAryOp),
+}
+
+impl InfixOp {
+    /// Eta-expand an operator. This wraps an operator, for example `==`, as a function `fun x1 x2
+    /// => x1 == x2`. Propagate the given position to the function body, for better error
+    /// reporting.
+    pub fn eta_expand(self, pos: TermPos) -> RichTerm {
+        let pos = pos.into_inherited();
+        match self {
+            InfixOp::Unary(op) => mk_fun!("x", mk_term::op1(op, mk_term::var("x")).with_pos(pos)),
+            InfixOp::Binary(op) => mk_fun!(
+                "x1",
+                "x2",
+                mk_term::op2(op, mk_term::var("x1"), mk_term::var("x2")).with_pos(pos)
+            ),
+            InfixOp::NAry(op) => {
+                let var_names = (1..=op.arity()).map(|i| format!("x{}", i));
+                let args: Vec<_> = var_names.clone().map(mk_term::var).collect();
+                var_names.rfold(mk_term::opn(op, args).with_pos(pos), |term, var| {
+                    mk_fun!(var, term)
+                })
+            }
+        }
+    }
 }
 
 /// Elaborate a record field definition specified as a path, like `a.b.c = foo`, into a regular

--- a/src/parser/utils.rs
+++ b/src/parser/utils.rs
@@ -66,6 +66,18 @@ pub enum InfixOp {
     Binary(BinaryOp),
 }
 
+impl From<UnaryOp> for InfixOp {
+    fn from(op: UnaryOp) -> Self {
+        InfixOp::Unary(op)
+    }
+}
+
+impl From<BinaryOp> for InfixOp {
+    fn from(op: BinaryOp) -> Self {
+        InfixOp::Binary(op)
+    }
+}
+
 impl InfixOp {
     /// Eta-expand an operator. This wraps an operator, for example `==`, as a function `fun x1 x2
     /// => x1 == x2`. Propagate the given position to the function body, for better error

--- a/src/term.rs
+++ b/src/term.rs
@@ -1228,6 +1228,13 @@ pub mod make {
         Term::Op2(op, t1.into(), t2.into()).into()
     }
 
+    pub fn opn<T>(op: NAryOp, args: Vec<T>) -> RichTerm
+    where
+        T: Into<RichTerm>,
+    {
+        Term::OpN(op, args.into_iter().map(T::into).collect()).into()
+    }
+
     pub fn assume<T>(types: Types, l: Label, t: T) -> RichTerm
     where
         T: Into<RichTerm>,


### PR DESCRIPTION
Add support for a curried operator `(op)`, such as `(==)`. This is handy to pass operators to higher-order functions or to use them in a pipeline:

```
[1,2,3,4]
|> lists.map ((+) 2)
|> lists.filter ((<=) 4)
|> (==) [4,5,6]
```

A curried operator like `(==)` is desugared at parsing time as `fun x1 x2 => x1 == x2`.