### PR TITLE
Produce a parse error diagnostic instead of a Term::ParseError in prepare

### DIFF
--- a/src/cache.rs
+++ b/src/cache.rs
@@ -602,8 +602,12 @@ impl Cache {
     ) -> Result<CacheOp<()>, Error> {
         let mut result = CacheOp::Cached(());
 
-        if self.parse(file_id)? == CacheOp::Done(ParseErrors::default()) {
-            result = CacheOp::Done(());
+        match self.parse(file_id)? {
+            CacheOp::Done(e) | CacheOp::Cached(e) if !e.no_errors() => return Err(e.into()),
+            CacheOp::Done(_) => {
+                result = CacheOp::Done(());
+            }
+            _ => {}
         };
 
         let import_res = self.resolve_imports(file_id).map_err(|cache_err| {

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -759,9 +759,12 @@ impl Cache {
             .map(|(name, content)| self.add_string(OsString::from(name), String::from(content)))
             .collect();
 
-        file_ids
-            .iter()
-            .try_for_each(|file_id| self.parse(*file_id).map(|_| ()))?;
+        for file_id in file_ids.iter() {
+            let errs = self.parse(*file_id)?.inner();
+            if !errs.no_errors() {
+                return Err(errs.into());
+            }
+        }
         self.stdlib_ids.replace(file_ids);
         Ok(CacheOp::Done(()))
     }


### PR DESCRIPTION
Addresses this issue https://github.com/tweag/nickel/pull/530#pullrequestreview-842654960
fixes with #530: #521

Both without #530
On master:
```
❯ nickel <<< '1 | doc ""'
Done: RichTerm { term: ParseError, pos: Original(RawSpan { src_id: FileId(1), start: ByteIndex(0), end: ByteIndex(10) }) }
```

On this branch:
```
❯ nickel <<< '1 | doc ""'
error: Unexpected token
  ┌─ <stdin>:1:10
  │
1 │ 1 | doc ""
  │          ^
```