### PR TITLE
Now quotes are optional for load comand

### DIFF
--- a/src/repl/command.rs
+++ b/src/repl/command.rs
@@ -97,11 +97,22 @@ impl FromStr for Command {
         let cmd: CommandType = cmd_str
             .parse()
             .map_err(|_| ReplError::UnknownCommand(cmd_str.clone()))?;
-        let arg: String = s.chars().skip(cmd_end + 1).collect();
+        let arg: String = s
+            .chars()
+            .skip(cmd_end + 1)
+            .collect::<String>()
+            .trim()
+            .to_string();
 
         match cmd {
             CommandType::Load => {
                 require_arg(cmd, &arg, Some("Please provide a file to load"))?;
+                let arg = if arg.starts_with('"') && arg.ends_with('"') {
+                    arg.chars().skip(1).take(arg.len() - 2).collect::<String>()
+                } else {
+                    arg
+                };
+                println!("{}", arg);
                 Ok(Command::Load(OsString::from(arg)))
             }
             CommandType::Typecheck => {


### PR DESCRIPTION
also add a small improvement, now the begining and end blank spaces of an argument ar trimed exept the one between quotes.

this fix #427 