### PR TITLE
bench stdlib typechecking

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,3 +101,7 @@ harness = false
 [[bench]]
 name = "mantis"
 harness = false
+
+[[bench]]
+name = "stdlib"
+harness = false

--- a/benches/stdlib.rs
+++ b/benches/stdlib.rs
@@ -1,0 +1,24 @@
+use criterion::{criterion_group, criterion_main, Criterion};
+use pprof::criterion::{Output, PProfProfiler};
+
+use nickel_lang::cache::Cache;
+
+pub fn typecheck_stdlib(c: &mut Criterion) {
+    let mut cache = Cache::new();
+    cache.load_stdlib().unwrap();
+    let type_env = cache.mk_types_env().unwrap();
+    c.bench_function("typecheck stdlib", |b| {
+        b.iter_batched(
+            || cache.clone(),
+            |mut c_local| c_local.typecheck_stdlib_(&type_env).unwrap(),
+            criterion::BatchSize::LargeInput,
+        )
+    });
+}
+
+criterion_group!(
+name = benches;
+config = Criterion::default().with_profiler(PProfProfiler::new(100, Output::Flamegraph(None)));
+targets = typecheck_stdlib
+);
+criterion_main!(benches);

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -802,14 +802,22 @@ impl Cache {
         // 1. The stdlib is meant to stay relatively light.
         // 2. Typechecking the standard library ought to occur only during development. Once the
         //    stdlib is stable, we won't have typecheck it at every execution.
+        let global_env = self.mk_types_env().map_err(|err| match err {
+            CacheError::NotParsed => CacheError::NotParsed,
+            CacheError::Error(_) => unreachable!(),
+        })?;
+        self.typecheck_stdlib_(&global_env)
+    }
+
+    /// Internal function to typecheck stdlib. Has to be public because it's used in benches.
+    pub fn typecheck_stdlib_(
+        &mut self,
+        global_env: &typecheck::Environment,
+    ) -> Result<CacheOp<()>, CacheError<TypecheckError>> {
         if let Some(ids) = self.stdlib_ids.as_ref().cloned() {
             ids.iter()
                 .try_fold(CacheOp::Cached(()), |cache_op, file_id| {
-                    let global_env = self.mk_types_env().map_err(|err| match err {
-                        CacheError::NotParsed => CacheError::NotParsed,
-                        CacheError::Error(_) => unreachable!(),
-                    })?;
-                    match self.typecheck(*file_id, &global_env)? {
+                    match self.typecheck(*file_id, global_env)? {
                         done @ CacheOp::Done(()) => Ok(done),
                         _ => Ok(cache_op),
                     }

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -809,7 +809,8 @@ impl Cache {
         self.typecheck_stdlib_(&global_env)
     }
 
-    /// Internal function to typecheck stdlib. Has to be public because it's used in benches.
+    /// Typecheck the stdlib, provided the initial typing environment. Has to be public because
+    /// it's used in benches. It probably does not have to be used for something else.
     pub fn typecheck_stdlib_(
         &mut self,
         global_env: &typecheck::Environment,


### PR DESCRIPTION
As part of the intent to bench the typechecker, this PR add a bench of stdlib.
It should as possible only bench the typechecking phase and not the previous ones (loading and parsing).