### PR TITLE
Preserve record location when applying record contract

### DIFF
--- a/src/eval/merge.rs
+++ b/src/eval/merge.rs
@@ -400,10 +400,16 @@ pub fn merge(
                 .iter()
                 .try_for_each(|rt| fixpoint::patch_field(rt, &rec_env, &env2))?;
 
+            let final_pos = if mode == MergeMode::Standard {
+                pos_op.into_inherited()
+            } else {
+                pos1.into_inherited()
+            };
+
             Ok(Closure {
                 body: RichTerm::new(
                     Term::Record(m, RecordAttrs::merge(attrs1, attrs2)),
-                    pos_op.into_inherited(),
+                    final_pos,
                 ),
                 env,
             })


### PR DESCRIPTION
When working on the dogfooding codebase, I noticed that a lot of errors (and in particular, the `missing field definition`) weren't able to correctly locate the offending value, in particular when the value is a record with a record contract applied (which is expected to be pretty frequent in Nickel):

![nickel-error-record-without-pos](https://user-images.githubusercontent.com/6530104/159315636-7c3a7098-2728-4381-a896-03e2e0a87e95.png)

This is due to record contract application being desugared to a (variant of) merge, with no position information. A first step is to give the same position to the elaborated merge as the contract parameter. However, this position is the position of the argument before evaluation, which isn't always helpful, because it can be proxied by variables or parameters to built-in contracts:

![nickel-record-loc-1](https://user-images.githubusercontent.com/6530104/159326874-facd75d8-9547-468c-8456-6c4b927c85e3.png)

A better solution was to do more or less the same thing, but after the evaluation of the (modified) merge: that is, when applying a record contract using `MergeContract(contract, record)`, we set the position of the final result to be the one of record. Now we get something more helpful:

![nickel-record-loc-2](https://user-images.githubusercontent.com/6530104/159327455-ca8f3fb7-518a-4d91-99f6-15fb7eee3bea.png)

