### PR TITLE
[Language server] walk contract types

### DIFF
--- a/lsp/nls/src/linearization/mod.rs
+++ b/lsp/nls/src/linearization/mod.rs
@@ -298,12 +298,17 @@ impl Linearizer for AnalysisHost {
                 // recursively linearize flat types
                 fn walk_types(
                     lin: &mut Linearization<Building>,
-                    outer_host: &AnalysisHost,
+                    outer_host: &mut AnalysisHost,
                     t: &nickel::types::Types,
                 ) {
+                    let mut scope = outer_host.scope.clone();
+                    let (scope_id, next_scope_id) = outer_host.next_scope_id.next();
+                    outer_host.next_scope_id = next_scope_id;
+                    scope.push(scope_id);
+
                     let inner_host = AnalysisHost {
                         env: outer_host.env.clone(),
-                        scope: outer_host.scope.clone(),
+                        scope,
                         ..Default::default()
                     };
                     match &t.0 {

--- a/lsp/nls/src/linearization/mod.rs
+++ b/lsp/nls/src/linearization/mod.rs
@@ -81,6 +81,19 @@ impl AnalysisHost {
     }
 }
 
+impl Default for AnalysisHost {
+    fn default() -> Self {
+        Self {
+            env: Environment::new(),
+            scope: Default::default(),
+            next_scope_id: Default::default(),
+            meta: Default::default(),
+            record_fields: Default::default(),
+            access: Default::default(),
+        }
+    }
+}
+
 impl Linearizer for AnalysisHost {
     type Building = Building;
     type Completed = Completed;


### PR DESCRIPTION
Linearize contract annotations

Previously only the direct reference of a contract was linearized.
That means for annotations like below, `AlwaysTrue` could be referenced and navigated to

```nickel
let AlwaysTrue = EqualsTo true in
let value | #AlwaysTrue = true in
in value
```

This PR allows much more general constructs on the RHS of `|` by traversing the AST of the contract expression.
Therefore, now `AlwaysTrue` can be accessed even in code like this:

```nickel
let AlwaysTrue = EqualsTo true in
let contrs = {
  AlwaysFalse = EqualsTo false,
} in
let t | #AlwaysTrue = true in
let not | #AlwaysTrue -> #contrs.AlwaysFalse = fun x => !x in
```


