### PR TITLE
Fix record.update contract

### DIFF
--- a/stdlib/record.ncl
+++ b/stdlib/record.ncl
@@ -57,7 +57,7 @@
 
         ```nickel
         insert "foo" foo { bar = "bar" } =>
-          { foo = "foo", bar = "bar }  
+          { foo = "foo", bar = "bar }
 
         {}
         |> insert "file.%{ext}" "data/text"
@@ -74,12 +74,12 @@
 
         ```nickel
         remove "foo" foo { foo = "foo", bar = "bar" } =>
-          { bar = "bar }  
+          { bar = "bar }
         ```
       "%m
       = fun field r => %record_remove% field r,
 
-    update | forall a. Str -> a -> { ; a} -> { ; a}
+    update | forall a. Str -> a -> {_: a} -> {_: a}
       | doc m%"
         Update a field of a record with a new value. `update` doesn't mutate the
         original record but returns a new one instead. If the field to update is absent
@@ -87,21 +87,21 @@
 
         ```nickel
         remove "foo" foo { foo = "foo", bar = "bar" } =>
-          { bar = "bar" }  
+          { bar = "bar" }
         ```
 
         As opposed to overriding a value with the merge operator `&`, `update`
         will only change the specified field and won't automatically update the other
-        fields which depend on it: 
+        fields which depend on it:
 
         ```nickel
         { foo = bar + 1, bar | default = 0 } & { bar = 1 } =>
           { foo = 2, bar = 1 }
         update "bar" 1 {foo = bar + 1, bar | default = 0 } =>
-          { foo = 1, bar = 1 } 
+          { foo = 1, bar = 1 }
         ```
       "%m
-      = fun field content r => 
+      = fun field content r =>
         let r = if %has_field% field r then
           %record_remove% field r
         else


### PR DESCRIPTION
The `record.update` contract `forall a. Str -> a -> {; a} -> {; a}` is boguous, and currently fails on valid inputs:

```nickel
nickel> record.update "foo" 1 {foo = 2}
error: contract broken by a function: extra field `foo`
  ┌─ :1:30
  │
1 │ forall a. Str -> a -> {a} -> {a}
  │                              --- expected return type
  │
  ┌─ <unknown> (generated by evaluation):1:1
  │
1 │ { ... }
  │ ------- evaluated to this value
  │
  = This error may happen in the following situation:
    1. A function `f` is bound by a contract: e.g. `Bool -> Num`.
    2. `f` returns a value of the wrong type: e.g. `f = fun c => "string"` while `Num` is expected.
  = Either change the contract accordingly, or change the return value of `f`

note: 
   ┌─ <stdlib/record>:82:14
   │
82 │     update | forall a. Str -> a -> { ; a} -> { ; a}
   │              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ bound here
```

It's not even well-kinded (the same variable is used as a type and as a row). The right annotation is `{_ : a}` instead of `{ ; a}`. This PR fixes the contract annotation.