### PR TITLE
[Fix] Typechecking with parse errors

### DIFF
--- a/lsp/nls/src/files.rs
+++ b/lsp/nls/src/files.rs
@@ -82,7 +82,7 @@ fn typecheck(server: &mut Server, file_id: FileId) -> Result<CacheOp<()>, Vec<Di
 fn parse_and_typecheck(server: &mut Server, uri: Url, file_id: FileId) -> Result<()> {
     let diagnostics = server
         .cache
-        .parse(file_id)
+        .parse_lax(file_id)
         .map_err(|parse_err| parse_err.to_diagnostic(server.cache.files_mut(), None))
         .map(|parse_errs| {
             // Parse errors are not fatal

--- a/src/bin/nickel.rs
+++ b/src/bin/nickel.rs
@@ -139,7 +139,7 @@ fn main() {
                     query_print::write_query_result(&mut std::io::stdout(), &term, attrs).unwrap()
                 })
             }
-            Some(Command::Typecheck) => program.typecheck().map(|_| ()),
+            Some(Command::Typecheck) => program.typecheck(),
             Some(Command::Repl { .. }) => unreachable!(),
             #[cfg(feature = "doc")]
             Some(Command::Doc { .. }) => program.output_doc(),

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -62,7 +62,10 @@ impl grammar::ExtendedTermParser {
 }
 
 impl grammar::TermParser {
-    pub fn parse_term_tolerant(
+    /// Parse a term from a token stream in an error tolerant way: parse errors are accumulated and
+    /// returned, instead of returning an error. The `Err` variant corresponds to a non-recoverable
+    /// error.
+    pub fn parse_term_lax(
         &self,
         file_id: FileId,
         lexer: lexer::Lexer,
@@ -84,7 +87,7 @@ impl grammar::TermParser {
         file_id: FileId,
         lexer: lexer::Lexer,
     ) -> Result<RichTerm, ParseErrors> {
-        match self.parse_term_tolerant(file_id, lexer) {
+        match self.parse_term_lax(file_id, lexer) {
             Ok((t, e)) if e.no_errors() => Ok(t),
             Ok((_, e)) => Err(e),
             Err(e) => Err(e.into()),

--- a/src/program.rs
+++ b/src/program.rs
@@ -395,6 +395,18 @@ mod tests {
         p.eval_full()
     }
 
+    fn typecheck(s: &str) -> Result<(), Error> {
+        let src = Cursor::new(s);
+
+        let mut p = Program::new_from_source(src, "<test>").map_err(|io_err| {
+            Error::EvalError(EvalError::Other(
+                format!("IO error: {}", io_err),
+                TermPos::None,
+            ))
+        })?;
+        p.typecheck()
+    }
+
     #[test]
     fn evaluation_full() {
         use crate::mk_record;
@@ -437,5 +449,15 @@ mod tests {
         // example would go into an infinite loop, and stack overflow. If it does, this just means
         // that this test fails.
         eval_full("{y = fun x => x, x = fun y => y}").unwrap();
+    }
+
+    #[test]
+    // Regression test for issue 715 (https://github.com/tweag/nickel/issues/715)
+    // Check that program::typecheck() fail on parse error
+    fn typecheck_invalid_input() {
+        assert_matches!(
+            typecheck("{foo = 1 + `, bar : Str = \"a\"}"),
+            Err(Error::ParseErrors(_))
+        );
     }
 }

--- a/src/program.rs
+++ b/src/program.rs
@@ -369,6 +369,7 @@ mod tests {
     use crate::parser::{grammar, lexer};
     use crate::position::TermPos;
     use crate::term::SharedTerm;
+    use assert_matches::assert_matches;
     use codespan::Files;
     use std::io::Cursor;
 


### PR DESCRIPTION
Fix #715. We had several similar issues, which stemmed from the fact that when error-tolerant parsing was implemented, `parse` has just been made error tolerant, and the responsibility of hard failing on recoverable errors was delegated to each call site. But the only component that needs error tolerance is one call in the LSP, while for all the others, you usually want to fail on parse error, and this additional step has been missing a several times.

To limit future troubles, the current error-tolerant `parse` has been renamed to `parse_lax`, and `parse` is a strict wrapper that fails when errors are encountered. In other word, error-tolerance is now opt-in in after PR, while it was the default before.