### PR TITLE
[Language Server] Move utility functions into linearization interface

### DIFF
--- a/lsp/nls/src/cache.rs
+++ b/lsp/nls/src/cache.rs
@@ -4,10 +4,10 @@ use codespan::FileId;
 use nickel::{
     cache::{Cache, CacheError, CacheOp, CachedTerm, EntryState},
     error::TypecheckError,
-    typecheck::{self, linearization::Completed},
+    typecheck,
 };
 
-use crate::linearization::AnalysisHost;
+use crate::linearization::{completed::Completed, AnalysisHost};
 
 pub trait CacheExt {
     fn update_content(&mut self, path: impl Into<OsString>, s: String) -> io::Result<FileId>;

--- a/lsp/nls/src/linearization/building.rs
+++ b/lsp/nls/src/linearization/building.rs
@@ -1,0 +1,16 @@
+use std::collections::HashMap;
+
+use nickel::typecheck::linearization::{LinearizationState, ScopeId};
+
+use super::{interface::Unresolved, LinearizationItem};
+
+/// A concrete [LinearizationState]
+/// Holds any inner datatype that can be used as stable resource
+/// while recording terms.
+#[derive(Default)]
+pub struct Building {
+    pub linearization: Vec<LinearizationItem<Unresolved>>,
+    pub scope: HashMap<Vec<ScopeId>, Vec<usize>>,
+}
+
+impl LinearizationState for Building {}

--- a/lsp/nls/src/linearization/building.rs
+++ b/lsp/nls/src/linearization/building.rs
@@ -68,7 +68,7 @@ impl Building {
             let id = self.id_gen().get_and_advance();
             self.push(LinearizationItem {
                 id,
-                pos: ident.pos,
+                pos: ident.pos.unwrap(),
                 // temporary, the actual type is resolved later and the item retyped
                 ty: TypeWrapper::Concrete(AbsType::Dyn()),
                 kind: TermKind::RecordField {

--- a/lsp/nls/src/linearization/building.rs
+++ b/lsp/nls/src/linearization/building.rs
@@ -1,8 +1,19 @@
-use std::collections::HashMap;
+use std::{collections::HashMap, mem};
 
-use nickel::typecheck::linearization::{LinearizationState, ScopeId};
+use log::debug;
+use nickel::{
+    identifier::Ident,
+    term::{MetaValue, RichTerm, Term},
+    typecheck::{
+        linearization::{LinearizationState, ScopeId},
+        TypeWrapper,
+    },
+    types::AbsType,
+};
 
-use super::{interface::Unresolved, LinearizationItem};
+use crate::linearization::interface::{TermKind, UsageState};
+
+use super::{interface::Unresolved, Environment, IdGen, LinearizationItem};
 
 /// A concrete [LinearizationState]
 /// Holds any inner datatype that can be used as stable resource
@@ -10,7 +21,229 @@ use super::{interface::Unresolved, LinearizationItem};
 #[derive(Default)]
 pub struct Building {
     pub linearization: Vec<LinearizationItem<Unresolved>>,
-    pub scope: HashMap<Vec<ScopeId>, Vec<usize>>,
+    pub scope: HashMap<Vec<ScopeId>, Vec<ID>>,
+}
+
+pub type ID = usize;
+
+impl Building {
+    pub(super) fn push(&mut self, item: LinearizationItem<Unresolved>) {
+        self.scope
+            .remove(&item.scope)
+            .map(|mut s| {
+                s.push(item.id);
+                s
+            })
+            .or_else(|| Some(vec![item.id]))
+            .into_iter()
+            .for_each(|l| {
+                self.scope.insert(item.scope.clone(), l);
+            });
+        self.linearization.push(item);
+    }
+
+    pub(super) fn add_usage(&mut self, decl: usize, usage: usize) {
+        match self
+            .linearization
+            .get_mut(decl)
+            .expect("Could not find parent")
+            .kind
+        {
+            TermKind::Structure => unreachable!(),
+            TermKind::Usage(_) => unreachable!(),
+            TermKind::Record(_) => unreachable!(),
+            TermKind::Declaration(_, ref mut usages)
+            | TermKind::RecordField { ref mut usages, .. } => usages.push(usage),
+        };
+    }
+
+    pub(super) fn register_fields(
+        &mut self,
+        record_fields: &HashMap<Ident, RichTerm>,
+        record: usize,
+        scope: Vec<ScopeId>,
+        env: &mut Environment,
+    ) {
+        for (ident, value) in record_fields.iter() {
+            let id = self.id_gen().get_and_advance();
+            self.push(LinearizationItem {
+                id,
+                pos: ident.pos,
+                // temporary, the actual type is resolved later and the item retyped
+                ty: TypeWrapper::Concrete(AbsType::Dyn()),
+                kind: TermKind::RecordField {
+                    record,
+                    ident: ident.clone(),
+                    usages: Vec::new(),
+                    value: None,
+                },
+                scope: scope.clone(),
+                meta: match value.term.as_ref() {
+                    Term::MetaValue(meta @ MetaValue { .. }) => Some(MetaValue {
+                        value: None,
+                        ..meta.clone()
+                    }),
+                    _ => None,
+                },
+            });
+            env.insert(ident.clone(), id);
+            self.add_record_field(record, (ident.clone(), id))
+        }
+    }
+
+    pub(super) fn add_record_field(
+        &mut self,
+        record: usize,
+        (field_ident, reference_id): (Ident, usize),
+    ) {
+        match self
+            .linearization
+            .get_mut(record)
+            .expect("Could not find record")
+            .kind
+        {
+            TermKind::Record(ref mut fields) => {
+                fields.insert(field_ident, reference_id);
+            }
+            _ => unreachable!(),
+        }
+    }
+
+    pub(super) fn resolve_reference<'a>(
+        &'a self,
+        item: &'a LinearizationItem<TypeWrapper>,
+    ) -> Option<&'a LinearizationItem<TypeWrapper>> {
+        // if item is a usage, resolve the usage first
+        match item.kind {
+            TermKind::Usage(UsageState::Resolved(Some(pointed))) => self.linearization.get(pointed),
+            _ => Some(item),
+        }
+        // load referenced value, either from record field or declaration
+        .and_then(|item_pointer| {
+            match item_pointer.kind {
+                // if declaration is a record field, resolve its value
+                TermKind::RecordField { value, .. } => {
+                    debug!("parent referenced a record field {:?}", value);
+                    value
+                        // retrieve record
+                        .and_then(|value_index| self.linearization.get(value_index))
+                }
+                // if declaration is a let biding resolve its value
+                TermKind::Declaration(_, _) => self.linearization.get(item_pointer.id + 1),
+
+                // if something else was referenced, stop.
+                _ => Some(item_pointer),
+            }
+        })
+    }
+
+    pub(super) fn resolve_record_references(&mut self, mut defers: Vec<(usize, usize, Ident)>) {
+        let mut unresolved: Vec<(usize, usize, Ident)> = Vec::new();
+
+        while let Some(deferred) = defers.pop() {
+            // child_item: current deferred usage item
+            //       i.e.: root.<child>
+            // parent_accessor_id: id of the parent usage
+            //               i.e.: <parent>.child
+            // child_ident: identifier the child item references
+            let (child_item, parent_accessor_id, child_ident) = &deferred;
+            // resolve the value referenced by the parent accessor element
+            // get the parent accessor, and read its resolved reference
+            let parent_referenced = self.linearization.get(*parent_accessor_id);
+
+            if let Some(LinearizationItem {
+                kind: TermKind::Usage(UsageState::Deferred { .. }),
+                ..
+            }) = parent_referenced
+            {
+                debug!("parent references deferred usage");
+                unresolved.push(deferred.clone());
+                continue;
+            }
+
+            // load the parent referenced declaration (i.e.: a declaration or record field term)
+            let parent_declaration = parent_referenced
+                .and_then(|parent_usage_value| self.resolve_reference(parent_usage_value));
+
+            if let Some(LinearizationItem {
+                kind: TermKind::Usage(UsageState::Deferred { .. }),
+                ..
+            }) = parent_declaration
+            {
+                debug!("parent references deferred usage");
+                unresolved.push(deferred.clone());
+                continue;
+            }
+
+            let referenced_declaration = parent_declaration
+                // resolve indirection by following the usage
+                .and_then(|parent_declaration| self.resolve_reference(parent_declaration))
+                // get record field
+                .and_then(|parent_declaration| match &parent_declaration.kind {
+                    TermKind::Record(fields) => {
+                        fields.get(child_ident).and_then(|child_declaration_id| {
+                            self.linearization.get(*child_declaration_id)
+                        })
+                    }
+                    _ => None,
+                });
+
+            let referenced_declaration =
+                referenced_declaration.and_then(|referenced| match referenced.kind {
+                    TermKind::Usage(UsageState::Resolved(Some(pointed))) => {
+                        self.linearization.get(pointed)
+                    }
+                    TermKind::RecordField { value, .. } => value
+                        // retrieve record
+                        .and_then(|value_index| self.linearization.get(value_index))
+                        // retrieve field
+                        .and_then(|record| match &record.kind {
+                            TermKind::Record(fields) => {
+                                debug!(
+                                    "parent referenced a nested record indirectly`: {:?}",
+                                    fields
+                                );
+                                fields
+                                    .get(child_ident)
+                                    .and_then(|accessor_id| self.linearization.get(*accessor_id))
+                            }
+                            TermKind::Usage(UsageState::Resolved(Some(pointed))) => {
+                                self.linearization.get(*pointed)
+                            }
+                            _ => None,
+                        })
+                        .or(Some(referenced)),
+
+                    _ => Some(referenced),
+                });
+
+            let referenced_id = referenced_declaration.map(|reference| reference.id);
+
+            debug!(
+                "Associating child {} to value {:?}",
+                child_ident, referenced_declaration
+            );
+
+            {
+                let child: &mut LinearizationItem<TypeWrapper> =
+                    self.linearization.get_mut(*child_item).unwrap();
+                child.kind = TermKind::Usage(UsageState::Resolved(referenced_id));
+            }
+
+            if let Some(referenced_id) = referenced_id {
+                self.add_usage(referenced_id, *child_item);
+            }
+
+            if defers.is_empty() && !unresolved.is_empty() {
+                debug!("unresolved references: {:?}", unresolved);
+                defers = mem::take(&mut unresolved);
+            }
+        }
+    }
+
+    pub(super) fn id_gen(&self) -> IdGen {
+        IdGen::new(self.linearization.len())
+    }
 }
 
 impl LinearizationState for Building {}

--- a/lsp/nls/src/linearization/interface.rs
+++ b/lsp/nls/src/linearization/interface.rs
@@ -1,0 +1,52 @@
+use std::collections::HashMap;
+
+use nickel::{
+    identifier::Ident,
+    position::TermPos,
+    term::MetaValue,
+    typecheck::{
+        linearization::{LinearizationState, ScopeId},
+        TypeWrapper,
+    },
+    types::Types,
+};
+
+pub trait ResolutionState {}
+/// Types are available as [TypeWrapper] only during recording
+/// They are resolved after typechecking has collected all terms into concrete
+/// [Types]
+pub type Unresolved = TypeWrapper;
+impl ResolutionState for Unresolved {}
+
+/// When resolved a concrete [Types] is known
+pub type Resolved = Types;
+impl ResolutionState for Resolved {}
+
+/// Abstact term kinds.
+/// Currently tracks
+/// 1. Declarations
+/// 2. Usages
+/// 3. Records, listing their fields
+/// 4. wildcard (Structure) for any other kind of term.
+/// Can be extended later to represent Contracts, Records, etc.
+#[derive(Debug, Clone, PartialEq)]
+pub enum TermKind {
+    Declaration(Ident, Vec<usize>),
+    Usage(UsageState),
+    Record(HashMap<Ident, usize>),
+    RecordField {
+        ident: Ident,
+        record: usize,
+        usages: Vec<usize>,
+        value: Option<usize>,
+    },
+    Structure,
+}
+
+/// Some usages cannot be fully resolved in a first pass (i.e. recursive record fields)
+/// In these cases we defer the resolution to a second pass during linearization
+#[derive(Debug, Clone, PartialEq)]
+pub enum UsageState {
+    Resolved(Option<usize>),
+    Deferred { parent: usize, child: Ident },
+}

--- a/lsp/nls/src/linearization/interface.rs
+++ b/lsp/nls/src/linearization/interface.rs
@@ -1,15 +1,6 @@
 use std::collections::HashMap;
 
-use nickel::{
-    identifier::Ident,
-    position::TermPos,
-    term::MetaValue,
-    typecheck::{
-        linearization::{LinearizationState, ScopeId},
-        TypeWrapper,
-    },
-    types::Types,
-};
+use nickel::{identifier::Ident, typecheck::TypeWrapper, types::Types};
 
 pub trait ResolutionState {}
 /// Types are available as [TypeWrapper] only during recording

--- a/lsp/nls/src/linearization/mod.rs
+++ b/lsp/nls/src/linearization/mod.rs
@@ -269,7 +269,7 @@ impl Linearizer for AnalysisHost {
     /// their location in the source.
     ///
     /// Additionally, resolves concrete types for all items.
-    fn linearize(
+    fn complete(
         self,
         mut lin: Linearization<Building>,
         (table, reported_names): (UnifTable, HashMap<usize, Ident>),

--- a/lsp/nls/src/requests/completion.rs
+++ b/lsp/nls/src/requests/completion.rs
@@ -33,7 +33,7 @@ pub fn handle_completion(
 
     Trace::enrich(&id, linearization);
 
-    let item = linearization.item_at(locator);
+    let item = linearization.item_at(&locator);
 
     if item == None {
         server.reply(Response::new_ok(id, Value::Null));

--- a/lsp/nls/src/requests/completion.rs
+++ b/lsp/nls/src/requests/completion.rs
@@ -6,7 +6,7 @@ use lsp_types::{CompletionItem, CompletionParams};
 use serde_json::Value;
 
 use crate::{
-    requests::utils::find_linearization_index,
+    requests::utils::CompletedExt,
     server::Server,
     trace::{Enrich, Trace},
 };
@@ -33,14 +33,15 @@ pub fn handle_completion(
 
     Trace::enrich(&id, linearization);
 
-    let index = find_linearization_index(&linearization.lin, locator);
+    let item = linearization.item_at(locator);
 
-    if index == None {
+    if item == None {
         server.reply(Response::new_ok(id, Value::Null));
         return Ok(());
     }
 
-    let item = linearization.lin[index.unwrap()].to_owned();
+    let item = item.unwrap().to_owned();
+
     let in_scope: Vec<_> = linearization
         .get_in_scope(&item)
         .iter()

--- a/lsp/nls/src/requests/completion.rs
+++ b/lsp/nls/src/requests/completion.rs
@@ -6,7 +6,7 @@ use lsp_types::{CompletionItem, CompletionParams};
 use serde_json::Value;
 
 use crate::{
-    requests::utils::CompletedExt,
+    linearization::interface::TermKind,
     server::Server,
     trace::{Enrich, Trace},
 };
@@ -46,9 +46,7 @@ pub fn handle_completion(
         .get_in_scope(&item)
         .iter()
         .filter_map(|i| match i.kind {
-            nickel::typecheck::linearization::TermKind::Declaration(ref ident, _) => {
-                Some((ident.clone(), i.ty.clone()))
-            }
+            TermKind::Declaration(ref ident, _) => Some((ident.clone(), i.ty.clone())),
             _ => None,
         })
         .map(|(ident, _)| CompletionItem {

--- a/lsp/nls/src/requests/goto.rs
+++ b/lsp/nls/src/requests/goto.rs
@@ -5,15 +5,12 @@ use lsp_server::{RequestId, Response, ResponseError};
 use lsp_types::{
     GotoDefinitionParams, GotoDefinitionResponse, Location, Range, ReferenceParams, Url,
 };
-use nickel::{
-    position::{RawSpan, TermPos},
-    typecheck::linearization::{self, UsageState},
-};
+use nickel::position::{RawSpan, TermPos};
 use serde_json::Value;
 
 use crate::{
     diagnostic::LocationCompat,
-    requests::utils::CompletedExt,
+    linearization::interface::{TermKind, UsageState},
     server::Server,
     trace::{Enrich, Trace},
 };
@@ -58,7 +55,7 @@ pub fn handle_to_definition(
     debug!("found referencing item: {:?}", item);
 
     let location = match item.kind {
-        linearization::TermKind::Usage(UsageState::Resolved(Some(usage_id))) => {
+        TermKind::Usage(UsageState::Resolved(Some(usage_id))) => {
             let definition = linearization.id_mapping[&usage_id];
             let definition = linearization.lin[definition].clone();
             let location = match definition.pos {
@@ -128,8 +125,7 @@ pub fn handle_to_usages(
     debug!("found referencing item: {:?}", item);
 
     let locations = match &item.kind {
-        linearization::TermKind::Declaration(_, usages)
-        | linearization::TermKind::RecordField { usages, .. } => {
+        TermKind::Declaration(_, usages) | TermKind::RecordField { usages, .. } => {
             let mut locations = Vec::new();
 
             for reference_id in usages.iter() {

--- a/lsp/nls/src/requests/goto.rs
+++ b/lsp/nls/src/requests/goto.rs
@@ -43,7 +43,7 @@ pub fn handle_to_definition(
 
     Trace::enrich(&id, linearization);
 
-    let item = linearization.item_at(locator);
+    let item = linearization.item_at(&locator);
 
     if item == None {
         server.reply(Response::new_ok(id, Value::Null));
@@ -106,7 +106,7 @@ pub fn handle_to_usages(
     let locator = (file_id, ByteIndex(start as u32));
     let linearization = server.lin_cache_get(&file_id)?;
 
-    let item = linearization.item_at(locator);
+    let item = linearization.item_at(&locator);
 
     if item == None {
         server.reply(Response::new_ok(id, Value::Null));

--- a/lsp/nls/src/requests/goto.rs
+++ b/lsp/nls/src/requests/goto.rs
@@ -56,8 +56,7 @@ pub fn handle_to_definition(
 
     let location = match item.kind {
         TermKind::Usage(UsageState::Resolved(Some(usage_id))) => {
-            let definition = linearization.id_mapping[&usage_id];
-            let definition = linearization.lin[definition].clone();
+            let definition = linearization.get_item(usage_id).unwrap();
             let location = match definition.pos {
                 TermPos::Original(RawSpan {
                     start: ByteIndex(start),
@@ -129,8 +128,7 @@ pub fn handle_to_usages(
             let mut locations = Vec::new();
 
             for reference_id in usages.iter() {
-                let reference = linearization.id_mapping[reference_id];
-                let reference = linearization.lin[reference].clone();
+                let reference = linearization.get_item(*reference_id).unwrap();
                 let location = match reference.pos {
                     TermPos::Original(RawSpan {
                         start: ByteIndex(start),

--- a/lsp/nls/src/requests/hover.rs
+++ b/lsp/nls/src/requests/hover.rs
@@ -3,7 +3,6 @@ use codespan_lsp::position_to_byte_index;
 use log::debug;
 use lsp_server::{RequestId, Response, ResponseError};
 use lsp_types::{Hover, HoverContents, HoverParams, LanguageString, MarkedString, Range};
-use nickel::position::TermPos;
 use serde_json::Value;
 
 use crate::{
@@ -55,14 +54,12 @@ pub fn handle(
 
     let (ty, meta) = linearization.resolve_item_type_meta(&item);
 
-    let range = match item.pos {
-        TermPos::Original(span) | TermPos::Inherited(span) => Some(Range::from_codespan(
-            &file_id,
-            &(span.start.0 as usize..span.end.0 as usize),
-            server.cache.files(),
-        )),
-        TermPos::None => None,
-    };
+    let range = Range::from_codespan(
+        &file_id,
+        &(item.pos.start.to_usize()..item.pos.end.to_usize()),
+        server.cache.files(),
+    );
+
     server.reply(Response::new_ok(
         id,
         Hover {
@@ -81,7 +78,7 @@ pub fn handle(
                 }),
             ]),
 
-            range,
+            range: Some(range),
         },
     ));
     Ok(())

--- a/lsp/nls/src/requests/hover.rs
+++ b/lsp/nls/src/requests/hover.rs
@@ -8,7 +8,6 @@ use serde_json::Value;
 
 use crate::{
     diagnostic::LocationCompat,
-    requests::utils::CompletedExt,
     server::Server,
     trace::{Enrich, Trace},
 };

--- a/lsp/nls/src/requests/hover.rs
+++ b/lsp/nls/src/requests/hover.rs
@@ -3,17 +3,12 @@ use codespan_lsp::position_to_byte_index;
 use log::debug;
 use lsp_server::{RequestId, Response, ResponseError};
 use lsp_types::{Hover, HoverContents, HoverParams, LanguageString, MarkedString, Range};
-use nickel::{
-    position::TermPos,
-    term::MetaValue,
-    typecheck::linearization::{self, Completed, TermKind, UsageState},
-    types::Types,
-};
+use nickel::position::TermPos;
 use serde_json::Value;
 
 use crate::{
     diagnostic::LocationCompat,
-    requests::utils::find_linearization_index,
+    requests::utils::CompletedExt,
     server::Server,
     trace::{Enrich, Trace},
 };
@@ -45,21 +40,21 @@ pub fn handle(
 
     let locator = (file_id, ByteIndex(start as u32));
 
-    let completed = server.lin_cache_get(&file_id)?;
-    let linearization = &completed.lin;
-    let index = find_linearization_index(linearization, locator);
+    let linearization = server.lin_cache_get(&file_id)?;
+    let item = linearization.item_at(locator);
 
-    Trace::enrich(&id, completed);
+    Trace::enrich(&id, linearization);
 
-    if index == None {
+    if item == None {
         server.reply(Response::new_ok(id, Value::Null));
         return Ok(());
     }
 
-    let item = linearization[index.unwrap()].to_owned();
+    let item = item.unwrap().to_owned();
+
     debug!("{:?}", item);
 
-    let (ty, meta) = resolve_type_meta(&item, completed);
+    let (ty, meta) = linearization.resolve_item_type_meta(&item);
 
     let range = match item.pos {
         TermPos::Original(span) | TermPos::Inherited(span) => Some(Range::from_codespan(
@@ -91,48 +86,4 @@ pub fn handle(
         },
     ));
     Ok(())
-}
-
-fn resolve_type_meta(
-    item: &linearization::LinearizationItem<Types>,
-    completed: &Completed,
-) -> (Types, Vec<String>) {
-    let mut extra = Vec::new();
-
-    let item = match item.kind {
-        TermKind::Usage(UsageState::Resolved(usage)) => usage
-            .and_then(|u| completed.get_item(u + 1))
-            .unwrap_or(item),
-        TermKind::Declaration(_, _) => completed.get_item(item.id + 1).unwrap_or(item),
-        _ => item,
-    };
-
-    if let Some(MetaValue {
-        ref doc,
-        ref types,
-        ref contracts,
-        priority,
-        ..
-    }) = item.meta.as_ref()
-    {
-        if let Some(doc) = doc {
-            extra.push(doc.to_owned());
-        }
-        if let Some(types) = types {
-            extra.push(types.label.tag.to_string());
-        }
-        if !contracts.is_empty() {
-            extra.push(
-                contracts
-                    .iter()
-                    .map(|contract| format!("{}", contract.label.types,))
-                    .collect::<Vec<_>>()
-                    .join(","),
-            );
-        }
-
-        extra.push(format!("Merge Priority: {:?}", priority));
-    }
-
-    (item.ty.to_owned(), extra)
 }

--- a/lsp/nls/src/requests/hover.rs
+++ b/lsp/nls/src/requests/hover.rs
@@ -39,7 +39,7 @@ pub fn handle(
     let locator = (file_id, ByteIndex(start as u32));
 
     let linearization = server.lin_cache_get(&file_id)?;
-    let item = linearization.item_at(locator);
+    let item = linearization.item_at(&locator);
 
     Trace::enrich(&id, linearization);
 

--- a/lsp/nls/src/requests/mod.rs
+++ b/lsp/nls/src/requests/mod.rs
@@ -2,4 +2,3 @@ pub mod completion;
 pub mod goto;
 pub mod hover;
 pub mod symbols;
-mod utils;

--- a/lsp/nls/src/requests/symbols.rs
+++ b/lsp/nls/src/requests/symbols.rs
@@ -22,7 +22,7 @@ pub fn handle_document_symbols(
     if let Some(completed) = server.lin_cache.get(&file_id) {
         Trace::enrich(&id, completed);
         let symbols = completed
-            .lin
+            .linearization
             .iter()
             .filter_map(|item| match &item.kind {
                 TermKind::Declaration(name, _) => {

--- a/lsp/nls/src/requests/symbols.rs
+++ b/lsp/nls/src/requests/symbols.rs
@@ -1,6 +1,6 @@
 use crate::{
     linearization::interface::TermKind,
-    term::TermPosExt,
+    term::RawSpanExt,
     trace::{Enrich, Trace},
 };
 use lsp_server::{RequestId, Response, ResponseError};
@@ -26,15 +26,11 @@ pub fn handle_document_symbols(
             .iter()
             .filter_map(|item| match &item.kind {
                 TermKind::Declaration(name, _) => {
-                    let range = item
-                        .pos
-                        .try_to_range()
-                        .or_else(|| Some((file_id, (0usize..0usize))))
-                        .map(|(file_id, range)| {
-                            codespan_lsp::byte_span_to_range(server.cache.files(), file_id, range)
-                                .unwrap()
-                        })
-                        .unwrap();
+                    let (file_id, span) = item.pos.to_range();
+
+                    let range =
+                        codespan_lsp::byte_span_to_range(server.cache.files(), file_id, span)
+                            .unwrap();
 
                     // `deprecated` is a required field but causes a warning although we are not using it
                     #[allow(deprecated)]

--- a/lsp/nls/src/requests/symbols.rs
+++ b/lsp/nls/src/requests/symbols.rs
@@ -1,4 +1,5 @@
 use crate::{
+    linearization::interface::TermKind,
     term::TermPosExt,
     trace::{Enrich, Trace},
 };
@@ -24,7 +25,7 @@ pub fn handle_document_symbols(
             .lin
             .iter()
             .filter_map(|item| match &item.kind {
-                nickel::typecheck::linearization::TermKind::Declaration(name, _) => {
+                TermKind::Declaration(name, _) => {
                     let range = item
                         .pos
                         .try_to_range()

--- a/lsp/nls/src/server.rs
+++ b/lsp/nls/src/server.rs
@@ -17,9 +17,10 @@ use lsp_types::{
 };
 
 use nickel::cache::Cache;
-use nickel::typecheck::{linearization::Completed, Environment};
+use nickel::typecheck::Environment;
 
 use crate::{
+    linearization::completed::Completed,
     requests::{completion, goto, hover, symbols},
     trace::Trace,
 };

--- a/lsp/nls/src/term.rs
+++ b/lsp/nls/src/term.rs
@@ -1,20 +1,14 @@
 use std::ops::Range;
 
 use codespan::FileId;
-use nickel::position::{RawSpan, TermPos};
+use nickel::position::RawSpan;
 
-pub trait TermPosExt {
-    fn try_to_range(&self) -> Option<(FileId, Range<usize>)>;
+pub trait RawSpanExt {
+    fn to_range(self) -> (FileId, Range<usize>);
 }
 
-impl TermPosExt for TermPos {
-    fn try_to_range(&self) -> Option<(FileId, Range<usize>)> {
-        match self {
-            TermPos::Inherited(RawSpan { src_id, start, end })
-            | TermPos::Original(RawSpan { src_id, start, end }) => {
-                Some((*src_id, (start.0 as usize..end.0 as usize)))
-            }
-            TermPos::None => None,
-        }
+impl RawSpanExt for RawSpan {
+    fn to_range(self) -> (FileId, Range<usize>) {
+        (self.src_id, (self.start.to_usize()..self.end.to_usize()))
     }
 }

--- a/lsp/nls/src/trace.rs
+++ b/lsp/nls/src/trace.rs
@@ -229,7 +229,7 @@ pub mod param {
         fn enrich(id: &RequestId, param: &Completed) {
             Self::with_trace(|mut t| {
                 t.received.entry(id.to_owned()).and_modify(|item| {
-                    item.params.linearization_size = Some(param.lin.len());
+                    item.params.linearization_size = Some(param.linearization.len());
                 });
                 Ok(())
             })

--- a/lsp/nls/src/trace.rs
+++ b/lsp/nls/src/trace.rs
@@ -220,9 +220,10 @@ impl<T, E: Display> ResultExt<E> for Result<T, E> {
 
 pub mod param {
 
+    use crate::linearization::completed::Completed;
+
     use super::{Enrich, ResultExt, Trace};
     use lsp_server::RequestId;
-    use nickel::typecheck::linearization::Completed;
 
     impl Enrich<&Completed> for Trace {
         fn enrich(id: &RequestId, param: &Completed) {

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -415,7 +415,7 @@ impl Cache {
             }
             Some(CachedTerm { term, state, .. }) if *state >= EntryState::Parsed => {
                 if *state < EntryState::Typechecking {
-                    type_check(term, global_env, self, StubHost::<(), _>::new())?;
+                    type_check(term, global_env, self, StubHost::<(), (), _>::new())?;
                     self.update_state(file_id, EntryState::Typechecking);
                 }
 
@@ -652,7 +652,7 @@ impl Cache {
             return Err(Error::ParseErrors(errs));
         }
         let (term, pending) = import_resolution::resolve_imports(term, self)?;
-        type_check(&term, global_env, self, StubHost::<(), _>::new())?;
+        type_check(&term, global_env, self, StubHost::<(), (), _>::new())?;
         let term = transform::transform(term);
         Ok((term, pending))
     }

--- a/src/typecheck/linearization.rs
+++ b/src/typecheck/linearization.rs
@@ -26,7 +26,6 @@ use std::marker::PhantomData;
 use std::ops::{Deref, DerefMut};
 
 use super::TypeWrapper;
-use crate::environment::Environment as GenericEnvironment;
 use crate::{identifier::Ident, position::TermPos, term::Term};
 
 /// Holds the state of a linearization, either in progress or finalized
@@ -118,7 +117,7 @@ pub trait Linearizer {
     /// Defines how to turn a [Building] Linearization of the tracked type into
     /// a [Self::Completed] linearization.
     /// By default creates an entirely empty [Self::Completed] object
-    fn linearize(
+    fn complete(
         self,
         _lin: Linearization<Self::Building>,
         _extra: Self::CompletionExtra,

--- a/src/typecheck/mod.rs
+++ b/src/typecheck/mod.rs
@@ -218,7 +218,7 @@ where
     }
 
     let lin = linearizer
-        .linearize(building, (table.clone(), names))
+        .complete(building, (table.clone(), names))
         .into_inner();
     Ok((to_type(&table, ty), lin))
 }

--- a/src/typecheck/mod.rs
+++ b/src/typecheck/mod.rs
@@ -50,7 +50,7 @@ use crate::{mk_tyw_arrow, mk_tyw_enum, mk_tyw_enum_row, mk_tyw_record, mk_tyw_ro
 use std::collections::{HashMap, HashSet};
 use std::convert::TryInto;
 
-use self::linearization::{Building, Linearization, Linearizer, ScopeId, StubHost};
+use self::linearization::{Linearization, Linearizer, ScopeId, StubHost};
 
 pub mod error;
 pub mod linearization;
@@ -185,18 +185,17 @@ pub struct State<'a> {
 ///
 /// Note that this function doesn't recursively typecheck imports (anymore), but just the current
 /// file. It however still needs the resolver to get the apparent type of imports.
-pub fn type_check<L, LL>(
+pub fn type_check<LL>(
     t: &RichTerm,
     global_env: &Environment,
     resolver: &impl ImportResolver,
     mut linearizer: LL,
 ) -> Result<(Types, LL::Completed), TypecheckError>
 where
-    L: Default,
-    LL: Linearizer<L, (UnifTable, HashMap<usize, Ident>)>,
+    LL: Linearizer<CompletionExtra = (HashMap<usize, Option<TypeWrapper>>, HashMap<usize, Ident>)>,
 {
     let (mut table, mut names) = (UnifTable::new(), HashMap::new());
-    let mut building = Linearization::building();
+    let mut building = Linearization::new(LL::Building::default());
     let ty = TypeWrapper::Ptr(new_var(&mut table));
 
     {
@@ -249,8 +248,8 @@ pub fn type_check_in_env(
     type_check_(
         &mut state,
         Envs::from_global(global),
-        &mut Linearization::building::<()>(),
-        StubHost::<(), ()>::new(),
+        &mut Linearization::new(()),
+        StubHost::<()>::new(),
         false,
         t,
         ty.clone(),
@@ -273,11 +272,11 @@ pub fn type_check_in_env(
 ///
 /// Registers every term with the `linearizer` and makes sure to scope the
 /// liearizer accordingly
-fn type_check_<S, E>(
+fn type_check_<L: Linearizer>(
     state: &mut State,
     mut envs: Envs,
-    lin: &mut Linearization<Building<S>>,
-    mut linearizer: impl Linearizer<S, E>,
+    lin: &mut Linearization<L::Building>,
+    mut linearizer: L,
     strict: bool,
     rt: &RichTerm,
     ty: TypeWrapper,

--- a/src/typecheck/mod.rs
+++ b/src/typecheck/mod.rs
@@ -50,7 +50,7 @@ use crate::{mk_tyw_arrow, mk_tyw_enum, mk_tyw_enum_row, mk_tyw_record, mk_tyw_ro
 use std::collections::{HashMap, HashSet};
 use std::convert::TryInto;
 
-use self::linearization::{Building, Completed, Linearization, Linearizer, ScopeId, StubHost};
+use self::linearization::{Building, Linearization, Linearizer, ScopeId, StubHost};
 
 pub mod error;
 pub mod linearization;
@@ -185,14 +185,15 @@ pub struct State<'a> {
 ///
 /// Note that this function doesn't recursively typecheck imports (anymore), but just the current
 /// file. It however still needs the resolver to get the apparent type of imports.
-pub fn type_check<L>(
+pub fn type_check<L, LL>(
     t: &RichTerm,
     global_env: &Environment,
     resolver: &impl ImportResolver,
-    mut linearizer: impl Linearizer<L, (UnifTable, HashMap<usize, Ident>)>,
-) -> Result<(Types, Completed), TypecheckError>
+    mut linearizer: LL,
+) -> Result<(Types, LL::Completed), TypecheckError>
 where
     L: Default,
+    LL: Linearizer<L, (UnifTable, HashMap<usize, Ident>)>,
 {
     let (mut table, mut names) = (UnifTable::new(), HashMap::new());
     let mut building = Linearization::building();
@@ -219,7 +220,7 @@ where
 
     let lin = linearizer
         .linearize(building, (table.clone(), names))
-        .into();
+        .into_inner();
     Ok((to_type(&table, ty), lin))
 }
 


### PR DESCRIPTION
This PR moves all implementation details of linearization into the nls module.
What is left in nickel is only the linearization interface. 
All components not strictly needed to stub the interface during normal execution are now part of nls.

This is in particular the concrete states and their data
- `Building`
- `Completed`
- `LinearizationItem`

Refactoring also allowed to flatten the `Building<BuildingResource>` removing an unnecessary indirection  

This PR might look a bit grim with 16 files changed but it's mostly moved code.
