### PR TITLE
Make the -f flag global

### DIFF
--- a/src/bin/nickel.rs
+++ b/src/bin/nickel.rs
@@ -16,8 +16,7 @@ use structopt::StructOpt;
 /// The interpreter of the Nickel language.
 struct Opt {
     /// The input file. Standard input by default
-    #[structopt(short = "f", long)]
-    #[structopt(parse(from_os_str))]
+    #[structopt(short = "f", long, global = true, parse(from_os_str))]
     file: Option<PathBuf>,
 
     #[cfg(debug_assertions)]


### PR DESCRIPTION
Fix a small but longstanding painpoint of argument ordering for the executable. Until now, the `-f/--file` argument had to be specified before a subcommand or it would fail otherwise: `nickel -f foo.ncl export` works, but not `nickel export -f foo.ncl`. This PR makes the `-f/--file` argument global, making both version working.