### PR TITLE
Fix the format of records printed by the REPL

### DIFF
--- a/src/term.rs
+++ b/src/term.rs
@@ -525,7 +525,7 @@ impl Term {
                     _ => "",
                 };
 
-                format!("{{ {}{}}}", fields_str.join(", "), suffix)
+                format!("{{ {}{} }}", fields_str.join(", "), suffix)
             }
             Term::Array(elements) => {
                 let elements_str: Vec<String> = elements


### PR DESCRIPTION
Fix the format of records printed by the REPL.

Before:
```sh-session
$ ./target/debug/nickel <<< '{a=1}'
{ a = 1}
```

After:

```sh-session
$ ./target/debug/nickel <<< '{a=1}'
{ a = 1 }
```