### PR TITLE
Merge null values and empty lists

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -952,13 +952,13 @@ impl ToDiagnostic<FileId> for EvalError {
                 // (either variable or field) as the name of the missing field.
                 let mut field: Option<String> = None;
                 let mut pos_record = TermPos::None;
-                let mut pos_access: Option<TermPos> = None;
+                let mut pos_access = TermPos::None;
 
                 for elt in callstack.as_ref().iter().rev() {
                     match elt {
                         StackElem::Var { id, pos, .. } if !id.is_generated() && field.is_none() => {
                             field = Some(id.to_string());
-                            pos_access = Some(*pos);
+                            pos_access = *pos;
                         }
                         StackElem::Field {
                             id,
@@ -966,8 +966,8 @@ impl ToDiagnostic<FileId> for EvalError {
                             pos_access: pos_acc,
                             ..
                         } => {
-                            field.get_or_insert(id.to_string());
-                            pos_access.get_or_insert(*pos_acc);
+                            field = Some(id.to_string());
+                            pos_access = *pos_acc;
                             pos_record = *pos_rec;
                             break;
                         }
@@ -981,7 +981,7 @@ impl ToDiagnostic<FileId> for EvalError {
                     labels.push(primary(&span).with_message("in this record"));
                 }
 
-                if let Some(span) = pos_access.map(TermPos::into_opt).flatten() {
+                if let Some(span) = pos_access.into_opt() {
                     labels.push(secondary(&span).with_message("accessed here"));
                 }
 

--- a/src/eval/merge.rs
+++ b/src/eval/merge.rs
@@ -119,6 +119,10 @@ pub fn merge(
 
     match (t1.into_owned(), t2.into_owned()) {
         // Merge is idempotent on basic terms
+        (Term::Null, Term::Null) => Ok(Closure::atomic_closure(RichTerm::new(
+            Term::Null,
+            pos_op.into_inherited(),
+        ))),
         (Term::Bool(b1), Term::Bool(b2)) => {
             if b1 == b2 {
                 Ok(Closure::atomic_closure(RichTerm::new(
@@ -219,6 +223,9 @@ pub fn merge(
                 ))
             }
         }
+        (Term::Array(arr1), Term::Array(arr2)) if arr1.is_empty() && arr2.is_empty() => Ok(
+            Closure::atomic_closure(RichTerm::new(Term::Array(arr1), pos_op.into_inherited())),
+        ),
         (Term::MetaValue(meta1), Term::MetaValue(meta2)) => {
             // For now, we blindly closurize things and copy environments in this section. A
             // careful analysis would make it possible to spare a few closurize operations and more


### PR DESCRIPTION
Implement the obvious merging of null values and empty lists, instead of erroring out. This avoid undue non-mergeable terms errors (that I encountered in practice while dog fooding).

Bundled with a tiny clean-up in `error.rs` done *en passant*.