### PR TITLE
[language server] Fix duplicate ids

### DIFF
--- a/lsp/nls/src/linearization/mod.rs
+++ b/lsp/nls/src/linearization/mod.rs
@@ -185,7 +185,7 @@ impl Linearizer for AnalysisHost {
                     let id = id_gen.get_and_advance();
                     self.env.insert(ident.to_owned(), id);
                     lin.push(LinearizationItem {
-                        id: id_gen.get_and_advance(),
+                        id,
                         ty,
                         pos: ident.pos.unwrap(),
                         scope: self.scope.clone(),


### PR DESCRIPTION
Fix duplicate ids introduced in #599.

The linearization skipped an id and consequently reused an occupied id.


