### PR TITLE
Fix: #521

### DIFF
--- a/src/grammar.lalrpop
+++ b/src/grammar.lalrpop
@@ -362,7 +362,10 @@ ChunkExpr: StrChunk<RichTerm> = HashBrace <t: WithPos<Term>> "}" => StrChunk::Ex
 
 HashBrace = { "#{", "multstr #{" };
 
-StaticString: String = StringStart <s: ChunkLiteral> StringEnd => s;
+StaticString: String = {
+    StringStart <s: ChunkLiteral> StringEnd => s,
+    StringStart StringEnd => String::new(),
+};
 
 EnumTag: Ident = {
     <Ident>,

--- a/src/grammar.lalrpop
+++ b/src/grammar.lalrpop
@@ -362,10 +362,7 @@ ChunkExpr: StrChunk<RichTerm> = HashBrace <t: WithPos<Term>> "}" => StrChunk::Ex
 
 HashBrace = { "#{", "multstr #{" };
 
-StaticString: String = {
-    StringStart <s: ChunkLiteral> StringEnd => s,
-    StringStart StringEnd => String::new(),
-};
+StaticString: String = StringStart <s: ChunkLiteral?> StringEnd => s.unwrap_or_default();
 
 EnumTag: Ident = {
     <Ident>,


### PR DESCRIPTION
Imports and doc strings will now be parsed even if they are empty.
If we want to disallow them it should be done after parsing.

This turned out not to be related to error-tolerant parsing, we just were not handling empty strings.

We now allow:
```
let foo | doc "" = 1
```

This error on empty import has been fixed as well.

Before:

```
nickel> let f = import ""
error: Unexpected token
  ┌─ repl-input-1:1:17
  │
1 │ let f = import ""
  │                 ^
```

After:

```
nickel> let f = import ""
error: Import of  failed: No such file or directory (os error 2)
  ┌─ repl-input-0:1:9
  │
1 │ let f = import ""
  │         --------- imported here
```