### PR TITLE
[Language Server] Explicitly link values

### DIFF
--- a/lsp/nls/src/linearization/interface.rs
+++ b/lsp/nls/src/linearization/interface.rs
@@ -24,18 +24,32 @@ impl ResolutionState for Resolved {}
 /// Can be extended later to represent Contracts, Records, etc.
 #[derive(Debug, Clone, PartialEq)]
 pub enum TermKind {
-    Declaration(Ident, Vec<ID>),
+    Declaration(Ident, Vec<ID>, ValueState),
     Usage(UsageState),
     Record(HashMap<Ident, ID>),
     RecordField {
         ident: Ident,
         record: ID,
         usages: Vec<ID>,
-        value: Option<ID>,
+        value: ValueState,
     },
     Structure,
 }
 
+#[derive(Debug, Clone, PartialEq)]
+pub enum ValueState {
+    Unknown,
+    Known(ID),
+}
+
+impl ValueState {
+    pub fn as_option(&self) -> Option<ID> {
+        match self {
+            ValueState::Unknown => None,
+            ValueState::Known(value) => Some(*value),
+        }
+    }
+}
 /// Some usages cannot be fully resolved in a first pass (i.e. recursive record fields)
 /// In these cases we defer the resolution to a second pass during linearization
 #[derive(Debug, Clone, PartialEq)]

--- a/lsp/nls/src/linearization/mod.rs
+++ b/lsp/nls/src/linearization/mod.rs
@@ -209,11 +209,11 @@ impl Linearizer for AnalysisHost {
             Term::Let(ident, _, _, _) | Term::Fun(ident, _) => {
                 self.env.insert(ident.to_owned(), id);
                 let value_ptr = match term {
-                    Term::LetPattern(_, _, _, _) => {
+                    Term::Let(_, _, _, _) => {
                         self.let_binding = Some(id);
                         ValueState::Unknown
                     }
-                    Term::FunPattern(_, _, _) => ValueState::Known(id),
+                    Term::Fun(_, _) => ValueState::Known(id),
                     _ => unreachable!(),
                 };
                 lin.push(LinearizationItem {

--- a/lsp/nls/src/linearization/mod.rs
+++ b/lsp/nls/src/linearization/mod.rs
@@ -467,7 +467,7 @@ impl Linearizer for AnalysisHost {
             record_fields: self.record_fields.as_mut().and_then(|(record, fields)| {
                 Some(*record).zip(fields.pop().map(|field| vec![field]))
             }),
-            let_binding: None,
+            let_binding: self.let_binding.take(),
             access: self.access.clone(),
         }
     }

--- a/lsp/nls/src/requests/completion.rs
+++ b/lsp/nls/src/requests/completion.rs
@@ -46,7 +46,7 @@ pub fn handle_completion(
         .get_in_scope(&item)
         .iter()
         .filter_map(|i| match i.kind {
-            TermKind::Declaration(ref ident, _) => Some((ident.clone(), i.ty.clone())),
+            TermKind::Declaration(ref ident, _, _) => Some((ident.clone(), i.ty.clone())),
             _ => None,
         })
         .map(|(ident, _)| CompletionItem {

--- a/lsp/nls/src/requests/goto.rs
+++ b/lsp/nls/src/requests/goto.rs
@@ -118,7 +118,7 @@ pub fn handle_to_usages(
     debug!("found referencing item: {:?}", item);
 
     let locations = match &item.kind {
-        TermKind::Declaration(_, usages) | TermKind::RecordField { usages, .. } => {
+        TermKind::Declaration(_, usages, _) | TermKind::RecordField { usages, .. } => {
             let mut locations = Vec::new();
 
             for reference_id in usages.iter() {

--- a/lsp/nls/src/requests/symbols.rs
+++ b/lsp/nls/src/requests/symbols.rs
@@ -25,7 +25,7 @@ pub fn handle_document_symbols(
             .linearization
             .iter()
             .filter_map(|item| match &item.kind {
-                TermKind::Declaration(name, _) => {
+                TermKind::Declaration(name, _, _) => {
                     let (file_id, span) = item.pos.to_range();
 
                     let range =


### PR DESCRIPTION
Fixes #585

Let identifier is associated with the referenced value explicitly.
Yet if the value is a function the generated item is the argument binding which receives the `meta` data.

