### PR TITLE
[Fix] nickel-lang.org's deploy workflow invocation

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -6,8 +6,6 @@ jobs:
   deploy:
     uses: tweag/nickel-lang.org/.github/workflows/deploy.yml@master
     with:
-      nickel_repository: ${{ github.repository }}
-      nickel_ref: ${{ github.sha }}
       production_deploy: false
     secrets:
       CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}


### PR DESCRIPTION
Since https://github.com/tweag/nickel-lang.org/pull/14, [nickel-lang.org](https://github.com/tweag/nickel-lang.org) now uses flakes to fetch nickel from there, which removed the `nickel_repository` and `nickel_ref` parameters from the deploy workflow. This PR fixes the workflow invocation from the nickel repository by removing those obsolete parameters.