### PR TITLE
Allow record operation chain as a parameter of Array type

### DIFF
--- a/src/grammar.lalrpop
+++ b/src/grammar.lalrpop
@@ -252,7 +252,7 @@ Applicative: UniTerm = {
 };
 
 // The parametrized array type.
-TypeArray: Types = "Array" <AsType<Atom>> =>
+TypeArray: Types = "Array" <AsType<RecordOperand>> =>
     Types(AbsType::Array(Box::new(<>)));
 
 RecordOperand: UniTerm = {


### PR DESCRIPTION
Fix an unjustified limitation in the grammar: the parameter of the type/contract `Array` must currently be an `Atom`, rejecting things like `Array lib.MyContract` (requires parenthesis around `lib.MyContract`). This PR fixes this by accepting the same rule for the argument than the vanilla function application, which in particular allow field projection, making `Array lib.MyContract` accepted.