### PR TITLE
Rename crates nickel* to nickel-lang* for publication

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -925,7 +925,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4a24736216ec316047a1fc4252e27dabb04218aa4a3f37c6e7ddbf1f9782b54"
 
 [[package]]
-name = "nickel"
+name = "nickel-lang"
 version = "0.1.0"
 dependencies = [
  "ansi_term 0.12.1",
@@ -939,6 +939,7 @@ dependencies = [
  "lalrpop-util",
  "logos",
  "md-5",
+ "nickel-lang-utilities",
  "pprof",
  "pretty_assertions",
  "regex 0.2.11",
@@ -954,9 +955,42 @@ dependencies = [
  "structopt",
  "termimad",
  "toml",
- "utilities",
  "void",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "nickel-lang-nls"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "assert_matches",
+ "codespan",
+ "codespan-lsp",
+ "codespan-reporting",
+ "csv",
+ "derive_more",
+ "env_logger",
+ "lalrpop",
+ "lalrpop-util",
+ "lazy_static",
+ "log",
+ "lsp-server",
+ "lsp-types",
+ "nickel-lang",
+ "pretty_assertions",
+ "serde",
+ "serde_json",
+ "structopt",
+]
+
+[[package]]
+name = "nickel-lang-utilities"
+version = "0.1.0"
+dependencies = [
+ "codespan",
+ "criterion",
+ "nickel-lang",
 ]
 
 [[package]]
@@ -982,31 +1016,6 @@ dependencies = [
  "cfg-if",
  "libc",
  "memoffset",
-]
-
-[[package]]
-name = "nls"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "assert_matches",
- "codespan",
- "codespan-lsp",
- "codespan-reporting",
- "csv",
- "derive_more",
- "env_logger",
- "lalrpop",
- "lalrpop-util",
- "lazy_static",
- "log",
- "lsp-server",
- "lsp-types",
- "nickel",
- "pretty_assertions",
- "serde",
- "serde_json",
- "structopt",
 ]
 
 [[package]]
@@ -1905,15 +1914,6 @@ name = "utf8parse"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "936e4b492acfd135421d8dca4b1aa80a7bfc26e702ef3af710e0752684df5372"
-
-[[package]]
-name = "utilities"
-version = "0.1.0"
-dependencies = [
- "codespan",
- "criterion",
- "nickel",
-]
 
 [[package]]
 name = "uuid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,13 @@
 [package]
-name = "nickel"
+name = "nickel-lang"
 version = "0.1.0"
-authors = ["Nicl team"]
-license = "MIT OR Apache-2.0"
+authors = ["Nickel team"]
+license = "MIT"
 readme = "README.md"
 description = "Programmable configuration files."
+homepage = "https://nickel-lang.org"
+repository = "https://github.com/tweag/nickel"
+keywords = ["configuration", "language", "nix"]
 edition = "2018"
 
 [[bin]]
@@ -57,7 +60,7 @@ pretty_assertions = "0.5.1"
 assert_matches = "1.4.0"
 criterion = "0.3"
 pprof = { version = "0.4.4", features = ["criterion", "flamegraph"] }
-utilities = {path = "utilities"}
+nickel-lang-utilities = {path = "utilities", version = "0.1.0"}
 
 [workspace]
 members = [

--- a/benches/arrays.rs
+++ b/benches/arrays.rs
@@ -1,6 +1,6 @@
 use criterion::{criterion_group, criterion_main, Criterion};
+use nickel_lang_utilities::{bench, EvalMode};
 use pprof::criterion::{Output, PProfProfiler};
-use utilities::{bench, EvalMode};
 
 fn fold_strings(c: &mut Criterion) {
     bench(

--- a/benches/functions.rs
+++ b/benches/functions.rs
@@ -1,7 +1,7 @@
 use criterion::{criterion_group, criterion_main, Criterion};
-use nickel::term::Term;
+use nickel_lang::term::Term;
+use nickel_lang_utilities::{bench_expect, EvalMode};
 use pprof::criterion::{Output, PProfProfiler};
-use utilities::{bench_expect, EvalMode};
 
 fn church(c: &mut Criterion) {
     let expect = |term| matches!(term, Term::Bool(true));

--- a/benches/numeric.rs
+++ b/benches/numeric.rs
@@ -1,6 +1,6 @@
 use criterion::{criterion_group, criterion_main, Criterion};
+use nickel_lang_utilities::{bench, EvalMode};
 use pprof::criterion::{Output, PProfProfiler};
-use utilities::{bench, EvalMode};
 
 fn fibonacci(c: &mut Criterion) {
     bench(

--- a/benches/records.rs
+++ b/benches/records.rs
@@ -1,6 +1,6 @@
 use criterion::{criterion_group, criterion_main, Criterion};
+use nickel_lang_utilities::{bench_args, EvalMode};
 use pprof::criterion::{Output, PProfProfiler};
-use utilities::{bench_args, EvalMode};
 
 fn count_letters(c: &mut Criterion) {
     bench_args(

--- a/benches/serialization.rs
+++ b/benches/serialization.rs
@@ -1,5 +1,5 @@
 use criterion::{criterion_group, criterion_main, Criterion};
-use nickel::program::Program;
+use nickel_lang::program::Program;
 use pprof::criterion::{Output, PProfProfiler};
 use std::io::Cursor;
 use std::path::PathBuf;

--- a/flake.nix
+++ b/flake.nix
@@ -250,7 +250,7 @@
             # https://github.com/rust-lang/cargo/issues/1596
             # https://github.com/rust-lang/cargo/issues/1197
             # https://github.com/rust-lang/cargo/issues/5777
-            sed -i '/utilities/d' Cargo.toml
+            sed -i '/nickel-lang-utilities/d' Cargo.toml
           '';
 
           buildPhase = ''
@@ -261,7 +261,7 @@
             # (https://github.com/rustwasm/wasm-pack/issues/869), we have to
             # run wasm-opt manually
             echo "[Nix build script]Manually running wasm-opt..."
-            wasm-opt ${if optimize then "-O4 " else "-O0"} pkg/nickel_bg.wasm -o pkg/nickel_bg.wasm
+            wasm-opt ${if optimize then "-O4 " else "-O0"} pkg/nickel_lang_bg.wasm -o pkg/nickel_lang_bg.wasm
 
             runHook postBuild
           '';

--- a/lsp/nls/Cargo.toml
+++ b/lsp/nls/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "nls"
+name = "nickel-lang-nls"
 version = "0.1.0"
 authors = ["Nicl team"]
 license = "MIT OR Apache-2.0"
@@ -25,7 +25,7 @@ lsp-types = "0.88"
 log = "0.4"
 env_logger = "0.9"
 anyhow = "1.0"
-nickel = {path = "../../"}
+nickel-lang = {path = "../../", version = "0.1.0"}
 derive_more = "0.99"
 lazy_static = "1"
 csv = "1"

--- a/lsp/nls/src/cache.rs
+++ b/lsp/nls/src/cache.rs
@@ -1,7 +1,7 @@
 use std::{collections::HashMap, ffi::OsString, io};
 
 use codespan::FileId;
-use nickel::{
+use nickel_lang::{
     cache::{Cache, CacheError, CacheOp, CachedTerm, EntryState},
     error::TypecheckError,
     typecheck,

--- a/lsp/nls/src/files.rs
+++ b/lsp/nls/src/files.rs
@@ -7,7 +7,7 @@ use lsp_types::{
     notification::{DidOpenTextDocument, Notification},
     DidChangeTextDocumentParams, DidOpenTextDocumentParams, PublishDiagnosticsParams, Url,
 };
-use nickel::{
+use nickel_lang::{
     cache::{CacheError, CacheOp},
     error::ToDiagnostic,
 };

--- a/lsp/nls/src/linearization/building.rs
+++ b/lsp/nls/src/linearization/building.rs
@@ -1,7 +1,7 @@
 use std::{collections::HashMap, mem};
 
 use log::debug;
-use nickel::{
+use nickel_lang::{
     identifier::Ident,
     term::{MetaValue, RichTerm, Term},
     typecheck::{

--- a/lsp/nls/src/linearization/completed.rs
+++ b/lsp/nls/src/linearization/completed.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use codespan::ByteIndex;
-use nickel::{
+use nickel_lang::{
     term::MetaValue,
     typecheck::linearization::{LinearizationState, Scope, ScopeId},
 };

--- a/lsp/nls/src/linearization/interface.rs
+++ b/lsp/nls/src/linearization/interface.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use nickel::{identifier::Ident, typecheck::TypeWrapper, types::Types};
+use nickel_lang::{identifier::Ident, typecheck::TypeWrapper, types::Types};
 
 use super::building::ID;
 

--- a/lsp/nls/src/linearization/mod.rs
+++ b/lsp/nls/src/linearization/mod.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use codespan::ByteIndex;
 use log::debug;
-use nickel::{
+use nickel_lang::{
     identifier::Ident,
     position::{RawSpan, TermPos},
     term::{MetaValue, RichTerm, Term, UnaryOp},
@@ -26,7 +26,7 @@ pub mod building;
 pub mod completed;
 pub mod interface;
 
-pub type Environment = nickel::environment::Environment<Ident, usize>;
+pub type Environment = nickel_lang::environment::Environment<Ident, usize>;
 
 /// A recorded item of a given state of resolution state
 /// Tracks a unique id used to build a reference table after finalizing
@@ -332,8 +332,8 @@ impl Linearizer for AnalysisHost {
                         Term::StrChunks(chunks) => chunks
                             .iter()
                             .filter_map(|chunk| match chunk {
-                                nickel::term::StrChunk::Literal(_) => None,
-                                nickel::term::StrChunk::Expr(rt, _) => Some(rt),
+                                nickel_lang::term::StrChunk::Literal(_) => None,
+                                nickel_lang::term::StrChunk::Expr(rt, _) => Some(rt),
                             })
                             .for_each(|rt| walk_terms(lin, host.scope(), rt)),
                         Term::App(rt1, rt2) => {
@@ -351,7 +351,7 @@ impl Linearizer for AnalysisHost {
                 fn walk_types(
                     lin: &mut Linearization<Building>,
                     outer_host: &mut AnalysisHost,
-                    t: &nickel::types::Types,
+                    t: &nickel_lang::types::Types,
                 ) {
                     let mut scope = outer_host.scope.clone();
                     let (scope_id, next_scope_id) = outer_host.next_scope_id.next();

--- a/lsp/nls/src/requests/goto.rs
+++ b/lsp/nls/src/requests/goto.rs
@@ -5,7 +5,7 @@ use lsp_server::{RequestId, Response, ResponseError};
 use lsp_types::{
     GotoDefinitionParams, GotoDefinitionResponse, Location, Range, ReferenceParams, Url,
 };
-use nickel::position::RawSpan;
+use nickel_lang::position::RawSpan;
 use serde_json::Value;
 
 use crate::{

--- a/lsp/nls/src/server.rs
+++ b/lsp/nls/src/server.rs
@@ -16,8 +16,8 @@ use lsp_types::{
     TextDocumentSyncOptions, WorkDoneProgressOptions,
 };
 
-use nickel::cache::Cache;
-use nickel::typecheck::Environment;
+use nickel_lang::cache::Cache;
+use nickel_lang::typecheck::Environment;
 
 use crate::{
     linearization::completed::Completed,

--- a/lsp/nls/src/term.rs
+++ b/lsp/nls/src/term.rs
@@ -1,7 +1,7 @@
 use std::ops::Range;
 
 use codespan::FileId;
-use nickel::position::RawSpan;
+use nickel_lang::position::RawSpan;
 
 pub trait RawSpanExt {
     fn to_range(self) -> (FileId, Range<usize>);

--- a/src/bin/nickel.rs
+++ b/src/bin/nickel.rs
@@ -1,11 +1,11 @@
 //! Entry point of the program.
-use nickel::error::{Error, IOError};
-use nickel::program::Program;
-use nickel::repl::query_print;
+use nickel_lang::error::{Error, IOError};
+use nickel_lang::program::Program;
+use nickel_lang::repl::query_print;
 #[cfg(feature = "repl")]
-use nickel::repl::rustyline_frontend;
-use nickel::term::{RichTerm, Term};
-use nickel::{serialize, serialize::ExportFormat};
+use nickel_lang::repl::rustyline_frontend;
+use nickel_lang::term::{RichTerm, Term};
+use nickel_lang::{serialize, serialize::ExportFormat};
 use std::path::PathBuf;
 use std::{fs, process};
 // use std::ffi::OsStr;

--- a/src/term.rs
+++ b/src/term.rs
@@ -1220,7 +1220,7 @@ impl From<Term> for RichTerm {
 ///
 /// It is used somehow as a match statement, going from
 /// ```
-/// # use nickel::term::{RichTerm, Term};
+/// # use nickel_lang::term::{RichTerm, Term};
 /// let rt = RichTerm::from(Term::Num(5.0));
 ///
 /// match rt.term.into_owned() {
@@ -1231,8 +1231,8 @@ impl From<Term> for RichTerm {
 /// ```
 /// to
 /// ```
-/// # use nickel::term::{RichTerm, Term};
-/// # use nickel::match_sharedterm;
+/// # use nickel_lang::term::{RichTerm, Term};
+/// # use nickel_lang::match_sharedterm;
 /// let rt = RichTerm::from(Term::Num(5.0));
 ///
 /// match_sharedterm!{rt.term, with {

--- a/tests/basics_fail.rs
+++ b/tests/basics_fail.rs
@@ -1,7 +1,7 @@
 use assert_matches::assert_matches;
-use nickel::error::{Error, EvalError};
+use nickel_lang::error::{Error, EvalError};
 
-use utilities::eval;
+use nickel_lang_utilities::eval;
 
 #[test]
 fn div_by_zero() {

--- a/tests/contracts_fail.rs
+++ b/tests/contracts_fail.rs
@@ -1,8 +1,8 @@
 use assert_matches::assert_matches;
 use codespan::Files;
-use nickel::error::{Error, EvalError, ToDiagnostic};
+use nickel_lang::error::{Error, EvalError, ToDiagnostic};
 
-use utilities::eval;
+use nickel_lang_utilities::eval;
 
 macro_rules! assert_raise_blame {
     ($term:expr) => {{
@@ -134,7 +134,7 @@ fn records_contracts_poly() {
 
 #[test]
 fn lists_contracts() {
-    use nickel::label::ty_path::Elem;
+    use nickel_lang::label::ty_path::Elem;
 
     assert_matches!(
         eval("%deep_seq% ([1, \"a\"] | Array Num) 0"),

--- a/tests/destructuring.rs
+++ b/tests/destructuring.rs
@@ -1,8 +1,8 @@
 use assert_matches::assert_matches;
-use nickel::error::{Error, EvalError, TypecheckError};
-use nickel::term::Term;
+use nickel_lang::error::{Error, EvalError, TypecheckError};
+use nickel_lang::term::Term;
 
-use utilities::eval_file;
+use nickel_lang_utilities::eval_file;
 
 #[test]
 fn simple() {

--- a/tests/examples.rs
+++ b/tests/examples.rs
@@ -1,7 +1,7 @@
 use assert_matches::assert_matches;
-use nickel::error::{Error, EvalError};
-use nickel::program::Program;
-use nickel::term::RichTerm;
+use nickel_lang::error::{Error, EvalError};
+use nickel_lang::program::Program;
+use nickel_lang::term::RichTerm;
 use std::path::PathBuf;
 
 fn eval_file(file: &str) -> Result<RichTerm, Error> {

--- a/tests/free_vars.rs
+++ b/tests/free_vars.rs
@@ -1,9 +1,9 @@
-use nickel::{identifier::Ident, term::Term, transform::free_vars};
+use nickel_lang::{identifier::Ident, term::Term, transform::free_vars};
 
 use std::collections::{HashMap, HashSet};
 use std::iter::IntoIterator;
 
-use utilities::parse;
+use nickel_lang_utilities::parse;
 
 // fn is_subset_of<'a>(free_vars: impl IntoIterator<Item = &'a Ident>, rec_fields: &Vec<&Ident>) -> bool {
 //    free_vars.into_iter().all(|id| rec_fields.contains(&id))

--- a/tests/imports.rs
+++ b/tests/imports.rs
@@ -1,7 +1,7 @@
 use assert_matches::assert_matches;
-use nickel::error::{Error, EvalError, TypecheckError};
-use nickel::program::Program;
-use nickel::term::Term;
+use nickel_lang::error::{Error, EvalError, TypecheckError};
+use nickel_lang::program::Program;
+use nickel_lang::term::Term;
 use std::io::BufReader;
 use std::path::PathBuf;
 
@@ -85,7 +85,7 @@ fn static_typing_fail() {
 
 #[test]
 fn serialize() {
-    use nickel::term::Term;
+    use nickel_lang::term::Term;
     let mut prog = Program::new_from_source(
         BufReader::new(
             format!(

--- a/tests/infinite_rec.rs
+++ b/tests/infinite_rec.rs
@@ -1,7 +1,7 @@
 use assert_matches::assert_matches;
-use nickel::error::{Error, EvalError};
+use nickel_lang::error::{Error, EvalError};
 
-use utilities::eval;
+use nickel_lang_utilities::eval;
 
 #[test]
 fn infinite_loops() {

--- a/tests/merge_fail.rs
+++ b/tests/merge_fail.rs
@@ -1,8 +1,8 @@
 use assert_matches::assert_matches;
-use nickel::error::{Error, EvalError};
-use nickel::position::TermPos;
-use nickel::program::Program;
-use nickel::term::RichTerm;
+use nickel_lang::error::{Error, EvalError};
+use nickel_lang::position::TermPos;
+use nickel_lang::program::Program;
+use nickel_lang::term::RichTerm;
 use std::io::Cursor;
 
 fn eval_full(s: &str) -> Result<RichTerm, Error> {

--- a/tests/pass.rs
+++ b/tests/pass.rs
@@ -1,5 +1,5 @@
-use nickel::program::Program;
-use nickel::term::Term;
+use nickel_lang::program::Program;
+use nickel_lang::term::Term;
 use std::ffi::OsString;
 use std::path::PathBuf;
 use std::thread;

--- a/tests/query.rs
+++ b/tests/query.rs
@@ -1,5 +1,5 @@
-use nickel::program::Program;
-use nickel::term::{SharedTerm, Term};
+use nickel_lang::program::Program;
+use nickel_lang::term::{SharedTerm, Term};
 
 #[test]
 pub fn test_query_metadata_basic() {

--- a/tests/records_fail.rs
+++ b/tests/records_fail.rs
@@ -1,7 +1,7 @@
 use assert_matches::assert_matches;
-use nickel::error::{Error, EvalError, TypecheckError};
+use nickel_lang::error::{Error, EvalError, TypecheckError};
 
-use utilities::eval;
+use nickel_lang_utilities::eval;
 
 #[test]
 fn records_access() {

--- a/tests/stdlib_arrays_fail.rs
+++ b/tests/stdlib_arrays_fail.rs
@@ -1,7 +1,7 @@
 use assert_matches::assert_matches;
-use nickel::error::{Error, EvalError};
+use nickel_lang::error::{Error, EvalError};
 
-use utilities::eval;
+use nickel_lang_utilities::eval;
 
 #[test]
 fn elem_at() {

--- a/tests/stdlib_typecheck.rs
+++ b/tests/stdlib_typecheck.rs
@@ -1,5 +1,5 @@
 use assert_matches::assert_matches;
-use nickel::cache::Cache;
+use nickel_lang::cache::Cache;
 
 #[test]
 fn stdlib_typecheck() {

--- a/tests/typecheck_fail.rs
+++ b/tests/typecheck_fail.rs
@@ -1,11 +1,11 @@
 use assert_matches::assert_matches;
 use codespan::Files;
-use nickel::cache::resolvers::DummyResolver;
-use nickel::error::TypecheckError;
-use nickel::parser::{grammar, lexer};
-use nickel::term::RichTerm;
-use nickel::typecheck::{type_check_in_env, Environment};
-use nickel::types::Types;
+use nickel_lang::cache::resolvers::DummyResolver;
+use nickel_lang::error::TypecheckError;
+use nickel_lang::parser::{grammar, lexer};
+use nickel_lang::term::RichTerm;
+use nickel_lang::typecheck::{type_check_in_env, Environment};
+use nickel_lang::types::Types;
 
 fn type_check(rt: &RichTerm) -> Result<Types, TypecheckError> {
     type_check_in_env(rt, &Environment::new(), &mut DummyResolver {})

--- a/tests/unbound_type_variables.rs
+++ b/tests/unbound_type_variables.rs
@@ -2,12 +2,12 @@
 // unbound type variable error anymore. Instead, the variable is interpreted as a term variable:
 // the tests should still fail, but they can now fail with a standard unbound identifier error.
 use assert_matches::assert_matches;
-use nickel::{
+use nickel_lang::{
     error::{Error, EvalError, ParseError, ParseErrors, TypecheckError},
     identifier::Ident,
 };
 
-use utilities::eval;
+use nickel_lang_utilities::eval;
 
 macro_rules! assert_unbound {
     ( $term:expr, $var:expr ) => {

--- a/utilities/Cargo.lock
+++ b/utilities/Cargo.lock
@@ -1613,7 +1613,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "936e4b492acfd135421d8dca4b1aa80a7bfc26e702ef3af710e0752684df5372"
 
 [[package]]
-name = "utilities"
+name = "nickel_lang_utilities"
 version = "0.1.0"
 dependencies = [
  "criterion",

--- a/utilities/Cargo.toml
+++ b/utilities/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
-name = "utilities"
+name = "nickel-lang-utilities"
 version = "0.1.0"
-authors = ["Yann Hamdaoui <yann.hamdaoui@gmail.com>"]
+authors = ["The Nickel Team <nickel-lang@protonmail.com>"]
+description = "Common helper functions for the tests and benchmarks of the nickel-lang crate."
 edition = "2018"
 
 [lib]
@@ -9,6 +10,6 @@ bench = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-nickel = {path = "../"}
+nickel-lang = {path = "../", version = "0.1.0"}
 criterion = "0.3"
 codespan = "0.11"

--- a/utilities/src/lib.rs
+++ b/utilities/src/lib.rs
@@ -1,7 +1,7 @@
 //! Helpers for tests and benches.
 use codespan::Files;
 use criterion::Criterion;
-use nickel::{
+use nickel_lang::{
     error::{Error, ParseError},
     parser::{grammar, lexer},
     program::Program,


### PR DESCRIPTION
The name `nickel` is already taken on crates.io by some web framework. This renames the crates of this repo to `nickel-lang*`, and add misc missing metadata to prepare their publication on crates.io.