### PR TITLE
[Style] Use Wasm* instead of WASM*

### DIFF
--- a/src/repl/wasm_frontend.rs
+++ b/src/repl/wasm_frontend.rs
@@ -15,7 +15,7 @@ use std::convert::TryInto;
 use std::io::Cursor;
 use wasm_bindgen::prelude::*;
 
-/// Return codes of the Wasm REPL.
+/// Return codes of the WASM REPL.
 ///
 /// wasm-bindgen doesn't support exporting arbitrary enumeration. Thus we have to encode these
 /// enums as structures with a tag and values. The values that are actually set depend on the
@@ -29,7 +29,7 @@ pub enum WasmResultTag {
     Error = 3,
 }
 
-/// Severity of an error diagnostic. Wasm wrapper for the corresponding codespan type.
+/// Severity of an error diagnostic. WASM wrapper for the corresponding codespan type.
 #[derive(Serialize_repr, Clone, Copy, Eq, PartialEq)]
 #[repr(u8)]
 pub enum WasmErrorSeverity {
@@ -56,7 +56,7 @@ impl From<Severity> for WasmErrorSeverity {
     }
 }
 
-/// Style of an error label. Wasm wrapper for the corresponding codespan type.
+/// Style of an error label. WASM wrapper for the corresponding codespan type.
 #[derive(Serialize_repr, Clone, Copy, Eq, PartialEq)]
 #[repr(u8)]
 pub enum WasmErrorLabelStyle {
@@ -73,7 +73,7 @@ impl From<LabelStyle> for WasmErrorLabelStyle {
     }
 }
 
-/// A serializable error diagnostic. Wasm wrapper for the corresponding codespan type.
+/// A serializable error diagnostic. WASM wrapper for the corresponding codespan type.
 #[derive(Serialize)]
 pub struct WasmErrorDiagnostic {
     pub severity: WasmErrorSeverity,
@@ -97,7 +97,7 @@ impl WasmErrorDiagnostic {
     }
 }
 
-/// A serializable error label. Wasm wrapper for the corresponding codespan type.
+/// A serializable error label. WASM wrapper for the corresponding codespan type.
 #[derive(Serialize)]
 pub struct WasmErrorLabel {
     msg: String,
@@ -140,7 +140,7 @@ impl WasmErrorLabel {
     }
 }
 
