### PR TITLE
Add slug header to manual sections

### DIFF
--- a/doc/manual/contracts.md
+++ b/doc/manual/contracts.md
@@ -1,4 +1,8 @@
-# Contracts
+---
+slug: contracts
+---
+
+# Contracts in Nickel
 
 (For the motivation behind contracts and a high-level overview of contracts and
 types, first read the [correctness](./correctness.md) section.)
@@ -194,7 +198,7 @@ given format:
 ```nickel
 let Nullable = fun contract label value =>
   if value == null then
-    value 
+    value
   else
     contract.apply contract label value in
 // succeeds
@@ -218,7 +222,7 @@ missing:
 ```nickel
 let MyConfig = {
   path | Str,
- 
+
   connection | {
     server_port | Port,
     host | Str,
@@ -410,7 +414,7 @@ We've already seen that the primitive types `Num`, `Str` and `Bool` can be used
 as contracts. In fact, any type constructor of the
 [static type system](./typing.md) can be used to combine contracts.
 
-#### Array 
+#### Array
 
 An array contract checks that the value is an array and applies the parameter
 contract to each element:

--- a/doc/manual/cookbook.md
+++ b/doc/manual/cookbook.md
@@ -1,3 +1,7 @@
+---
+slug: cookbook
+---
+
 # Cookbook
 
 For now, this is an unorganized, temporary document not to forget some pieces of

--- a/doc/manual/correctness.md
+++ b/doc/manual/correctness.md
@@ -1,4 +1,8 @@
-# Correctness
+---
+slug: correctness
+---
+
+# Correctness in Nickel
 
 One of the main value proposition of Nickel is to make configurations
 programmable. However, a not less important one is to help you write *correct*
@@ -97,7 +101,7 @@ types and contracts directly follow from this distinction.
 In the next paragraphs, we consider two typical examples to illustrate the
 difference between types and contracts in practice.
 
-### Case 1: a function operating on arrays 
+### Case 1: a function operating on arrays
 
 Say we need a function to convert an array of key-value pairs to an array of keys
 and an array of values. Let's call it `split`:

--- a/doc/manual/merging.md
+++ b/doc/manual/merging.md
@@ -1,3 +1,7 @@
+---
+slug: merging
+---
+
 # Merging records
 
 In Nickel, the basic building blocks for data are records (objects in JSON or

--- a/doc/manual/syntax.md
+++ b/doc/manual/syntax.md
@@ -1,12 +1,16 @@
+---
+slug: syntax
+---
+
 # Nickel Syntax
 
 ## Simple values
 
-There are three basic kind of values in Nickel : 
- 1. numeric values, 
+There are three basic kind of values in Nickel :
+ 1. numeric values,
  2. boolean values,
  3. strings.
- 
+
 ### Numeric values
 
 Nickel has a support for numbers, positive and negative, with or without decimals.
@@ -31,7 +35,7 @@ There are a some predefined operators for working with numbers :
 | /        | The division operator                                | `1 / 2 = 0.5` |
 | %        | The modulo operator (returns the *signed* remainder) | `5 % 3 = 2`   |
 
-> **Remark about the `-` operator:**  
+> **Remark about the `-` operator:**
 > Since `-` can be used inside an identifier, the subtraction operators **needs** to be surrounded by spaces:
 > write `1 - 1`, not `1-1`.
 
@@ -119,7 +123,7 @@ This line has no more identation.
 "This line has no indentation.
   This line is indented.
     This line is even more indented.
-This line has no more indentation." 
+This line has no more indentation."
 ```
 
 The only special sequence in a multiline string is the string interpolation.
@@ -202,7 +206,7 @@ false
 
 ## Composite values
 
-### Array 
+### Array
 An array is a sequence of values. They are delimited by `[` and `]`, and elements are separated with `,`.
 
 Examples:
@@ -250,7 +254,7 @@ It is possible to write records of records via the *piecewise syntax*, where we 
 ```
 > { a = { b = 1 } }
 { a = { b = 1 } }
- 
+
 > { a.b = 1 }
 { a = { b = 1 } }
 
@@ -411,7 +415,7 @@ error: Blame error: contract broken by a value.
 3
 ```
 
-Adding documentation can be done with `| doc < string >`.  
+Adding documentation can be done with `| doc < string >`.
 Examples:
 ```
 > 5 | doc "The number five"
@@ -428,7 +432,7 @@ true
 
 Record contracts can set default values using the `default` metadata:
 It is noted as `| default = < default value >`.
-This is especially useful when merging records (more about this in the dedicated document about merge).  
+This is especially useful when merging records (more about this in the dedicated document about merge).
 Examples:
 ```
 > let Ais2ByDefault = { a | default = 2 } in

--- a/doc/manual/types-vs-contracts.md
+++ b/doc/manual/types-vs-contracts.md
@@ -1,4 +1,8 @@
-# Type vs contracts: when to?
+---
+slug: type-vs-contract
+---
+
+# Type vs contract: when to?
 
 You are writing Nickel code and wonder how it should be annotated. Leave it
 alone? Add type annotations? Use contracts? Here is a quick guide when you don't

--- a/doc/manual/typing.md
+++ b/doc/manual/typing.md
@@ -1,3 +1,7 @@
+---
+slug: typing
+---
+
 # Typing in Nickel
 
 (For the motivations behind typing and a high-level overview of contracts and


### PR DESCRIPTION
Add a `slug` field to the manual section's frontmatter. This is used on the website to build the routes.