### PR TITLE
Reduce memory leaks by attaching free variables to record fields

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1910,6 +1910,7 @@ checksum = "936e4b492acfd135421d8dca4b1aa80a7bfc26e702ef3af710e0752684df5372"
 name = "utilities"
 version = "0.1.0"
 dependencies = [
+ "codespan",
  "criterion",
  "nickel",
 ]

--- a/lsp/nls/src/linearization/mod.rs
+++ b/lsp/nls/src/linearization/mod.rs
@@ -290,7 +290,7 @@ impl Linearizer for AnalysisHost {
                     }
                 }
             }
-            Term::Record(fields, _) | Term::RecRecord(fields, _, _) => {
+            Term::Record(fields, _) | Term::RecRecord(fields, ..) => {
                 lin.push(LinearizationItem {
                     id,
                     pos: pos.unwrap(),
@@ -340,7 +340,7 @@ impl Linearizer for AnalysisHost {
                             walk_terms(lin, host.scope(), rt1);
                             walk_terms(lin, host.scope(), rt2);
                         }
-                        Term::Record(rts, _) | Term::RecRecord(rts, _, _) => rts
+                        Term::Record(rts, _) | Term::RecRecord(rts, ..) => rts
                             .values()
                             .for_each(|rt| walk_terms(lin, host.scope(), rt)),
                         _ => {}

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -520,7 +520,7 @@ impl Cache {
                                 CacheError::Error(ImportError::ParseErrors(err.into(), pos))
                             })?;
                         }
-                        Term::RecRecord(ref mut map, ref mut dyn_fields, _) => {
+                        Term::RecRecord(ref mut map, ref mut dyn_fields, ..) => {
                             let map_res: Result<_, UnboundTypeVariableError> = std::mem::take(map)
                                 .into_iter()
                                 .map(|(id, t)| Ok((id, transform::transform(t)?)))

--- a/src/eval/lazy.rs
+++ b/src/eval/lazy.rs
@@ -124,8 +124,7 @@ impl ThunkData {
         }
     }
 
-    /// Return the potential field dependencies stored in a revertible thunk. Return `None` for a
-    /// non revertible thunk. See [`transform::free_vars`].
+    /// Return the potential field dependencies stored in a revertible thunk. See [`transform::free_vars`]
     pub fn deps(&self) -> ThunkDeps<&HashSet<Ident>> {
         match self.inner {
             InnerThunkData::Standard(_) => ThunkDeps::Empty,
@@ -246,9 +245,8 @@ impl Thunk {
         !term.is_whnf() && !term.is_metavalue()
     }
 
-    /// Return the potential field dependencies stored in a revertible thunk. Return `None` for a
-    /// non revertible thunk. Calling `deps` immutably borrows the internal `RefCell`. See
-    /// [`transform::free_vars`].
+    /// Return the potential field dependencies stored in a revertible thunk. Calling `deps`
+    /// immutably borrows the internal `RefCell`. See [`transform::free_vars`].
     pub fn deps(&self) -> ThunkDeps<Ref<'_, HashSet<Ident>>> {
         let borrowed = self.data.borrow();
 
@@ -262,20 +260,20 @@ impl Thunk {
     }
 }
 
-/// Different possible states for the field dependencies of a thunk:
+/// Possible alternatives for the field dependencies of a thunk.
 ///
-/// The parameter `D` is the type used to represent dependencies. It is usually a form of
-/// `HashSet<Ident>`, but is used with various reference types.
+/// The parameter `D` is the type used to represent dependencies. It is usually a variant of a
+/// reference to a `HashSet<Ident>`.
 pub enum ThunkDeps<D> {
     /// The thunk is revertible, containing potential recursive references to other fields, and the
     /// set of dependencies has been computed
     Known(D),
-    /// The thunk is revertible, but thet set of dependencies hasn't been computed. In that case,
+    /// The thunk is revertible, but the set of dependencies hasn't been computed. In that case,
     /// the interpreter should be conservative and assume that any recursive references can appear
     /// in the content of the corresponding thunk.
     Unknown,
     /// The thunk is not revertible and can't contain recursive references. The interpreter can
-    /// safely eschew the environment patching process entirely.
+    /// safely eschews the environment patching process entirely.
     Empty,
 }
 

--- a/src/eval/mod.rs
+++ b/src/eval/mod.rs
@@ -366,7 +366,9 @@ where
 
                 let thunk = match btype {
                     BindingType::Normal => Thunk::new(closure, IdentKind::Let),
-                    BindingType::Revertible => Thunk::new_rev(closure, IdentKind::Let),
+                    BindingType::Revertible(deps) => {
+                        Thunk::new_rev(closure, IdentKind::Let, deps.clone())
+                    }
                 };
 
                 env.insert(x.clone(), thunk);
@@ -498,7 +500,7 @@ where
                     }
                 }
             }
-            Term::RecRecord(ts, dyn_fields, attrs) => {
+            Term::RecRecord(ts, dyn_fields, attrs, _) => {
                 let rec_env = fixpoint::rec_env(ts.iter(), &env)?;
 
                 ts.iter()
@@ -750,7 +752,7 @@ pub fn subst(rt: RichTerm, global_env: &Environment, env: &Environment) -> RichT
 
                 RichTerm::new(Term::Record(map, attrs), pos)
             }
-            Term::RecRecord(map, dyn_fields, attrs) => {
+            Term::RecRecord(map, dyn_fields, attrs, deps) => {
                 let map = map
                     .into_iter()
                     .map(|(id, t)| {
@@ -771,7 +773,7 @@ pub fn subst(rt: RichTerm, global_env: &Environment, env: &Environment) -> RichT
                     })
                     .collect();
 
-                RichTerm::new(Term::RecRecord(map, dyn_fields, attrs), pos)
+                RichTerm::new(Term::RecRecord(map, dyn_fields, attrs, deps), pos)
             }
             Term::Array(ts) => {
                 let ts = ts

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -179,7 +179,8 @@ fn record_terms() {
             .into_iter()
             .collect(),
             Vec::new(),
-            Default::default()
+            Default::default(),
+            None,
         )
         .into()
     );
@@ -198,6 +199,7 @@ fn record_terms() {
                 mk_app!(mk_term::op1(UnaryOp::Ite(), Num(4.)), Num(5.), Num(6.))
             )],
             Default::default(),
+            None,
         )
         .into()
     );
