### PR TITLE
[Manual] Set language for markdown code blocks

### DIFF
--- a/doc/manual/contracts.md
+++ b/doc/manual/contracts.md
@@ -450,7 +450,7 @@ that must hold about the return value of the function.
 Function contracts, as opposed to a contract like `Num`, have the peculiarity of
 involving two parties in the contract checking. For example:
 
-```
+```nickel
 let add_semi | Str -> Str = fun x => x ++ ";" in
 add_semi 1
 
@@ -577,7 +577,7 @@ What we can do is to not perform all the checks right away, but **return a new
 value, which is wrapping the original value with delayed checks inside**. This
 is the rationale behind contracts returning a value. Let us see:
 
-```
+```nickel
 let NumBoolDict = fun label value =>
   if builtin.is_record value then
     let check_fields = value
@@ -608,7 +608,7 @@ iterate through the array without building up anything interesting.
 
 For laziness, the interesting bit happens here:
 
-```
+```nickel
 value
   |> record.map (fun _name value =>
     contract.apply Bool label value)

--- a/doc/manual/merging.md
+++ b/doc/manual/merging.md
@@ -337,7 +337,7 @@ base & patch
 
 This evaluates to:
 
-```
+```nickel
 {
   firewall = {
     enabled = false,

--- a/doc/manual/syntax.md
+++ b/doc/manual/syntax.md
@@ -18,7 +18,7 @@ Internally, those numbers are stored as 64-bits floating point numbers, followin
 
 Examples:
 
-```
+```nickel
 1
 0.543
 42
@@ -210,7 +210,7 @@ false
 An array is a sequence of values. They are delimited by `[` and `]`, and elements are separated with `,`.
 
 Examples:
-```
+```nickel
 [1, 2, 3]
 ["Hello", "World"]
 [1, true, "true"]
@@ -231,7 +231,7 @@ Elements inside a record are unordered.
 Two records can be _merged_ together using the operator `&`. The reader can find more information about merging in the relevant documentation.
 
 Examples:
-```
+```nickel
 {}
 {a = 3}
 {my_id_n5 = "my id number 5", "my id n4" = "my id number 4" }
@@ -372,7 +372,7 @@ To give a type to a value, we write it with `< value > : < type >`.
 More information on typing in the relevant document.
 
 Examples:
-```
+```nickel
 5 : Num
 "Hello" : Str
 

--- a/doc/manual/typing.md
+++ b/doc/manual/typing.md
@@ -102,7 +102,7 @@ annotation. We will refer to such an annotated expression as a *statically typed
 block*.
 
 Example:
-```
+```nickel
 # Let binding
 let f : Num -> Bool = fun x => x % 2 == 0 in
 
@@ -366,7 +366,7 @@ let r3 = {may = 1300, june = 400, total = may + june} in
 ```
 
 Result:
-```
+```nickel
 {partial1 = 570, partial2 = 1770}
 ```
 


### PR DESCRIPTION
Set `nickel` language for markdown code blocks of the manual when appropriate, to get syntax coloring in code editor and on the website.