### PR TITLE
Fix contract application

### DIFF
--- a/src/grammar.lalrpop
+++ b/src/grammar.lalrpop
@@ -524,6 +524,7 @@ InfixExpr: RichTerm = {
 }
 
 BOpPre: BinaryOp = {
+    "assume" => BinaryOp::Assume(),
     "unwrap" => BinaryOp::Unwrap(),
     "go_field" => BinaryOp::GoField(),
     "has_field" => BinaryOp::HasField(),
@@ -699,6 +700,7 @@ extern {
         "is_fun" => Token::Normal(NormalToken::IsFun),
         "is_list" => Token::Normal(NormalToken::IsList),
         "is_record" => Token::Normal(NormalToken::IsRecord),
+        "assume" => Token::Normal(NormalToken::Assume),
         "blame" => Token::Normal(NormalToken::Blame),
         "chng_pol" => Token::Normal(NormalToken::ChangePol),
         "polarity" => Token::Normal(NormalToken::Polarity),

--- a/src/parser/lexer.rs
+++ b/src/parser/lexer.rs
@@ -162,6 +162,8 @@ pub enum NormalToken<'input> {
     #[token("%is_record%")]
     IsRecord,
 
+    #[token("%assume%")]
+    Assume,
     #[token("%blame%")]
     Blame,
     #[token("%chng_pol%")]

--- a/src/typecheck/operation.rs
+++ b/src/typecheck/operation.rs
@@ -197,9 +197,14 @@ pub fn get_bop_type(
             mk_typewrapper::str(),
             mk_typewrapper::str(),
         ),
+        // Ideally: Contract -> Label -> Dyn -> Dyn
+        // Currenty: Dyn -> Dyn -> (Dyn -> Dyn)
+        BinaryOp::Assume() => (
+            mk_typewrapper::dynamic(),
+            mk_typewrapper::dynamic(),
+            mk_tyw_arrow!(mk_typewrapper::dynamic(), mk_typewrapper::dynamic()),
+        ),
         // Sym -> Dyn -> Dyn -> Dyn
-        // This should not happen, as `ApplyContract()` is only produced during evaluation.
-        BinaryOp::Assume() => panic!("cannot typecheck assume"),
         BinaryOp::Unwrap() => (
             mk_typewrapper::sym(),
             mk_typewrapper::dynamic(),

--- a/stdlib/contracts.ncl
+++ b/stdlib/contracts.ncl
@@ -7,11 +7,14 @@
 
   string = fun l t => if %is_str% t then t else %blame% l,
 
-  list = fun elt l t => if %is_list% t then %map% t (elt (%go_list% l)) else %blame% l,
+  list = fun elt l t =>
+    if %is_list% t then
+      %map% t (fun value => %assume% elt (%go_list% l) value)
+    else %blame% l,
 
   func = fun s t l e =>
       if %is_fun% e then
-          (fun x => t (%go_codom% l) (e (s (%chng_pol% (%go_dom% l)) x)))
+          (fun x => %assume% t (%go_codom% l) (e (%assume% s (%chng_pol% (%go_dom% l)) x)))
       else
           %blame% l,
 
@@ -28,23 +31,23 @@
       if (case t) then
           t
       else
-          contr (%tag% "NotRowExt" l) t,
+          %assume% contr (%tag% "NotRowExt" l) t,
 
   record = fun cont l t =>
       if %is_record% t then
-          cont {} l t
+          %assume% (cont {}) l t
       else
           %blame% (%tag% "not a record" l),
 
   dyn_record = fun contr l t =>
       if %is_record% t then
-          %record_map% t (fun _field => contr l)
+          %record_map% t (fun _field value => %assume% contr l value)
       else
           %blame% (%tag% "not a record" l),
 
   record_extend = fun field contr cont acc l t =>
       if %has_field% field t then
-          let acc = acc$[field = contr (%go_field% field l) (t."#{field}")] in
+          let acc = acc$[field = %assume% contr (%go_field% field l) (t."#{field}")] in
           let t = t -$ field in
           cont acc l t
       else
@@ -151,5 +154,30 @@
         ```
         "#m
       = fun msg l => %tag% msg l,
+
+    apply
+      | doc m#"
+        Apply a contract to a label and a value.
+
+        Type: `Contract -> Lbl -> Dyn -> Dyn`
+        (for technical reasons, this element isn't actually statically typed)
+
+        Nickel supports user-defined contracts defined as functions, but also as
+        records. Moreover, the interpreter performs additional book-keeping for
+        error reporting when applying a contract in an expression `value |
+        #Contract`. You should not use standard function application to apply a
+        contract, but this function instead. 
+
+        For example:
+        ```
+        let Nullable = fun contract label value =>
+          if value == null then null
+          else contracts.apply contract label value
+        in
+        let Contract = Nullable {foo | Num} in
+        ({foo = 1} | #Contract)
+        ```
+        "#m
+      = fun contract label value => %assume% contract label value,
   },
 }

--- a/tests/pass/contracts.ncl
+++ b/tests/pass/contracts.ncl
@@ -109,9 +109,9 @@ let Assert = fun l x => x || %blame% l in
 
   // nested_metavalues
   // Regression test for #402
-  let myContract = { x | Str } in
+  let MyContract = { x | Str } in
   {
-    foo | #myContract | default = { x = "From foo" },
+    foo | #MyContract | default = { x = "From foo" },
     bar | #{..} | default = foo
   } == { foo.x = "From foo", bar.x = "From foo"},
 
@@ -121,7 +121,7 @@ let Assert = fun l x => x || %blame% l in
   (f {foo = 1}).bar == 1,
   // user-written contract application
   let Extend = fun base label value =>
-    let derived = if builtins.isRecord base then
+    let derived = if builtins.is_record base then
       (base & {foo | Num})
     else
       base in

--- a/tests/pass/contracts.ncl
+++ b/tests/pass/contracts.ncl
@@ -114,5 +114,22 @@ let Assert = fun l x => x || %blame% l in
     foo | #myContract | default = { x = "From foo" },
     bar | #{..} | default = foo
   } == { foo.x = "From foo", bar.x = "From foo"},
