### PR TITLE
[Language Server] Add explicit UsageState for unbound names

### DIFF
--- a/lsp/nls/src/linearization/building.rs
+++ b/lsp/nls/src/linearization/building.rs
@@ -115,7 +115,7 @@ impl Building {
     ) -> Option<&'a LinearizationItem<TypeWrapper>> {
         // if item is a usage, resolve the usage first
         match item.kind {
-            TermKind::Usage(UsageState::Resolved(Some(pointed))) => self.linearization.get(pointed),
+            TermKind::Usage(UsageState::Resolved(pointed)) => self.linearization.get(pointed),
             _ => Some(item),
         }
         // load referenced value, either from record field or declaration
@@ -190,7 +190,7 @@ impl Building {
 
             let referenced_declaration =
                 referenced_declaration.and_then(|referenced| match referenced.kind {
-                    TermKind::Usage(UsageState::Resolved(Some(pointed))) => {
+                    TermKind::Usage(UsageState::Resolved(pointed)) => {
                         self.linearization.get(pointed)
                     }
                     TermKind::RecordField { value, .. } => value
@@ -207,7 +207,7 @@ impl Building {
                                     .get(child_ident)
                                     .and_then(|accessor_id| self.linearization.get(*accessor_id))
                             }
-                            TermKind::Usage(UsageState::Resolved(Some(pointed))) => {
+                            TermKind::Usage(UsageState::Resolved(pointed)) => {
                                 self.linearization.get(*pointed)
                             }
                             _ => None,
@@ -227,7 +227,7 @@ impl Building {
             {
                 let child: &mut LinearizationItem<TypeWrapper> =
                     self.linearization.get_mut(*child_item).unwrap();
-                child.kind = TermKind::Usage(UsageState::Resolved(referenced_id));
+                child.kind = TermKind::Usage(UsageState::from(referenced_id));
             }
 
             if let Some(referenced_id) = referenced_id {

--- a/lsp/nls/src/linearization/completed.rs
+++ b/lsp/nls/src/linearization/completed.rs
@@ -108,9 +108,7 @@ impl Completed {
         let mut extra = Vec::new();
 
         let item = match item.kind {
-            TermKind::Usage(UsageState::Resolved(usage)) => {
-                usage.and_then(|u| self.get_item(u)).unwrap_or(item)
-            }
+            TermKind::Usage(UsageState::Resolved(usage)) => self.get_item(usage).unwrap_or(item),
             TermKind::Declaration(_, _) => self.get_item(item.id).unwrap_or(item),
             _ => item,
         };

--- a/lsp/nls/src/linearization/interface.rs
+++ b/lsp/nls/src/linearization/interface.rs
@@ -2,6 +2,8 @@ use std::collections::HashMap;
 
 use nickel::{identifier::Ident, typecheck::TypeWrapper, types::Types};
 
+use super::building::ID;
+
 pub trait ResolutionState {}
 /// Types are available as [TypeWrapper] only during recording
 /// They are resolved after typechecking has collected all terms into concrete
@@ -22,14 +24,14 @@ impl ResolutionState for Resolved {}
 /// Can be extended later to represent Contracts, Records, etc.
 #[derive(Debug, Clone, PartialEq)]
 pub enum TermKind {
-    Declaration(Ident, Vec<usize>),
+    Declaration(Ident, Vec<ID>),
     Usage(UsageState),
-    Record(HashMap<Ident, usize>),
+    Record(HashMap<Ident, ID>),
     RecordField {
         ident: Ident,
-        record: usize,
-        usages: Vec<usize>,
-        value: Option<usize>,
+        record: ID,
+        usages: Vec<ID>,
+        value: Option<ID>,
     },
     Structure,
 }
@@ -38,6 +40,16 @@ pub enum TermKind {
 /// In these cases we defer the resolution to a second pass during linearization
 #[derive(Debug, Clone, PartialEq)]
 pub enum UsageState {
-    Resolved(Option<usize>),
-    Deferred { parent: usize, child: Ident },
+    Unbound,
+    Resolved(ID),
+    Deferred { parent: ID, child: Ident },
+}
+
+impl From<Option<ID>> for UsageState {
+    fn from(option: Option<ID>) -> Self {
+        match option {
+            Some(id) => UsageState::Resolved(id),
+            None => UsageState::Unbound,
+        }
+    }
 }

--- a/lsp/nls/src/linearization/mod.rs
+++ b/lsp/nls/src/linearization/mod.rs
@@ -198,7 +198,7 @@ impl Linearizer for AnalysisHost {
                     pos: ident.pos.unwrap(),
                     ty: TypeWrapper::Concrete(AbsType::Dyn()),
                     scope: self.scope.clone(),
-                    kind: TermKind::Usage(UsageState::Resolved(self.env.get(ident))),
+                    kind: TermKind::Usage(UsageState::from(self.env.get(ident))),
                     meta: self.meta.take(),
                 });
 
@@ -266,7 +266,7 @@ impl Linearizer for AnalysisHost {
                                 scope: self.scope.clone(),
                                 // id = parent: full let binding including the body
                                 // id = parent + 1: actual delcaration scope, i.e. _ = < definition >
-                                kind: TermKind::Usage(UsageState::Resolved(parent)),
+                                kind: TermKind::Usage(UsageState::from(parent)),
                                 meta: None,
                             });
                             if let Some(parent) = parent {

--- a/lsp/nls/src/requests/goto.rs
+++ b/lsp/nls/src/requests/goto.rs
@@ -55,7 +55,7 @@ pub fn handle_to_definition(
     debug!("found referencing item: {:?}", item);
 
     let location = match item.kind {
-        TermKind::Usage(UsageState::Resolved(Some(usage_id))) => {
+        TermKind::Usage(UsageState::Resolved(usage_id)) => {
             let definition = linearization.get_item(usage_id).unwrap();
             let location = match definition.pos {
                 RawSpan {


### PR DESCRIPTION
NLS used options to represent whether a name was bound or not -- `Resolved(None)` meins the usage us unbound.
This change just adds an explicit `Unbound` state and an `impl From<Option<ID>> for UsageState` 