### PR TITLE
Fix/destructuring empty metavalue

### DIFF
--- a/src/destruct.rs
+++ b/src/destruct.rs
@@ -34,7 +34,7 @@ pub enum LastMatch {
 /// A destructuring pattern without the `x @` part.
 #[derive(Debug, PartialEq, Clone)]
 pub enum Destruct {
-    /// A record pattern, the onlyone implemented for now.
+    /// A record pattern, the only one implemented for now.
     Record {
         matches: Vec<Match>,
         open: bool,

--- a/src/grammar.lalrpop
+++ b/src/grammar.lalrpop
@@ -27,6 +27,7 @@ use crate::{
         make as mk_term},
     types::{Types, AbsType},
     position::TermPos,
+    label::Label,
 };
 
 grammar<'input, 'err>(src_id: FileId, errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParseError>>);
@@ -273,16 +274,17 @@ Pattern: (Option<Ident>,Destruct) = {
 };
 
 Destruct: Destruct = {
-    "{" <mut matches: (<Match> ",")*> <last:LastMatch?> "}" => {
-        let (open, rst) = match last {
+    <start: @L> "{" <mut matches: (<Match> ",")*> <last:LastMatch?> "}" <end: @R> => {
+        let (open, rest) = match last {
 	    Some(LastMatch::Match(m)) => {
 	        matches.push(m);
 	        (false,None)
 	    },
-	    Some(LastMatch::Ellipsis(rst)) => (true, rst),
+	    Some(LastMatch::Ellipsis(rest)) => (true, rest),
 	    _ => (false, None),
 	};
-	Destruct::Record(matches, open, rst)
+	let span = mk_span(src_id, start, end);
+	Destruct::Record{matches, open, rest, span}
     },
 };
 
@@ -291,7 +293,16 @@ Match: Match = {
 	let meta = match (default, anns) {
 	    (Some(d), Some(m)) => MetaValue::flatten(d,m),
 	    (Some(m),_) | (_,Some(m)) => m,
-  	    _ => MetaValue::new(),
+  	    _ => match left {
+	        Ident{pos: TermPos::Original(span), ..} => MetaValue {
+	            contracts: vec![Contract{
+	                types: Types(AbsType::Dyn().into()),
+		        label: Label{span, ..Label::dummy()},
+		    }],
+		    ..Default::default()
+		},
+		_ => MetaValue::new(),
+	    },
 	};
 	Match::Assign(left, meta, right)
     },
@@ -299,7 +310,16 @@ Match: Match = {
 	let meta = match (default, anns) {
 	    (Some(d), Some(m)) => MetaValue::flatten(d,m),
 	    (Some(m),_) | (_,Some(m)) => m,
-  	    _ => MetaValue::new(),
+  	    _ => match id {
+	        Ident{pos: TermPos::Original(span), ..} => MetaValue {
+	            contracts: vec![Contract{
+	                types: Types(AbsType::Dyn().into()),
+		        label: Label{span, ..Label::dummy()},
+		    }],
+		    ..Default::default()
+		},
+		_ => MetaValue::new(),
+	    },
 	};
 	Match::Simple(id, meta)
     },

--- a/src/grammar.lalrpop
+++ b/src/grammar.lalrpop
@@ -296,7 +296,7 @@ Match: Match = {
   	    _ => MetaValue {
 	            contracts: vec![Contract{
 	                types: Types(AbsType::Dyn().into()),
-		        label: Label{span: left.pos.unwrap(), ..Label::dummy()},
+		        label: Label{span: left.pos.unwrap(), ..Default::default()},
 		    }],
 		    ..Default::default()
 	    },
@@ -310,7 +310,7 @@ Match: Match = {
   	    _ => MetaValue {
 	            contracts: vec![Contract{
 	                types: Types(AbsType::Dyn().into()),
-		        label: Label{span: id.pos.unwrap(), ..Label::dummy()},
+		        label: Label{span: id.pos.unwrap(), ..Default::default()},
 		    }],
 		    ..Default::default()
 	    },

--- a/src/grammar.lalrpop
+++ b/src/grammar.lalrpop
@@ -293,15 +293,12 @@ Match: Match = {
 	let meta = match (default, anns) {
 	    (Some(d), Some(m)) => MetaValue::flatten(d,m),
 	    (Some(m),_) | (_,Some(m)) => m,
-  	    _ => match left {
-	        Ident{pos: TermPos::Original(span), ..} => MetaValue {
+  	    _ => MetaValue {
 	            contracts: vec![Contract{
 	                types: Types(AbsType::Dyn().into()),
-		        label: Label{span, ..Label::dummy()},
+		        label: Label{span: left.pos.unwrap(), ..Label::dummy()},
 		    }],
 		    ..Default::default()
-		},
-		_ => MetaValue::new(),
 	    },
 	};
 	Match::Assign(left, meta, right)
@@ -310,15 +307,12 @@ Match: Match = {
 	let meta = match (default, anns) {
 	    (Some(d), Some(m)) => MetaValue::flatten(d,m),
 	    (Some(m),_) | (_,Some(m)) => m,
-  	    _ => match id {
-	        Ident{pos: TermPos::Original(span), ..} => MetaValue {
+  	    _ => MetaValue {
 	            contracts: vec![Contract{
 	                types: Types(AbsType::Dyn().into()),
-		        label: Label{span, ..Label::dummy()},
+		        label: Label{span: id.pos.unwrap(), ..Label::dummy()},
 		    }],
 		    ..Default::default()
-		},
-		_ => MetaValue::new(),
 	    },
 	};
 	Match::Simple(id, meta)

--- a/src/label.rs
+++ b/src/label.rs
@@ -268,3 +268,21 @@ impl Label {
         }
     }
 }
+
+impl Default for Label {
+    fn default() -> Label {
+        Label {
+            types: Rc::new(Types(AbsType::Dyn())),
+            tag: "".to_string(),
+            span: RawSpan {
+                src_id: Files::new().add("<null>", String::from("")),
+                start: 0.into(),
+                end: 1.into(),
+            },
+            arg_thunk: None,
+            arg_pos: TermPos::None,
+            polarity: true,
+            path: Vec::new(),
+        }
+    }
+}

--- a/src/term.rs
+++ b/src/term.rs
@@ -1349,7 +1349,7 @@ pub mod make {
         I: Into<Ident>,
     {
         match pat.into() {
-            d @ (Destruct::Record(..) | Destruct::List(_)) => {
+            d @ (Destruct::Record { .. } | Destruct::List { .. }) => {
                 Term::LetPattern(id.map(|i| i.into()), d, t1.into(), t2.into()).into()
             }
             Destruct::Empty => {

--- a/src/typecheck/mod.rs
+++ b/src/typecheck/mod.rs
@@ -285,8 +285,8 @@ fn type_check_<L: Linearizer>(
     // TODO: The insertion of values in the type environment is done but everything is
     // typed as `Dyn`.
     fn inject_pat_vars(pat: &Destruct, envs: &mut Envs) {
-        if let Destruct::Record(matches, _, rst) = pat {
-            if let Some(id) = rst {
+        if let Destruct::Record { matches, rest, .. } = pat {
+            if let Some(id) = rest {
                 envs.insert(id.clone(), TypeWrapper::Concrete(AbsType::Dyn()));
             }
             matches.iter().for_each(|m| match m {


### PR DESCRIPTION
Now every metavalues generated by destructuring have labels.
For final users, it means:
- better errors messages,
- errors pointing on a part of the code.

Can be improved but may require custom contracts/blames.