+
+  // mixing type and record contracts
+  let f | #{foo | Num} -> #{bar | Num} = fun r =>
+    {bar = r.foo} in
+  (f {foo = 1}).bar == 1,
+  // user-written contract application
+  let Extend = fun base label value =>
+    let derived = if builtins.isRecord base then
+      (base & {foo | Num})
+    else
+      base in
+    contracts.apply derived label value in
+  let Contract = Extend {bar | Num, ..} in
+  let Id = Extend (fun label value => value) in
+  ({bar = 1, foo = 1} | #Contract)
+    & ({baz = 1} | #Id)
+  == {foo = 1, bar = 1, baz = 1},
 ]
 |> lists.foldl (fun x y => (x | #Assert) && y) true


### PR DESCRIPTION
Initially, contracts have been simply functions, that we just applied to a label and a value. This is not true anymore, as contracts can now be records. Even for functions, contract application is different from plain function application, as it does additional book-keeping for better error reporting.

The stdlib, and in particular the `contracts` part, keeps considering contract as functions, simply applying them. To cope with that, the `open_contract` transformation wraps every subcontract as a function of the form `fun label value => %assume% contract label value`. This PR inverses the workflow: it makes the functions from the stdlib not assume anymore that what they receive is a readily applicable function, but any contract. Doing so, they can now be used with any contract, and not only the one generated by `open_contract`. `open_contract` is free from wrapping every subcontract it encounters.

To do so, this PRs re-introduces `%assume%` as a first-class operator. It also makes it available in the stdlib to users as the `contracts.apply` function.

The concrete motivations of this change are:

- the initial issue was that the whole contract application phase was losing position information, giving unlocated `missing field definition`. Because `open_contract` was the one introducing the `%assume%`, it would need to be threaded with position information to solve the issue. Here, `open_contract` don't care about `assume` anymore. The contract application transformation is now responsible for this, and can set the positions as needed.
- the contract implementations from the stdlib are more resilient. We dropped the pre-condition that anything passed to them must be of the form `fun label value => %assume% contract label value.` They now accept any kind of contract,and are more in line with what a custom contract should be. This will also help for the implementation of #573.