### PR TITLE
Hide enum types in the stdlib and the manual

### DIFF
--- a/doc/manual/syntax.md
+++ b/doc/manual/syntax.md
@@ -6,10 +6,11 @@ slug: syntax
 
 ## Simple values
 
-There are three basic kind of values in Nickel :
- 1. numeric values,
- 2. boolean values,
- 3. strings.
+There are four basic kind of values in Nickel :
+ 1. numeric values
+ 2. boolean values
+ 3. strings
+ 4. enum tags
 
 ### Numeric values
 
@@ -177,6 +178,40 @@ def concat(str_array, log=false):
     res.append(s)
   return res"
 ```
+
+#### Enum tags
+
+Enumeration tags are used to express finite alternatives. They are formed
+by writing a backtick `` ` `` followed by any valid identifier. For example,
+`builtin.serialize` takes an export format as a first argument, which is an enum
+tag among `` `Json ``, `` `Toml `` or `` `Yaml `` (as of version 0.1):
+
+```nickel
+builtin.serialize `Json {foo = 1}
+# gives "{
+#          \"foo\": 1
+#        }"
+builtin.serialize `Toml {foo = 1}
+# gives "foo = 1
+#       "
+```
+
+An enum tag `` `foo `` is serialized as the string `"foo"`:
+
+```nickel
+let as_yaml_string = builtin.serialize `Yaml {foo = `bar}
+# gives "---
+#       foo: bar
+#       "
+
+```
+
+While it's technically possible to just use strings in place of enum tags, using
+an enum tag insists on the fact that only a finite number of alternatives can be
+used for the corresponding value.
+
+Enum are also handled more finely by the typechecker, however, as of the version
+0.1 of Nickel, enum types have been temporary disabled for incidental reasons.
 
 ## Equality
 

--- a/doc/manual/syntax.md
+++ b/doc/manual/syntax.md
@@ -210,8 +210,8 @@ While it's technically possible to just use strings in place of enum tags, using
 an enum tag insists on the fact that only a finite number of alternatives can be
 used for the corresponding value.
 
-Enum are also handled more finely by the typechecker, however, as of the version
-0.1 of Nickel, enum types have been temporary disabled for incidental reasons.
+Enum will also be handled more finely by the typechecker, however, as of the
+version 0.1 of Nickel, enum types are not yet supported.
 
 ## Equality
 

--- a/doc/manual/typing.md
+++ b/doc/manual/typing.md
@@ -192,21 +192,23 @@ The following type constructors are available:
   let occurences : {_: Num} = {a = 1, b = 3, c = 0} in
   record.map (fun char count => count + 1) occurences : {_ : Num}
   ```
-- **Enum**: `<tag1, .., tagn>`: an enumeration comprised of alternatives `tag1`,
-  .., `tagn`. An enumeration literal is prefixed with a backtick and serialized
-  as a string. It is useful to encode finite alternatives. The advantage over
-  strings is that the typechecker handles them more finely: it is able to detect
-  incomplete matches, for example.
 
-  Example:
-  ```nickel
-  let protocol : <http, ftp, sftp> = `http in
-  (switch {
-    `http => 1,
-    `ftp => 2,
-    `sftp => 3
-  } protocol) : Num
-  ```
+<!-- - **Enum**: `<tag1, .., tagn>`: an enumeration comprised of alternatives `tag1`, -->
+<!--   .., `tagn`. An enumeration literal is prefixed with a backtick and serialized -->
+<!--   as a string. It is useful to encode finite alternatives. The advantage over -->
+<!--   strings is that the typechecker handles them more finely: it is able to detect -->
+<!--   incomplete matches, for example. -->
+<!--  -->
+<!--   Example: -->
+<!--   ```nickel -->
+<!--   let protocol : <http, ftp, sftp> = `http in -->
+<!--   (switch { -->
+<!--     `http => 1, -->
+<!--     `ftp => 2, -->
+<!--     `sftp => 3 -->
+<!--   } protocol) : Num -->
+<!--   ``` -->
+
 - **Arrow (function)**: `S -> T`. A function taking arguments of type `S` and returning a value of
   type `T`. For multi-parameters functions, just iterate the arrow constructor.
 
@@ -383,28 +385,28 @@ could still write `addTotal {total = 1, foo = 1} {total = 2, foo = 2}` but not
 What comes before the tail may include several fields, is in e.g. `forall a.
 {total: Num, subtotal: Num | a} -> Num`.
 
-Note that row polymorphism also works with enums, with the same intuition of a
-tail that can be substituted for something else. For example:
-
-```nickel
-let portOf : forall a. <http, ftp | a> -> Num = fun protocol =>
-switch {
-  `http -> 80,
-  `ftp -> 21,
-  _ -> 8000,
-} protocol
-```
-
-Because the `switch` statement has a catch-all case `_`, this function is indeed
-able to handle other tags than `http` and `ftp`, as expressed by its polymorphic
-type.
+<!-- Note that row polymorphism also works with enums, with the same intuition of a -->
+<!-- tail that can be substituted for something else. For example: -->
+<!--  -->
+<!-- ```nickel -->
+<!-- let portOf : forall a. <http, ftp | a> -> Num = fun protocol => -->
+<!-- switch { -->
+<!--   `http -> 80, -->
+<!--   `ftp -> 21, -->
+<!--   _ -> 8000, -->
+<!-- } protocol -->
+<!-- ``` -->
+<!--  -->
+<!-- Because the `switch` statement has a catch-all case `_`, this function is indeed -->
+<!-- able to handle other tags than `http` and `ftp`, as expressed by its polymorphic -->
+<!-- type. -->
 
 ### Take-away
 
 The type system of Nickel has usual basic types (`Dyn`, `Num`, `Str`, and
-`Bool`) and type constructors for arrays, records, enums and functions. Nickel
+`Bool`) and type constructors for arrays, records and functions. Nickel
 features generics via polymorphism, introduced by the `forall` keyword. A type
-can not only be generic in other types, but records and enums types can also be
+can not only be generic in other types, but records types can also be
 generic in their tail. The tail is delimited by `|`.
 
 ## Interaction between statically typed and dynamically typed code

--- a/stdlib/array.ncl
+++ b/stdlib/array.ncl
@@ -13,6 +13,8 @@
       = fun label =>
         label
         |> contract.tag "must be one of `Less, `Equal, or `Greater"
