### PR TITLE
Make the builtin contract implementations inaccessible from user-code

### DIFF
--- a/src/stdlib.rs
+++ b/src/stdlib.rs
@@ -34,14 +34,14 @@ pub mod contracts {
     macro_rules! generate_accessor {
         ($value:ident) => {
             pub fn $value() -> RichTerm {
-                mk_term::var(stringify!($value))
+                mk_term::var(format!("${}", stringify!($value)))
             }
         };
     }
 
     // `dyn` is a reserved keyword in rust
     pub fn dynamic() -> RichTerm {
-        mk_term::var("dyn")
+        mk_term::var("$dyn")
     }
 
     generate_accessor!(num);

--- a/stdlib/contracts.ncl
+++ b/stdlib/contracts.ncl
@@ -1,51 +1,51 @@
 {
-  dyn = fun l t => t,
+  "$dyn" = fun l t => t,
 
-  num = fun l t => if %is_num% t then t else %blame% l,
+  "$num" = fun l t => if %is_num% t then t else %blame% l,
 
-  bool = fun l t => if %is_bool% t then t else %blame% l,
+  "$bool" = fun l t => if %is_bool% t then t else %blame% l,
 
-  string = fun l t => if %is_str% t then t else %blame% l,
+  "$string" = fun l t => if %is_str% t then t else %blame% l,
 
-  list = fun elt l t =>
+  "$fail" = fun l t => %blame% l,
+
+  "$list" = fun elt l t =>
     if %is_list% t then
       %map% t (fun value => %assume% elt (%go_list% l) value)
     else %blame% l,
 
-  func = fun s t l e =>
+  "$func" = fun s t l e =>
       if %is_fun% e then
           (fun x => %assume% t (%go_codom% l) (e (%assume% s (%chng_pol% (%go_dom% l)) x)))
       else
           %blame% l,
 
-  forall_var = fun sy pol l t =>
+  "$forall_var" = fun sy pol l t =>
       let lPol = %polarity% l in
       if pol == lPol then
           %unwrap% sy t (%blame% l)
       else
           %wrap% sy t,
 
-  fail = fun l t => %blame% (%tag% "Fail" l),
-
-  row_extend = fun contr case l t =>
+  "$row_extend" = fun contr case l t =>
       if (case t) then
           t
       else
           %assume% contr (%tag% "NotRowExt" l) t,
 
-  record = fun cont l t =>
+  "$record" = fun cont l t =>
       if %is_record% t then
           %assume% (cont {}) l t
       else
           %blame% (%tag% "not a record" l),
 
-  dyn_record = fun contr l t =>
+  "$dyn_record" = fun contr l t =>
       if %is_record% t then
           %record_map% t (fun _field value => %assume% contr l value)
       else
           %blame% (%tag% "not a record" l),
 
-  record_extend = fun field contr cont acc l t =>
+  "$record_extend" = fun field contr cont acc l t =>
       if %has_field% field t then
           let acc = acc$[field = %assume% contr (%go_field% field l) (t."#{field}")] in
           let t = t -$ field in
@@ -53,7 +53,7 @@
       else
           %blame% (%tag% "missing field `#{field}`" l),
 
-  forall_tail = fun sy pol acc l t =>
+  "$forall_tail" = fun sy pol acc l t =>
       let magic_fld = "_%wrapped" in
       if pol == (%polarity% l) then
           if %has_field% magic_fld t then
@@ -69,9 +69,9 @@
       else
           acc$[magic_fld = %wrap% sy t],
 
-  dyn_tail = fun acc l t => acc & t,
+  "$dyn_tail" = fun acc l t => acc & t,
 
-  empty_tail = fun acc l t =>
+  "$empty_tail" = fun acc l t =>
       if t == {} then acc
       else %blame% (%tag% "extra field `#{%head% (%fields% t)}`" l),
 

--- a/tests/basics_fail.rs
+++ b/tests/basics_fail.rs
@@ -42,7 +42,7 @@ fn comparisons() {
 #[test]
 fn boolean_ops() {
     assert_matches!(
-        eval("let throw | fail = null in false || true && throw"),
+        eval("let throw | (fun l _v => %blame% l) = null in false || true && throw"),
         Err(Error::EvalError(EvalError::BlameError(..)))
     );
     assert_matches!(

--- a/tests/pass/metavalues.ncl
+++ b/tests/pass/metavalues.ncl
@@ -35,7 +35,7 @@ let Assert = fun l x => x || %blame% l in
 
   // Check that the environments of contracts are correctly saved and restored when merging. See
   // issue [#117](https://github.com/tweag/nickel/issues/117)
-  (let ctr_num = let x = num in {a | x} in
+  (let ctr_num = let x = Num in {a | x} in
     let ctr_id = let x = fun l x => x in {a | x} in
     let val = let x = 1 in {a = x} in
     let def = let x = 2 in {a | default = x} in


### PR DESCRIPTION
The implementation of builtin contracts is pure Nickel code written as part of the stdlib. Currently, they pollute the user environment at the top-level by introducing identifiers like `list`, `record`, etc. everywhere accessible. Beside the risk of confusion stemming from those identifiers seemingly defined nowhere but still being present in the environment, this caused clashes when trying to change the name of some stdlib modules. Since the uniterm syntax, those contracts are not to be used directly, since one can use `Num`, `List`, etc. directly as terms instead.

This PR prefixes the identifiers of the builtin contract implementations with a `$` (willingly distinct from the `%` used to introduce intermediate variables holding thunks at run-time) which makes them inaccessible from user code directly, because there is no way to write an identifier that starts with `$`.