### PR TITLE
Fix field without definition assigned null value

### DIFF
--- a/src/eval/mod.rs
+++ b/src/eval/mod.rs
@@ -276,7 +276,7 @@ where
 ///
 /// # Arguments
 ///
-/// - `t0`: the term to evaluate
+/// - `clos`: the closure to evaluate
 /// - `global_env`: the global environment containing the builtin functions of the language. Accessible from anywhere in the
 /// program.
 /// - `resolver`: the interface to fetch imports.
@@ -562,7 +562,7 @@ where
             Term::MetaValue(meta) if enriched_strict => {
                 if meta.value.is_some() {
                     /* Since we are forcing a metavalue, we are morally evaluating `force t` rather
-                     * than `t` iteself.  Updating a thunk after having performed this forcing may
+                     * than `t` itself. Updating a thunk after having performed this forcing may
                      * alter the semantics of the program in an unexpected way (see issue
                      * https://github.com/tweag/nickel/issues/123): we update potential thunks now
                      * so that their content remains a meta value.

--- a/src/grammar.lalrpop
+++ b/src/grammar.lalrpop
@@ -337,7 +337,7 @@ RecordField: (FieldPath, RichTerm) = {
             if let Some(deft) = t {
                 deft
             } else {
-                RichTerm::new(Term::Null, pos)
+                RichTerm::new(Term::MetaValue(MetaValue::new()), pos)
             }
         };
 

--- a/tests/records_fail.rs
+++ b/tests/records_fail.rs
@@ -49,3 +49,19 @@ fn dynamic_not_recursive() {
         Err(Error::TypecheckError(TypecheckError::UnboundIdentifier(..)))
     );
 }
+
+#[test]
+fn missing_field() {
+    assert_matches!(
+        eval("{foo | Num, bar = foo + 1}.foo"),
+        Err(Error::EvalError(EvalError::MissingFieldDef(..)))
+    );
+    assert_matches!(
+        eval("{foo : Num, bar = foo + 1}.foo"),
+        Err(Error::EvalError(EvalError::MissingFieldDef(..)))
+    );
+    assert_matches!(
+        eval("{foo, bar = foo + 1}.foo"),
+        Err(Error::EvalError(EvalError::MissingFieldDef(..)))
+    )
+}


### PR DESCRIPTION
Fixes #697

When a record field is not given an annotation or a default value, it was previously given `Term::Null`. Here we switch this to an empty `MetaValue`.

Also made a minor revision to the Rust docs in the evaluator.