### PR TITLE
[Fix] Typing of stdlib items annotated with a contract

### DIFF
--- a/tests/pass/typechecking.ncl
+++ b/tests/pass/typechecking.ncl
@@ -189,6 +189,7 @@ let typecheck = [
   string.length : Str -> Num,
   (string.length "Ok") : Num,
   (string.length "Ok" == 2) : Bool,
+
   # partial application
   (string.split ".") : Str -> Array Str,
   (array.length [] == 0) : Bool,
@@ -197,7 +198,12 @@ let typecheck = [
   # wildcards
   ("hello" : _) : Str,
   ((fun x => x + 1) : _ -> Num) : Num -> Num,
-  ({"foo" = 1} : {foo : _}) : {foo: Num}
+  ({"foo" = 1} : {foo : _}) : {foo: Num},
+
+  # Regression test for #700 (https://github.com/tweag/nickel/issues/700)
+  # The (| ExportFormat) cast is only temporary, and can be removed once #671
+  # (https://github.com/tweag/nickel/issues/671) is closed
+  (record.update "foo" 5 {foo = 1}) : {_: Num},
 ] in
 
 true


### PR DESCRIPTION
Fix #700. However, require a fix to #701 which currently causes tests to fail (and any meaningful test that we can think of, unfortunately, will have the same issue) before getting green CI and being mergeable.