### PR TITLE
Fix command output + Improve editor setup docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,12 @@ abstractions or just feel ad hoc. Nickel buys you more for less.
 Use `nickel help` for a list of subcommands, and `nickel help <subcommand>`
 for help about a specific subcommand.
 
+#### Editor Setup
+
+Nickel has syntax highlighting plugins for Vim/Neovim, and VSCode.
+In editor diagnostics, type hints, and auto-completion are provided by the Nickel Language Server.
+Please follow [this guide](https://github.com/tweag/nickel/tree/master/lsp) to setup syntax highlighting and NLS.
+
 ### Build
 
 [rust-guide]: https://doc.rust-lang.org/cargo/getting-started/installation.html

--- a/README.md
+++ b/README.md
@@ -88,15 +88,13 @@ abstractions or just feel ad hoc. Nickel buys you more for less.
 2. Run your first program:
   ```console
   $ ./nickel <<< 'let x = 2 in x + x'
-  Typechecked: Ok(Types(Dyn))
-  Done: Num(4.0)
+  4
   ```
   Or load it from a file:
   ```console
   $ echo 'let s = "world" in "Hello, " ++ s' > program.ncl
   $ ./nickel -f program.ncl
-  Typechecked: Ok(Types(Dyn))
-  Done: Str("Hello, world")
+  "Hello, world"
   ```
 3. Start a REPL:
   ```console

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ for help about a specific subcommand.
 #### Editor Setup
 
 Nickel has syntax highlighting plugins for Vim/Neovim, and VSCode.
-In editor diagnostics, type hints, and auto-completion are provided by the Nickel Language Server.
+In-editor diagnostics, type hints, and auto-completion are provided by the Nickel Language Server.
 Please follow [this guide](https://github.com/tweag/nickel/tree/master/lsp) to setup syntax highlighting and NLS.
 
 ### Build

--- a/lsp/README.md
+++ b/lsp/README.md
@@ -103,6 +103,14 @@ The VS Code extension offers three configuration options:
 
 ### (Neo)Vim
 
+Before proceeding install the [Nickel syntax highlighting plugin](https://github.com/nickel-lang/vim-nickel) using your Vim plugin manager.
+Without this plugin your LSP client will not start NLS.
+
+With Vim-Plug:
+```vim
+Plug 'nickel-lang/vim-nickel'
+```
+
 #### Neovim builtin LSP
 
 `nls` is supported in

--- a/lsp/README.md
+++ b/lsp/README.md
@@ -104,7 +104,7 @@ The VS Code extension offers three configuration options:
 ### (Neo)Vim
 
 Before proceeding install the [Nickel syntax highlighting plugin](https://github.com/nickel-lang/vim-nickel) using your Vim plugin manager.
-Without this plugin your LSP client will not start NLS.
+Without this plugin your LSP client may not start NLS on nickel source files.
 
 With Vim-Plug:
 ```vim


### PR DESCRIPTION
The example output has changed. This PR makes the readme match reality.
Added a note in getting started about the LSP.
Added a note in the LSP readme about vim syntax highlighting being a prerequisite.