### PR TITLE
Allow piecewise signatures in records definition

### DIFF
--- a/src/grammar.lalrpop
+++ b/src/grammar.lalrpop
@@ -23,15 +23,7 @@ grammar<'input, 'err>(src_id: FileId, errors: &'err mut Vec<ErrorRecovery<usize,
 WithPos<Rule>: RichTerm = <l: @L> <t: Rule> <r: @R> => t.with_pos(mk_pos(src_id, l, r));
 CheckUnbound<Rule>: Types = <l: @L> <t: Rule> <r: @R> =>? check_unbound(&t, mk_span(src_id, l, r)).map_err(|e| lalrpop_util::ParseError::User{error: e}).and(Ok(t));
 
-TypeAnnot: MetaValue = ":" <l: @L> <ty_res: CheckUnbound<Types>> <r: @R> => MetaValue {
-    doc: None,
-    types: Some(Contract {types: ty_res.clone(), label: mk_label(ty_res, src_id, l, r)}),
-    contracts: Vec::new(),
-    priority: Default::default(),
-    value: None,
-};
-
-MetaAnnotAtom: MetaValue = {
+AnnotAtom: MetaValue = {
     "|" <l: @L> <ty_res: CheckUnbound<Types>> <r: @R> => MetaValue {
         doc: None,
         types: None,
@@ -53,6 +45,13 @@ MetaAnnotAtom: MetaValue = {
         priority: Default::default(),
         value: None,
     },
+    ":" <l: @L> <ty_res: CheckUnbound<Types>> <r: @R> => MetaValue {
+        doc: None,
+        types: Some(Contract {types: ty_res.clone(), label: mk_label(ty_res, src_id, l, r)}),
+        contracts: Vec::new(),
+        priority: Default::default(),
+        value: None,
+    },
 };
 
 DefaultAnnot: MetaValue = "?" <t: Term> => MetaValue {
@@ -61,19 +60,7 @@ DefaultAnnot: MetaValue = "?" <t: Term> => MetaValue {
     ..Default::default()
 };
 
-MetaAnnot: MetaValue = <anns: MetaAnnotAtom+> => anns.into_iter().fold(MetaValue::new(), MetaValue::flatten);
-
-Annot: MetaValue = {
-    <TypeAnnot>,
-    <ty_ann: TypeAnnot?> <meta: MetaAnnot> => {
-        if let Some(ty_meta) = ty_ann {
-            MetaValue::flatten(ty_meta, meta)
-        }
-        else {
-            meta
-        }
-    }
-};
+Annot: MetaValue = <anns: AnnotAtom+> => anns.into_iter().fold(MetaValue::new(), MetaValue::flatten);
 
 pub Term: RichTerm = WithPos<RootTerm>;
 
@@ -208,34 +195,21 @@ Atom: RichTerm = {
 };
 
 RecordField: (FieldPathElem, RichTerm) = {
-    <path: FieldPath> <ty_ann: TypeAnnot?> "=" <t: Term> => {
-        let t = if let Some(mut meta) = ty_ann {
-            let pos = t.pos;
-            meta.value = Some(t);
-            RichTerm::new(Term::MetaValue(meta), pos)
-        }
-        else {
-            t
-        };
-
-        elaborate_field_path(path, t)
-    },
-    <path: FieldPath> <ty_ann: TypeAnnot> <meta: MetaAnnot> "=" <t: Term> => {
-        let pos = t.pos;
-        let mut meta = MetaValue::flatten(ty_ann, meta);
-        meta.value = Some(t);
-        let t = RichTerm::new(Term::MetaValue(meta), pos);
-
-        elaborate_field_path(path, t)
-    },
-    <l: @L> <path: FieldPath> <meta: MetaAnnot> <r: @R> <t: ("=" <Term>)?> => {
-        let mut meta = meta;
+    <l: @L> <path: FieldPath> <ann: Annot?> <r: @R> <t: ("=" <Term>)?> => {
         let pos = t.as_ref()
             .map(|t| t.pos.clone())
             .unwrap_or(mk_pos(src_id, l, r));
-        meta.value = t;
-        let t = RichTerm::new(Term::MetaValue(meta), pos);
-        elaborate_field_path(path, t)
+        let term = if let Some(mut meta) = ann {
+            meta.value = t;
+            RichTerm::new(Term::MetaValue(meta), pos)
+        } else {
+            if let Some(deft) = t {
+                deft
+            } else {
+                RichTerm::new(Term::Null, pos)
+            }
+        };
+        elaborate_field_path(path, term)
     }
 }
 
@@ -278,7 +252,7 @@ Destruct: Destruct = {
 };
 
 Match: Match = {
-    <left:Ident> <anns: MetaAnnot?> <default: DefaultAnnot?> "=" <right: Pattern> => {
+    <left:Ident> <anns: Annot?> <default: DefaultAnnot?> "=" <right: Pattern> => {
 	let meta = match (default, anns) {
 	    (Some(d), Some(m)) => MetaValue::flatten(d,m),
 	    (Some(m),_) | (_,Some(m)) => m,
@@ -286,7 +260,7 @@ Match: Match = {
 	};
 	Match::Assign(left, meta, right)
     },
-    <id:Ident> <anns: MetaAnnot?> <default: DefaultAnnot?> => {
+    <id:Ident> <anns: Annot?> <default: DefaultAnnot?> => {
 	let meta = match (default, anns) {
 	    (Some(d), Some(m)) => MetaValue::flatten(d,m),
 	    (Some(m),_) | (_,Some(m)) => m,

--- a/tests/merge_fail.rs
+++ b/tests/merge_fail.rs
@@ -1,0 +1,32 @@
+use assert_matches::assert_matches;
+use nickel::error::{Error, EvalError};
+use nickel::position::TermPos;
+use nickel::program::Program;
+use nickel::term::RichTerm;
+use std::io::Cursor;
+
+fn eval_full(s: &str) -> Result<RichTerm, Error> {
+    let src = Cursor::new(s);
+
+    let mut p = Program::new_from_source(src, "<test>").map_err(|io_err| {
+        Error::EvalError(EvalError::Other(
+            format!("IO error: {}", io_err),
+            TermPos::None,
+        ))
+    })?;
+    p.eval_full()
+}
+
+macro_rules! assert_merge_fails {
+    ($term:expr) => {
+        assert_matches!(
+            eval_full($term),
+            Err(Error::EvalError(EvalError::MergeIncompatibleArgs(..)))
+        )
+    };
+}
+
+#[test]
+fn merge_conflict_inside_metavalue() {
+    assert_merge_fails!("{ foo = (fun x => x) (1 | default), foo = (fun x => x) (1 | default) } & {foo | default = 2 }");
+}

--- a/tests/pass/records.ncl
+++ b/tests/pass/records.ncl
@@ -80,5 +80,18 @@ let Assert = fun l x => x || %blame% l in
       g = fun y => f (y + (-1))
     }.f 10 in
     with_res "done" == "done",
+
+    // piecewise signatures
+    {
+        foo : Num,
+        bar = 3,
+        foo = 5
+    }.foo == 5,
+    {
+        foo : Num,
+        foo = 1,
+        bar : Num = foo,
+    }.bar == 1,
+    let {foo : Num} = {foo = 1} in foo == 1,
 ]
 |> lists.foldl (fun x y => (x | #Assert) && y) true

--- a/tests/typecheck_fail.rs
+++ b/tests/typecheck_fail.rs
@@ -222,3 +222,11 @@ fn dynamic_record_field() {
         Err(TypecheckError::TypeMismatch(..))
     );
 }
+
+#[test]
+fn piecewise_signature() {
+    assert_matches!(
+        type_check_expr("{foo : Num, foo = \"bar\"}"),
+        Err(TypecheckError::TypeMismatch(..))
+    );
+}


### PR DESCRIPTION
Implementation of #496.
Merged `TypeAnnot` into `MetaAnnot` (renamed now as `Annot`) inside `grammar.lalrpop`.
This allows that kind of Nickel code inside records:
```
{
   foo : Num,
   bar = 3,
   foo = 5
}
```
It could also let these partial type-annotations to be used when destructuring a record like so: `let {foo : Num, bar} = x`
However the semantic of this specific case needs to be precised.

> Wether or not to allow undefined type-annotated fields are yet to be decided, and are allowed for now as this is a pre-relase.
> Wether or not to allow code in the middle of a field's type annotation and definition is yet to be decided also.
> Both these points should be debated in a separated issue before modifying this feature.