### PR TITLE
Fixup conversion to snake_case

### DIFF
--- a/stdlib/strings.ncl
+++ b/stdlib/strings.ncl
@@ -16,7 +16,7 @@
       ```
       "#m
     = fun l s =>
-      if %isStr% s then
+      if %is_str% s then
         if s == "true" || s == "True" then
           "true"
         else if s == "false" || s == "False" then
@@ -42,8 +42,8 @@
       "#m
     = let pattern = m#"^[+-]?(\d+(\.\d*)?(e[+-]?\d+)?|\.\d+(e[+-]?\d+)?)$"#m in
       fun l s =>
-        if %isStr% s then
-          if %strIsMatch% s pattern then
+        if %is_str% s then
+          if %str_is_match% s pattern then
             s
           else
             %blame% (%tag% "invalid num literal" l)
@@ -67,7 +67,7 @@
       ```
       "#m
     = fun l s =>
-      if %isStr% s then
+      if %is_str% s then
         if length s == 1 then
           s
         else
@@ -89,8 +89,8 @@
       "#m
     = fun l s =>
       let pattern = m#"_?[a-zA-Z][_a-zA-Z0-9]*"#m in
-      if %isStr% s then
-        if %strIsMatch% s pattern then
+      if %is_str% s then
+        if %str_is_match% s pattern then
             s
           else
             %blame% (%tag% "invalid enum tag" l)
@@ -112,8 +112,8 @@
       ```
       "#m
     = fun l s =>
-      if %isStr% s then
-        if %strLength% s > 0 then
+      if %is_str% s then
+        if %str_length% s > 0 then
           s
         else
           %blame% (%tag% "empty string" l)
@@ -149,7 +149,7 @@
         [ "1,2,3" ]
       ```
       "#m
-    = fun sep s => %strSplit% s sep,
+    = fun sep s => %str_split% s sep,
 
     trim : Str -> Str
     | doc m#"
@@ -163,7 +163,7 @@
         "1   2   3"
       ```
       "#m
-    = fun s => %strTrim% s,
+    = fun s => %str_trim% s,
 
     chars : Str -> List Str
     | doc m#"
@@ -175,7 +175,7 @@
           [ "H", "e", "l", "l", "o" ]
       ```
       "#m
-    = fun s => %strChars% s,
+    = fun s => %str_chars% s,
 
     code | #CharLiteral -> Num
     | doc m#"
@@ -191,7 +191,7 @@
           error
       ```
       "#m
-    = fun s => %charCode% s,
+    = fun s => %char_code% s,
 
     from_code | Num -> #CharLiteral
     | doc m#"
@@ -207,7 +207,7 @@
           error
       ```
       "#m
-    = fun s => %charFromCode% s,
+    = fun s => %char_from_code% s,
 
     uppercase : Str -> Str
     | doc m#"
@@ -224,7 +224,7 @@
           "."
       ```
       "#m
-    = fun s => %strUppercase% s,
+    = fun s => %str_uppercase% s,
 
     lowercase : Str -> Str
     | doc m#"
@@ -241,7 +241,7 @@
           "."
       ```
       "#m
-    = fun s => %strLowercase% s,
+    = fun s => %str_lowercase% s,
 
     contains: Str -> Str -> Bool
     | doc m#"
@@ -257,7 +257,7 @@
           false
       ```
       "#m
-    = fun subs s => %strContains% s subs,
+    = fun subs s => %str_contains% s subs,
 
     replace: Str -> Str -> Str -> Str
     | doc m#"
@@ -272,7 +272,7 @@
       ```
       "#m
     = fun pattern replace s =>
-       %strReplace% s pattern replace,
+       %str_replace% s pattern replace,
 
     replace_regex: Str -> Str -> Str -> Str
     | doc m#"
@@ -287,7 +287,7 @@
       ```
       "#m
     = fun pattern replace s =>
-       %strReplaceRegex% s pattern replace,
+       %str_replace_regex% s pattern replace,
 
     is_match : Str -> Str -> Bool
     | doc m#"
@@ -301,7 +301,7 @@
           false
       ```
       "#m
-    = fun regex s => %strIsMatch% s regex,
+    = fun regex s => %str_is_match% s regex,
 
     match : Str -> Str -> {match: Str, index: Num, groups: List Str}
     | doc m#"
@@ -316,7 +316,7 @@
           { match = "3", index = 3, groups = [ ] }
       ```
       "#m
-    = fun regex s => %strMatch% s regex,
+    = fun regex s => %str_match% s regex,
 
     length : Str -> Num
     | doc m#"
@@ -330,7 +330,7 @@
           2
       ```
       "#m
-    = fun s => %strLength% s,
+    = fun s => %str_length% s,
 
     substring: Num -> Num -> Str -> Str
     | doc m#"
@@ -346,7 +346,7 @@
           error
       ```
       "#m
-    = fun start end s => %strSubstr% s start end,
+    = fun start end s => %str_substr% s start end,
 
     from_num | Num -> Str
     | doc m#"
@@ -355,9 +355,9 @@
       from_num 42 =>
         "42"
       "#m
-    = fun n => %toStr% n,
+    = fun n => %to_str% n,
 
-    // from_enum | < | Dyn> -> Str = fun tag => %toStr% tag,
+    // from_enum | < | Dyn> -> Str = fun tag => %to_str% tag,
     from_enum | Dyn -> Str
     | doc m#"
       Converts an enum variant to its string representation.
@@ -368,7 +368,7 @@
         "MyEnum"
       ```
       "#m
-    = fun tag => %toStr% tag,
+    = fun tag => %to_str% tag,
 
     from_bool | Bool -> Str
     | doc m#"
@@ -380,7 +380,7 @@
           "true"
       ```
       "#m
-    = fun b => %toStr% b,
+    = fun b => %to_str% b,
 
     to_num | #NumLiteral -> Num
     | doc m#"
@@ -392,7 +392,7 @@
           123
       ```
       "#m
-    = fun s => %numFromStr% s,
+    = fun s => %num_from_str% s,
 
     to_bool | #BoolLiteral -> Bool
     | doc m#"
@@ -409,7 +409,7 @@
       "#m
     = fun s => s == "true",
 
-    // to_enum | #Ident -> < | Dyn> = fun s => %enumFromStr% s,
+    // to_enum | #Ident -> < | Dyn> = fun s => %enum_from_str% s,
     to_enum | #Ident -> Dyn
     | doc m#"
       Converts any string that represents an enum variant to that enum variant.
@@ -420,6 +420,6 @@
           `Hello
       ```
       "#m
-    = fun s => %enumFromStr% s,
+    = fun s => %enum_from_str% s,
   }
 }


### PR DESCRIPTION
In #518, I had forgotten to change the names of the primitives in
`stdlib/strings.ncl`. I noticed the omission because this was breaking
the example in the nickel-lang.org playground.