### PR TITLE
Fix lists.lowercase docstring

### DIFF
--- a/stdlib/strings.ncl
+++ b/stdlib/strings.ncl
@@ -233,11 +233,11 @@
 
       For example:
       ```nickel
-        uppercase "A" =>
+        lowercase "A" =>
           "a"
-        uppercase "Æ" =>
+        lowercase "Æ" =>
           "æ"
-        uppercase "." =>
+        lowercase "." =>
           "."
       ```
       "#m


### PR DESCRIPTION
It was mentioning `uppercase` in the example instead of `lowercase`,
likely due to a bad copy/paste.