### PR TITLE
Do not discard position after evaluation

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -1339,7 +1339,7 @@ mod tests {
 
     /// Evaluate a term without import support.
     fn eval_no_import(t: RichTerm) -> Result<Term, EvalError> {
-        eval(t, &Environment::new(), &mut DummyResolver {}).map(|rt| *rt.term)
+        eval(t, &Environment::new(), &mut DummyResolver {}).map(Term::from)
     }
 
     fn parse(s: &str) -> Option<RichTerm> {

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -18,9 +18,7 @@ fn parse(s: &str) -> Result<RichTerm, ParseError> {
 }
 
 fn parse_without_pos(s: &str) -> RichTerm {
-    let mut result = parse(s).unwrap();
-    result.clean_pos();
-    result
+    parse(s).unwrap().without_pos()
 }
 
 fn lex(s: &str) -> Result<Vec<(usize, Token, usize)>, InternalParseError> {

--- a/src/repl/mod.rs
+++ b/src/repl/mod.rs
@@ -37,13 +37,13 @@ pub mod wasm_frontend;
 /// Result of the evaluation of an input.
 pub enum EvalResult {
     /// The input has been evaluated to a term.
-    Evaluated(Term),
+    Evaluated(RichTerm),
     /// The input was a toplevel let, which has been bound in the environment.
     Bound(Ident),
 }
 
-impl From<Term> for EvalResult {
-    fn from(t: Term) -> Self {
+impl From<RichTerm> for EvalResult {
+    fn from(t: RichTerm) -> Self {
         EvalResult::Evaluated(t)
     }
 }

--- a/src/repl/rustyline_frontend.rs
+++ b/src/repl/rustyline_frontend.rs
@@ -78,7 +78,7 @@ pub fn repl(histfile: PathBuf) -> Result<(), InitError> {
                     }),
                     Ok(Command::Print(exp)) => {
                         match repl.eval_full(&exp) {
-                            Ok(EvalResult::Evaluated(t)) => println!("{}\n", t.deep_repr()),
+                            Ok(EvalResult::Evaluated(rt)) => println!("{}\n", rt.as_ref().deep_repr()),
                             Ok(EvalResult::Bound(_)) => (),
                             Err(err) => program::report(repl.cache_mut(), err),
                         };
@@ -103,7 +103,7 @@ pub fn repl(histfile: PathBuf) -> Result<(), InitError> {
             }
             Ok(line) => {
                 match repl.eval(&line) {
-                    Ok(EvalResult::Evaluated(t)) => println!("{}\n", t.shallow_repr()),
+                    Ok(EvalResult::Evaluated(rt)) => println!("{}\n", rt.as_ref().shallow_repr()),
                     Ok(EvalResult::Bound(_)) => (),
                     Err(err) => program::report(repl.cache_mut(), err),
                 };

--- a/src/repl/simple_frontend.rs
+++ b/src/repl/simple_frontend.rs
@@ -82,7 +82,9 @@ pub fn input<R: REPL>(repl: &mut R, line: &str) -> Result<InputResult, InputErro
     } else {
         repl.eval(&line)
             .map(|eval_res| match eval_res {
-                EvalResult::Evaluated(rt) => InputResult::Success(format!("{}\n", rt.as_ref().shallow_repr())),
+                EvalResult::Evaluated(rt) => {
+                    InputResult::Success(format!("{}\n", rt.as_ref().shallow_repr()))
+                }
                 EvalResult::Bound(_) => InputResult::Success(String::new()),
             })
             .map_err(InputError::from)

--- a/src/repl/simple_frontend.rs
+++ b/src/repl/simple_frontend.rs
@@ -65,7 +65,7 @@ pub fn input<R: REPL>(repl: &mut R, line: &str) -> Result<InputResult, InputErro
             Ok(Command::Print(exp)) => repl
                 .eval_full(&exp)
                 .map(|res| match res {
-                    EvalResult::Evaluated(t) => InputResult::Success(t.deep_repr()),
+                    EvalResult::Evaluated(rt) => InputResult::Success(rt.as_ref().deep_repr()),
                     EvalResult::Bound(_) => InputResult::Blank,
                 })
                 .map_err(InputError::from),
@@ -82,7 +82,7 @@ pub fn input<R: REPL>(repl: &mut R, line: &str) -> Result<InputResult, InputErro
     } else {
         repl.eval(&line)
             .map(|eval_res| match eval_res {
-                EvalResult::Evaluated(t) => InputResult::Success(format!("{}\n", t.shallow_repr())),
+                EvalResult::Evaluated(rt) => InputResult::Success(format!("{}\n", rt.as_ref().shallow_repr())),
                 EvalResult::Bound(_) => InputResult::Success(String::new()),
             })
             .map_err(InputError::from)

--- a/src/serialize.rs
+++ b/src/serialize.rs
@@ -299,7 +299,8 @@ mod tests {
                     mk_term::op2(BinaryOp::Eq(), from_json, evaluated.clone()),
                     &Environment::new(),
                     &mut $crate::cache::resolvers::DummyResolver {}
-                ),
+                )
+                .map(Term::from),
                 Ok(Term::Bool(true))
             );
             assert_eq!(
@@ -307,7 +308,8 @@ mod tests {
                     mk_term::op2(BinaryOp::Eq(), from_yaml, evaluated.clone()),
                     &Environment::new(),
                     &mut $crate::cache::resolvers::DummyResolver {}
-                ),
+                )
+                .map(Term::from),
                 Ok(Term::Bool(true))
             );
             assert_eq!(
@@ -315,7 +317,8 @@ mod tests {
                     mk_term::op2(BinaryOp::Eq(), from_toml, evaluated),
                     &Environment::new(),
                     &mut $crate::cache::resolvers::DummyResolver {}
-                ),
+                )
+                .map(Term::from),
                 Ok(Term::Bool(true))
             );
         };

--- a/src/term.rs
+++ b/src/term.rs
@@ -873,10 +873,15 @@ impl RichTerm {
     ///
     /// It allows to use rust `Eq` trait to compare the values of the underlying terms.
     #[cfg(test)]
-    pub fn clean_pos(&mut self) {
-        self.pos = TermPos::None;
-        self.term
-            .apply_to_rich_terms(|rt: &mut Self| rt.clean_pos());
+    pub fn without_pos(mut self) -> Self {
+        fn clean_pos(rt: &mut RichTerm) {
+            rt.pos = TermPos::None;
+            rt.term
+                .apply_to_rich_terms(|rt: &mut RichTerm| clean_pos(rt));
+        }
+
+        clean_pos(&mut self);
+        self
     }
 
     /// Set the position and return the term updated.

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -5,11 +5,11 @@ use std::io::Cursor;
 
 pub fn eval(s: impl std::string::ToString) -> Result<Term, Error> {
     let mut p = Program::new_from_source(Cursor::new(s.to_string()), "test").unwrap();
-    p.eval()
+    p.eval().map(Term::from)
 }
 
 pub fn eval_file(f: &str) -> Result<Term, Error> {
     let mut p =
         Program::new_from_file(format!("{}/tests/{}", env!("CARGO_MANIFEST_DIR"), f)).unwrap();
-    p.eval()
+    p.eval().map(Term::from)
 }

--- a/tests/destructuring.rs
+++ b/tests/destructuring.rs
@@ -1,5 +1,5 @@
 use assert_matches::assert_matches;
-use nickel::error::{Error, EvalError, TypecheckError};
+use nickel::error::{Error, EvalError};
 use nickel::term::Term;
 
 #[path = "./common.rs"]

--- a/tests/examples.rs
+++ b/tests/examples.rs
@@ -1,10 +1,10 @@
 use assert_matches::assert_matches;
 use nickel::error::{Error, EvalError};
 use nickel::program::Program;
-use nickel::term::Term;
+use nickel::term::RichTerm;
 use std::path::PathBuf;
 
-fn eval_file(file: &str) -> Result<Term, Error> {
+fn eval_file(file: &str) -> Result<RichTerm, Error> {
     let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     path.push(format!("examples/{}", file));
     let mut p = Program::new_from_file(path).expect("could not load file as a program");

--- a/tests/imports.rs
+++ b/tests/imports.rs
@@ -21,7 +21,7 @@ fn nested() {
         "should_be = 3",
     )
     .unwrap();
-    assert_eq!(prog.eval(), Ok(Term::Num(3.)));
+    assert_eq!(prog.eval().map(Term::from), Ok(Term::Num(3.)));
 }
 
 #[test]
@@ -31,7 +31,7 @@ fn root_path() {
         "should_be = 44",
     )
     .unwrap();
-    assert_eq!(prog.eval(), Ok(Term::Num(44.)));
+    assert_eq!(prog.eval().map(Term::from), Ok(Term::Num(44.)));
 }
 
 #[test]
@@ -41,7 +41,7 @@ fn multi_imports() {
         "should_be = 5",
     )
     .unwrap();
-    assert_eq!(prog.eval(), Ok(Term::Num(5.)));
+    assert_eq!(prog.eval().map(Term::from), Ok(Term::Num(5.)));
 }
 
 #[test]
@@ -97,7 +97,7 @@ fn serialize() {
         "shoud success",
     )
     .unwrap();
-    assert_eq!(prog.eval(), Ok(Term::Bool(true)));
+    assert_eq!(prog.eval().map(Term::from), Ok(Term::Bool(true)));
 }
 
 #[test]
@@ -107,5 +107,8 @@ fn circular_imports_fail() {
         "should_fail",
     )
     .unwrap();
-    assert_matches!(prog.eval(), Ok(Term::RecRecord(..)) | Ok(Term::Record(..)));
+    assert_matches!(
+        prog.eval().map(Term::from),
+        Ok(Term::RecRecord(..)) | Ok(Term::Record(..))
+    );
 }

--- a/tests/pass.rs
+++ b/tests/pass.rs
@@ -12,7 +12,7 @@ fn run(path: impl Into<OsString>) {
     let path = path.into();
     let mut p = Program::new_from_file(path.clone()).expect("could not load file as a program");
     assert_eq!(
-        p.eval(),
+        p.eval().map(Term::from),
         Ok(Term::Bool(true)),
         "error evaluating {}",
         path.to_string_lossy(),


### PR DESCRIPTION
Fix #510. The `eval` family previously returned a `Term`, discarding the position information of the root node of the AST. It now returns a `RichTerm`, and the caller is free of using or discarding the position information.