### PR TITLE
[Fix] Misinterpretation of long candidate interpolation sequences `%..%{`

### DIFF
--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -355,10 +355,6 @@ fn multiline_str_escape() {
         parse_without_pos(r##"m%"%Hel%%lo%%%"%m"##),
         mk_single_chunk("%Hel%%lo%%%"),
     );
-    assert_eq!(
-        parse_without_pos(r##"m%"%Hel%%{lo%%%{"%m"##),
-        mk_single_chunk("%Hel%%{lo%%%{"),
-    );
 }
 
 #[test]

--- a/tests/pass/strings.ncl
+++ b/tests/pass/strings.ncl
@@ -20,5 +20,9 @@ let Assert = fun l x => x || %blame% l in
   let s = "Hello" in m%%""%%{s}" World"%%m == "\"Hello\" World",
   let s = "Hello" in m%%""%%%{s}" World"%%m == "\"%Hello\" World",
   m%%""%%s"%%m == "\"%%s",
+
+  # regression test for issue #659 (https://github.com/tweag/nickel/issues/659)
+  let b = "x" in m%"a%%{b}c"%m == "a%xc",
+  m%"%Hel%%{"1"}lo%%%{"2"}"%m == "%Hel%1lo%%2",
 ]
 |> array.foldl (fun x y => (x | Assert) && y) true


### PR DESCRIPTION
Fix #659.

The lexer was considering a candidate interpolation sequence (a sequence of `%` followed by `{`, such as `%%%%{`) as an actual interpolation token only if the number of `%` exactly matches the number of `%` of the delimiters of the multi-line string. The right behavior is to do so when the number of `%` is greater or equals than the number of `%` in the opening delimiters. The remaining prefix must then be converted to a standard str literal token `%...%`.