### PR TITLE
Recursive let

### DIFF
--- a/benches/numeric/fibonacci.ncl
+++ b/benches/numeric/fibonacci.ncl
@@ -1,9 +1,9 @@
 {
-  run = {
-      f = fun n =>
-        if n == 0 || n == 1 then
-          1
-        else
-          f (n - 1) + f (n - 2)
-    }.f
+  run =
+    let rec f = fun n =>
+      if n == 0 || n == 1 then
+        1
+      else
+        f (n - 1) + f (n - 2)
+    in f
 }

--- a/doc/manual/syntax.md
+++ b/doc/manual/syntax.md
@@ -328,7 +328,8 @@ Examples:
 ```
 
 ### Let-In
-Let-in allows the binding of an expression. It is used as `let <ident> = <expr> in <expr>`.
+Let-in allows the binding of an expression. It is used as `let <rec?> <ident> = <expr> in <expr>`.
+The `rec` keyword in Let-in constructs allows the let binding to become recursive, enabling the use of the `<ident>` within the first `<expr>`.
 
 Examples:
 ```
@@ -340,6 +341,15 @@ true
 
 > let a = 1 in let b = 2 in a + b
 3
+
+> let rec f = fun n => if n == 0 then n else n + f (n - 1) in f 10
+55
+
+> let rec fib = fun n => if n <= 2 then 1 else fib (n - 1) + fib (n - 2) in fib 9
+34
+
+> let rec repeat = fun n x => if n <= 0 then [] else repeat (n - 1) x @ [x] in repeat 3 "foo"
+["foo", "foo", "foo"]
 ```
 
 ## Functions

--- a/examples/fibonacci/README.md
+++ b/examples/fibonacci/README.md
@@ -3,9 +3,6 @@
 This is a basic example of a recursive function: fibonnacci. This is the naive,
 exponential version of fibonacci: don't call it on a big value!
 
-Currently, only record bindings are recursive. To use a recursive function, one
-has to use a record.
-
 ## Run
 
 ```

--- a/examples/fibonacci/fibonacci.ncl
+++ b/examples/fibonacci/fibonacci.ncl
@@ -1,15 +1,11 @@
-# Currently, only record bindings are recursive. To use a recursive function,
-# one has to use a record.
-
 # This is the naive, exponential version of fibonacci: don't call it on a big
 # value!
-let fibonacci = {
- f = fun n =>
+let rec fibonacci = fun n =>
   if n == 0 then
     0
   else if n == 1 then
     1
   else
-    f (n - 1) + f (n - 2)
-}.f in
+    fibonacci (n - 1) + fibonacci (n - 2)
+in
 fibonacci 10