-/// Wasm wrapper for the result type of the initialization of the REPL.
+/// WASM wrapper for the result type of the initialization of the REPL.
 #[wasm_bindgen]
 pub struct WasmInitResult {
     msg: String,
@@ -159,7 +159,7 @@ impl WasmInitResult {
         self.state
     }
 
-    /// Make an `WasmInitResult` result from an `InputError`.
+    /// Make a `WasmInitResult` result from an `InputError`.
     fn error(mut state: ReplState, error: InputError) -> Self {
         WasmInitResult {
             msg: err_to_string(&mut state.0.cache_mut(), &error),
@@ -169,7 +169,7 @@ impl WasmInitResult {
     }
 }
 
-/// Wasm wrapper for the result type of an execution of the REPL.
+/// WASM wrapper for the result type of an execution of the REPL.
 #[wasm_bindgen]
 pub struct WasmInputResult {
     msg: String,
@@ -189,7 +189,7 @@ impl WasmInputResult {
         self.errors.clone()
     }
 
-    /// Make an `WasmInputResult` from an `InputError`.
+    /// Make a `WasmInputResult` from an `InputError`.
     fn error(cache: &mut Cache, error: InputError) -> Self {
         let (msg, errors) = match error {
             InputError::NickelError(err) => {
@@ -241,11 +241,11 @@ impl From<InputResult> for WasmInputResult {
     }
 }
 
-/// Wasm-compatible wrapper around `ReplImpl`.
+/// WASM-compatible wrapper around `ReplImpl`.
 #[wasm_bindgen]
 pub struct ReplState(ReplImpl);
 
-/// Wasm-compatible wrapper around `serialize::ExportFormat`.
+/// WASM-compatible wrapper around `serialize::ExportFormat`.
 #[wasm_bindgen]
 pub enum WasmExportFormat {
     Raw = "raw",
@@ -297,7 +297,7 @@ pub fn err_to_string(cache: &mut Cache, error: &InputError) -> String {
     }
 }
 
-/// Return a new instance of the Wasm REPL, with the standard library loaded.
+/// Return a new instance of the WASM REPL, with the standard library loaded.
 #[wasm_bindgen]
 pub fn repl_init() -> WasmInitResult {
     let mut repl = ReplImpl::new();
@@ -311,7 +311,7 @@ pub fn repl_init() -> WasmInitResult {
     }
 }
 
-/// Evaluate an input in the Wasm REPL.
+/// Evaluate an input in the WASM REPL.
 #[wasm_bindgen]
 pub fn repl_input(state: &mut ReplState, line: &str) -> WasmInputResult {
     input(&mut state.0, line)
@@ -319,7 +319,7 @@ pub fn repl_input(state: &mut ReplState, line: &str) -> WasmInputResult {
         .unwrap_or_else(|err| WasmInputResult::error(state.0.cache_mut(), err))
 }
 
-/// Evaluate an input in the Wasm REPL and serialize it.
+/// Evaluate an input in the WASM REPL and serialize it.
 #[wasm_bindgen]
 pub fn repl_serialize(
     state: &mut ReplState,

--- a/src/repl/wasm_frontend.rs
+++ b/src/repl/wasm_frontend.rs
@@ -15,24 +15,24 @@ use std::convert::TryInto;
 use std::io::Cursor;
 use wasm_bindgen::prelude::*;
 
-/// Return codes of the WASM REPL.
+/// Return codes of the Wasm REPL.
 ///
 /// wasm-bindgen doesn't support exporting arbitrary enumeration. Thus we have to encode these
 /// enums as structures with a tag and values. The values that are actually set depend on the
 /// tag.
 #[wasm_bindgen]
 #[derive(Clone, Copy, Eq, PartialEq)]
-pub enum WASMResultTag {
+pub enum WasmResultTag {
     Success = 0,
     Blank = 1,
     Partial = 2,
     Error = 3,
 }
 
-/// Severity of an error diagnostic. WASM wrapper for the corresponding codespan type.
+/// Severity of an error diagnostic. Wasm wrapper for the corresponding codespan type.
 #[derive(Serialize_repr, Clone, Copy, Eq, PartialEq)]
 #[repr(u8)]
-pub enum WASMErrorSeverity {
+pub enum WasmErrorSeverity {
     Bug = 5,
     /// An error.
     Error = 4,
@@ -44,71 +44,71 @@ pub enum WASMErrorSeverity {
     Help = 1,
 }
 
-impl From<Severity> for WASMErrorSeverity {
-    fn from(s: Severity) -> WASMErrorSeverity {
+impl From<Severity> for WasmErrorSeverity {
+    fn from(s: Severity) -> WasmErrorSeverity {
         match s {
-            Severity::Bug => WASMErrorSeverity::Bug,
-            Severity::Error => WASMErrorSeverity::Error,
-            Severity::Warning => WASMErrorSeverity::Warning,
-            Severity::Note => WASMErrorSeverity::Note,
-            Severity::Help => WASMErrorSeverity::Help,
+            Severity::Bug => WasmErrorSeverity::Bug,
+            Severity::Error => WasmErrorSeverity::Error,
+            Severity::Warning => WasmErrorSeverity::Warning,
+            Severity::Note => WasmErrorSeverity::Note,
+            Severity::Help => WasmErrorSeverity::Help,
         }
     }
 }
 
-/// Style of an error label. WASM wrapper for the corresponding codespan type.
+/// Style of an error label. Wasm wrapper for the corresponding codespan type.
 #[derive(Serialize_repr, Clone, Copy, Eq, PartialEq)]
 #[repr(u8)]
-pub enum WASMErrorLabelStyle {
+pub enum WasmErrorLabelStyle {
     Primary = 0,
     Secondary = 1,
 }
 
-impl From<LabelStyle> for WASMErrorLabelStyle {
-    fn from(label_style: LabelStyle) -> WASMErrorLabelStyle {
+impl From<LabelStyle> for WasmErrorLabelStyle {
+    fn from(label_style: LabelStyle) -> WasmErrorLabelStyle {
         match label_style {
-            LabelStyle::Primary => WASMErrorLabelStyle::Primary,
-            LabelStyle::Secondary => WASMErrorLabelStyle::Secondary,
+            LabelStyle::Primary => WasmErrorLabelStyle::Primary,
+            LabelStyle::Secondary => WasmErrorLabelStyle::Secondary,
         }
     }
 }
 
-/// A serializable error diagnostic. WASM wrapper for the corresponding codespan type.
+/// A serializable error diagnostic. Wasm wrapper for the corresponding codespan type.
 #[derive(Serialize)]
-pub struct WASMErrorDiagnostic {
-    pub severity: WASMErrorSeverity,
+pub struct WasmErrorDiagnostic {
+    pub severity: WasmErrorSeverity,
     msg: String,
     notes: Vec<String>,
-    labels: Vec<WASMErrorLabel>,
+    labels: Vec<WasmErrorLabel>,
 }
 
-impl WASMErrorDiagnostic {
+impl WasmErrorDiagnostic {
     fn from_codespan(files: &Files<String>, diag: Diagnostic<FileId>) -> Self {
-        WASMErrorDiagnostic {
+        WasmErrorDiagnostic {
             severity: diag.severity.into(),
             msg: diag.message,
             notes: diag.notes,
             labels: diag
                 .labels
                 .into_iter()
-                .map(|label| WASMErrorLabel::from_codespan(files, label))
+                .map(|label| WasmErrorLabel::from_codespan(files, label))
                 .collect(),
         }
     }
 }
 
-/// A serializable error label. WASM wrapper for the corresponding codespan type.
+/// A serializable error label. Wasm wrapper for the corresponding codespan type.
 #[derive(Serialize)]
-pub struct WASMErrorLabel {
+pub struct WasmErrorLabel {
     msg: String,
-    pub style: WASMErrorLabelStyle,
+    pub style: WasmErrorLabelStyle,
     pub line_start: usize,
     pub col_start: usize,
     pub line_end: usize,
     pub col_end: usize,
 }
 
-impl WASMErrorLabel {
+impl WasmErrorLabel {
     fn from_codespan(files: &Files<String>, label: Label<FileId>) -> Self {
         let start_loc = files.location(label.file_id, label.range.start as u32);
         let end_loc = files.location(label.file_id, label.range.end as u32);
@@ -129,7 +129,7 @@ impl WASMErrorLabel {
             _ => (0, 0, 0, 0),
         };
 
-        WASMErrorLabel {
+        WasmErrorLabel {
             msg: label.message,
             style: label.style.into(),
             line_start,
@@ -140,16 +140,16 @@ impl WASMErrorLabel {
     }
 }
 
-/// WASM wrapper for the result type of the initialization of the REPL.
+/// Wasm wrapper for the result type of the initialization of the REPL.
 #[wasm_bindgen]
-pub struct WASMInitResult {
+pub struct WasmInitResult {
     msg: String,
-    pub tag: WASMResultTag,
+    pub tag: WasmResultTag,
     state: ReplState,
 }
 
 #[wasm_bindgen]
-impl WASMInitResult {
+impl WasmInitResult {
     #[wasm_bindgen(getter)]
     pub fn msg(&self) -> String {
         self.msg.clone()
@@ -159,26 +159,26 @@ impl WASMInitResult {
         self.state
     }
 
-    /// Make an `WASMInitResult` result from an `InputError`.
+    /// Make an `WasmInitResult` result from an `InputError`.
     fn error(mut state: ReplState, error: InputError) -> Self {
-        WASMInitResult {
+        WasmInitResult {
             msg: err_to_string(&mut state.0.cache_mut(), &error),
-            tag: WASMResultTag::Error,
+            tag: WasmResultTag::Error,
             state,
         }
     }
 }
 
-/// WASM wrapper for the result type of an execution of the REPL.
+/// Wasm wrapper for the result type of an execution of the REPL.
 #[wasm_bindgen]
-pub struct WASMInputResult {
+pub struct WasmInputResult {
     msg: String,
-    pub tag: WASMResultTag,
+    pub tag: WasmResultTag,
     errors: JsValue,
 }
 
 #[wasm_bindgen]
-impl WASMInputResult {
+impl WasmInputResult {
     #[wasm_bindgen(getter)]
     pub fn msg(&self) -> String {
         self.msg.clone()
@@ -189,7 +189,7 @@ impl WASMInputResult {
         self.errors.clone()
     }
 
-    /// Make an `WASMInputResult` from an `InputError`.
+    /// Make an `WasmInputResult` from an `InputError`.
     fn error(cache: &mut Cache, error: InputError) -> Self {
         let (msg, errors) = match error {
             InputError::NickelError(err) => {
@@ -197,57 +197,57 @@ impl WASMInputResult {
                 let diagnostics = err.to_diagnostic(cache.files_mut(), contracts_id);
 
                 let msg = diags_to_string(cache, &diagnostics);
-                let errors: Vec<WASMErrorDiagnostic> = diagnostics
+                let errors: Vec<WasmErrorDiagnostic> = diagnostics
                     .into_iter()
-                    .map(|diag| WASMErrorDiagnostic::from_codespan(cache.files(), diag))
+                    .map(|diag| WasmErrorDiagnostic::from_codespan(cache.files(), diag))
                     .collect();
                 (msg, errors)
             }
             InputError::Other(err) => (err, Vec::new()),
         };
 
-        WASMInputResult {
+        WasmInputResult {
             msg,
-            tag: WASMResultTag::Error,
+            tag: WasmResultTag::Error,
             errors: JsValue::from_serde(&errors).unwrap(),
         }
     }
 
     /// Generate a serializable empty list.
     fn empty_errors() -> JsValue {
-        JsValue::from_serde(&Vec::<WASMErrorDiagnostic>::new()).unwrap()
+        JsValue::from_serde(&Vec::<WasmErrorDiagnostic>::new()).unwrap()
     }
 }
 
-impl From<InputResult> for WASMInputResult {
+impl From<InputResult> for WasmInputResult {
     fn from(ir: InputResult) -> Self {
         match ir {
-            InputResult::Success(msg) => WASMInputResult {
+            InputResult::Success(msg) => WasmInputResult {
                 msg,
-                tag: WASMResultTag::Success,
-                errors: WASMInputResult::empty_errors(),
+                tag: WasmResultTag::Success,
+                errors: WasmInputResult::empty_errors(),
             },
-            InputResult::Blank => WASMInputResult {
+            InputResult::Blank => WasmInputResult {
                 msg: String::new(),
-                tag: WASMResultTag::Blank,
-                errors: WASMInputResult::empty_errors(),
+                tag: WasmResultTag::Blank,
+                errors: WasmInputResult::empty_errors(),
             },
-            InputResult::Partial => WASMInputResult {
+            InputResult::Partial => WasmInputResult {
                 msg: String::new(),
-                tag: WASMResultTag::Partial,
-                errors: WASMInputResult::empty_errors(),
+                tag: WasmResultTag::Partial,
+                errors: WasmInputResult::empty_errors(),
             },
         }
     }
 }
 
-/// WASM-compatible wrapper around `ReplImpl`.
+/// Wasm-compatible wrapper around `ReplImpl`.
 #[wasm_bindgen]
 pub struct ReplState(ReplImpl);
 
-/// WASM-compatible wrapper around `serialize::ExportFormat`.
+/// Wasm-compatible wrapper around `serialize::ExportFormat`.
 #[wasm_bindgen]
-pub enum WASMExportFormat {
+pub enum WasmExportFormat {
     Raw = "raw",
     Json = "json",
     Yaml = "yaml",
@@ -256,15 +256,15 @@ pub enum WASMExportFormat {
 
 pub type ExportFormaParseError = ();
 
-impl TryInto<ExportFormat> for WASMExportFormat {
+impl TryInto<ExportFormat> for WasmExportFormat {
     type Error = ExportFormaParseError;
 
     fn try_into(self) -> Result<ExportFormat, ExportFormaParseError> {
         match self {
-            WASMExportFormat::Raw => Ok(ExportFormat::Raw),
-            WASMExportFormat::Json => Ok(ExportFormat::Json),
-            WASMExportFormat::Yaml => Ok(ExportFormat::Yaml),
-            WASMExportFormat::Toml => Ok(ExportFormat::Toml),
+            WasmExportFormat::Raw => Ok(ExportFormat::Raw),
+            WasmExportFormat::Json => Ok(ExportFormat::Json),
+            WasmExportFormat::Yaml => Ok(ExportFormat::Yaml),
+            WasmExportFormat::Toml => Ok(ExportFormat::Toml),
             _ => Err(()),
         }
     }
@@ -297,36 +297,36 @@ pub fn err_to_string(cache: &mut Cache, error: &InputError) -> String {
     }
 }
 
-/// Return a new instance of the WASM REPL, with the standard library loaded.
+/// Return a new instance of the Wasm REPL, with the standard library loaded.
 #[wasm_bindgen]
-pub fn repl_init() -> WASMInitResult {
+pub fn repl_init() -> WasmInitResult {
     let mut repl = ReplImpl::new();
     match repl.load_stdlib() {
-        Ok(()) => WASMInitResult {
+        Ok(()) => WasmInitResult {
             msg: String::new(),
-            tag: WASMResultTag::Success,
+            tag: WasmResultTag::Success,
             state: ReplState(repl),
         },
-        Err(err) => WASMInitResult::error(ReplState(repl), err.into()),
+        Err(err) => WasmInitResult::error(ReplState(repl), err.into()),
     }
 }
 
-/// Evaluate an input in the WASM REPL.
+/// Evaluate an input in the Wasm REPL.
 #[wasm_bindgen]
-pub fn repl_input(state: &mut ReplState, line: &str) -> WASMInputResult {
+pub fn repl_input(state: &mut ReplState, line: &str) -> WasmInputResult {
     input(&mut state.0, line)
-        .map(WASMInputResult::from)
-        .unwrap_or_else(|err| WASMInputResult::error(state.0.cache_mut(), err))
+        .map(WasmInputResult::from)
+        .unwrap_or_else(|err| WasmInputResult::error(state.0.cache_mut(), err))
 }
 
-/// Evaluate an input in the WASM REPL and serialize it.
+/// Evaluate an input in the Wasm REPL and serialize it.
 #[wasm_bindgen]
 pub fn repl_serialize(
     state: &mut ReplState,
-    format: WASMExportFormat,
+    format: WasmExportFormat,
     line: &str,
-) -> WASMInputResult {
+) -> WasmInputResult {
     serialize(&mut state.0, format.try_into().unwrap_or_default(), line)
-        .map(WASMInputResult::from)
-        .unwrap_or_else(|err| WASMInputResult::error(state.0.cache_mut(), err))
+        .map(WasmInputResult::from)
+        .unwrap_or_else(|err| WasmInputResult::error(state.0.cache_mut(), err))
 }


### PR DESCRIPTION
Depend on #513. Follow-up of #513, now for WASM: use `Wasm` instead of `WASM` as prescribed by CamelCase.