### PR TITLE
Fix instantiation of polymorphic functions accessed from a record

### DIFF
--- a/examples/lists/lists.ncl
+++ b/examples/lists/lists.ncl
@@ -1,19 +1,12 @@
 // Example list functions. This code is illustrative: prefer using the list
 // stdlib functions `lists.map` and `lists.fold` instead.
 let my_list_lib = {
-  // We have to wrap `head` and `tail` with the right annotations if we want our
-  // map and fold to be statically typed. This is due to a current issue with
-  // the how the stdlib is typed, see
-  // https://github.com/tweag/nickel/issues/226. It won't be needed eventually.
-  head | forall a. List a -> a = fun l => %head% l,
-  tail | forall a. List a -> List a = fun l => %tail% l,
-
   map : forall a b. (a -> b) -> List a -> List b = fun f list =>
     if list == [] then
       []
     else
-      let head = head list in
-      let tail = tail list in
+      let head = lists.head list in
+      let tail = lists.tail list in
       [f head] @ map f tail,
 
   fold : forall a b. (a -> b -> b) -> List a -> b -> b =
@@ -21,7 +14,9 @@ let my_list_lib = {
         if list == [] then
           first
         else
-          f (head list) (fold f (tail list) first),
+          let head = lists.head list in
+          let tail = lists.tail list in
+          f head (fold f tail first),
 } in
 // Compute `7!`
 let l = my_list_lib.map (fun x => x+1) [1, 2, 3, 4, 5, 6] in

--- a/src/typecheck/mod.rs
+++ b/src/typecheck/mod.rs
@@ -593,8 +593,6 @@ fn type_check_<L: Linearizer>(
         Term::Op1(op, t) => {
             let (ty_arg, ty_res) = get_uop_type(state, op)?;
 
-            unify(state, strict, ty, ty_res)
-                .map_err(|err| err.into_typecheck_err(state, rt.pos))?;
             type_check_(
                 state,
                 envs.clone(),
@@ -603,7 +601,11 @@ fn type_check_<L: Linearizer>(
                 strict,
                 t,
                 ty_arg,
-            )
+            )?;
+
+            let instantiated = instantiate_foralls(state, ty_res, ForallInst::Ptr);
+            unify(state, strict, ty, instantiated)
+                .map_err(|err| err.into_typecheck_err(state, rt.pos))
         }
         Term::Op2(op, t1, t2) => {
             let (ty_arg1, ty_arg2, ty_res) = get_bop_type(state, op)?;

--- a/tests/pass/typechecking.ncl
+++ b/tests/pass/typechecking.ncl
@@ -4,7 +4,7 @@ let typecheck = [
   false : Bool,
   0 : Num,
   45 : Num,
-  fun x => x : forall a. a -> a,
+  (fun x => x) : forall a. a -> a,
   let x = 3 in (x : Num),
   4 + false,
   (true | Num) : Num,
@@ -82,7 +82,7 @@ let typecheck = [
   let r : {bla : Bool, blo : Num} = {blo = 1, bla = true} in
     ((if r.bla then r.blo else 2) : Num),
 
-  let f : forall a. (forall r. {bla : Bool, blo : a, ble : a | r} -> a) =
+  let f : forall a r. {bla : Bool, blo : a, ble : a | r} -> a =
       fun r => if r.bla then r.blo else r.ble in
     (if (f {bla = true, blo = false, ble = true, blip = 1, }) then
       (f {bla = true, blo = 1, ble = 2, blip = `blip, })
@@ -181,8 +181,8 @@ let typecheck = [
   (strings.length "Ok" == 2) : Bool,
   // partial application
   (strings.split ".") : Str -> List Str,
-  // TODO: fix issue with `forall`
-  // (lists.length [] == 0) : Bool,
+  (lists.length [] == 0) : Bool,
+  (lists.map (fun x => x ++ "1") ["a", "b", "c"]) : List Str,
 ] in
 
 true


### PR DESCRIPTION
Fix the last avatar of #375. Currently the polymorphic functions from the stdlib can't be used in typed code, because they are not instantiated correctly:

```
nickel>(lists.map (fun x => x + 1) [1,2,3]) : List Num
error: Type mismatch
...
```

The general issue is not stdlib-specific, but has to do with a polymorphic function accessed from a record being the head of an application. If we use a variable as a gateway, then it works again:

```
nickel>(let m = lists.map in m (fun x => x + 1) [1,2,3]) : List Num
[2,3,4]
```

This PR fixes the issue by always instantiating the type resulting from the application of a unary operator (which record access is), and by re-ordering the information flow to check the final result type only after we've instantiated potential heading foralls.

To be honest, this is quite ad-hoc (it arbitrarily only covers the case of unary operators): the proper fix is to close #584, but in the meantime, those few lines of diff allow us to use the functions from the stdlib in typed code and relegate the issue to edge cases that, I hope, are much rarer.