### PR TITLE
Implementing let blocks, adding non-regression test

### DIFF
--- a/lsp/nls/src/linearization.rs
+++ b/lsp/nls/src/linearization.rs
@@ -12,7 +12,7 @@ use nickel::{
             ScopeId, TermKind, Unresolved, UsageState,
         },
         reporting::{to_type, NameReg},
-        TypeWrapper, UnifTable,
+        Closure, Envs, TypeWrapper, UnifTable,
     },
     types::AbsType,
 };
@@ -569,7 +569,12 @@ impl Linearizer<BuildingResource, (UnifTable, HashMap<usize, Ident>)> for Analys
                      scope,
                      meta,
                  }| LinearizationItem {
-                    ty: to_type(&table, &reported_names, &mut NameReg::new(), ty),
+                    ty: to_type(
+                        &table,
+                        &reported_names,
+                        &mut NameReg::new(),
+                        Closure::new(ty, Envs::new()),
+                    ),
                     id,
                     pos,
                     kind,

--- a/src/error.rs
+++ b/src/error.rs
@@ -432,9 +432,6 @@ impl ParseError {
                 InternalParseError::Lexical(LexicalError::InvalidAsciiEscapeCode(location)) => {
                     ParseError::InvalidAsciiEscapeCode(mk_span(file_id, location, location + 2))
                 }
-                InternalParseError::UnboundTypeVariables(idents, span) => {
-                    ParseError::UnboundTypeVariables(idents, span)
-                }
             },
         }
     }

--- a/src/grammar.lalrpop
+++ b/src/grammar.lalrpop
@@ -7,7 +7,7 @@ use lalrpop_util::ErrorRecovery;
 
 use super::ExtendedTerm;
 use super::utils::{StringKind, mk_pos, mk_label, strip_indent, SwitchCase,
-    FieldPathElem, strip_indent_doc, build_record, elaborate_field_path,
+    FieldPathElem, strip_indent_doc, build_letblock, build_record, elaborate_field_path,
     ChunkLiteralPart, RecordLastField};
 use super::lexer::{Token, NormalToken, StringToken, MultiStringToken};
 
@@ -87,19 +87,24 @@ pub ExtendedTerm: ExtendedTerm = {
     Term => ExtendedTerm::RichTerm(<>),
 }
 
