### PR TITLE
Expose the user manual as a flake outut

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -331,6 +331,15 @@
           '';
         }).vsix;
 
+      userManual = pkgs.stdenv.mkDerivation {
+        name = "nickel-user-manual-${version}";
+        src = ./doc/manual;
+        installPhase = ''
+          mkdir -p $out
+          cp -r ./ "$out"
+        '';
+      };
+
     in
     rec {
       defaultPackage = packages.build;
@@ -339,6 +348,7 @@
         buildWasm = buildNickelWASM { optimize = true; };
         dockerImage = buildDocker packages.build; # TODO: docker image should be a passthru
         inherit vscodeExtension;
+        inherit userManual;
       };
 
       devShell = devShells.stable;


### PR DESCRIPTION
Required to make it accessible from the `nickel-lang.org` repo.