### PR TITLE
doc: Fix typos

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,7 +38,7 @@ by email, or using any other method with the maintainers of this repository
 The following resources are oriented toward Nickel users:
 
 - The [README](./README.md) and the [design rationale](./RATIONALE.md)
-- The [blog post serie][blog-series] and the [release blog post][blog-release].
+- The [blog post series][blog-series] and the [release blog post][blog-release].
 - The [user manual][user-manual].
 
 For Nickel contributors (or aspiring contributors), the following technical

--- a/RATIONALE.md
+++ b/RATIONALE.md
@@ -123,7 +123,7 @@ In the following example,
 ```
 
 the configuration language has no reason to suspect that `id` and `baseURL`
-contents have been mistakingly swapped. It would need to be aware of the fact
+contents have been mistakenly swapped. It would need to be aware of the fact
 that `id` should be an integer and `baseURL` a string. Surely, an error will
 eventually pop up downstream in the pipeline, but how and when? Will the bug be
 easy to track down if the data has gone through several transformations, inside

--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ to be used in production. The next steps we plan to work on are:
 
 ## Related projects and inspirations
 
-- [Cue](https://cuelang.org/) is a configuration language with a focus on data
+- [CUE](https://cuelang.org/) is a configuration language with a focus on data
     validation. It introduces a new constraint system backed by a solid theory
     which ensures strong guarantees about your code. It allows for very elegant
     schema specifications. In return, the cost to pay is to abandon functions

--- a/doc/manual/contracts.md
+++ b/doc/manual/contracts.md
@@ -102,7 +102,7 @@ Our contract is simple: in the end, it tests the condition `value == "foo"`.
 Unfortunately, it has a few cascading ifs that don't look very nice. This is a
 necessary evil if you want to provide distinct error messages (`not a string`
 and `not a "foo"`). However, one could argue in this case that the information
-of the contract's name (which is automatically printed for contract violiation
+of the contract's name (which is automatically printed for contract violation
 error, as well as various other data) is enough to understand the error. In this
 case, we can write our contract more succinctly as:
 

--- a/doc/manual/correctness.md
+++ b/doc/manual/correctness.md
@@ -13,7 +13,7 @@ the following properties:
    trying to add a number to a string, or to call to a value which is not a
    function.
 2. The generated configuration is valid. Your program may be correct with
-   respect to the previous point while outputing a field `prto = "80"` instead
+   respect to the previous point while outputting a field `prto = "80"` instead
    of `port = 80`. The consumer of the configuration will probably fail.
    Typically, validity involves respecting a data schema.
 
@@ -208,7 +208,7 @@ function contract for `split` has the following limitations:
 
 #### Using a type annotation
 
-`split` is a generic function operating on builin types. This is a good
+`split` is a generic function operating on builtin types. This is a good
 candidate for static typing, which will help:
 
 - Ensure the property holds for all possible values of the parameter.

--- a/doc/manual/merging.md
+++ b/doc/manual/merging.md
@@ -6,7 +6,7 @@ slug: merging
 
 In Nickel, the basic building blocks for data are records (objects in JSON or
 attribute sets in Nix). Merging is a fundamental built-in operation whose role
-is to combine records togethers. Fields common to several records will be
+is to combine records together. Fields common to several records will be
 themselves recursively merged if possible, following the semantics described in
 this document.
 
@@ -413,7 +413,7 @@ let Port
     value >= 0 &&
     value <= 65535) in
 let GreaterThan
-  | doc "A number greater than the paramater"
+  | doc "A number greater than the parameter"
   = fun x => contract.from_predicate (fun value => value > x) in
 
 {

--- a/doc/manual/syntax.md
+++ b/doc/manual/syntax.md
@@ -116,10 +116,10 @@ Multiline strings are useful to write indented lines. The indentation is strippe
 Example:
 ```
 > m%"
-This line has no identation.
+This line has no indentation.
   This line is indented.
     This line is even more indented.
-This line has no more identation.
+This line has no more indentation.
 "%m
 "This line has no indentation.
   This line is indented.

--- a/doc/manual/typing.md
+++ b/doc/manual/typing.md
@@ -189,8 +189,8 @@ The following type constructors are available:
 
   Example:
   ```nickel
-  let occurences : {_: Num} = {a = 1, b = 3, c = 0} in
-  record.map (fun char count => count + 1) occurences : {_ : Num}
+  let occurrences : {_: Num} = {a = 1, b = 3, c = 0} in
+  record.map (fun char count => count + 1) occurrences : {_ : Num}
   ```
 
 <!-- - **Enum**: `<tag1, .., tagn>`: an enumeration comprised of alternatives `tag1`, -->
@@ -299,7 +299,7 @@ error: Incompatible types
 
 The reason is that **without an explicit polymorphic annotation, the typechecker
 will always infer non-polymorphic types**. If you need polymorphism, you have to
-write a type anntation. Here, `filter` is inferred to be of type `(Num -> Bool)
+write a type annotation. Here, `filter` is inferred to be of type `(Num -> Bool)
 -> Array Num -> Array Num`, guessed from the application in the right hand side of
 `result`.
 
@@ -579,8 +579,8 @@ expression or do anything non-trivial. Typically, replacing `1` with a compound
 expression `0 + 1` changes the type of `x` type to `Dyn` and makes the example
 fail. For now, the typechecker determines an apparent type that is not `Dyn`
 only for literals (numbers, strings, booleans), arrays, variables, imports and
-annotated expressions. Otherwise, the typechecker fallbacks to `Dyn`. It may do
-more in the future (assign `Dyn -> Dyn` to functions, `{_: Dyn}` to records,
+annotated expressions. Otherwise, the typechecker falls back to `Dyn`. It may
+do more in the future (assign `Dyn -> Dyn` to functions, `{_: Dyn}` to records,
 etc).
 
 ### Take-away
@@ -595,7 +595,7 @@ typechecker on, a contract annotation switches it back off.
 
 ## Using contracts as types
 
-<!-- TODO: find a good name for this section. Will need rework after meging
+<!-- TODO: find a good name for this section. Will need rework after merging
 types and contracts syntax -->
 
 Type annotations and contracts share the same syntax. This means that you can

--- a/lsp/README.md
+++ b/lsp/README.md
@@ -47,7 +47,7 @@ the following commands.
 
 ### Using Nix (without flakes)
 
-Alternatively, you can insall `nickel` and `nls` globally on older Nix versions
+Alternatively, you can install `nickel` and `nls` globally on older Nix versions
 without flakes via `nix-env`:
 
 ```

--- a/notes/intersection-and-union-types.md
+++ b/notes/intersection-and-union-types.md
@@ -34,7 +34,7 @@ On the other hand, the advantages and disadvantages of the Keil paper seem to co
  * They have an implementation roughly based on their ideas.
 
 And some cons:
- * Intersections need to be delayed, but Unions don't. So they need to tranform their types into Unions of Intersections of non-Union types.
+ * Intersections need to be delayed, but Unions don't. So they need to transform their types into Unions of Intersections of non-Union types.
 
 
 #### Next steps after Wadler and Keil


### PR DESCRIPTION
As I went through some documentation, I found this project fascinating, and couldn't help but to fix some typos 😅

I didn't check all the files, but went through a bunch of markdowns. I stuck with just updating typos for now, as I'm yet to go through all the documentation. If any wording or phrase change can make the documentation clearer for a newbie like myself, I'll follow up with a separate PR 👍
