### PR TITLE
[Fix] Fix panic evaluating switch in non strict mode

### DIFF
--- a/src/eval/mod.rs
+++ b/src/eval/mod.rs
@@ -345,6 +345,7 @@ where
                     stack.push_strictness(enriched_strict);
                 }
                 enriched_strict = true;
+
                 stack.push_arg(
                     Closure {
                         body: t2.clone(),
@@ -383,6 +384,11 @@ where
                 }
             }
             Term::Switch(exp, cases, default) => {
+                if !enriched_strict {
+                    stack.push_strictness(enriched_strict);
+                }
+                enriched_strict = true;
+
                 let has_default = default.is_some();
 
                 if let Some(t) = default {


### PR DESCRIPTION
Closes #689.

The evaluation of a switch is done in two steps:
1. a `Term::Switch` construct is evaluated. The lazy arguments (cases and default) are pushed on the stack, and an `Op1::Switch` applied to the matched expression is generated for the next tick of evaluation.
2. The `Op1(UnaryOp::Switch, exp)` is evaluated, and pops the required lazy arguments from the stack.

The issue was that the evaluation of unary operators (very beginning of step 2) may push a strictness marker AFTER the other args have been pushed. For other operators that is not an issue, because their actual evaluation hasn't started yet, and anything they may add to the stack will come after this marker. But because the switch has this first separate phase, the strictness marker comes on top of those args, while the implementation expects to pop arguments directly from the top of the stack.

This PR pushes the strictness marker before pushing the arguments of switch, in step 1., leading to the correct nesting of stack markers.