### PR TITLE
Get apparent type from imported term instead of defaulting to Dyn

### DIFF
--- a/src/repl/mod.rs
+++ b/src/repl/mod.rs
@@ -151,7 +151,7 @@ impl ReplImpl {
                 }
 
                 typecheck::type_check_in_env(&t, &self.env.type_env, &self.cache)?;
-                typecheck::Envs::env_add(&mut self.env.type_env, id.clone(), &t);
+                typecheck::Envs::env_add(&mut self.env.type_env, id.clone(), &t, &self.cache);
                 for id in &pending {
                     self.cache
                         .typecheck(*id, &self.init_type_env)
@@ -211,7 +211,7 @@ impl Repl for ReplImpl {
         for id in &pending {
             self.cache.resolve_imports(*id).unwrap();
         }
-        typecheck::Envs::env_add_term(&mut self.env.type_env, &term).unwrap();
+        typecheck::Envs::env_add_term(&mut self.env.type_env, &term, &self.cache).unwrap();
         eval::env_add_term(&mut self.env.eval_env, term.clone()).unwrap();
 
         Ok(term)
@@ -230,6 +230,7 @@ impl Repl for ReplImpl {
         Ok(typecheck::apparent_type(
             term.as_ref(),
             Some(&typecheck::Envs::from_global(&self.env.type_env)),
+            Some(&self.cache),
         )
         .into())
     }

--- a/tests/pass/typechecking.ncl
+++ b/tests/pass/typechecking.ncl
@@ -168,6 +168,10 @@ let typecheck = [
   // Typed import
   import "typed-import.ncl" : Num,
 
+  // Regression test for #430 (https://github.com/tweag/nickel/issues/430)
+  let x = import "typed-import.ncl"
+  in x : Num,
+
   // recursive_records_quoted
   {"foo" = 1} : {foo : Num},
 


### PR DESCRIPTION
Simple fix for issue #430 
Has the inconvenient of passing the ImportResolver to the `apparent_type` function.
Using `Option<_>` to allow one to simply ignore the apparent typing of the imported terms (notably useful for the `infer_type` function which doesn't have access to any ImportResolver).

Would it be needed to add a regression test for this particular issue ?