### PR TITLE
Convert TermPos to Raw spans throughout nls

### DIFF
--- a/lsp/nls/src/linearization/building.rs
+++ b/lsp/nls/src/linearization/building.rs
@@ -68,7 +68,7 @@ impl Building {
             let id = self.id_gen().get_and_advance();
             self.push(LinearizationItem {
                 id,
-                pos: ident.pos,
+                pos: ident.pos.unwrap(),
                 // temporary, the actual type is resolved later and the item retyped
                 ty: TypeWrapper::Concrete(AbsType::Dyn()),
                 kind: TermKind::RecordField {

--- a/lsp/nls/src/requests/hover.rs
+++ b/lsp/nls/src/requests/hover.rs
@@ -3,7 +3,6 @@ use codespan_lsp::position_to_byte_index;
 use log::debug;
 use lsp_server::{RequestId, Response, ResponseError};
 use lsp_types::{Hover, HoverContents, HoverParams, LanguageString, MarkedString, Range};
-use nickel::position::TermPos;
 use serde_json::Value;
 
 use crate::{
@@ -55,14 +54,12 @@ pub fn handle(
 
     let (ty, meta) = linearization.resolve_item_type_meta(&item);
 
-    let range = match item.pos {
-        TermPos::Original(span) | TermPos::Inherited(span) => Some(Range::from_codespan(
-            &file_id,
-            &(span.start.0 as usize..span.end.0 as usize),
-            server.cache.files(),
-        )),
-        TermPos::None => None,
-    };
+    let range = Range::from_codespan(
+        &file_id,
+        &(item.pos.start.to_usize()..item.pos.end.to_usize()),
+        server.cache.files(),
+    );
+
     server.reply(Response::new_ok(
         id,
         Hover {
@@ -81,7 +78,7 @@ pub fn handle(
                 }),
             ]),
 
-            range,
+            range: Some(range),
         },
     ));
     Ok(())

--- a/lsp/nls/src/requests/symbols.rs
+++ b/lsp/nls/src/requests/symbols.rs
@@ -1,6 +1,6 @@
 use crate::{
     linearization::interface::TermKind,
-    term::TermPosExt,
+    term::RawSpanExt,
     trace::{Enrich, Trace},
 };
 use lsp_server::{RequestId, Response, ResponseError};
@@ -26,15 +26,11 @@ pub fn handle_document_symbols(
             .iter()
             .filter_map(|item| match &item.kind {
                 TermKind::Declaration(name, _) => {
-                    let range = item
-                        .pos
-                        .try_to_range()
-                        .or_else(|| Some((file_id, (0usize..0usize))))
-                        .map(|(file_id, range)| {
-                            codespan_lsp::byte_span_to_range(server.cache.files(), file_id, range)
-                                .unwrap()
-                        })
-                        .unwrap();
+                    let (file_id, span) = item.pos.to_range();
+
+                    let range =
+                        codespan_lsp::byte_span_to_range(server.cache.files(), file_id, span)
+                            .unwrap();
 
                     // `deprecated` is a required field but causes a warning although we are not using it
                     #[allow(deprecated)]

--- a/lsp/nls/src/term.rs
+++ b/lsp/nls/src/term.rs
@@ -1,20 +1,14 @@
 use std::ops::Range;
 
 use codespan::FileId;
-use nickel::position::{RawSpan, TermPos};
+use nickel::position::RawSpan;
 
-pub trait TermPosExt {
-    fn try_to_range(&self) -> Option<(FileId, Range<usize>)>;
+pub trait RawSpanExt {
+    fn to_range(self) -> (FileId, Range<usize>);
 }
 
-impl TermPosExt for TermPos {
-    fn try_to_range(&self) -> Option<(FileId, Range<usize>)> {
-        match self {
-            TermPos::Inherited(RawSpan { src_id, start, end })
-            | TermPos::Original(RawSpan { src_id, start, end }) => {
-                Some((*src_id, (start.0 as usize..end.0 as usize)))
-            }
-            TermPos::None => None,
-        }
+impl RawSpanExt for RawSpan {
+    fn to_range(self) -> (FileId, Range<usize>) {
+        (self.src_id, (self.start.to_usize()..self.end.to_usize()))
     }
 }


### PR DESCRIPTION
`TermPos` is guaranteed to be not-none after linearization is done
We can use `RawSpan` from that point on instead ofunwraping the `TermPos` everywhere.

Alternative:
Keep the `TermPos` but unwrap whenever used
This could retain semantics of the different cases of `TermPos`