### PR TITLE
[Bench] add generate benchmark without Contracts.

### DIFF
--- a/benches/arrays.rs
+++ b/benches/arrays.rs
@@ -74,10 +74,17 @@ config = Criterion::default().with_profiler(PProfProfiler::new(100, Output::Flam
     }, {
         name = "generate normal 50",
         path = "arrays/generate",
+        subtest = "checked",
+        args = (50),
+    }, {
+        name = "generate normal unchecked 50",
+        path = "arrays/generate",
+        subtest = "unchecked",
         args = (50),
     }, {
         name = "generate deepseq 30",
         path = "arrays/generate",
+        subtest = "checked",
         args = (30),
         eval_mode = EvalMode::DeepSeq,
     }, {

--- a/benches/arrays/generate.ncl
+++ b/benches/arrays/generate.ncl
@@ -1,9 +1,18 @@
 let g = fun n => n*2 + 5 in
 {
-  generate | forall a. Num -> (Num -> a) -> Array a = fun n g =>
-    if n == 0 then []
-    else generate (n - 1) g @ [g n],
+  unchecked = {
+    generate = fun n g =>
+      if n == 0 then []
+      else generate (n - 1) g @ [g n],
 
-  run = fun n =>
-    generate n g,
+    run = fun n => generate n g,
+  },
+  checked = {
+    generate_with_contract | forall a. Num -> (Num -> a) -> Array a = fun n g =>
+      if n == 0 then []
+      else generate_with_contract (n - 1) g @ [g n],
+
+    run = fun n =>
+      generate_with_contract n g,
+  },
 }


### PR DESCRIPTION
More than double the time spent on the `generate normal 50` benchmark seems to be spent on contract checking. Hence this benchmark could be useful for isolating concerns.