### PR TITLE
style: Use Repl* instead of REPL*

### DIFF
--- a/src/bin/nickel.rs
+++ b/src/bin/nickel.rs
@@ -53,7 +53,7 @@ enum Command {
     /// Typecheck a program, but do not run it
     Typecheck,
     /// Start an REPL session
-    REPL {
+    Repl {
         #[structopt(long)]
         history_file: Option<PathBuf>,
     },
@@ -62,7 +62,7 @@ enum Command {
 fn main() {
     let opts = Opt::from_args();
 
-    if let Some(Command::REPL { history_file }) = opts.command {
+    if let Some(Command::Repl { history_file }) = opts.command {
         let histfile = if let Some(h) = history_file {
             h
         } else {
@@ -116,7 +116,7 @@ fn main() {
                 })
             }
             Some(Command::Typecheck) => program.typecheck().map(|_| ()),
-            Some(Command::REPL { .. }) => unreachable!(),
+            Some(Command::Repl { .. }) => unreachable!(),
             None => program.eval().map(|t| println!("Done: {:?}", t)),
         };
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -35,7 +35,7 @@ pub enum Error {
     ImportError(ImportError),
     SerializationError(SerializationError),
     IOError(IOError),
-    REPLError(REPLError),
+    ReplError(ReplError),
 }
 
 /// An error occurring during evaluation.
@@ -324,7 +324,7 @@ pub struct IOError(pub String);
 
 /// An error occurring during an REPL session.
 #[derive(Debug, PartialEq, Clone)]
-pub enum REPLError {
+pub enum ReplError {
     UnknownCommand(String),
     MissingArg {
         cmd: repl::command::CommandType,
@@ -400,9 +400,9 @@ pub fn escape(s: &str) -> String {
     .expect("escape(): converting from a string should give back a valid UTF8 string")
 }
 
-impl From<REPLError> for Error {
-    fn from(error: REPLError) -> Error {
-        Error::REPLError(error)
+impl From<ReplError> for Error {
+    fn from(error: ReplError) -> Error {
+        Error::ReplError(error)
     }
 }
 
@@ -772,7 +772,7 @@ impl ToDiagnostic<FileId> for Error {
             Error::ImportError(err) => err.to_diagnostic(files, contract_id),
             Error::SerializationError(err) => err.to_diagnostic(files, contract_id),
             Error::IOError(err) => err.to_diagnostic(files, contract_id),
-            Error::REPLError(err) => err.to_diagnostic(files, contract_id),
+            Error::ReplError(err) => err.to_diagnostic(files, contract_id),
         }
     }
 }
@@ -1415,19 +1415,19 @@ impl ToDiagnostic<FileId> for IOError {
     }
 }
 
-impl ToDiagnostic<FileId> for REPLError {
+impl ToDiagnostic<FileId> for ReplError {
     fn to_diagnostic(
         &self,
         _files: &mut Files<String>,
         _contract_id: Option<FileId>,
     ) -> Vec<Diagnostic<FileId>> {
         match self {
-            REPLError::UnknownCommand(s) => vec![Diagnostic::error()
+            ReplError::UnknownCommand(s) => vec![Diagnostic::error()
                 .with_message(format!("unknown command `{}`", s))
                 .with_notes(vec![String::from(
                     "type `:?` or `:help` for a list of available commands.",
                 )])],
-            REPLError::MissingArg { cmd, msg_opt } => {
+            ReplError::MissingArg { cmd, msg_opt } => {
                 let mut notes = msg_opt
                     .as_ref()
                     .map(|msg| vec![msg.clone()])

--- a/src/program.rs
+++ b/src/program.rs
@@ -136,7 +136,7 @@ impl Program {
 //TODO: also gather type information, such that `query a.b.c <<< '{ ... } : {a: {b: {c: Num}}}`
 //would additionally report `type: Num` for example.
 //TODO: not sure where this should go. It seems to embed too much logic to be in `Cache`, but is
-//common to both `Program` and `REPL`. Leaving it here as a stand-alone function for now
+//common to both `Program` and `Repl`. Leaving it here as a stand-alone function for now
 pub fn query(
     cache: &mut Cache,
     file_id: FileId,
@@ -175,7 +175,7 @@ pub fn query(
 /// This function is located here in `Program` because errors need a reference to `files` in
 /// order to produce a diagnostic (see [`label_alt`](../error/fn.label_alt.html)).
 //TODO: not sure where this should go. It seems to embed too much logic to be in `Cache`, but is
-//common to both `Program` and `REPL`. Leaving it here as a stand-alone function for now
+//common to both `Program` and `Repl`. Leaving it here as a stand-alone function for now
 pub fn report<E>(cache: &mut Cache, error: E)
 where
     E: ToDiagnostic<FileId>,

--- a/src/repl/command.rs
+++ b/src/repl/command.rs
@@ -28,9 +28,9 @@ pub enum Command {
 pub struct UnknownCommandError {}
 
 /// Check that an argument is non-empty, or return an error with the given optional message.
-fn require_arg(cmd: CommandType, arg: &str, msg_opt: Option<&str>) -> Result<(), REPLError> {
+fn require_arg(cmd: CommandType, arg: &str, msg_opt: Option<&str>) -> Result<(), ReplError> {
     if arg.trim().is_empty() {
-        Err(REPLError::MissingArg {
+        Err(ReplError::MissingArg {
             cmd,
             msg_opt: msg_opt.map(String::from),
         })
@@ -89,14 +89,14 @@ impl std::fmt::Display for CommandType {
 }
 
 impl FromStr for Command {
-    type Err = REPLError;
+    type Err = ReplError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let cmd_end = s.find(' ').unwrap_or_else(|| s.len());
         let cmd_str: String = s.chars().take(cmd_end).collect();
         let cmd: CommandType = cmd_str
             .parse()
-            .map_err(|_| REPLError::UnknownCommand(cmd_str.clone()))?;
+            .map_err(|_| ReplError::UnknownCommand(cmd_str.clone()))?;
         let arg: String = s.chars().skip(cmd_end + 1).collect();
 
         match cmd {

--- a/src/repl/mod.rs
+++ b/src/repl/mod.rs
@@ -7,7 +7,7 @@
 //! jupyter-kernel (which is not exactly user-facing, but still manages input/output and
 //! formatting), etc.
 use crate::cache::{Cache, GlobalEnv};
-use crate::error::{Error, EvalError, IOError, ParseError, ParseErrors, REPLError};
+use crate::error::{Error, EvalError, IOError, ParseError, ParseErrors, ReplError};
 use crate::identifier::Ident;
 use crate::parser::{grammar, lexer, ExtendedTerm};
 use crate::term::{RichTerm, Term};
@@ -49,7 +49,7 @@ impl From<Term> for EvalResult {
 }
 
 /// Interface of the REPL backend.
-pub trait REPL {
+pub trait Repl {
     /// Evaluate an expression, which can be either a standard term or a toplevel let-binding.
     fn eval(&mut self, exp: &str) -> Result<EvalResult, Error>;
     /// Fully evaluate an expression, which can be either a standard term or a toplevel let-binding.
@@ -65,7 +65,7 @@ pub trait REPL {
 }
 
 /// Standard implementation of the REPL backend.
-pub struct REPLImpl {
+pub struct ReplImpl {
     /// The underlying cache, storing input, loaded files and parsed terms.
     cache: Cache,
     /// The parser, supporting toplevel let declaration.
@@ -78,10 +78,10 @@ pub struct REPLImpl {
     init_type_env: typecheck::Environment,
 }
 
-impl REPLImpl {
+impl ReplImpl {
     /// Create a new empty REPL.
     pub fn new() -> Self {
-        REPLImpl {
+        ReplImpl {
             cache: Cache::new(),
             parser: grammar::ExtendedTermParser::new(),
             env: GlobalEnv::new(),
@@ -175,7 +175,7 @@ impl REPLImpl {
     }
 }
 
-impl REPL for REPLImpl {
+impl Repl for ReplImpl {
     fn eval(&mut self, exp: &str) -> Result<EvalResult, Error> {
         self.eval_(exp, false)
     }

--- a/src/repl/rustyline_frontend.rs
+++ b/src/repl/rustyline_frontend.rs
@@ -1,4 +1,4 @@
-//! Native terminal implementation of an REPL frontend using rustyline.
+//! Native terminal implementation of a REPL frontend using rustyline.
 use std::path::PathBuf;
 
 use super::command::Command;
@@ -21,7 +21,7 @@ pub fn config() -> Config {
 
 /// Main loop of the REPL.
 pub fn repl(histfile: PathBuf) -> Result<(), InitError> {
-    let mut repl = REPLImpl::new();
+    let mut repl = ReplImpl::new();
 
     match repl.load_stdlib() {
         Ok(()) => (),

--- a/src/repl/simple_frontend.rs
+++ b/src/repl/simple_frontend.rs
@@ -29,14 +29,14 @@ impl From<Error> for InputError {
 }
 
 /// Return a new instance of an REPL with the standard library loaded.
-pub fn init() -> Result<REPLImpl, Error> {
-    let mut repl = REPLImpl::new();
+pub fn init() -> Result<ReplImpl, Error> {
+    let mut repl = ReplImpl::new();
     repl.load_stdlib()?;
     Ok(repl)
 }
 
 /// Evaluate an input.
-pub fn input<R: REPL>(repl: &mut R, line: &str) -> Result<InputResult, InputError> {
+pub fn input<R: Repl>(repl: &mut R, line: &str) -> Result<InputResult, InputError> {
     if line.trim().is_empty() {
         Ok(InputResult::Blank)
     } else if line.starts_with(':') {
@@ -90,7 +90,7 @@ pub fn input<R: REPL>(repl: &mut R, line: &str) -> Result<InputResult, InputErro
 }
 
 /// Evaluate an input and serialize the result.
-pub fn serialize<R: REPL>(
+pub fn serialize<R: Repl>(
     repl: &mut R,
     format: ExportFormat,
     input: &str,

--- a/src/repl/wasm_frontend.rs
+++ b/src/repl/wasm_frontend.rs
@@ -1,6 +1,6 @@
 //! Web assembly interface to the REPL.
 use super::simple_frontend::{input, serialize, InputError, InputResult};
-use super::{ReplImpl, Repl};
+use super::{Repl, ReplImpl};
 use crate::cache::Cache;
 use crate::error::ToDiagnostic;
 use crate::serialize::ExportFormat;


### PR DESCRIPTION
In camelCase naming, acronyms do not remain fully capitalized unless
they are trivially short (like IO). This was pointed out by Clippy.

See https://rust-lang.github.io/api-guidelines/naming.html