### PR TITLE
Fix uninformative "empty metavalue" error

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -43,6 +43,8 @@ pub enum Error {
 pub enum EvalError {
     /// A blame occurred: a contract have been broken somewhere.
     BlameError(label::Label, CallStack),
+    /// A field required by a record contract is missing a definition.
+    MissingFieldDef(label::Label, CallStack),
     /// Mismatch between the expected type and the actual type of an expression.
     TypeError(
         /* expected type */ String,
@@ -206,6 +208,7 @@ impl ParseErrors {
     pub fn new(errors: Vec<ParseError>) -> ParseErrors {
         ParseErrors { errors }
     }
+
     pub fn errors(self) -> Option<Vec<ParseError>> {
         if self.errors.is_empty() {
             None
@@ -754,6 +757,15 @@ fn report_ty_path(l: &label::Label, files: &mut Files<String>) -> (Label<FileId>
     (label, notes)
 }
 
+/// Return a note diagnostic showing where a contract was bound.
+fn blame_label_note(l: &label::Label) -> Diagnostic<FileId> {
+    Diagnostic::note().with_labels(vec![Label::primary(
+        l.span.src_id,
+        l.span.start.to_usize()..l.span.end.to_usize(),
+    )
+    .with_message("bound here")])
+}
+
 impl ToDiagnostic<FileId> for Error {
     fn to_diagnostic(
         &self,
@@ -877,11 +889,7 @@ impl ToDiagnostic<FileId> for EvalError {
                     .with_labels(labels)
                     .with_notes(notes)];
 
-                diagnostics.push(Diagnostic::note().with_labels(vec![
-                    Label::primary(
-                        l.span.src_id,
-                        l.span.start.to_usize()..l.span.end.to_usize(),
-                    ).with_message("bound here")]));
+                diagnostics.push(blame_label_note(&l));
 
                 if ty_path::is_only_codom(&l.path) {
                 } else if let Some(id) = contract_id {
@@ -908,6 +916,42 @@ impl ToDiagnostic<FileId> for EvalError {
                 }
 
                 diagnostics
+            }
+            EvalError::MissingFieldDef(l, callstack) => {
+                use crate::eval::StackElem;
+
+                let mut field: Option<String> = None;
+                let mut pos_record = TermPos::None;
+
+                for elt in callstack.as_ref().iter().rev() {
+                    match elt {
+                        StackElem::Var(_, id, _) if !id.is_generated() && field.is_none() => {
+                            field = Some(id.to_string())
+                        }
+                        StackElem::Field(_, id, pos) => {
+                            field.get_or_insert(id.to_string());
+                            pos_record = *pos;
+                            break;
+                        }
+                        _ => (),
+                    }
+                }
+
+                let labels = pos_record
+                    .into_opt()
+                    .map(|span| vec![primary(&span).with_message("in this record")])
+                    .unwrap_or_default();
+
+                vec![
+                    Diagnostic::error()
+                        .with_message(format!(
+                            "missing definition for `{}`",
+                            field.unwrap_or(String::from("?"))
+                        ))
+                        .with_labels(labels)
+                        .with_notes(vec![]),
+                    blame_label_note(&l),
+                ]
             }
             EvalError::TypeError(expd, msg, orig_pos_opt, t) => {
                 let label = format!(

--- a/src/eval/mod.rs
+++ b/src/eval/mod.rs
@@ -605,9 +605,7 @@ where
                         }) => Closure { body: inner, env },
                         _ => unreachable!(),
                     }
-                }
-                // TODO: improve error message using some positions
-                else {
+                } else {
                     let label = meta.contracts.pop().unwrap().label;
                     return Err(EvalError::MissingFieldDef(label, call_stack));
                 }

--- a/src/eval/mod.rs
+++ b/src/eval/mod.rs
@@ -606,7 +606,7 @@ where
                         _ => unreachable!(),
                     }
                 } else {
-                    let label = meta.contracts.pop().unwrap().label;
+                    let label = meta.contracts.pop().or(meta.types).map(|ctr| ctr.label);
                     return Err(EvalError::MissingFieldDef(label, call_stack));
                 }
             }

--- a/src/eval/mod.rs
+++ b/src/eval/mod.rs
@@ -608,7 +608,8 @@ where
                 }
                 // TODO: improve error message using some positions
                 else {
-                    return Err(EvalError::Other(String::from("empty metavalue"), pos));
+                    let label = meta.contracts.pop().unwrap().label;
+                    return Err(EvalError::MissingFieldDef(label, call_stack));
                 }
             }
             Term::ResolvedImport(id) => {

--- a/src/eval/mod.rs
+++ b/src/eval/mod.rs
@@ -107,6 +107,12 @@ use lazy::*;
 use operation::{continuate_operation, OperationCont};
 use stack::Stack;
 
+impl AsRef<Vec<StackElem>> for CallStack {
+    fn as_ref(&self) -> &Vec<StackElem> {
+        &self.0
+    }
+}
+
 /// Kind of an identifier.
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum IdentKind {

--- a/src/eval/mod.rs
+++ b/src/eval/mod.rs
@@ -577,7 +577,7 @@ where
                 }
             }
             // Unwrapping of enriched terms
-            Term::MetaValue(meta) if enriched_strict => {
+            Term::MetaValue(mut meta) if enriched_strict => {
                 if meta.value.is_some() {
                     /* Since we are forcing a metavalue, we are morally evaluating `force t` rather
                      * than `t` iteself.  Updating a thunk after having performed this forcing may


### PR DESCRIPTION
~~Close #480~~ Partially fix #480 (see comments below). When a field without a definition is accessed, the error should now show the faulty record and the location of the field access. Unfortunately, the location of the record is currently lost because of the contract application pass, which doesn't set all the positions of the additional intermediate terms. However, this is a separate issue, and should be fixed by #509 (or a superseding one).