### PR TITLE
Add --nostdlib option in debug releases to skip stdlib loading

### DIFF
--- a/src/bin/nickel.rs
+++ b/src/bin/nickel.rs
@@ -19,6 +19,12 @@ struct Opt {
     #[structopt(short = "f", long)]
     #[structopt(parse(from_os_str))]
     file: Option<PathBuf>,
+
+    #[cfg(debug_assertions)]
+    /// Skip the standard library import, for debugging only, does not affect REPL
+    #[structopt(long)]
+    nostdlib: bool,
+
     #[structopt(subcommand)]
     command: Option<Command>,
 }
@@ -87,6 +93,11 @@ fn main() {
                 eprintln!("Error when reading input: {}", err);
                 process::exit(1)
             });
+
+        #[cfg(debug_assertions)]
+        if opts.nostdlib {
+            program.set_skip_stdlib();
+        }
 
         let result = match opts.command {
             Some(Command::Export { format, output }) => export(&mut program, format, output),

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -68,6 +68,10 @@ pub struct Cache {
     terms: HashMap<FileId, CachedTerm>,
     /// The list of ids corresponding to the stdlib modules
     stdlib_ids: Option<Vec<FileId>>,
+
+    #[cfg(debug_assertions)]
+    /// Skip loading the stdlib, used for debugging purpose
+    pub skip_stdlib: bool,
 }
 
 /// wrapping eval environment with typing environment
@@ -203,6 +207,9 @@ impl Cache {
             terms: HashMap::new(),
             imports: HashMap::new(),
             stdlib_ids: None,
+
+            #[cfg(debug_assertions)]
+            skip_stdlib: false,
         }
     }
 
@@ -800,6 +807,10 @@ impl Cache {
     /// type environment, use `load_stdlib()` then `mk_global_type` to avoid
     /// transformations and evaluation preparation.
     pub fn prepare_stdlib(&mut self) -> Result<GlobalEnv, Error> {
+        #[cfg(debug_assertions)]
+        if self.skip_stdlib {
+            return Ok(GlobalEnv::new());
+        }
         self.load_stdlib()?;
         let type_env = self.mk_types_env().unwrap();
 

--- a/src/program.rs
+++ b/src/program.rs
@@ -126,6 +126,11 @@ impl Program {
     {
         report(&mut self.cache, error)
     }
+
+    #[cfg(debug_assertions)]
+    pub fn set_skip_stdlib(&mut self) {
+        self.cache.skip_stdlib = true;
+    }
 }
 
 /// Query the metadata of a path of a term in the cache.


### PR DESCRIPTION
When debugging a problem, the debugging messages often gets unreadable because of the loading of the standard library.

As usually we debug against a minimal example containing the bug and want to trace what happends inside the software, we usually do not need the standard library (and could copy manually parts of it if needed).

So I propose to add an option `nostdlib` in **debug releases only** that would skip the loading of the standard library to allow this to be easily done.