### PR TITLE
Fix expect 'import not found' message in type_check_

### DIFF
--- a/src/typecheck/mod.rs
+++ b/src/typecheck/mod.rs
@@ -962,7 +962,7 @@ fn type_check_<S, E>(
             let t = state
                 .resolver
                 .get(*file_id)
-                .expect("Internal error: resolved import not found ({:?}) during typechecking.");
+                .expect("Internal error: resolved import not found during typechecking.");
             let ty_import: TypeWrapper =
                 apparent_type(t.as_ref(), Some(&Envs::from_envs(&envs))).into();
             unify(state, strict, ty, ty_import).map_err(|err| err.into_typecheck_err(state, rt.pos))


### PR DESCRIPTION
As pointed out in [a comment of #540](https://github.com/tweag/nickel/pull/540#discussion_r779407722), the message displayed by `expect` will not be formatted properly with the `{:?}` element.
We could pass it through a `format!` or simply drop it.

As the element to display is a simple file number (doesn't give us much informations on the bug itself), I propose to simply drop it.