### PR TITLE
Fix bad example in standardization meeting notes

### DIFF
--- a/notes/standardization-meeting-07.12.21.md
+++ b/notes/standardization-meeting-07.12.21.md
@@ -224,7 +224,7 @@ open_contract(#(open_contract(T))) =  open_contract(T)
   else contract label value in
 
   //cannot do
-  foo | #Nullable (C1 & C2 & C3)
+  foo | #Nullable (Num -> Num)
   ```
 - `#` is verbose: should we remove it? But in current situation, it is nice to
   embed value syntax in the type syntax as in


### PR DESCRIPTION
The example about the lack of an `open_contract` primitive operation is not relevant. Probably a blind copy-paste.