### PR TITLE
Fix: #523

### DIFF
--- a/src/bin/nickel.rs
+++ b/src/bin/nickel.rs
@@ -4,7 +4,7 @@ use nickel::program::Program;
 use nickel::repl::query_print;
 #[cfg(feature = "repl")]
 use nickel::repl::rustyline_frontend;
-use nickel::term::RichTerm;
+use nickel::term::{RichTerm, Term};
 use nickel::{serialize, serialize::ExportFormat};
 use std::path::PathBuf;
 use std::{fs, process};
@@ -117,7 +117,9 @@ fn main() {
             }
             Some(Command::Typecheck) => program.typecheck().map(|_| ()),
             Some(Command::Repl { .. }) => unreachable!(),
-            None => program.eval().map(|t| println!("Done: {:?}", t)),
+            None => program
+                .eval_full()
+                .map(|t| println!("{}", Term::from(t).deep_repr())),
         };
 
         if let Err(err) = result {


### PR DESCRIPTION
Fix: #523
This uses `eval_full` and `deep_repr` like print when evaluating files.
`deep_repr` output for contracts is far from ideal. This should probably be a separate issue.
 
```
❯ cargo run -- -f examples/record-contract/record-contract.ncl
{ metadata = { labels = { app = <contract,value="myApp">}, name = <contract,value="myApp">}, spec = { replicas = <doc,contract,value=3>, selector = { app = { name = "myApp"}, matchLabels = { app = <contract,value="myApp">}}, template = { metadata = { labels = { app = <contract,value="myApp">}, name = "myApp"}, spec = { containers = <contract,value=[ ... ]>}}}, apiVersion = <contract,value="1.1.0">, kind = <doc,contract,value=`ReplicationController>}
```