### PR TITLE
Reduce redundant closurizing when concatenating Arrays. 

### DIFF
--- a/src/eval/merge.rs
+++ b/src/eval/merge.rs
@@ -227,8 +227,7 @@ pub fn merge(
             if arr1.is_empty() && arr2.is_empty() =>
         {
             Ok(Closure::atomic_closure(RichTerm::new(
-                // TODO: investigate if we should choose attr2 here.
-                Term::Array(arr1, attrs1),
+                Term::Array(arr1, ArrayAttrs { closurized: true }),
                 pos_op.into_inherited(),
             )))
         }

--- a/src/eval/merge.rs
+++ b/src/eval/merge.rs
@@ -223,9 +223,15 @@ pub fn merge(
                 ))
             }
         }
-        (Term::Array(arr1), Term::Array(arr2)) if arr1.is_empty() && arr2.is_empty() => Ok(
-            Closure::atomic_closure(RichTerm::new(Term::Array(arr1), pos_op.into_inherited())),
-        ),
+        (Term::Array(arr1, attrs1), Term::Array(arr2, _attrs2))
+            if arr1.is_empty() && arr2.is_empty() =>
+        {
+            Ok(Closure::atomic_closure(RichTerm::new(
+                // TODO: investigate if we should choose attr2 here.
+                Term::Array(arr1, attrs1),
+                pos_op.into_inherited(),
+            )))
+        }
         (Term::MetaValue(meta1), Term::MetaValue(meta2)) => {
             // For now, we blindly closurize things and copy environments in this section. A
             // careful analysis would make it possible to spare a few closurize operations and more

--- a/src/eval/operation.rs
+++ b/src/eval/operation.rs
@@ -543,8 +543,6 @@ fn process_unary_operation(
                             .collect();
 
                         Ok(Closure {
-                            // TODO: as we've just mapped closurize over the
-                            // array, this should be closurized?
                             body: RichTerm::new(Term::Array(ts, ArrayAttrs { closurized: true }), pos_op_inh),
                             env: shared_env,
                         })
@@ -1739,14 +1737,14 @@ fn process_binary_operation(
         BinaryOp::ArrayConcat() => match_sharedterm! {t1, with {
                 Term::Array(ts1, attrs1) => match_sharedterm! {t2, with {
                         Term::Array(ts2, attrs2) => {
-                            let mut ts: Vec<RichTerm> = Vec::with_capacity(ts1.len() + ts2.len());
-
                             // NOTE: the [eval_closure] function in [eval] should've made sure
                             // that the array is closurized. We leave a debug_assert! here just
                             // in case something goes wrong in the future.
                             // If the assert failed, you may need to map closurize over `ts1` and `ts2`.
                             debug_assert!(attrs1.closurized, "the left-hand side of ArrayConcat (@) is not closurized.");
                             debug_assert!(attrs2.closurized, "the right-hand side of ArrayConcat (@) is not closurized.");
+
+                            let mut ts: Vec<RichTerm> = Vec::with_capacity(ts1.len() + ts2.len());
 
                             ts.extend(ts1.into_iter());
                             ts.extend(ts2.into_iter());

--- a/src/eval/operation.rs
+++ b/src/eval/operation.rs
@@ -487,9 +487,7 @@ fn process_unary_operation(
                     fields.sort();
                     let terms = fields.into_iter().map(mk_term::string).collect();
                     Ok(Closure::atomic_closure(RichTerm::new(
-                        // TODO: Since the array elements are simply Strings and
-                        // can't contain symbols this should be closurized?
-                        Term::Array(terms, Default::default()),
+                        Term::Array(terms, ArrayAttrs { closurized: true }),
                         pos_op_inh,
                     )))
                 }
@@ -511,7 +509,6 @@ fn process_unary_operation(
                     values.sort_by(|(id1, _), (id2, _)| id1.cmp(id2));
                     let terms = values.into_iter().map(|(_, t)| t).collect();
                     Ok(Closure {
-                        // TODO: see if we can assume this is closurized.
                         body: RichTerm::new(Term::Array(terms, Default::default()), pos_op_inh),
                         env,
                     })
@@ -548,7 +545,7 @@ fn process_unary_operation(
                         Ok(Closure {
                             // TODO: as we've just mapped closurize over the
                             // array, this should be closurized?
-                            body: RichTerm::new(Term::Array(ts, Default::default()), pos_op_inh),
+                            body: RichTerm::new(Term::Array(ts, ArrayAttrs { closurized: true }), pos_op_inh),
                             env: shared_env,
                         })
                     }
@@ -593,9 +590,7 @@ fn process_unary_operation(
 
                     Ok(Closure {
                         body: RichTerm::new(
-                            // TODO: as we've just mapped closurize over the
-                            // array, this should be closurized?
-                            Term::Array(ts, Default::default()),
+                            Term::Array(ts, ArrayAttrs { closurized: true }),
                             pos_op_inh,
                         ),
                         env: shared_env,
@@ -837,9 +832,7 @@ fn process_unary_operation(
                     .map(|c| RichTerm::from(Term::Str(c.to_string())))
                     .collect();
                 Ok(Closure::atomic_closure(RichTerm::new(
-                    // TODO: Since the array elements are simply Strings and
-                    // can't contain symbols this should be closurized?
-                    Term::Array(ts, Default::default()),
+                    Term::Array(ts, ArrayAttrs { closurized: true }),
                     pos_op_inh,
                 )))
             } else {
@@ -1759,7 +1752,7 @@ fn process_binary_operation(
                             ts.extend(ts2.into_iter());
 
                             let mut env = env1.clone();
-                            // TODO: investigate if this is sound?
+                            // TODO: Is there a cheaper way to "merge" two environements?
                             env.extend(env2.iter_elems().map(|(k, v)| (k.clone(), v.clone())));
 
                             Ok(Closure {
@@ -2002,9 +1995,7 @@ fn process_binary_operation(
                     .map(|s| Term::Str(String::from(s)).into())
                     .collect();
                 Ok(Closure::atomic_closure(RichTerm::new(
-                    // TODO: Since the array elements are simply Strings and
-                    // can't contain symbols this should be closurized?
-                    Term::Array(array, Default::default()),
+                    Term::Array(array, ArrayAttrs { closurized: true }),
                     pos_op_inh,
                 )))
             }
@@ -2101,9 +2092,10 @@ fn process_binary_operation(
                         mk_record!(
                             ("match", Term::Str(String::from(first_match.as_str()))),
                             ("index", Term::Num(first_match.start() as f64)),
-                            // TODO: Since the array elements are simply Strings and
-                            // can't contain symbols this should be closurized?
-                            ("groups", Term::Array(groups, Default::default()))
+                            (
+                                "groups",
+                                Term::Array(groups, ArrayAttrs { closurized: true })
+                            )
                         )
                     } else {
                         //FIXME: what should we return when there's no match?

--- a/src/eval/operation.rs
+++ b/src/eval/operation.rs
@@ -509,6 +509,8 @@ fn process_unary_operation(
                     values.sort_by(|(id1, _), (id2, _)| id1.cmp(id2));
                     let terms = values.into_iter().map(|(_, t)| t).collect();
                     Ok(Closure {
+                        // TODO: once sure that the Record is properly closurized, we can
+                        // safely assume that the extracted array here is, in turn, also closuried.
                         body: RichTerm::new(Term::Array(terms, Default::default()), pos_op_inh),
                         env,
                     })

--- a/src/eval/operation.rs
+++ b/src/eval/operation.rs
@@ -21,7 +21,7 @@ use crate::{
     position::TermPos,
     serialize,
     serialize::ExportFormat,
-    term::make as mk_term,
+    term::{make as mk_term, ArrayAttrs},
     term::{BinaryOp, NAryOp, RichTerm, StrChunk, Term, UnaryOp},
     transform::Closurizable,
 };
@@ -487,7 +487,9 @@ fn process_unary_operation(
                     fields.sort();
                     let terms = fields.into_iter().map(mk_term::string).collect();
                     Ok(Closure::atomic_closure(RichTerm::new(
-                        Term::Array(terms),
+                        // TODO: Since the array elements are simply Strings and
+                        // can't contain symbols this should be closurized?
+                        Term::Array(terms, Default::default()),
                         pos_op_inh,
                     )))
                 }
@@ -509,7 +511,8 @@ fn process_unary_operation(
                     values.sort_by(|(id1, _), (id2, _)| id1.cmp(id2));
                     let terms = values.into_iter().map(|(_, t)| t).collect();
                     Ok(Closure {
-                        body: RichTerm::new(Term::Array(terms), pos_op_inh),
+                        // TODO: see if we can assume this is closurized.
+                        body: RichTerm::new(Term::Array(terms, Default::default()), pos_op_inh),
                         env,
                     })
                 }
@@ -527,7 +530,7 @@ fn process_unary_operation(
                 .pop_arg()
                 .ok_or_else(|| EvalError::NotEnoughArgs(2, String::from("map"), pos_op))?;
             match_sharedterm! {t, with {
-                    Term::Array(ts) => {
+                    Term::Array(ts, _) => {
                         let mut shared_env = Environment::new();
                         let f_as_var = f.body.closurize(&mut env, f.env);
 
@@ -543,7 +546,9 @@ fn process_unary_operation(
                             .collect();
 
                         Ok(Closure {
-                            body: RichTerm::new(Term::Array(ts), pos_op_inh),
+                            // TODO: as we've just mapped closurize over the
+                            // array, this should be closurized?
+                            body: RichTerm::new(Term::Array(ts, Default::default()), pos_op_inh),
                             env: shared_env,
                         })
                     }
@@ -587,7 +592,12 @@ fn process_unary_operation(
                         .collect();
 
                     Ok(Closure {
-                        body: RichTerm::new(Term::Array(ts), pos_op_inh),
+                        body: RichTerm::new(
+                            // TODO: as we've just mapped closurize over the
+                            // array, this should be closurized?
+                            Term::Array(ts, Default::default()),
+                            pos_op_inh,
+                        ),
                         env: shared_env,
                     })
                 }
@@ -690,7 +700,7 @@ fn process_unary_operation(
                     });
                     Ok(seq_terms(terms, env, pos_op))
                 }
-                Term::Array(ts) if !ts.is_empty() => {
+                Term::Array(ts, _) if !ts.is_empty() => {
                     Ok(seq_terms(ts.into_iter().map(|t| (None, t)), env, pos_op))
                 }
                 _ => {
@@ -703,7 +713,7 @@ fn process_unary_operation(
             }
         }
         UnaryOp::ArrayHead() => {
-            if let Term::Array(ts) = &*t {
+            if let Term::Array(ts, _) = &*t {
                 if let Some(head) = ts.first() {
                     Ok(Closure {
                         body: head.clone(),
@@ -722,11 +732,11 @@ fn process_unary_operation(
             }
         }
         UnaryOp::ArrayTail() => match_sharedterm! {t, with {
-                    Term::Array(ts) => {
+                    Term::Array(ts, attrs) => {
                         let mut ts_it = ts.into_iter();
                         if ts_it.next().is_some() {
                             Ok(Closure {
-                                body: RichTerm::new(Term::Array(ts_it.collect()), pos_op_inh),
+                                body: RichTerm::new(Term::Array(ts_it.collect(), attrs), pos_op_inh),
                                 env,
                             })
                         } else {
@@ -743,7 +753,7 @@ fn process_unary_operation(
                 }
         },
         UnaryOp::ArrayLength() => {
-            if let Term::Array(ts) = &*t {
+            if let Term::Array(ts, _) = &*t {
                 // A num does not have any free variable so we can drop the environment
                 Ok(Closure {
                     body: RichTerm::new(Term::Num(ts.len() as f64), pos_op_inh),
@@ -827,7 +837,9 @@ fn process_unary_operation(
                     .map(|c| RichTerm::from(Term::Str(c.to_string())))
                     .collect();
                 Ok(Closure::atomic_closure(RichTerm::new(
-                    Term::Array(ts),
+                    // TODO: Since the array elements are simply Strings and
+                    // can't contain symbols this should be closurized?
+                    Term::Array(ts, Default::default()),
                     pos_op_inh,
                 )))
             } else {
@@ -1732,21 +1744,26 @@ fn process_binary_operation(
             }
         },
         BinaryOp::ArrayConcat() => match_sharedterm! {t1, with {
-                Term::Array(ts1) => match_sharedterm! {t2, with {
-                        Term::Array(ts2) => {
-                            let mut env = Environment::new();
+                Term::Array(ts1, attrs1) => match_sharedterm! {t2, with {
+                        Term::Array(ts2, attrs2) => {
                             let mut ts: Vec<RichTerm> = Vec::with_capacity(ts1.len() + ts2.len());
-                            ts.extend(
-                                ts1.into_iter()
-                                    .map(|t| t.closurize(&mut env, env1.clone())),
-                            );
-                            ts.extend(
-                                ts2.into_iter()
-                                    .map(|t| t.closurize(&mut env, env2.clone())),
-                            );
+
+                            // NOTE: the [eval_closure] function in [eval] should've made sure
+                            // that the array is closurized. We leave a debug_assert! here just
+                            // in case something goes wrong in the future.
+                            // If the assert failed, you may need to map closurize over `ts1` and `ts2`.
+                            debug_assert!(attrs1.closurized, "the left-hand side of ArrayConcat (@) is not closurized.");
+                            debug_assert!(attrs2.closurized, "the right-hand side of ArrayConcat (@) is not closurized.");
+
+                            ts.extend(ts1.into_iter());
+                            ts.extend(ts2.into_iter());
+
+                            let mut env = env1.clone();
+                            // TODO: investigate if this is sound?
+                            env.extend(env2.iter_elems().map(|(k, v)| (k.clone(), v.clone())));
 
                             Ok(Closure {
-                                body: RichTerm::new(Term::Array(ts), pos_op_inh),
+                                body: RichTerm::new(Term::Array(ts, ArrayAttrs { closurized: true }), pos_op_inh),
                                 env,
                             })
                         }
@@ -1776,7 +1793,7 @@ fn process_binary_operation(
             }
         },
         BinaryOp::ArrayElemAt() => match (&*t1, &*t2) {
-            (Term::Array(ts), Term::Num(n)) => {
+            (Term::Array(ts, _), Term::Num(n)) => {
                 let n_int = *n as usize;
                 if n.fract() != 0.0 {
                     Err(EvalError::Other(format!("elemAt: expected the 2nd agument to be an integer, got the floating-point value {}", n), pos_op))
@@ -1789,7 +1806,7 @@ fn process_binary_operation(
                     })
                 }
             }
-            (Term::Array(_), _) => Err(EvalError::TypeError(
+            (Term::Array(..), _) => Err(EvalError::TypeError(
                 String::from("Num"),
                 String::from("elemAt, 2nd argument"),
                 snd_pos,
@@ -1985,7 +2002,9 @@ fn process_binary_operation(
                     .map(|s| Term::Str(String::from(s)).into())
                     .collect();
                 Ok(Closure::atomic_closure(RichTerm::new(
-                    Term::Array(array),
+                    // TODO: Since the array elements are simply Strings and
+                    // can't contain symbols this should be closurized?
+                    Term::Array(array, Default::default()),
                     pos_op_inh,
                 )))
             }
@@ -2082,14 +2101,16 @@ fn process_binary_operation(
                         mk_record!(
                             ("match", Term::Str(String::from(first_match.as_str()))),
                             ("index", Term::Num(first_match.start() as f64)),
-                            ("groups", Term::Array(groups))
+                            // TODO: Since the array elements are simply Strings and
+                            // can't contain symbols this should be closurized?
+                            ("groups", Term::Array(groups, Default::default()))
                         )
                     } else {
                         //FIXME: what should we return when there's no match?
                         mk_record!(
                             ("match", Term::Str(String::new())),
                             ("index", Term::Num(-1.)),
-                            ("groups", Term::Array(Vec::new()))
+                            ("groups", Term::Array(Vec::new(), Default::default()))
                         )
                     };
 
@@ -2378,7 +2399,7 @@ fn eq(env: &mut Environment, c1: Closure, c2: Closure) -> EqResult {
                 gen_eqs(eqs, env, env1, env2)
             }
         }
-        (Term::Array(l1), Term::Array(l2)) if l1.len() == l2.len() => {
+        (Term::Array(l1, _), Term::Array(l2, _)) if l1.len() == l2.len() => {
             // Equalities are tested in reverse order, but that shouldn't matter. If it
             // does, just do `eqs.rev()`
             let eqs = l1.into_iter().zip(l2.into_iter());

--- a/src/grammar.lalrpop
+++ b/src/grammar.lalrpop
@@ -317,7 +317,7 @@ Atom: UniTerm = {
         let terms : Vec<RichTerm> = terms.into_iter()
             .chain(last.into_iter()).collect();
 
-        UniTerm::from(Term::Array(terms))
+        UniTerm::from(Term::Array(terms, Default::default()))
     },
     AsUniTerm<TypeAtom>,
 };

--- a/src/pretty.rs
+++ b/src/pretty.rs
@@ -576,7 +576,8 @@ where
                 )
                 .append(allocator.space())
                 .append(allocator.atom(tst)),
-            Array(fields) => allocator
+            Array(fields, _) => allocator
+                // NOTE: the Array attributes are ignored here.
                 .line()
                 .append(allocator.intersperse(
                     fields.iter().map(|rt| rt.to_owned().pretty(allocator)),

--- a/src/program.rs
+++ b/src/program.rs
@@ -403,8 +403,20 @@ mod tests {
         let mut expd = parse("[2, \"ab\", [1, [3]]]").unwrap();
 
         // Strings are parsed as StrChunks, but evaluated to Str, so we need to hack the array a bit
-        if let Term::Array(ref mut data) = SharedTerm::make_mut(&mut expd.term) {
+        // The evaluator will change the attributes so we neeed to anticipate that too.
+        if let Term::Array(ref mut data, ref mut attrs) = SharedTerm::make_mut(&mut expd.term) {
             *data.get_mut(1).unwrap() = mk_term::string("ab");
+            attrs.closurized = true;
+            if let Term::Array(data, attrs) =
+                SharedTerm::make_mut(&mut data.get_mut(2).unwrap().term)
+            {
+                attrs.closurized = true;
+                if let Term::Array(_, attrs) =
+                    SharedTerm::make_mut(&mut data.get_mut(1).unwrap().term)
+                {
+                    attrs.closurized = true;
+                }
+            }
         } else {
             panic!();
         }

--- a/src/term.rs
+++ b/src/term.rs
@@ -186,7 +186,10 @@ impl Default for BindingType {
 /// The attributes of an Array.
 #[derive(Debug, Default, Eq, PartialEq, Copy, Clone)]
 pub struct ArrayAttrs {
-    /// This is `true` when all of the array's elements are closurized.
+    /// A `closurized` array verifies the following conditions:
+    ///   - Each element is a generated variable with a unique name (although the same
+    ///     variable can occur in several places, it should always refer to the same thunk anyway).
+    ///   - The environment of the array's closure only contains those generated variables.
     pub closurized: bool,
 }
 

--- a/src/transform/free_vars.rs
+++ b/src/transform/free_vars.rs
@@ -143,7 +143,7 @@ fn collect_free_vars(rt: &mut RichTerm, free_vars: &mut HashSet<Ident>) {
             // case.
             *deps = Some(new_deps);
         }
-        Term::Array(ts) => {
+        Term::Array(ts, _) => {
             for t in ts {
                 collect_free_vars(t, free_vars);
             }

--- a/src/transform/share_normal_form.rs
+++ b/src/transform/share_normal_form.rs
@@ -139,7 +139,7 @@ pub fn transform_one(rt: RichTerm) -> RichTerm {
 
                 with_bindings(Term::RecRecord(map, dyn_fields, attrs, deps), bindings, pos)
             },
-            Term::Array(ts) => {
+            Term::Array(ts, attrs) => {
                 let mut bindings = Vec::with_capacity(ts.len());
 
                 let ts = ts
@@ -156,7 +156,7 @@ pub fn transform_one(rt: RichTerm) -> RichTerm {
                     })
                     .collect();
 
-                with_bindings(Term::Array(ts), bindings, pos)
+                with_bindings(Term::Array(ts, attrs), bindings, pos)
             },
             Term::MetaValue(meta) if meta.value.as_ref().map(|t| should_share(&t.term)).unwrap_or(false) => {
                     let mut meta = meta;

--- a/src/typecheck/mod.rs
+++ b/src/typecheck/mod.rs
@@ -366,7 +366,7 @@ fn type_check_<L: Linearizer>(
             unify(state, strict, ty, arr).map_err(|err| err.into_typecheck_err(state, rt.pos))?;
             type_check_(state, envs, lin, linearizer, strict, t, trg)
         }
-        Term::Array(terms) => {
+        Term::Array(terms, _) => {
             let ty_elts = state.table.fresh_unif_var();
 
             unify(state, strict, ty, mk_typewrapper::array(ty_elts.clone()))
@@ -817,7 +817,7 @@ pub fn apparent_type(
         Term::Bool(_) => ApparentType::Inferred(Types(AbsType::Bool())),
         Term::Sym(_) => ApparentType::Inferred(Types(AbsType::Sym())),
         Term::Str(_) | Term::StrChunks(_) => ApparentType::Inferred(Types(AbsType::Str())),
-        Term::Array(_) => {
+        Term::Array(..) => {
             ApparentType::Approximated(Types(AbsType::Array(Box::new(Types(AbsType::Dyn())))))
         }
         Term::Var(id) => envs


### PR DESCRIPTION
The important bit is the match arm in `eval::eval_closure` which uses a new attribute set in `Array` terms to remember when an array was closurized. This is then exploited in the `ArrayConcat` operation to avoid needlessly calling `closurize` on expressions of the form `a1 @ a2 @ ... @ an`.

In order to preserve (de)serialization of Arrays we need custom implementations like those of `Num` and `Record`; this is because `serde` will simply insert the extra attributes in the output and expect them in the input even though, in this case, they are just implementation details.

And because of this, testing is a bit more involved, for example the `evaluation_full` test initially failed for me because it compared equality of a parsing result (not closurized) to full evaluation result (closurized). If we write more of these kinds of tests, we may need some helper functions for this.