+        # The enum type syntax [| ... |] is not stable. Do not rely on it in
+        # your own Nickel programs.
         |> contract.apply [| Less, Equal, Greater |],
 
     NonEmpty

--- a/stdlib/array.ncl
+++ b/stdlib/array.ncl
@@ -1,5 +1,20 @@
 {
   array = {
+    ComparisonResult
+      | doc m%"
+          The result of a comparison. Must be one of the tags:
+
+          ```
+            `Less
+            `Equal
+            `Greater
+          ```
+        "%m
+      = fun label =>
+        label
+        |> contract.tag "must be one of `Less, `Equal, or `Greater"
+        |> contract.apply [| Less, Equal, Greater |],
+
     NonEmpty
       | doc m%"
         Contract to ensure the given array is not empty.
@@ -254,7 +269,7 @@
         "%m
       = fun f n => %generate% n f,
 
-    sort : forall a. (a -> a -> [| Less, Equal, Greater |]) -> Array a -> Array a
+    sort | forall a. (a -> a -> ComparisonResult) -> Array a -> Array a
       | doc m%"
         Sorts the given arrays based on the provided comparison operator.
 

--- a/stdlib/builtin.ncl
+++ b/stdlib/builtin.ncl
@@ -1,5 +1,65 @@
 {
   builtin = {
+    ValueType
+      | doc m%"
+        Possible dynamic type for a value. Must be one of the tags:
+
+        ```
+         `TypeNum
+         `TypeBool
+         `TypeStr
+         `TypeFun
+         `TypeArray
+         `TypeRecord
+         `Other
+        ```
+        "%m
+      = fun label =>
+        label
+        |> contract.tag m%"
+          must be one of `TypeNum, `TypeBool, `TypeStr, `TypeFun, `TypeArray`, `TypeRecord or `Other
+        "%m
+        | contract.apply [|
+            TypeNum,
+            TypeBool,
+            TypeStr,
+            TypeFun,
+            TypeArray,
+            TypeRecord,
+            Other
+          |],
+
+    HashAlgorithm
+      | doc m%"
+        Supportd hash algorithm. Must be one of the tag:
+
+        ```
+          `Md5
+          `Sha1
+          `Sha256
+          `Sha512
+        ```
+        "%m
+      = fun label =>
+        label
+        |> contract.tag "must be one of `Md5, `Sha1, `Sha256, `Sha512"
+        |> contract.apply [| Md5, Sha1, Sha256, Sha512 |],
+
+    ExportFormat
+      | doc m%"
+        Supported import and export format. Must be one of the tag:
+
+        ```
+          `Json
+          `Toml
+          `Yaml
+        ```
+        "%m
+      = fun label =>
+        label
+        |> contract.tag "must be one of `Json, `Toml or `Yaml"
+        |> contract.apply [| Json, Toml, Yaml |],
+
     is_num : Dyn -> Bool
     | doc m%"
       Checks if the given value is a number.
@@ -84,14 +144,7 @@
       "%m
     = fun x => %is_record% x,
 
-    typeof : Dyn -> [|
-      TypeNum,
-      TypeBool,
-      TypeStr,
-      TypeFun,
-      TypeArray,
-      TypeRecord,
-      Other |]
+    typeof | Dyn -> ValueType
     | doc m%"
       Results in a value representing the type of the typed value.
 
@@ -144,7 +197,7 @@
       "%m
     = fun x y => %deep_seq% x y,
 
-    hash : [| Md5, Sha1, Sha256, Sha512 |] -> Str -> Str
+    hash | HashAlgorithm -> Str -> Str
     | doc m%"
       Hashes the given string provided the desired hash algorithm.
 
@@ -156,7 +209,7 @@
       "%m
     = fun type s => %hash% type s,
 
-    serialize : [| Json, Toml, Yaml |] -> Dyn -> Str
+    serialize | ExportFormat -> Dyn -> Str
     | doc m%"
       Serializes the given value to the desired representation.
 
@@ -171,7 +224,7 @@
       "%m
     = fun format x => %serialize% format (%deep_seq% x x),
 
-    deserialize : [| Json, Toml, Yaml |] -> Str -> Dyn
+    deserialize | ExportFormat -> Str -> Dyn
     | doc m%"
       Deserializes the given string to a nickel value given the encoding of the string.
 

--- a/stdlib/builtin.ncl
+++ b/stdlib/builtin.ncl
@@ -19,6 +19,8 @@
         |> contract.tag m%"
           must be one of `TypeNum, `TypeBool, `TypeStr, `TypeFun, `TypeArray`, `TypeRecord or `Other
         "%m
+        # The enum type syntax [| ... |] is not stable. Do not rely on it in
+        # your own Nickel programs.
         | contract.apply [|
             TypeNum,
             TypeBool,
@@ -43,6 +45,8 @@
       = fun label =>
         label
         |> contract.tag "must be one of `Md5, `Sha1, `Sha256, `Sha512"
+        # The enum type syntax [| ... |] is not stable. Do not rely on it in
+        # your own Nickel programs.
         |> contract.apply [| Md5, Sha1, Sha256, Sha512 |],
 
     ExportFormat
@@ -58,6 +62,8 @@
       = fun label =>
         label
         |> contract.tag "must be one of `Json, `Toml or `Yaml"
+        # The enum type syntax [| ... |] is not stable. Do not rely on it in
+        # your own Nickel programs.
         |> contract.apply [| Json, Toml, Yaml |],
 
     is_num : Dyn -> Bool

--- a/stdlib/contract.ncl
+++ b/stdlib/contract.ncl
@@ -31,7 +31,7 @@
       if (case t) then
           t
       else
-          %assume% contr (%tag% "NotRowExt" l) t,
+          %assume% contr l t,
 
   "$record" = fun cont l t =>
       if %is_record% t then


### PR DESCRIPTION
The enum type syntax has been changed temporarily since the unified syntax
change. While we bikeshed on a new solid syntax, we don't want users to rely
on the temporary one.

This PR:

- Hides enum types from stdlib types by wrapping them as contracts with meaningful names and error messages.  When a user write, say, ``builtin.serialize `NonExistentFormat "foo"``, the error they will face is understandable without using the enum type syntax.
- Documents enum tags but not enum types in the syntax section of the manual.
- Hide documentation about enum types in the typing section of the manual.

That way, they can still be used under the hood the stdlib, but without facing users.