### PR TITLE
Disable record benchmarks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,9 +81,9 @@ harness = false
 name = "lists"
 harness = false
 
-[[bench]]
-name = "records"
-harness = false
+# [[bench]]
+# name = "records"
+# harness = false
 
 [[bench]]
 name = "serialization"

--- a/benches/records/merge.ncl
+++ b/benches/records/merge.ncl
@@ -4,7 +4,7 @@
       let l = lists.generate (fun _n => "a") n in
       lists.foldl (fun x y => x ++ y) "" l in
     let makeRecStep = fun state k =>
-      let name = state.prevName ++ (strings.fromNum k) in
+      let name = state.prevName ++ (strings.from_num k) in
       {
         value = state.value & {"#{name}" = {}},
         prevName = name,


### PR DESCRIPTION
These are two slow, and are one of the things preventing the benchmarks GitHub action from succeeding.