--- a/lsp/nls/src/linearization/mod.rs
+++ b/lsp/nls/src/linearization/mod.rs
@@ -161,11 +161,11 @@ impl Linearizer for AnalysisHost {
             Term::LetPattern(ident, destruct, ..) | Term::FunPattern(ident, destruct, _) => {
                 if let Some(ident) = ident {
                     let value_ptr = match term {
-                        Term::LetPattern(_, _, _, _) => {
+                        Term::LetPattern(..) => {
                             self.let_binding = Some(id);
                             ValueState::Unknown
                         }
-                        Term::FunPattern(_, _, _) => {
+                        Term::FunPattern(..) => {
                             // stub object
                             lin.push(LinearizationItem {
                                 id: id_gen.get_and_advance(),
@@ -218,13 +218,13 @@ impl Linearizer for AnalysisHost {
                     });
                 }
             }
-            Term::Let(ident, _, _, _) | Term::Fun(ident, _) => {
+            Term::Let(ident, ..) | Term::Fun(ident, ..) => {
                 let value_ptr = match term {
-                    Term::Let(_, _, _, _) => {
+                    Term::Let(..) => {
                         self.let_binding = Some(id);
                         ValueState::Unknown
                     }
-                    Term::Fun(_, _) => {
+                    Term::Fun(..) => {
                         // stub object
                         lin.push(LinearizationItem {
                             id: id_gen.get_and_advance(),

--- a/src/eval/mod.rs
+++ b/src/eval/mod.rs
@@ -95,8 +95,8 @@ use crate::{
     identifier::Ident,
     match_sharedterm, mk_app,
     term::{
-        make as mk_term, BinaryOp, BindingType, MetaValue, RichTerm, SharedTerm, StrChunk, Term,
-        UnaryOp,
+        make as mk_term, BinaryOp, BindingType, LetAttrs, MetaValue, RichTerm, SharedTerm,
+        StrChunk, Term, UnaryOp,
     },
 };
 
@@ -225,7 +225,7 @@ where
     use crate::transform::fresh_var;
 
     let var = fresh_var();
-    // Desugar to let x = term in deepSeq x x
+    // Desugar to let x = term in %deep_seq% x x
     let wrapper = mk_term::let_in(
         var.clone(),
         t0,
@@ -357,18 +357,24 @@ where
                     env,
                 }
             }
-            Term::Let(x, s, t, btype) => {
+            Term::Let(x, s, t, LetAttrs { binding_type, rec }) => {
                 let closure = Closure {
                     body: s.clone(),
                     env: env.clone(),
                 };
 
-                let thunk = match btype {
+                let mut thunk = match binding_type {
                     BindingType::Normal => Thunk::new(closure, IdentKind::Let),
                     BindingType::Revertible(deps) => {
                         Thunk::new_rev(closure, IdentKind::Let, deps.clone())
                     }
                 };
+
+                // Patch the environment with the (x <- closure) binding
+                if *rec {
+                    let thunk_ = thunk.clone();
+                    thunk.borrow_mut().env.insert(x.clone(), thunk_);
+                }
 
                 env.insert(x.clone(), thunk);
                 Closure {
@@ -692,11 +698,11 @@ pub fn subst(rt: RichTerm, global_env: &Environment, env: &Environment) -> RichT
             | v @ Term::Enum(_)
             | v @ Term::Import(_)
             | v @ Term::ResolvedImport(_) => RichTerm::new(v, pos),
-            Term::Let(id, t1, t2, btype) => {
+            Term::Let(id, t1, t2, attrs) => {
                 let t1 = subst_(t1, global_env, env, Cow::Borrowed(bound.as_ref()));
                 let t2 = subst_(t2, global_env, env, bound);
 
-                RichTerm::new(Term::Let(id, t1, t2, btype), pos)
+                RichTerm::new(Term::Let(id, t1, t2, attrs), pos)
             }
             p @ Term::LetPattern(..) => panic!("Pattern {:?} has not been transformed before evaluation", p),
             p @ Term::FunPattern(..) => panic!("Pattern {:?} has not been transformed before evaluation", p),

--- a/src/grammar.lalrpop
+++ b/src/grammar.lalrpop
@@ -166,7 +166,7 @@ UniTerm: UniTerm = {
     InfixExpr,
     AnnotatedInfixExpr,
     AsUniTerm<Forall>,
-    "let" <pat:Pattern> <meta: Annot<FixedType>?>
+    "let" <recursive:"rec"?> <pat:Pattern> <meta: Annot<FixedType>?>
         "=" <t1: Term>
         "in" <t2: Term> => {
         let t1 = if let Some(mut meta) = meta {
@@ -178,7 +178,9 @@ UniTerm: UniTerm = {
             t1
         };
 
-        UniTerm::from(mk_term::let_pat(pat.0, pat.1, t1, t2))
+	let is_rec = recursive.is_some();
+
+        UniTerm::from(mk_term::let_pat(is_rec, pat.0, pat.1, t1, t2))
     },
     <l: @L> "fun" <pats: Pattern+> "=>" <t: Term> <r: @R> => {
         let pos = mk_pos(src_id, l, r);
@@ -781,6 +783,7 @@ extern {
         "forall" => Token::Normal(NormalToken::Forall),
         "in" => Token::Normal(NormalToken::In),
         "let" => Token::Normal(NormalToken::Let),
+	"rec" => Token::Normal(NormalToken::Rec),
         "switch" => Token::Normal(NormalToken::Switch),
 
         "null" => Token::Normal(NormalToken::Null),

--- a/src/grammar.lalrpop
+++ b/src/grammar.lalrpop
@@ -166,9 +166,9 @@ UniTerm: UniTerm = {
     InfixExpr,
     AnnotatedInfixExpr,
     AsUniTerm<Forall>,
-    "let" <recursive:"rec"?> <pat:Pattern> <meta: Annot<FixedType>?>
+    "let" <l: @L> <recursive:"rec"?> <r: @R> <pat:Pattern> <meta: Annot<FixedType>?>
         "=" <t1: Term>
-        "in" <t2: Term> => {
+        "in" <t2: Term> =>? {
         let t1 = if let Some(mut meta) = meta {
             let pos = t1.pos;
             meta.value = Some(t1);
@@ -178,9 +178,7 @@ UniTerm: UniTerm = {
             t1
         };
 
-	let is_rec = recursive.is_some();
-
-        UniTerm::from(mk_term::let_pat(is_rec, pat.0, pat.1, t1, t2))
+        Ok(UniTerm::from(mk_let(recursive.is_some(), pat.0, pat.1, t1, t2, mk_span(src_id, l, r))?))
     },
     <l: @L> "fun" <pats: Pattern+> "=>" <t: Term> <r: @R> => {
         let pos = mk_pos(src_id, l, r);

--- a/src/parser/error.rs
+++ b/src/parser/error.rs
@@ -33,4 +33,7 @@ pub enum ParseError {
         RawSpan, /* tail position */
         RawSpan, /* whole record position */
     ),
+    /// A recursive let pattern was encountered. They are not currently supported because we
+    /// decided it was too involved to implement them.
+    RecursiveLetPattern(RawSpan),
 }

--- a/src/parser/lexer.rs
+++ b/src/parser/lexer.rs
@@ -68,6 +68,8 @@ pub enum NormalToken<'input> {
     In,
     #[token("let")]
     Let,
+    #[token("rec")]
+    Rec,
     #[token("switch")]
     Switch,
 

--- a/src/term.rs
+++ b/src/term.rs
@@ -1355,7 +1355,7 @@ pub mod make {
         Term::Let(id.into(), t1.into(), t2.into(), BindingType::Normal).into()
     }
 
-    pub fn let_pat<I, D, T1, T2>(id: Option<I>, pat: D, t1: T1, t2: T2) -> RichTerm
+    pub fn let_pat<I, D, T1, T2>(rec: bool, id: Option<I>, pat: D, t1: T1, t2: T2) -> RichTerm
     where
         T1: Into<RichTerm>,
         T2: Into<RichTerm>,

--- a/src/transform/desugar_destructuring.rs
+++ b/src/transform/desugar_destructuring.rs
@@ -34,9 +34,7 @@ use crate::destruct::{Destruct, Match};
 use crate::identifier::Ident;
 use crate::match_sharedterm;
 use crate::term::make::{op1, op2};
-use crate::term::{
-    BinaryOp::DynRemove, BindingType, MetaValue, RichTerm, Term, UnaryOp::StaticAccess,
-};
+use crate::term::{BinaryOp::DynRemove, MetaValue, RichTerm, Term, UnaryOp::StaticAccess};
 
 /// Entry point of the patterns desugaring.
 /// It desugar a `RichTerm` if possible (the term is a let pattern or a function with patterns in
@@ -117,7 +115,7 @@ pub fn desugar(rt: RichTerm) -> RichTerm {
                         x.clone(),
                         t_,
                         destruct_term(x.clone(), &pat, bind_open_field(x, &pat, body)),
-                        BindingType::Normal,
+                        Default::default(),
                     ),
                     pos,
                 )
@@ -161,7 +159,7 @@ fn bind_open_field(x: Ident, pat: &Destruct, body: RichTerm) -> RichTerm {
             }
         }),
         body,
-        BindingType::Normal,
+        Default::default(),
     )
     .into()
 }
@@ -177,7 +175,7 @@ fn destruct_term(x: Ident, pat: &Destruct, body: RichTerm) -> RichTerm {
                     id.clone(),
                     op1(StaticAccess(id.clone()), Term::Var(x.clone())),
                     t,
-                    BindingType::Normal,
+                    Default::default(),
                 ),
                 pos,
             ),

--- a/src/transform/free_vars.rs
+++ b/src/transform/free_vars.rs
@@ -53,10 +53,15 @@ fn collect_free_vars(rt: &mut RichTerm, free_vars: &mut HashSet<Ident>) {
 
             free_vars.extend(fresh);
         }
-        Term::Let(id, t1, t2, _) => {
+        Term::Let(id, t1, t2, attrs) => {
             let mut fresh = HashSet::new();
 
-            collect_free_vars(t1, free_vars);
+            if attrs.rec {
+                collect_free_vars(t1, &mut fresh);
+            } else {
+                collect_free_vars(t1, free_vars);
+            }
+
             collect_free_vars(t2, &mut fresh);
             fresh.remove(id);
 

--- a/src/transform/share_normal_form.rs
+++ b/src/transform/share_normal_form.rs
@@ -32,7 +32,7 @@ use crate::{
     identifier::Ident,
     match_sharedterm,
     position::TermPos,
-    term::{BindingType, RichTerm, Term},
+    term::{BindingType, LetAttrs, RichTerm, Term},
 };
 
 use std::{collections::HashSet, rc::Rc};
@@ -165,7 +165,11 @@ pub fn transform_one(rt: RichTerm) -> RichTerm {
                     meta.value
                         .replace(RichTerm::new(Term::Var(fresh_var.clone()), t.pos));
                     let inner = RichTerm::new(Term::MetaValue(meta), pos);
-                    RichTerm::new(Term::Let(fresh_var, t, inner, BindingType::Normal), pos)
+                    let attrs = LetAttrs {
+                        binding_type: BindingType::Normal,
+                        rec : false,
+                    };
+                    RichTerm::new(Term::Let(fresh_var, t, inner, attrs), pos)
             }
         } else rt
     }
@@ -203,6 +207,19 @@ fn with_bindings(
 ) -> RichTerm {
     bindings.into_iter().fold(
         RichTerm::new(body, pos.into_inherited()),
-        |acc, (id, t, btype)| RichTerm::new(Term::Let(id, t, acc, btype), pos),
+        |acc, (id, t, binding_type)| {
+            RichTerm::new(
+                Term::Let(
+                    id,
+                    t,
+                    acc,
+                    LetAttrs {
+                        binding_type,
+                        rec: false,
+                    },
+                ),
+                pos,
+            )
+        },
     )
 }

--- a/tests/contracts_fail.rs
+++ b/tests/contracts_fail.rs
@@ -127,7 +127,7 @@ fn records_contracts_poly() {
                 (forall b. {a: Num, b: Num ; b} -> { a: Num ; b})
                 -> {a: Num ; a}
                 -> { ; a}
-            = fun f rec => %record_remove% \"b\" (%record_remove% \"a\" (f rec)) in
+            = fun f r => %record_remove% \"b\" (%record_remove% \"a\" (f r)) in
         f (fun x => x) {a = 1, b = true, c = 3}"
     );
 }

--- a/tests/free_vars.rs
+++ b/tests/free_vars.rs
@@ -163,3 +163,19 @@ fn nested_records() {
         HashMap::from([("a", vec!["c"]), ("b", vec!["a", "c"]), ("c", vec!["b"]),])
     ));
 }
+
+#[test]
+fn recursive_let() {
+    assert!(check_stat_vars(
+        "{
+          a = let rec b = b + a + h in b,
+          b = let rec a = a + b in f (a + 1) z,
+          c = let rec foo = b in let rec bar = c in if a.r then [b] else {foo = c}
+        }",
+        HashMap::from([
+            ("a", vec!["a"]),
+            ("b", vec!["b"]),
+            ("c", vec!["a", "b", "c"])
+        ])
+    ));
+}

--- a/tests/pass.rs
+++ b/tests/pass.rs
@@ -117,3 +117,8 @@ fn importing() {
 fn overriding() {
     check_file("overriding.ncl");
 }
+
+#[test]
+fn recursive_let() {
+    check_file("recursive_let.ncl");
+}

--- a/tests/pass/contracts.ncl
+++ b/tests/pass/contracts.ncl
@@ -81,7 +81,7 @@ let Assert = fun l x => x || %blame% l in
     (remove (extend {}) == {} | Assert) &&
     (extend (remove {foo = 2}) == {foo =1} | Assert) &&
     (let f | forall a b. {f: a -> a, arg: a ; b} -> a =
-        fun rec => rec.f (rec.arg) in
+        fun r => r.f (r.arg) in
       f { f = fun x => x ++ " suffix", arg = "foo" }
       == "foo suffix"
       | Assert)

--- a/tests/pass/recursive_let.ncl
+++ b/tests/pass/recursive_let.ncl
@@ -1,0 +1,7 @@
+let Assert = fun l x => x || %blame% l in
+
+[
+  let rec f = fun n => if n == 0 then n else f (n - 1) in f 10 == 0,
+  let rec fib = fun n => if n == 0 || n == 1 then 1 else fib (n - 1) + fib (n - 2) in fib 5 == 8,
+]
+|> array.foldl (fun x y => (x | Assert) && y) true

--- a/tests/pass/typechecking.ncl
+++ b/tests/pass/typechecking.ncl
@@ -74,6 +74,15 @@ let typecheck = [
     fun x => switch {`blo => `bla, `ble => `bli, _ => `bla} x in
     f `bli,
 
+  # recursive let bindings
+  let rec f : forall a. a -> Num -> a = fun x n =>
+    if n == 0 then x else if f "0" n == "1" then f x (n - 1) else f x (f 1 n) in
+    (f "0" 2 : Str),
+  let rec f : Num -> Num = fun x => if x == 0 then x else f (x - 1) in
+    (f 10 : Num),
+  let rec repeat : forall a. Num -> a -> Array a = fun n x =>
+    if n <= 0 then [] else repeat (n - 1) x @ [x] in (repeat 3 "foo" : Array Str),
+
   # static records
   ({bla = 1} : {bla : Num}),
   ({blo = true, bla = 1} : {bla : Num, blo : Bool}),

--- a/tests/typecheck_fail.rs
+++ b/tests/typecheck_fail.rs
@@ -230,3 +230,10 @@ fn piecewise_signature() {
         Err(TypecheckError::TypeMismatch(..))
     );
 }
+#[test]
+fn recursive_let() {
+    assert_matches!(
+        type_check_expr("let rec f : Num -> Num = fun x => f \"hoi\" in null"),
+        Err(TypecheckError::TypeMismatch(..))
+    );
+}


### PR DESCRIPTION
Resolves #525. Unfortunately, this PR adds "rec" as a keyword, meaning that tests that use "rec" as a shorthand for "record" were  changed to use "r" instead.