### PR TITLE
Xavier/type wildcards

### DIFF
--- a/src/cache.rs
+++ b/src/cache.rs
@@ -6,7 +6,7 @@ use crate::position::TermPos;
 use crate::stdlib as nickel_stdlib;
 use crate::term::{RichTerm, SharedTerm, Term};
 use crate::transform::import_resolution;
-use crate::typecheck;
+use crate::typecheck::{self, Wildcards};
 use crate::typecheck::{linearization::StubHost, type_check};
 use crate::types::UnboundTypeVariableError;
 use crate::{eval, parser, transform};
@@ -68,6 +68,8 @@ pub struct Cache {
     terms: HashMap<FileId, CachedTerm>,
     /// The list of ids corresponding to the stdlib modules
     stdlib_ids: Option<Vec<FileId>>,
+    /// The inferred type of wildcards for each `FileId`.
+    wildcards: HashMap<FileId, Wildcards>,
 
     #[cfg(debug_assertions)]
     /// Skip loading the stdlib, used for debugging purpose
@@ -205,6 +207,7 @@ impl Cache {
             files: Files::new(),
             file_ids: HashMap::new(),
             terms: HashMap::new(),
+            wildcards: HashMap::new(),
             imports: HashMap::new(),
             stdlib_ids: None,
 
@@ -437,8 +440,10 @@ impl Cache {
             }
             Some(CachedTerm { term, state, .. }) if *state >= EntryState::Parsed => {
                 if *state < EntryState::Typechecking {
-                    type_check(term, global_env, self, StubHost::<(), (), _>::new())?;
+                    let (_, _, wildcards) =
+                        type_check(term, global_env, self, StubHost::<(), (), _>::new())?;
                     self.update_state(file_id, EntryState::Typechecking);
+                    self.wildcards.insert(file_id, wildcards);
                 }
 
                 if let Some(imports) = self.imports.get(&file_id).cloned() {
@@ -469,7 +474,7 @@ impl Cache {
                     let CachedTerm {
                         term, parse_errs, ..
                     } = self.terms.remove(&file_id).unwrap();
-                    let term = transform::transform(term)?;
+                    let term = transform::transform(term, self.wildcards.get(&file_id))?;
                     self.terms.insert(
                         file_id,
                         CachedTerm {
@@ -520,6 +525,7 @@ impl Cache {
                     state,
                     parse_errs,
                 } = self.terms.remove(&file_id).unwrap();
+                let wildcards = self.wildcards.get(&file_id);
 
                 if state < EntryState::Transforming {
                     let pos = term.pos;
@@ -528,7 +534,7 @@ impl Cache {
                         Term::Record(ref mut map, _) => {
                             let map_res: Result<_, UnboundTypeVariableError> = std::mem::take(map)
                                 .into_iter()
-                                .map(|(id, t)| Ok((id, transform::transform(t)?)))
+                                .map(|(id, t)| Ok((id, transform::transform(t, wildcards)?)))
                                 .collect();
                             *map = map_res.map_err(|err| {
                                 CacheError::Error(ImportError::ParseErrors(err.into(), pos))
@@ -537,14 +543,17 @@ impl Cache {
                         Term::RecRecord(ref mut map, ref mut dyn_fields, ..) => {
                             let map_res: Result<_, UnboundTypeVariableError> = std::mem::take(map)
                                 .into_iter()
-                                .map(|(id, t)| Ok((id, transform::transform(t)?)))
+                                .map(|(id, t)| Ok((id, transform::transform(t, wildcards)?)))
                                 .collect();
 
                             let dyn_fields_res: Result<_, UnboundTypeVariableError> =
                                 std::mem::take(dyn_fields)
                                     .into_iter()
                                     .map(|(id_t, t)| {
-                                        Ok((transform::transform(id_t)?, transform::transform(t)?))
+                                        Ok((
+                                            transform::transform(id_t, wildcards)?,
+                                            transform::transform(t, wildcards)?,
+                                        ))
                                     })
                                     .collect();
 
@@ -689,8 +698,9 @@ impl Cache {
             return Err(Error::ParseErrors(errs));
         }
         let (term, pending) = import_resolution::resolve_imports(term, self)?;
-        type_check(&term, global_env, self, StubHost::<(), (), _>::new())?;
-        let term = transform::transform(term).map_err(|err| Error::ParseErrors(err.into()))?;
+        let (_, _, wildcards) = type_check(&term, global_env, self, StubHost::<(), (), _>::new())?;
+        let term = transform::transform(term, Some(&wildcards))
+            .map_err(|err| Error::ParseErrors(err.into()))?;
         Ok((term, pending))
     }
 

--- a/src/grammar.lalrpop
+++ b/src/grammar.lalrpop
@@ -66,7 +66,11 @@ use crate::{
     label::Label,
 };
 
-grammar<'input, 'err>(src_id: FileId, errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParseError>>);
+grammar<'input, 'err, 'wcard>(
+    src_id: FileId,
+    errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParseError>>,
+    next_wildcard_id: &'wcard mut usize,
+);
 
 WithPos<Rule>: Rule = <l: @L> <t: Rule> <r: @R> => t.with_pos(mk_pos(src_id, l, r));
 
@@ -762,6 +766,11 @@ TypeAtom: Types = {
         Types(AbsType::Enum(Box::new(ty)))
     },
     "{" "_" ":" <Types> "}" => Types(AbsType::DynRecord(Box::new(<>))),
+    "_" => {
+        let id = *next_wildcard_id;
+        *next_wildcard_id += 1;
+        Types(AbsType::Wildcard(id))
+    },
 }
 
 extern {

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -37,8 +37,9 @@ impl grammar::ExtendedTermParser {
         lexer: lexer::Lexer,
     ) -> Result<(ExtendedTerm, ParseErrors), ParseError> {
         let mut parse_errors = Vec::new();
+        let mut next_wildcard_id = 0;
         let result = self
-            .parse(file_id, &mut parse_errors, lexer)
+            .parse(file_id, &mut parse_errors, &mut next_wildcard_id, lexer)
             .map_err(|err| ParseError::from_lalrpop(err, file_id));
 
         let parse_errors = ParseErrors::from_recoverable(parse_errors, file_id);
@@ -71,8 +72,9 @@ impl grammar::TermParser {
         lexer: lexer::Lexer,
     ) -> Result<(RichTerm, ParseErrors), ParseError> {
         let mut parse_errors = Vec::new();
+        let mut wildcard_id = 0;
         let result = self
-            .parse(file_id, &mut parse_errors, lexer)
+            .parse(file_id, &mut parse_errors, &mut wildcard_id, lexer)
             .map_err(|err| ParseError::from_lalrpop(err, file_id));
 
         let parse_errors = ParseErrors::from_recoverable(parse_errors, file_id);

--- a/src/parser/uniterm.rs
+++ b/src/parser/uniterm.rs
@@ -352,7 +352,8 @@ pub fn fix_type_vars(ty: &mut Types) {
             | AbsType::Str()
             | AbsType::Sym()
             | AbsType::Flat(_)
-            | AbsType::RowEmpty() => (),
+            | AbsType::RowEmpty()
+            | AbsType::Wildcard(_) => (),
             AbsType::Arrow(ref mut s, ref mut t) => {
                 fix_type_vars_aux(s.as_mut(), Cow::Borrowed(bound_vars.as_ref()));
                 fix_type_vars_aux(t.as_mut(), bound_vars);

--- a/src/pretty.rs
+++ b/src/pretty.rs
@@ -782,6 +782,7 @@ where
                     .append(allocator.space())
                     .append(codom.pretty(allocator)),
             },
+            Wildcard(_) => allocator.text("_"),
         }
     }
 }

--- a/src/program.rs
+++ b/src/program.rs
@@ -150,7 +150,7 @@ impl Program {
 
         let rt = cache.parse_nocache(*main_id)?.0;
         let rt = if apply_transforms {
-            crate::transform::transform(rt).unwrap()
+            crate::transform::transform(rt, None).unwrap()
         } else {
             rt
         };

--- a/src/repl/mod.rs
+++ b/src/repl/mod.rs
@@ -12,6 +12,7 @@ use crate::identifier::Ident;
 use crate::parser::{grammar, lexer, ExtendedTerm};
 use crate::term::{RichTerm, Term};
 use crate::transform::import_resolution;
+use crate::typecheck::TypeCheckingOutput;
 use crate::types::Types;
 use crate::{eval, transform, typecheck};
 use codespan::FileId;
@@ -134,7 +135,7 @@ impl ReplImpl {
                 repl_impl.cache.resolve_imports(*id).unwrap();
             }
 
-            let (_, wildcards) =
+            let TypeCheckingOutput { wildcards, .. } =
                 typecheck::type_check_in_env(&t, &repl_impl.env.type_env, &repl_impl.cache)?;
 
             if let Some(id) = id {
@@ -232,9 +233,21 @@ impl Repl for ReplImpl {
         for id in &pending {
             self.cache.resolve_imports(*id).unwrap();
         }
+        let TypeCheckingOutput { wildcards, .. } =
+            typecheck::type_check_in_env(&term, &self.env.type_env, &self.cache)?;
         // Substitute the wildcard types for their inferred types
-        let (_, wildcards) = typecheck::type_check_in_env(&term, &self.env.type_env, &self.cache)?;
-        let term = transform::substitute_wildcards::transform_one(term, &wildcards);
+        // We need to `traverse` the term, in case the type depends on inner terms that also contain wildcards
+        let term = term
+            .traverse(
+                &mut |rt: RichTerm, _| -> Result<RichTerm, std::convert::Infallible> {
+                    Ok(transform::substitute_wildcards::transform_one(
+                        rt, &wildcards,
+                    ))
+                },
+                &mut (),
+                crate::term::TraverseOrder::TopDown,
+            )
+            .unwrap();
 
         Ok(typecheck::apparent_type(
             term.as_ref(),

--- a/src/transform/free_vars.rs
+++ b/src/transform/free_vars.rs
@@ -178,7 +178,8 @@ fn collect_type_free_vars(ty: &mut Types, set: &mut HashSet<Ident>) {
         | AbsType::Str()
         | AbsType::Sym()
         | AbsType::Var(_)
-        | AbsType::RowEmpty() => (),
+        | AbsType::RowEmpty()
+        | AbsType::Wildcard(_) => (),
         AbsType::Forall(_, ty)
         | AbsType::Enum(ty)
         | AbsType::StaticRecord(ty)

--- a/src/transform/substitute_wildcards.rs
+++ b/src/transform/substitute_wildcards.rs
@@ -1,0 +1,62 @@
+//! Substitute wildcard types with their inferred type.
+//!
+//! During type checking, wildcard types are treated as type variables that may end up unified
+//! with a concrete type.  If this is the case, this pass will substitute these wildcards with
+//! the type inferred during type checking.  Otherwise, wildcards will be substituted with
+//! `Dyn`.
+use std::rc::Rc;
+
+use crate::{
+    label::Label,
+    match_sharedterm,
+    term::{Contract, MetaValue, RichTerm, Term},
+    typecheck::Wildcards,
+    types::{AbsType, Types},
+};
+
+/// If the top-level node of the AST is a meta-value with a wildcard type annotation, replace
+/// both the type annotation and the label's type with the inferred type.
+pub fn transform_one(rt: RichTerm, wildcards: &Wildcards) -> RichTerm {
+    let pos = rt.pos;
+    match_sharedterm! {rt.term,
+        with {
+            Term::MetaValue(meta @ MetaValue {
+                types:
+                    Some(Contract {
+                        types: Types(AbsType::Wildcard(_)),
+                        ..
+                    }),
+                ..
+            }) => {
+                let mut meta = meta;
+                let Contract { types, label } = meta.types.take().unwrap();  // Safe, we know there's a type
+
+                // Replace the type annotation
+                let types = if let Types(AbsType::Wildcard(id)) = types {
+                    get_wildcard_type(wildcards, id)
+                } else {
+                    types
+                };
+
+                // Replace the blame label
+                let label = Label {
+                    types: if let Types(AbsType::Wildcard(id)) = label.types.as_ref() {
+                        Rc::new(get_wildcard_type(wildcards, *id))
+                    } else {
+                        label.types
+                    },
+                    ..label
+                };
+
+                meta.types.replace(Contract { types, label });
+
+                RichTerm::new(Term::MetaValue(meta), pos)
+            }
+        } else rt
+    }
+}
+
+/// Get the inferred type for a wildcard, or Dyn if no type was inferred.
+fn get_wildcard_type(wildcards: &Wildcards, id: usize) -> Types {
+    wildcards.get(&id).cloned().unwrap_or(Types(AbsType::Dyn()))
+}

--- a/src/types.rs
+++ b/src/types.rs
@@ -400,7 +400,8 @@ impl Types {
             | AbsType::Sym()
             | AbsType::Var(_)
             | AbsType::RowEmpty()
-            | AbsType::Flat(_) => Ok(ty.0),
+            | AbsType::Flat(_)
+            | AbsType::Wildcard(_) => Ok(ty.0),
             AbsType::Forall(id, ty_inner) => (*ty_inner)
                 .traverse(f, state, order)
                 .map(|ty| AbsType::Forall(id, Box::new(ty))),

--- a/src/types.rs
+++ b/src/types.rs
@@ -100,6 +100,8 @@ pub enum AbsType<Ty> {
     DynRecord(Ty /*, Ty  Row */),
     /// A parametrized array.
     Array(Ty),
+    /// A type wildcard, wrapping an ID unique within a given file.
+    Wildcard(usize),
 }
 
 impl<Ty> AbsType<Ty> {
@@ -130,6 +132,7 @@ impl<Ty> AbsType<Ty> {
             AbsType::StaticRecord(t) => Ok(AbsType::StaticRecord(f(t)?)),
             AbsType::DynRecord(t) => Ok(AbsType::DynRecord(f(t)?)),
             AbsType::Array(t) => Ok(AbsType::Array(f(t)?)),
+            AbsType::Wildcard(i) => Ok(AbsType::Wildcard(i)),
         }
     }
 
@@ -147,6 +150,10 @@ impl<Ty> AbsType<Ty> {
             self,
             AbsType::RowExtend(..) | AbsType::RowEmpty() | AbsType::Dyn()
         )
+    }
+
+    pub fn is_wildcard(&self) -> bool {
+        matches!(self, AbsType::Wildcard(_))
     }
 }
 
@@ -313,6 +320,7 @@ impl Types {
             AbsType::DynRecord(ref ty) => {
                 mk_app!(contract::dyn_record(), ty.subcontract(h, pol, sy)?)
             }
+            AbsType::Wildcard(_) => contract::dynamic(),
         };
 
         Ok(ctr)
@@ -485,6 +493,7 @@ impl fmt::Display for Types {
                 AbsType::Arrow(_, _) => write!(f, "({}) -> {}", dom, codom),
                 _ => write!(f, "{} -> {}", dom, codom),
             },
+            AbsType::Wildcard(_) => write!(f, "_"),
         }
     }
 }
@@ -551,5 +560,10 @@ mod test {
         assert_format_eq("Num -> Array (Array Str) -> Num");
         assert_format_eq("Array (Num -> Num)");
         assert_format_eq("Array (Array (Array Dyn) -> Num)");
+
+        assert_format_eq("_");
+        assert_format_eq("_ -> _");
+        assert_format_eq("{x: _, y: Bool}");
+        assert_format_eq("{_: _}");
     }
 }

--- a/tests/pass/typechecking.ncl
+++ b/tests/pass/typechecking.ncl
@@ -192,6 +192,11 @@ let typecheck = [
   (string.split ".") : Str -> Array Str,
   (array.length [] == 0) : Bool,
   (array.map (fun x => x ++ "1") ["a", "b", "c"]) : Array Str,
+
+  # wildcards
+  ("hello" : _) : Str,
+  ((fun x => x + 1) : _ -> Num) : Num -> Num,
+  ({"foo" = 1} : {foo : _}) : {foo: Num}
 ] in
 
 true

--- a/tests/query.rs
+++ b/tests/query.rs
@@ -1,5 +1,5 @@
 use nickel_lang::program::Program;
-use nickel_lang::term::{SharedTerm, Term};
+use nickel_lang::term::{MetaValue, SharedTerm, Term};
 
 #[test]
 pub fn test_query_metadata_basic() {
@@ -30,4 +30,58 @@ pub fn test_query_metadata_from_func() {
     } else {
         panic!();
     }
+}
+
+#[test]
+pub fn test_query_with_wildcard() {
+    /// Checks whether `lhs` and `rhs` both evaluate to terms with the same static type
+    fn assert_types_eq(lhs: &str, rhs: &str) {
+        let term1 = Program::new_from_source(lhs.as_bytes(), "regr_tests")
+            .unwrap()
+            .query(None)
+            .unwrap();
+        let term2 = Program::new_from_source(rhs.as_bytes(), "regr_tests")
+            .unwrap()
+            .query(None)
+            .unwrap();
+        if let (
+            Term::MetaValue(MetaValue {
+                types: Some(contract1),
+                ..
+            }),
+            Term::MetaValue(MetaValue {
+                types: Some(contract2),
+                ..
+            }),
+        ) = (term1, term2)
+        {
+            assert_eq!(contract1.types, contract2.types);
+            assert_eq!(
+                contract1.label.types.as_ref(),
+                contract2.label.types.as_ref()
+            );
+        } else {
+            panic!();
+        }
+    }
+
+    // Without wildcard, the result has no type annotation
+    let mut program = Program::new_from_source("10".as_bytes(), "regr_tests").unwrap();
+    let result = program.query(None).unwrap();
+    assert!(!matches!(result, Term::MetaValue(_)));
+
+    // With a wildcard, there is a type annotation, inferred to be Num
+    assert_types_eq("10 : _", "10 : Num");
+
+    // Wildcard infers record type
+    assert_types_eq(
+        r#"{foo: Str = "quux"} : _"#,
+        r#"{foo: Str = "quux"} : {foo: Str}"#,
+    );
+
+    // Wildcard infers function type, infers inside `let`
+    assert_types_eq(
+        r#"let f : _ = fun x => x + 1 in f"#,
+        r#"(fun x => x + 1) : Num -> Num"#,
+    );
 }

--- a/tests/typecheck_fail.rs
+++ b/tests/typecheck_fail.rs
@@ -249,8 +249,13 @@ fn fails_only_with_wildcard() {
     );
     // However, with one, we get a type error
     assert_matches!(
-        type_check_expr("let head = fun l => %head% l in (head 10) : _"),
+        type_check_expr("(let head = fun l => %head% l in (head 10)) : _"),
         Err(TypecheckError::TypeMismatch(..))
+    );
+    // With an actual array, this passes
+    assert_matches!(
+        type_check_expr("(let head = fun l => %head% l in (head [10])) : _"),
+        Ok(_)
     );
 }
 

--- a/tests/typecheck_fail.rs
+++ b/tests/typecheck_fail.rs
@@ -4,11 +4,12 @@ use nickel_lang::cache::resolvers::DummyResolver;
 use nickel_lang::error::TypecheckError;
 use nickel_lang::parser::{grammar, lexer};
 use nickel_lang::term::RichTerm;
-use nickel_lang::typecheck::{type_check_in_env, Environment, Wildcards};
-use nickel_lang::types::{AbsType, Types};
+use nickel_lang::typecheck::{type_check_in_env, Environment, TypeCheckingOutput};
+use nickel_lang::types::Types;
 
 fn type_check(rt: &RichTerm) -> Result<Types, TypecheckError> {
-    type_check_in_env(rt, &Environment::new(), &mut DummyResolver {}).map(|(t, _)| t)
+    type_check_in_env(rt, &Environment::new(), &mut DummyResolver {})
+        .map(|TypeCheckingOutput { types, .. }| types)
 }
 
 fn type_check_expr(s: impl std::string::ToString) -> Result<Types, TypecheckError> {

--- a/tests/typecheck_fail.rs
+++ b/tests/typecheck_fail.rs
@@ -4,14 +4,14 @@ use nickel_lang::cache::resolvers::DummyResolver;
 use nickel_lang::error::TypecheckError;
 use nickel_lang::parser::{grammar, lexer};
 use nickel_lang::term::RichTerm;
-use nickel_lang::typecheck::{type_check_in_env, Environment};
+use nickel_lang::typecheck::{type_check_in_env, Environment, Wildcards};
 use nickel_lang::types::Types;
 
-fn type_check(rt: &RichTerm) -> Result<Types, TypecheckError> {
+fn type_check(rt: &RichTerm) -> Result<(Types, Wildcards), TypecheckError> {
     type_check_in_env(rt, &Environment::new(), &mut DummyResolver {})
 }
 
-fn type_check_expr(s: impl std::string::ToString) -> Result<Types, TypecheckError> {
+fn type_check_expr(s: impl std::string::ToString) -> Result<(Types, Wildcards), TypecheckError> {
     let s = s.to_string();
     let id = Files::new().add("<test>", s.clone());
     type_check(
@@ -170,7 +170,7 @@ fn let_inference() {
 fn polymorphic_row_constraints() {
     // Assert that the result of evaluation is either directly a `RowConflict` error, or a
     // `RowConflict` wrapped in an `ArrowTypeMismatch`.
-    fn assert_row_conflict(res: Result<Types, TypecheckError>) {
+    fn assert_row_conflict(res: Result<(Types, Wildcards), TypecheckError>) {
         assert!(match res.unwrap_err() {
             TypecheckError::RowConflict(_, _, _, _, _) => true,
             TypecheckError::ArrowTypeMismatch(_, _, _, err_boxed, _) => {


### PR DESCRIPTION
@yannham Here's a draft for the wildcards :-) Let me know what you think.  I think I should add more tests, but I'm not yet sure where, and which kinds.

Implementation of #495, type wildcards.

Wildcards are implemented as a type `AbsType::Wildcard(usize)`, marked with a unique `usize` identifier.

Type checking is done by interpreting wildcards as type variables during unification.  After a term is typechecked, the type variable associated with each wildcard is converted to a concrete type, and the mapping from wildcard ID to concrete type is returned: `wildcards: HashMap<usize, Types>`.

A new program transformation `substitute_wildcards` is added.  It takes the mapping `wildcards` as input, along with a term, and substitutes any wildcard annotation in the term with its concrete type taken from `wildcards`, or with `Dyn` if no type was inferred for that particular wildcard.

The cache has been updated to store the wildcard mappings for each file after type checking is done, such that they can be reused when later applying program transformations to the same file.