@@ -213,6 +215,7 @@ fn record_terms() {
             .collect(),
             Vec::new(),
             Default::default(),
+            None,
         )
         .into()
     );

--- a/src/parser/utils.rs
+++ b/src/parser/utils.rs
@@ -250,7 +250,7 @@ where
         }
     });
 
-    Term::RecRecord(static_map, dynamic_fields, attrs)
+    Term::RecRecord(static_map, dynamic_fields, attrs, None)
 }
 
 /// Merge two fields by performing the merge of both their value and MetaValue if any.

--- a/src/repl/query_print.rs
+++ b/src/repl/query_print.rs
@@ -191,7 +191,7 @@ fn write_query_result_<R: QueryPrinter>(
                 fields.sort();
                 renderer.write_fields(out, fields.into_iter())
             }
-            Term::RecRecord(map, dyn_fields, _) if !map.is_empty() => {
+            Term::RecRecord(map, dyn_fields, ..) if !map.is_empty() => {
                 let mut fields: Vec<_> = map.keys().collect();
                 fields.sort();
                 let dynamic = Ident::from("<dynamic>");

--- a/src/repl/rustyline_frontend.rs
+++ b/src/repl/rustyline_frontend.rs
@@ -56,7 +56,7 @@ pub fn repl(histfile: PathBuf) -> Result<(), InitError> {
                         Term::Record(map, _) => {
                              println!("Loaded {} symbol(s) in the environment.", map.len())
                         }
-                        Term::RecRecord(map, dyn_fields, _) => {
+                        Term::RecRecord(map, dyn_fields, ..) => {
                             if !dyn_fields.is_empty() {
                                 println!("Warning: loading dynamic fields is currently not supported. {} symbols ignored", dyn_fields.len());
                             }

--- a/src/term.rs
+++ b/src/term.rs
@@ -203,8 +203,8 @@ pub struct RecordDeps {
     pub dyn_fields: Vec<HashSet<Ident>>,
 }
 
-/// Potential dependencies of a single field over sibling fields in a recursive record.
-pub type FieldDeps = Option<Rc<HashSet<Ident>>>;
+/// Potential dependencies of a single field over the sibling fields in a recursive record.
+pub type FieldDeps = Option<HashSet<Ident>>;
 
 #[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Copy, Clone)]
 pub enum MergePriority {

--- a/src/term.rs
+++ b/src/term.rs
@@ -204,7 +204,7 @@ pub struct RecordDeps {
 }
 
 /// Potential dependencies of a single field over the sibling fields in a recursive record.
-pub type FieldDeps = Option<HashSet<Ident>>;
+pub type FieldDeps = Option<Rc<HashSet<Ident>>>;
 
 #[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Copy, Clone)]
 pub enum MergePriority {

--- a/src/term.rs
+++ b/src/term.rs
@@ -24,7 +24,7 @@ use crate::position::TermPos;
 use crate::types::{AbsType, Types, UnboundTypeVariableError};
 use codespan::FileId;
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::ffi::OsString;
 use std::fmt;
 use std::ops::Deref;
@@ -93,6 +93,7 @@ pub enum Term {
         HashMap<Ident, RichTerm>,
         Vec<(RichTerm, RichTerm)>, /* field whose name is defined by interpolation */
         RecordAttrs,
+        Option<RecordDeps>, /* dependency tracking between fields. None before the free var pass */
     ),
     /// A switch construct. The evaluation is done by the corresponding unary operator, but we
     /// still need this one for typechecking.
@@ -165,10 +166,12 @@ impl From<MetaValue> for Term {
 /// Type of let-binding. This only affects run-time behavior. Revertible bindings introduce
 /// revertible thunks at evaluation, which are devices used for the implementation of recursive
 /// records merging. See the [`merge`] and [`eval`] modules for more details.
-#[derive(Debug, Eq, PartialEq, Copy, Clone)]
+#[derive(Debug, Eq, PartialEq, Clone)]
 pub enum BindingType {
     Normal,
-    Revertible,
+    /// In the revertible case, we also store an optional set of dependencies. See
+    /// [`transform::free_vars`] for more details.
+    Revertible(FieldDeps),
 }
 
 impl Default for BindingType {
@@ -189,6 +192,19 @@ impl RecordAttrs {
         }
     }
 }
+
+/// Store field interdependencies in a recursive record. Map each static and dynamic field to the
+/// set of recursive fields that syntactically appears in their definition as free variables.
+#[derive(Debug, Default, Eq, PartialEq, Clone)]
+pub struct RecordDeps {
+    /// Must have exactly the same keys as the static fields map of the recursive record.
+    pub stat_fields: HashMap<Ident, HashSet<Ident>>,
+    /// Must have exactly the same length as the dynamic fields list of the recursive record.
+    pub dyn_fields: Vec<HashSet<Ident>>,
+}
+
+/// Potential dependencies of a single field over sibling fields in a recursive record.
+pub type FieldDeps = Option<Rc<HashSet<Ident>>>;
 
 #[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Copy, Clone)]
 pub enum MergePriority {
@@ -336,7 +352,7 @@ impl Term {
             Record(ref mut static_map, _) => {
                 static_map.iter_mut().for_each(|(_, t)| func(t));
             }
-            RecRecord(ref mut static_map, ref mut dyn_fields, _) => {
+            RecRecord(ref mut static_map, ref mut dyn_fields, ..) => {
                 static_map.iter_mut().for_each(|(_, t)| func(t));
                 dyn_fields.iter_mut().for_each(|(t1, t2)| {
                     func(t1);
@@ -488,14 +504,14 @@ impl Term {
     /// Return a deep string representation of a term, used for printing in the REPL
     pub fn deep_repr(&self) -> String {
         match self {
-            Term::Record(fields, _) | Term::RecRecord(fields, _, _) => {
+            Term::Record(fields, _) | Term::RecRecord(fields, ..) => {
                 let fields_str: Vec<String> = fields
                     .iter()
                     .map(|(ident, term)| format!("{} = {}", ident, term.as_ref().deep_repr()))
                     .collect();
 
                 let suffix = match self {
-                    Term::RecRecord(_, dyn_fields, _) if !dyn_fields.is_empty() => ", ..",
+                    Term::RecRecord(_, dyn_fields, ..) if !dyn_fields.is_empty() => ", ..",
                     _ => "",
                 };
 
@@ -1071,7 +1087,7 @@ impl RichTerm {
                     pos,
                 )
             },
-            Term::RecRecord(map, dyn_fields, attrs) => {
+            Term::RecRecord(map, dyn_fields, attrs, deps) => {
                 // The annotation on `map_res` uses Result's corresponding trait to convert from
                 // Iterator<Result> to a Result<Iterator>
                 let map_res: Result<HashMap<Ident, RichTerm>, E> = map
@@ -1089,7 +1105,7 @@ impl RichTerm {
                     })
                     .collect();
                 RichTerm::new(
-                    Term::RecRecord(map_res?, dyn_fields_res?, attrs),
+                    Term::RecRecord(map_res?, dyn_fields_res?, attrs, deps),
                     pos,
                 )
             },

--- a/src/transform/free_vars.rs
+++ b/src/transform/free_vars.rs
@@ -1,0 +1,231 @@
+//! Annotate recursive record fields with the intersection of the set of their free variables and
+//! the fields of the record. This way, we can track dependencies between recursive fields, which
+//! make it possible in particular to avoid potential memory leaks by providing only references to
+//! the recursive fields that actually appear in the definition of each field when computing the
+//! fixpoint.
+use crate::{
+    destruct::{Destruct, Match},
+    identifier::Ident,
+    term::{RecordDeps, RichTerm, SharedTerm, StrChunk, Term},
+    types::{AbsType, Types},
+};
+
+use std::collections::{HashMap, HashSet};
+
+/// Apply the full free var transformation on a term.
+pub fn transform(rt: &mut RichTerm) {
+    collect_free_vars(rt, &mut HashSet::new())
+}
+
+/// Collect the free variables of a term inside the provided hashset. Doing so, fill the recursive
+/// record dependencies data accordingly.
+fn collect_free_vars(rt: &mut RichTerm, free_vars: &mut HashSet<Ident>) {
+    match SharedTerm::make_mut(&mut rt.term) {
+        Term::Var(id) => {
+            free_vars.insert(id.clone());
+        }
+        Term::ParseError
+        | Term::Null
+        | Term::Bool(_)
+        | Term::Num(_)
+        | Term::Str(_)
+        | Term::Lbl(_)
+        | Term::Sym(_)
+        | Term::Enum(_)
+        | Term::Import(_)
+        | Term::ResolvedImport(_) => (),
+        Term::Fun(id, t) => {
+            let mut fresh = HashSet::new();
+
+            collect_free_vars(t, &mut fresh);
+            fresh.remove(id);
+
+            free_vars.extend(fresh);
+        }
+        Term::FunPattern(id, dest_pat, body) => {
+            let mut fresh = HashSet::new();
+
+            collect_free_vars(body, &mut fresh);
+            bind_pattern(dest_pat, &mut fresh);
+            if let Some(id) = id {
+                fresh.remove(id);
+            }
+
+            free_vars.extend(fresh);
+        }
+        Term::Let(id, t1, t2, _) => {
+            let mut fresh = HashSet::new();
+
+            collect_free_vars(t1, free_vars);
+            collect_free_vars(t2, &mut fresh);
+            fresh.remove(id);
+
+            free_vars.extend(fresh);
+        }
+        Term::LetPattern(id, dest_pat, t1, t2) => {
+            let mut fresh = HashSet::new();
+
+            collect_free_vars(t1, free_vars);
+            collect_free_vars(t2, &mut fresh);
+            bind_pattern(dest_pat, &mut fresh);
+            if let Some(id) = id {
+                fresh.remove(id);
+            }
+
+            free_vars.extend(fresh);
+        }
+        Term::App(t1, t2) => {
+            collect_free_vars(t1, free_vars);
+            collect_free_vars(t2, free_vars);
+        }
+        Term::Switch(t, cases, default) => {
+            collect_free_vars(t, free_vars);
+            for t in cases.values_mut().chain(default.iter_mut()) {
+                collect_free_vars(t, free_vars);
+            }
+        }
+        Term::Op1(_, t) => collect_free_vars(t, free_vars),
+        Term::Op2(_, t1, t2) => {
+            collect_free_vars(t1, free_vars);
+            collect_free_vars(t2, free_vars);
+        }
+        Term::OpN(_, ts) => {
+            for t in ts {
+                collect_free_vars(t, free_vars);
+            }
+        }
+        Term::Wrapped(_, t) => collect_free_vars(t, free_vars),
+        Term::Record(map, _) => {
+            for t in map.values_mut() {
+                collect_free_vars(t, free_vars);
+            }
+        }
+        Term::RecRecord(map, dyn_fields, _, deps) => {
+            let rec_fields: HashSet<Ident> = map.keys().cloned().collect();
+            let mut fresh = HashSet::new();
+            let mut new_deps = RecordDeps {
+                stat_fields: HashMap::with_capacity(map.len()),
+                dyn_fields: Vec::with_capacity(dyn_fields.len()),
+            };
+
+            for (id, t) in map.iter_mut() {
+                fresh.clear();
+
+                collect_free_vars(t, &mut fresh);
+                new_deps
+                    .stat_fields
+                    .insert(id.clone(), &fresh & &rec_fields);
+
+                free_vars.extend(&fresh - &rec_fields);
+            }
+            for (t1, t2) in dyn_fields.iter_mut() {
+                fresh.clear();
+
+                // Currently, the identifier part of a dynamic definition is not recursive, i.e.
+                // one can't write `{foo = "hey", "%{foo}" = 5}`. Hence, we add their free
+                // variables directly in the final set without taking them into account for
+                // recursive dependencies.
+                collect_free_vars(t1, free_vars);
+                collect_free_vars(t2, &mut fresh);
+                new_deps.dyn_fields.push(&fresh & &rec_fields);
+
+                free_vars.extend(&fresh - &rec_fields);
+            }
+
+            // Even if deps were previously filled (it shouldn't), we had to recompute the free
+            // variables anyway for the nodes higher up, because deps alone is not sufficient to
+            // reconstruct the full set of free variables. At this point, we override it in any
+            // case.
+            *deps = Some(new_deps);
+        }
+        Term::Array(ts) => {
+            for t in ts {
+                collect_free_vars(t, free_vars);
+            }
+        }
+        Term::StrChunks(chunks) => {
+            for chunk in chunks {
+                match chunk {
+                    StrChunk::Expr(t, _) => collect_free_vars(t, free_vars),
+                    _ => (),
+                }
+            }
+        }
+        Term::MetaValue(meta) => {
+            for ctr in meta.contracts.iter_mut().chain(meta.types.iter_mut()) {
+                collect_type_free_vars(&mut ctr.types, free_vars)
+            }
+
+            if let Some(ref mut t) = meta.value {
+                collect_free_vars(t, free_vars);
+            }
+        }
+    }
+}
+
+/// Collect the free variables of the potential terms inside a type (custom contracts) and insert
+/// them the provided hashset. Doing so, fill the recursive records dependencies data accordingly.
+fn collect_type_free_vars(ty: &mut Types, set: &mut HashSet<Ident>) {
+    match &mut ty.0 {
+        AbsType::Dyn()
+        | AbsType::Num()
+        | AbsType::Bool()
+        | AbsType::Str()
+        | AbsType::Sym()
+        | AbsType::Var(_)
+        | AbsType::RowEmpty() => (),
+        AbsType::Forall(_, ty)
+        | AbsType::Enum(ty)
+        | AbsType::StaticRecord(ty)
+        | AbsType::DynRecord(ty)
+        | AbsType::Array(ty) => collect_type_free_vars(ty.as_mut(), set),
+        AbsType::Arrow(ty1, ty2) => {
+            collect_type_free_vars(ty1.as_mut(), set);
+            collect_type_free_vars(ty2.as_mut(), set);
+        }
+        AbsType::RowExtend(_, ty_opt, tail) => {
+            if let Some(ref mut ty) = ty_opt {
+                collect_type_free_vars(ty, set);
+            }
+            collect_type_free_vars(tail.as_mut(), set);
+        }
+        AbsType::Flat(ref mut rt) => collect_free_vars(rt, set),
+    }
+}
+
+/// Remove the variables bound by a destructuring pattern from a set of free variables.
+fn bind_pattern(dest_pat: &Destruct, free_vars: &mut HashSet<Ident>) {
+    match dest_pat {
+        Destruct::Record { matches, rest, .. } => {
+            for m in matches {
+                bind_match(m, free_vars);
+            }
+
+            if let Some(rest) = rest {
+                free_vars.remove(rest);
+            }
+        }
+        Destruct::Array { matches, .. } => {
+            for m in matches {
+                bind_match(m, free_vars);
+            }
+        }
+        Destruct::Empty => {}
+    }
+}
+
+/// Remove the variables bound by a match expression (constituents of a destructuring pattern) from
+/// a set of free variables.
+fn bind_match(m: &Match, free_vars: &mut HashSet<Ident>) {
+    match m {
+        Match::Assign(_, _, (id, sub_pat)) => {
+            if let Some(id) = id {
+                free_vars.remove(id);
+            }
+            bind_pattern(sub_pat, free_vars);
+        }
+        Match::Simple(id, _) => {
+            free_vars.remove(id);
+        }
+    }
+}

--- a/src/transform/mod.rs
+++ b/src/transform/mod.rs
@@ -13,6 +13,7 @@ generate_counter!(FreshVarCounter, usize);
 
 pub mod apply_contracts;
 pub mod desugar_destructuring;
+pub mod free_vars;
 pub mod import_resolution;
 pub mod share_normal_form;
 
@@ -22,7 +23,13 @@ pub mod share_normal_form;
 /// Do not perform transformations on the imported files. If needed, either do it yourself using
 /// pending imports returned by [`resolve_imports`](../fn.resolve_imports.html) or use the
 /// [`Cache`](../../cache/struct.Cache.html)
-pub fn transform(rt: RichTerm) -> Result<RichTerm, UnboundTypeVariableError> {
+pub fn transform(mut rt: RichTerm) -> Result<RichTerm, UnboundTypeVariableError> {
+    free_vars::transform(&mut rt);
+    transform_no_free_vars(rt)
+}
+
+/// Same as [`transform`], but doesn't apply the free vars transformation.
+pub fn transform_no_free_vars(rt: RichTerm) -> Result<RichTerm, UnboundTypeVariableError> {
     let rt = rt.traverse(
         &mut |rt: RichTerm, _| -> Result<RichTerm, UnboundTypeVariableError> {
             // before anything, we have to desugar the syntax

--- a/src/transform/share_normal_form.rs
+++ b/src/transform/share_normal_form.rs
@@ -34,7 +34,8 @@ use crate::{
     position::TermPos,
     term::{BindingType, RichTerm, Term},
 };
-use std::collections::HashSet;
+
+use std::{collections::HashSet, rc::Rc};
 
 /// Transform the top-level term of an AST to a share normal form, if it can.
 ///
@@ -95,7 +96,7 @@ pub fn transform_one(rt: RichTerm) -> RichTerm {
                     if is_non_rec {
                         BindingType::Normal
                     } else {
-                        BindingType::Revertible(field_deps)
+                        BindingType::Revertible(field_deps.map(Rc::new))
                     }
                 }
 

--- a/src/transform/share_normal_form.rs
+++ b/src/transform/share_normal_form.rs
@@ -34,7 +34,6 @@ use crate::{
     position::TermPos,
     term::{BindingType, RichTerm, Term},
 };
-use std::rc::Rc;
 
 /// Transform the top-level term of an AST to a share normal form, if it can.
 ///
@@ -92,7 +91,7 @@ pub fn transform_one(rt: RichTerm) -> RichTerm {
                         if !t.as_ref().is_constant() {
                             let fresh_var = fresh_var();
                             let pos_t = t.pos;
-                            let field_deps = deps.as_ref().and_then(|deps| deps.stat_fields.get(&id)).cloned().map(Rc::new);
+                            let field_deps = deps.as_ref().and_then(|deps| deps.stat_fields.get(&id)).cloned();
                             // If the fields has an empty set of dependencies, we can eschew the
                             // useless introduction of a revertible thunk. Note that if
                             // `field_deps` being `None` doesn't mean "empty dependencies" but
@@ -121,7 +120,7 @@ pub fn transform_one(rt: RichTerm) -> RichTerm {
                         if !t.as_ref().is_constant() {
                             let fresh_var = fresh_var();
                             let pos_t = t.pos;
-                            let field_deps = deps.as_ref().and_then(|deps| deps.dyn_fields.get(index)).cloned().map(Rc::new);
+                            let field_deps = deps.as_ref().and_then(|deps| deps.dyn_fields.get(index)).cloned();
                             bindings.push((fresh_var.clone(), t, BindingType::Revertible(field_deps)));
                             (id_t, RichTerm::new(Term::Var(fresh_var), pos_t))
                         } else {

--- a/src/typecheck/mod.rs
+++ b/src/typecheck/mod.rs
@@ -492,7 +492,7 @@ fn type_check_<L: Linearizer>(
         }
         // If some fields are defined dynamically, the only potential type that works is `{_ : a}`
         // for some `a`
-        Term::RecRecord(stat_map, dynamic, _) if !dynamic.is_empty() => {
+        Term::RecRecord(stat_map, dynamic, ..) if !dynamic.is_empty() => {
             let ty_dyn = state.table.fresh_unif_var();
 
             for id in stat_map.keys() {

--- a/tests/free_vars.rs
+++ b/tests/free_vars.rs
@@ -1,0 +1,165 @@
+use nickel::{identifier::Ident, term::Term, transform::free_vars};
+
+use std::collections::{HashMap, HashSet};
+use std::iter::IntoIterator;
+
+use utilities::parse;
+
+// fn is_subset_of<'a>(free_vars: impl IntoIterator<Item = &'a Ident>, rec_fields: &Vec<&Ident>) -> bool {
+//    free_vars.into_iter().all(|id| rec_fields.contains(&id))
+// }
+
+fn free_vars_eq(free_vars: &HashSet<Ident>, expected: Vec<&str>) -> bool {
+    let expected_set: HashSet<Ident> = expected.into_iter().map(|s| Ident::from(s)).collect();
+    *free_vars == expected_set
+}
+
+fn stat_free_vars_incl(
+    stat_fields: &HashMap<Ident, HashSet<Ident>>,
+    mut expected: HashMap<&str, Vec<&str>>,
+) -> bool {
+    stat_fields
+        .iter()
+        .all(|(id, set)| free_vars_eq(set, expected.remove(id.as_ref()).unwrap()))
+}
+
+fn dyn_free_vars_incl(dyn_fields: &Vec<HashSet<Ident>>, mut expected: Vec<Vec<&str>>) -> bool {
+    dyn_fields
+        .iter()
+        .enumerate()
+        .all(|(i, set)| free_vars_eq(set, std::mem::take(&mut expected[i])))
+}
+
+fn check_dyn_vars(expr: &str, expected: Vec<Vec<&str>>) -> bool {
+    let mut rt = parse(expr).unwrap();
+    free_vars::transform(&mut rt);
+
+    match rt.term.into_owned() {
+        Term::RecRecord(_, dyns, _, deps) => {
+            let deps = deps.unwrap();
+            dyns.len() == deps.dyn_fields.len() && dyn_free_vars_incl(&deps.dyn_fields, expected)
+        }
+        _ => panic!("{} hasn't been parsed as a record", expr),
+    }
+}
+
+fn check_stat_vars(expr: &str, expected: HashMap<&str, Vec<&str>>) -> bool {
+    let mut rt = parse(expr).unwrap();
+    free_vars::transform(&mut rt);
+
+    match rt.term.into_owned() {
+        Term::RecRecord(map, _, _, deps) => {
+            let deps = deps.unwrap();
+            println!(
+                "-- comparing {:#?} **AND* {:#?}",
+                deps.stat_fields, expected
+            );
+            map.len() == deps.stat_fields.len() && stat_free_vars_incl(&deps.stat_fields, expected)
+        }
+        _ => panic!("{} hasn't been parsed as a record", expr),
+    }
+}
+
+#[test]
+fn static_record() {
+    assert!(check_stat_vars(
+        "{
+          a = b + 1 + h,
+          b = f (a + 1) z,
+          c = if a.r then [b] else {foo = c}
+        }",
+        HashMap::from([
+            ("a", vec!["b"]),
+            ("b", vec!["a"]),
+            ("c", vec!["a", "b", "c"])
+        ])
+    ));
+}
+
+#[test]
+fn dynamic_record() {
+    assert!(check_dyn_vars(
+        "{
+          a = null,
+          b = null,
+          \"%{\"a_dyn\"}\" = b + 1 + h,
+          \"%{\"b_dyn\"}\" = f (a + 1) z,
+          \"%{\"c\"}\" = if a.r then [b] else {foo = c, bar.booz = a_dyn}
+        }",
+        vec![vec!["b"], vec!["a"], vec!["a", "b"]]
+    ));
+}
+
+#[test]
+fn simple_let() {
+    assert!(check_stat_vars(
+        "{
+          a = let b = 0 in b + a + h,
+          b = let a = c in f (a + 1) z,
+          c = let foo = null in let bar = null in if a.r then [b] else {foo = c}
+        }",
+        HashMap::from([
+            ("a", vec!["a"]),
+            ("b", vec!["c"]),
+            ("c", vec!["a", "b", "c"])
+        ])
+    ));
+}
+
+#[test]
+fn destruct_let() {
+    assert!(check_stat_vars(
+        "{
+          a = let {b={foo, bar}} = null in b + a + h,
+          b = let {a, b={c=e@{d}}} = null in f (a + 1 - c) z,
+          c = null
+        }",
+        HashMap::from([("a", vec!["a", "b"]), ("b", vec!["c"]), ("c", vec![]),])
+    ));
+}
+
+#[test]
+fn simple_fun() {
+    assert!(check_stat_vars(
+        "{
+          a = let f = fun a b => a + b + c in f null,
+          b = (fun a => a + (fun b => b + (fun z => c))) a,
+          c = [],
+        }",
+        HashMap::from([("a", vec!["c"]), ("b", vec!["a", "c"]), ("c", vec![]),])
+    ));
+}
+
+#[test]
+fn destruct_fun() {
+    assert!(check_stat_vars(
+        "{
+          a = let f = fun {a=foo} {b=b@{}} => a + b + c in f null,
+          b = (fun {a={b={a}}} => a + (fun {foo={bar=b@{b=e}}} => b + (fun z => b))) c,
+          c = [],
+        }",
+        HashMap::from([("a", vec!["a", "c"]), ("b", vec!["c"]), ("c", vec![]),])
+    ));
+}
+
+#[test]
+fn nested_records() {
+    assert!(check_stat_vars(
+        "{
+          a = {
+            foo = {bar = a},
+            a = 2 + c,
+          },
+          b = {
+            bar = a,
+            baz = {b = b},
+            baz.e = c,
+          },
+          c = {
+            baz.b = b,
+            baz.e = b,
+          },
+        }",
+        HashMap::from([("a", vec!["c"]), ("b", vec!["a", "c"]), ("c", vec!["b"]),])
+    ));
+}

--- a/tests/typecheck_fail.rs
+++ b/tests/typecheck_fail.rs
@@ -29,7 +29,6 @@ macro_rules! assert_typecheck_fails {
 
 #[test]
 fn unbound_variable_always_throws() {
-    type_check_expr("x").map_err(|err| println!("{:#?}", err));
     assert_matches!(
         type_check_expr("x"),
         Err(TypecheckError::UnboundIdentifier(..))

--- a/utilities/Cargo.toml
+++ b/utilities/Cargo.toml
@@ -11,3 +11,4 @@ bench = false
 [dependencies]
 nickel = {path = "../"}
 criterion = "0.3"
+codespan = "0.11"


### PR DESCRIPTION
# Free vars pass

Partially address #389. Continuation of #543 and #588. The idea is to annotate the fields of recursive records with their free variables (or, more precisely, with the other fields of the record that syntactically appear in their definition, that is the intersection of their free variables and the set of fields of the record) during a transformation pass, and leverage this information when building the fixpoint to avoid undue leaks.

Thanks to this data, we can add to the local environment of each fields only those fields that they use (or, at least, that appear in their definition). Before, every field was added, creating cycles of reference-counted pointers (and thus leaks) in pretty much any record:

```nickel
{
  a = "foo",
  b = a ++ " bar",
  c = b ++ " baz",
}
```

Before this PR, this recursive record would evaluate to an object where each field `a`, `b` and `c` retains a reference (`Rc<RefCell<_>>`) to all other fields, thus creating cycles that wouldn't be reclaimed (`a` -> `a`, `a` -> `b` -> `a`, etc).

After this PR, `a` retains no reference to its siblings, `b` only retains a reference to `a`, and `c` only to `b`. This is a DAG that should be deallocated without problem. Only mutually recursive fields like `{foo = fun a => bar (a +1), bar = fun a => foo (a + 1)}` should leak.

## Content

This PR:

- Augment the `RecRecord` variant to store additional free variables data
- Add a free_vars pass to fill those data during program transformation. In #543 and #588, @Avi-D-coder  tried various approaches to avoid having to do a separate pass or suffer a quadratic complexity for this pass. It turns out it is difficult to both avoid adding a whole new traversal just for free variables and not butcher the current term traversal interface. In the end, I went for a separate traversal. Given the current state, I don't expect it to have bad consequences, and that most of the time is taken by evaluation anyway. This makes the change simpler and a better separation of matters.
- Use the additional data when creating the fixpoint of a recursive records. This requires to persist the free vars data beyond the first evaluation of a recursive records, because since overriding, we produce new recursive records in the middle of evaluation when merging. The free vars are thus directly attached to the revertible thunks introduced by recursive records. This brings a bonus: we can now detect at transformation time expressions that don't actually depend on the other fields of a record recursively, and don't bother introducing a revertible thunk in this case, that would be recomputed at each subsequent merge and consume more memory.
- add unit tests for the computation of free variables.
 