-RootTerm: RichTerm = {
-    "let" <id:Ident> <meta: Annot?> "=" <t1: Term> "in"
-        <t2: Term> => {
-        let t1 = if let Some(mut meta) = meta {
-            let pos = t1.pos;
-            meta.value = Some(t1);
+LetBlockField : (Ident, RichTerm) = {
+    <id: Ident> <meta: Annot?> "=" <term: Term> => {
+        let term = if let Some(mut meta) = meta {
+            let pos = term.pos;
+            meta.value = Some(term);
             RichTerm::new(Term::MetaValue(meta), pos)
         }
         else {
-            t1
+            term
         };
+        (id, term)
+    }
+}
 
-        mk_term::let_in(id, t1, t2)
+RootTerm: RichTerm = {
+    "let" <defs: (<LetBlockField> ",")*> <last: LetBlockField?> "in" <term: Term> => {
+        let lets = defs.into_iter().chain(last.into_iter());
+        RichTerm::from(build_letblock(lets, term))
     },
     <l: @L> "fun" <ps:Pattern+> "=>" <t: Term> <r: @R> => {
         let pos = mk_pos(src_id, l, r);

--- a/src/grammar.lalrpop
+++ b/src/grammar.lalrpop
@@ -6,8 +6,8 @@ use codespan::FileId;
 use lalrpop_util::ErrorRecovery;
 
 use super::ExtendedTerm;
-use super::utils::{StringKind, mk_pos, mk_label, mk_span, strip_indent, SwitchCase,
-    FieldPathElem, strip_indent_doc, build_record, elaborate_field_path, check_unbound,
+use super::utils::{StringKind, mk_pos, mk_label, strip_indent, SwitchCase,
+    FieldPathElem, strip_indent_doc, build_record, elaborate_field_path,
     ChunkLiteralPart, RecordLastField};
 use super::lexer::{Token, NormalToken, StringToken, MultiStringToken};
 
@@ -22,9 +22,8 @@ use crate::types::{Types, AbsType};
 grammar<'input, 'err>(src_id: FileId, errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParseError>>);
 
 WithPos<Rule>: RichTerm = <l: @L> <t: Rule> <r: @R> => t.with_pos(mk_pos(src_id, l, r));
-CheckUnbound<Rule>: Types = <l: @L> <t: Rule> <r: @R> =>? check_unbound(&t, mk_span(src_id, l, r)).map_err(|e| lalrpop_util::ParseError::User{error: e}).and(Ok(t));
 
-TypeAnnot: MetaValue = ":" <l: @L> <ty_res: CheckUnbound<Types>> <r: @R> => MetaValue {
+TypeAnnot: MetaValue = ":" <l: @L> <ty_res: Types> <r: @R> => MetaValue {
     doc: None,
     types: Some(Contract {types: ty_res.clone(), label: mk_label(ty_res, src_id, l, r)}),
     contracts: Vec::new(),
@@ -33,7 +32,7 @@ TypeAnnot: MetaValue = ":" <l: @L> <ty_res: CheckUnbound<Types>> <r: @R> => Meta
 };
 
 MetaAnnotAtom: MetaValue = {
-    "|" <l: @L> <ty_res: CheckUnbound<Types>> <r: @R> => MetaValue {
+    "|" <l: @L> <ty_res: Types> <r: @R> => MetaValue {
         doc: None,
         types: None,
         contracts: vec![Contract {types: ty_res.clone(), label: mk_label(ty_res, src_id, l, r)}],

--- a/src/parser/error.rs
+++ b/src/parser/error.rs
@@ -1,6 +1,3 @@
-use crate::identifier::Ident;
-use crate::position::RawSpan;
-
 #[derive(Clone, PartialEq, Debug)]
 pub enum LexicalError {
     /// A closing brace '}' does not match an opening brace '{'.
@@ -17,6 +14,4 @@ pub enum LexicalError {
 pub enum ParseError {
     /// A specific lexical error
     Lexical(LexicalError),
-    /// Unbound type variable(s)
-    UnboundTypeVariables(Vec<Ident>, RawSpan),
 }

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -373,30 +373,3 @@ fn line_comments() {
         parse_without_pos("{field = foo}")
     );
 }
-
-#[test]
-fn unbound_type_variables() {
-    // should fail, "a" is unbound
-    assert_matches!(
-        parse("1 | a"),
-        Err(ParseError::UnboundTypeVariables(unbound_vars, _)) if (unbound_vars.contains(&Ident::from("a")) && unbound_vars.len() == 1)
-    );
-
-    // should fail, "d" is unbound
-    assert_matches!(
-        parse("null: forall a b c. a -> (b -> List c) -> {foo : List {_ : d}, bar: b | Dyn}"),
-        Err(ParseError::UnboundTypeVariables(unbound_vars, _)) if (unbound_vars.contains(&Ident::from("d")) && unbound_vars.len() == 1)
-    );
-
-    // should fail, "e" is unbound
-    assert_matches!(
-        parse("null: forall a b c. a -> (b -> List c) -> {foo : List {_ : a}, bar: b | e}"),
-        Err(ParseError::UnboundTypeVariables(unbound_vars, _)) if (unbound_vars.contains(&Ident::from("e")) && unbound_vars.len() == 1)
-    );
-
-    // should fail, "a" is unbound
-    assert_matches!(
-        parse("null: a -> (forall a. a -> a)"),
-        Err(ParseError::UnboundTypeVariables(unbound_vars, _)) if (unbound_vars.contains(&Ident::from("a")) && unbound_vars.len() == 1)
-    );
-}

--- a/src/parser/utils.rs
+++ b/src/parser/utils.rs
@@ -106,6 +106,24 @@ pub fn elaborate_field_path(
     (fst, content)
 }
 
+pub fn build_letblock<I>(fields: I, rest: RichTerm) -> Term
+where
+    I: IntoIterator<Item = (Ident, RichTerm)>,
+{
+    let fields = fields.into_iter().collect::<Vec<(Ident, RichTerm)>>();
+
+    if fields.len() == 1 {
+        let (id, term) = fields[0].clone();
+        Term::Let(id, term, rest)
+    } else {
+        let mut data = vec![];
+        for (id, term) in fields.iter() {
+            data.push((id.clone(), term.clone()));
+        }
+        Term::LetBlock(data, rest)
+    }
+}
+
 /// Build a record from a list of field definitions. If a field is defined several times, the
 /// different definitions are merged.
 pub fn build_record<I>(fields: I, attrs: RecordAttrs) -> Term

--- a/src/parser/utils.rs
+++ b/src/parser/utils.rs
@@ -1,5 +1,5 @@
 use std::collections::hash_map::Entry;
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::fmt::Debug;
 
 use codespan::FileId;
@@ -8,10 +8,9 @@ use crate::identifier::Ident;
 /// A few helpers to generate position spans and labels easily during parsing
 use crate::label::Label;
 use crate::mk_app;
-use crate::parser::error::ParseError;
 use crate::position::{RawSpan, TermPos};
 use crate::term::{make as mk_term, BinaryOp, RecordAttrs, RichTerm, StrChunk, Term};
-use crate::types::{AbsType, Types};
+use crate::types::Types;
 
 /// Distinguish between the standard string separators `"`/`"` and the multi-line string separators
 /// `m#"`/`"#m` in the parser.
@@ -418,65 +417,4 @@ pub fn strip_indent_doc(doc: String) -> String {
         })
         .next()
         .expect("expected non-empty chunks after indentation of documentation")
-}
-
-/// Recursively checks for unbound type variables in a type
-pub fn check_unbound(types: &Types, span: RawSpan) -> Result<(), ParseError> {
-    // heavy lifting function, recurses into a type expression and returns a set of unbound vars
-    fn find_unbound_vars(types: &Types, unbound_set: &mut HashSet<Ident>) {
-        match &types.0 {
-            AbsType::Var(ident) => {
-                unbound_set.insert(ident.clone());
-            }
-            AbsType::Forall(ident, ty) => {
-                // forall needs a "scoped" set for the variables in its nodes
-                let mut forall_unbound_vars = HashSet::new();
-                find_unbound_vars(ty, &mut forall_unbound_vars);
-
-                forall_unbound_vars.remove(ident);
-
-                // once the forall vars are recursed into and analyzed, the parent set and
-                // the forall set are merged
-                unbound_set.extend(forall_unbound_vars);
-            }
-            AbsType::Arrow(s, t) => {
-                find_unbound_vars(s, unbound_set);
-                find_unbound_vars(t, unbound_set);
-            }
-            AbsType::DynRecord(ty)
-            | AbsType::StaticRecord(ty)
-            | AbsType::List(ty)
-            | AbsType::Enum(ty) => {
-                find_unbound_vars(ty, unbound_set);
-            }
-            AbsType::RowExtend(_, opt_ty, ty) => {
-                if let Some(ty) = opt_ty {
-                    find_unbound_vars(ty, unbound_set);
-                }
-
-                find_unbound_vars(ty, unbound_set);
-            }
-            AbsType::Dyn()
-            | AbsType::Bool()
-            | AbsType::Num()
-            | AbsType::Str()
-            | AbsType::Sym()
-            | AbsType::Flat(_)
-            | AbsType::RowEmpty() => {}
-        }
-    }
-
-    let mut unbound_set: HashSet<Ident> = HashSet::new();
-
-    // recurse into type and find unbound type vars
-    find_unbound_vars(types, &mut unbound_set);
-
-    if !unbound_set.is_empty() {
-        return Err(ParseError::UnboundTypeVariables(
-            unbound_set.into_iter().collect(),
-            span,
-        ));
-    }
-
-    Ok(())
 }

--- a/src/repl/mod.rs
+++ b/src/repl/mod.rs
@@ -79,7 +79,7 @@ pub struct REPLImpl {
     /// The typing environment, counterpart of the eval environment for typechecking. Entries are
     /// [`TypeWrapper`](../typecheck/enum.TypeWrapper.html) for the ease of interacting with the
     /// typechecker, but there are not any unification variable in it.
-    type_env: typecheck::Environment,
+    type_env: typecheck::GlobalEnvironment,
 }
 
 impl REPLImpl {
@@ -90,7 +90,7 @@ impl REPLImpl {
             parser: grammar::ExtendedTermParser::new(),
             eval_env: eval::Environment::new(),
             init_eval_env: eval::Environment::new(),
-            type_env: typecheck::Environment::new(),
+            type_env: typecheck::GlobalEnvironment::new(),
         }
     }
 
@@ -101,7 +101,7 @@ impl REPLImpl {
 
         self.eval_env = self.cache.mk_global_env().unwrap();
         self.init_eval_env = self.eval_env.clone();
-        self.type_env = typecheck::Envs::mk_global(&self.eval_env);
+        self.type_env = typecheck::mk_global(&self.eval_env);
         Ok(())
     }
 
@@ -237,7 +237,10 @@ impl REPL for REPLImpl {
 
         Ok(typecheck::apparent_type(
             term.as_ref(),
-            Some(&typecheck::Envs::from_global(&self.type_env)),
+            Some((
+                &typecheck::Envs::from_global(&self.type_env),
+                &self.type_env,
+            )),
         )
         .into())
     }

--- a/src/typecheck/mod.rs
+++ b/src/typecheck/mod.rs
@@ -842,6 +842,32 @@ fn type_check_<S, E>(
                 Closure::new(ty, env),
             )
         }
+        Term::LetBlock(defs, rest) => {
+            for (id, term) in defs.iter() {
+                let ty_let = binding_type(term.as_ref(), &mut env, global, state.table, strict);
+                type_check_(
+                    state,
+                    global,
+                    lin,
+                    linearizer.scope(ScopeId::Left),
+                    strict,
+                    term,
+                    Closure::new(ty_let.clone(), env.clone()),
+                )?;
+                env.insert(id.clone(), Closure::new(ty_let, env.clone()));
+            }
+
+            type_check_(
+                state,
+                global,
+                lin,
+                linearizer,
+                strict,
+                rest,
+                Closure::new(ty, env),
+            )
+        }
+
         Term::App(e, t) => {
             let src = TypeWrapper::Ptr(new_var(state.table));
             let arr = mk_tyw_arrow!(src.clone(), ty);

--- a/src/types.rs
+++ b/src/types.rs
@@ -376,11 +376,11 @@ impl fmt::Display for Types {
             }
             AbsType::Sym() => write!(f, "Sym"),
             AbsType::Flat(ref t) => write!(f, "#{}", t.as_ref().shallow_repr()),
-            AbsType::Var(var) => write!(f, "{}", var),
-            AbsType::Forall(i, ref ty) => {
+            AbsType::Var(Ident(ref var, _)) => write!(f, "{}", var),
+            AbsType::Forall(Ident(ref i, _), ref ty) => {
                 let mut curr: &Types = ty.as_ref();
                 write!(f, "forall {}", i)?;
-                while let Types(AbsType::Forall(i, ref ty)) = curr {
+                while let Types(AbsType::Forall(Ident(ref i, _), ref ty)) = curr {
                     write!(f, " {}", i)?;
                     curr = ty;
                 }
@@ -390,7 +390,7 @@ impl fmt::Display for Types {
             AbsType::StaticRecord(row) => write!(f, "{{{}}}", row),
             AbsType::DynRecord(ty) => write!(f, "{{_: {}}}", ty),
             AbsType::RowEmpty() => Ok(()),
-            AbsType::RowExtend(id, ty_opt, tail) => {
+            AbsType::RowExtend(Ident(id, _), ty_opt, tail) => {
                 write!(f, "{}", id)?;
 
                 if let Some(ty) = ty_opt {

--- a/tests/pass/let_block.ncl
+++ b/tests/pass/let_block.ncl
@@ -1,0 +1,25 @@
+let letfoo = 3,
+    letbar : Num = 2,
+    lettoto : Bool = false,
+    lettutu = true,
+    lettest = "i'm a test",
+    f = fun x => x,
+    f2 : Num -> Bool = fun x => x == 2,
+in
+
+let letres = f2 2,
+    letisbar = fun y => y == letbar,
+in
+
+let letx = 5 in
+
+{
+    res = letres,
+    isbary = letisbar 2,
+    isbarn = letisbar 3,
+    toto = lettoto,
+    tutu = lettutu,
+    test = lettest,
+    f3 = f 3,
+    x = letx
+}

--- a/tests/typecheck_fail.rs
+++ b/tests/typecheck_fail.rs
@@ -4,11 +4,11 @@ use nickel::cache::resolvers::DummyResolver;
 use nickel::error::TypecheckError;
 use nickel::parser::{grammar, lexer};
 use nickel::term::RichTerm;
-use nickel::typecheck::{type_check_in_env, Environment};
+use nickel::typecheck::{type_check_in_env, GlobalEnvironment};
 use nickel::types::Types;
 
 fn type_check(rt: &RichTerm) -> Result<Types, TypecheckError> {
-    type_check_in_env(rt, &Environment::new(), &mut DummyResolver {})
+    type_check_in_env(rt, &GlobalEnvironment::new(), &mut DummyResolver {})
 }
 
 fn type_check_expr(s: impl std::string::ToString) -> Result<Types, TypecheckError> {


### PR DESCRIPTION
Implementation of let blocks in the form:
```
let foo = 3,
    bar : Num = 2,
    message = "Hello World",
    f = fun x => x,
    f2 : Num -> Bool = fun x => x == 2,
in
```
Adds a new node `LetBlock` in the AST that basically mimic all actions from simple `Let` term, simply looping through all the definitions and adding them to the environment before passing the environment to the final term.

Made for feature request #494 
Waiting for PR #502 and #470 to be merged.
Requesting reviews on the regression test to be sure to cover edge cases.