### PR TITLE
[Style]Small refactor for identifiers

### DIFF
--- a/lsp/nls/src/linearization.rs
+++ b/lsp/nls/src/linearization.rs
@@ -88,7 +88,7 @@ impl BuildingExt for Linearization<Building<BuildingResource>> {
             let id = self.id_gen().get_and_advance();
             self.push(LinearizationItem {
                 id,
-                pos: ident.1,
+                pos: ident.pos,
                 // temporary, the actual type is resolved later and the item retyped
                 ty: TypeWrapper::Concrete(AbsType::Dyn()),
                 kind: TermKind::RecordField {
@@ -326,7 +326,7 @@ impl Linearizer<BuildingResource, (UnifTable, HashMap<usize, Ident>)> for Analys
         // `offset` is used to find the [LinearizationItem] representing the field
         // Field items are inserted immediately after the record
         if !matches!(term, Term::Op1(UnaryOp::StaticAccess(_), _)) {
-            if let Some((record, (offset, Ident(_, field_pos)))) = self
+            if let Some((record, (offset, Ident {pos: field_pos, ..}))) = self
                 .record_fields
                 .take()
                 .map(|(record, mut fields)| (record, fields.pop().unwrap()))
@@ -379,7 +379,7 @@ impl Linearizer<BuildingResource, (UnifTable, HashMap<usize, Ident>)> for Analys
                 lin.push(LinearizationItem {
                     id,
                     ty,
-                    pos: ident.1,
+                    pos: ident.pos,
                     scope: self.scope.clone(),
                     kind: TermKind::Declaration(ident.to_owned(), Vec::new()),
                     meta: self.meta.take(),
@@ -395,7 +395,7 @@ impl Linearizer<BuildingResource, (UnifTable, HashMap<usize, Ident>)> for Analys
 
                 lin.push(LinearizationItem {
                     id: root_id,
-                    pos: ident.1,
+                    pos: ident.pos,
                     ty: TypeWrapper::Concrete(AbsType::Dyn()),
                     scope: self.scope.clone(),
                     kind: TermKind::Usage(UsageState::Resolved(self.env.get(ident))),
@@ -413,7 +413,7 @@ impl Linearizer<BuildingResource, (UnifTable, HashMap<usize, Ident>)> for Analys
                         let id = id_gen.get_and_advance();
                         lin.push(LinearizationItem {
                             id,
-                            pos: accessor.1,
+                            pos: accessor.pos,
                             ty: TypeWrapper::Concrete(AbsType::Dyn()),
                             scope: self.scope.clone(),
                             kind: TermKind::Usage(UsageState::Deferred {
@@ -463,7 +463,7 @@ impl Linearizer<BuildingResource, (UnifTable, HashMap<usize, Ident>)> for Analys
                             let id = id_gen.get_and_advance();
                             lin.push(LinearizationItem {
                                 id,
-                                pos: ident.1,
+                                pos: ident.pos,
                                 ty: TypeWrapper::Concrete(AbsType::Var(ident.to_owned())),
                                 scope: self.scope.clone(),
                                 // id = parent: full let binding including the body

--- a/lsp/nls/src/linearization.rs
+++ b/lsp/nls/src/linearization.rs
@@ -326,7 +326,7 @@ impl Linearizer<BuildingResource, (UnifTable, HashMap<usize, Ident>)> for Analys
         // `offset` is used to find the [LinearizationItem] representing the field
         // Field items are inserted immediately after the record
         if !matches!(term, Term::Op1(UnaryOp::StaticAccess(_), _)) {
-            if let Some((record, (offset, Ident {pos: field_pos, ..}))) = self
+            if let Some((record, (offset, Ident { pos: field_pos, .. }))) = self
                 .record_fields
                 .take()
                 .map(|(record, mut fields)| (record, fields.pop().unwrap()))

--- a/lsp/nls/src/requests/completion.rs
+++ b/lsp/nls/src/requests/completion.rs
@@ -51,7 +51,7 @@ pub fn handle_completion(
             _ => None,
         })
         .map(|(ident, _)| CompletionItem {
-            label: ident.0,
+            label: ident.label,
             ..Default::default()
         })
         .collect();

--- a/lsp/nls/src/requests/symbols.rs
+++ b/lsp/nls/src/requests/symbols.rs
@@ -38,7 +38,7 @@ pub fn handle_document_symbols(
                     // `deprecated` is a required field but causes a warning although we are not using it
                     #[allow(deprecated)]
                     Some(DocumentSymbol {
-                        name: name.0.to_owned(),
+                        name: name.to_string(),
                         detail: Some(format!("{}", item.ty)),
                         kind: SymbolKind::Variable,
                         tags: None,

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -364,9 +364,9 @@ pub enum StackElem {
 /// Kind of an identifier.
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum IdentKind {
-    Let(),
-    Lam(),
-    Record(),
+    Let,
+    Lam,
+    Record,
 }
 
 /// A closure, a term together with an environment.
@@ -402,7 +402,7 @@ pub fn env_add_term(env: &mut Environment, rt: RichTerm) -> Result<(), EnvBuildE
             let ext = bindings.into_iter().map(|(id, t)| {
                 (
                     id,
-                    Thunk::new(Closure::atomic_closure(t), IdentKind::Record()),
+                    Thunk::new(Closure::atomic_closure(t), IdentKind::Record),
                 )
             });
 
@@ -419,7 +419,7 @@ pub fn env_add(env: &mut Environment, id: Ident, rt: RichTerm, local_env: Enviro
         body: rt,
         env: local_env,
     };
-    env.insert(id, Thunk::new(closure, IdentKind::Let()));
+    env.insert(id, Thunk::new(closure, IdentKind::Let));
 }
 
 /// Determine if a thunk is worth being put on the stack for future update.
@@ -588,7 +588,7 @@ where
                     body: s,
                     env: env.clone(),
                 };
-                env.insert(x, Thunk::new(closure, IdentKind::Let()));
+                env.insert(x, Thunk::new(closure, IdentKind::Let));
                 Closure { body: t, env }
             }
             Term::Switch(exp, cases, default) => {
@@ -725,7 +725,7 @@ where
                                 body: rt.clone(),
                                 env: Environment::new(),
                             };
-                            rec_env.insert(id.clone(), Thunk::new(closure, IdentKind::Let()));
+                            rec_env.insert(id.clone(), Thunk::new(closure, IdentKind::Let));
                             Ok(rec_env)
                         }
                     },
@@ -1400,7 +1400,7 @@ mod tests {
             Ident::from("g"),
             Thunk::new(
                 Closure::atomic_closure(Term::Num(1.0).into()),
-                IdentKind::Let(),
+                IdentKind::Let,
             ),
         );
 
@@ -1421,7 +1421,7 @@ mod tests {
             .map(|(id, t)| {
                 (
                     id.into(),
-                    Thunk::new(Closure::atomic_closure(t), IdentKind::Let()),
+                    Thunk::new(Closure::atomic_closure(t), IdentKind::Let),
                 )
             })
             .collect()

--- a/src/grammar.lalrpop
+++ b/src/grammar.lalrpop
@@ -301,7 +301,8 @@ LastMatch: LastMatch = {
     ".."<Ident?> => LastMatch::Ellipsis(<>),
 };
 
-Ident: Ident = <l:@L> <i: "identifier"> <r:@R> => Ident(i.to_string(), mk_pos(src_id, l, r));
+Ident: Ident = <l:@L> <i: "identifier"> <r:@R>
+    => Ident { label: i.to_string(), pos: mk_pos(src_id, l, r) };
 
 Bool: bool = {
     "true" => true,

--- a/src/identifier.rs
+++ b/src/identifier.rs
@@ -48,7 +48,10 @@ where
     String: From<F>,
 {
     fn from(val: F) -> Self {
-        Ident {label: String::from(val), pos: TermPos::None}
+        Ident {
+            label: String::from(val),
+            pos: TermPos::None,
+        }
     }
 }
 

--- a/src/identifier.rs
+++ b/src/identifier.rs
@@ -6,23 +6,26 @@ use crate::position::TermPos;
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(into = "String", from = "String")]
-pub struct Ident(pub String, pub TermPos);
+pub struct Ident {
+    pub label: String,
+    pub pos: TermPos,
+}
 
 impl PartialOrd for Ident {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        self.0.partial_cmp(&other.0)
+        self.label.partial_cmp(&other.label)
     }
 }
 
 impl Ord for Ident {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        self.0.cmp(&other.0)
+        self.label.cmp(&other.label)
     }
 }
 
 impl PartialEq for Ident {
     fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
+        self.label == other.label
     }
 }
 
@@ -30,14 +33,13 @@ impl Eq for Ident {}
 
 impl Hash for Ident {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        self.0.hash(state);
+        self.label.hash(state);
     }
 }
 
 impl fmt::Display for Ident {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let Ident(ident, _) = self;
-        write!(f, "{}", ident)
+        write!(f, "{}", self.label)
     }
 }
 
@@ -46,12 +48,12 @@ where
     String: From<F>,
 {
     fn from(val: F) -> Self {
-        Ident(String::from(val), TermPos::None)
+        Ident {label: String::from(val), pos: TermPos::None}
     }
 }
 
 impl Into<String> for Ident {
     fn into(self) -> String {
-        self.0
+        self.label
     }
 }

--- a/src/operation.rs
+++ b/src/operation.rs
@@ -441,7 +441,7 @@ fn process_unary_operation(
                     Some(e) => Ok(Closure { body: e, env }),
 
                     None => Err(EvalError::FieldMissing(
-                        id.0,
+                        id.label,
                         String::from("(.)"),
                         RichTerm {
                             term: Box::new(Term::Record(static_map, attrs)),
@@ -587,11 +587,11 @@ fn process_unary_operation(
                 let rec = rec
                     .into_iter()
                     .map(|e| {
-                        let (Ident(s, ident_pos), t) = e;
+                        let (id, t) = e;
                         let pos = t.pos.into_inherited();
                         (
-                            Ident(s.clone(), ident_pos),
-                            mk_app!(f_as_var.clone(), mk_term::string(s), t)
+                            id.clone(),
+                            mk_app!(f_as_var.clone(), mk_term::string(id.label), t)
                                 .closurize(&mut shared_env, env.clone())
                                 .with_pos(pos),
                         )

--- a/src/parser/utils.rs
+++ b/src/parser/utils.rs
@@ -130,7 +130,10 @@ pub fn elaborate_field_path(
             };
 
             if let Some(static_access) = static_access {
-                let id = Ident(static_access, exp.pos);
+                let id = Ident {
+                    label: static_access,
+                    pos: exp.pos,
+                };
 
                 let mut map = HashMap::new();
                 map.insert(id, acc);
@@ -194,7 +197,14 @@ where
                     });
 
                     if is_static.is_ok() {
-                        insert_static_field(&mut static_map, Ident(buffer, e.pos), t)
+                        insert_static_field(
+                            &mut static_map,
+                            Ident {
+                                label: buffer,
+                                pos: e.pos,
+                            },
+                            t,
+                        )
                     } else {
                         dynamic_fields.push((e, t));
                     }

--- a/src/stack.rs
+++ b/src/stack.rs
@@ -194,7 +194,7 @@ impl Stack {
     /// If the argument is not tracked, it is directly returned.
     pub fn pop_arg_as_thunk(&mut self) -> Option<(Thunk, TermPos)> {
         match self.0.pop() {
-            Some(Marker::Arg(arg, pos)) => Some((Thunk::new(arg, IdentKind::Lam()), pos)),
+            Some(Marker::Arg(arg, pos)) => Some((Thunk::new(arg, IdentKind::Lam), pos)),
             Some(Marker::TrackedArg(arg_thunk, pos)) => Some((arg_thunk, pos)),
             Some(m) => {
                 self.0.push(m);
@@ -303,7 +303,7 @@ impl Stack {
             Some(Marker::TrackedArg(thunk, _)) => Some(thunk.clone()),
             Some(Marker::Arg(..)) => {
                 let (closure, pos) = self.pop_arg().unwrap();
-                let thunk = Thunk::new(closure, IdentKind::Lam());
+                let thunk = Thunk::new(closure, IdentKind::Lam);
                 self.push_tracked_arg(thunk.clone(), pos);
                 Some(thunk)
             }
@@ -354,7 +354,7 @@ mod tests {
     }
 
     fn some_thunk_marker() -> Marker {
-        let mut thunk = Thunk::new(some_closure(), IdentKind::Let());
+        let mut thunk = Thunk::new(some_closure(), IdentKind::Let);
         Marker::Thunk(thunk.mk_update_frame().unwrap())
     }
 
@@ -386,9 +386,9 @@ mod tests {
         let mut s = Stack::new();
         assert_eq!(0, s.count_thunks());
 
-        let mut thunk = Thunk::new(some_closure(), IdentKind::Let());
+        let mut thunk = Thunk::new(some_closure(), IdentKind::Let);
         s.push_thunk(thunk.mk_update_frame().unwrap());
-        thunk = Thunk::new(some_closure(), IdentKind::Let());
+        thunk = Thunk::new(some_closure(), IdentKind::Let);
         s.push_thunk(thunk.mk_update_frame().unwrap());
 
         assert_eq!(2, s.count_thunks());
@@ -398,7 +398,7 @@ mod tests {
 
     #[test]
     fn thunk_blackhole() {
-        let mut thunk = Thunk::new(some_closure(), IdentKind::Let());
+        let mut thunk = Thunk::new(some_closure(), IdentKind::Let);
         let thunk_upd = thunk.mk_update_frame();
         assert_matches!(thunk_upd, Ok(..));
         assert_matches!(thunk.mk_update_frame(), Err(..));

--- a/src/transformations.rs
+++ b/src/transformations.rs
@@ -500,7 +500,7 @@ impl Closurizable for RichTerm {
             body: self,
             env: with_env,
         };
-        env.insert(var.clone(), Thunk::new(closure, IdentKind::Record()));
+        env.insert(var.clone(), Thunk::new(closure, IdentKind::Record));
 
         RichTerm::new(Term::Var(var), pos.into_inherited())
     }


### PR DESCRIPTION
While working on #507,I took the occasion to use a (IMHO) slightly better style for structures `Ident` and `IdentKind`. Separating those purely stylistic changes in this PR to avoid cluttering the diff of #507.