### PR TITLE
Use `Environment::disjoin_union` instead of reconstructing environments

### DIFF
--- a/src/eval/operation.rs
+++ b/src/eval/operation.rs
@@ -1751,13 +1751,11 @@ fn process_binary_operation(
                             ts.extend(ts1.into_iter());
                             ts.extend(ts2.into_iter());
 
-                            let mut env = env1.clone();
-                            // TODO: Is there a cheaper way to "merge" two environements?
-                            env.extend(env2.iter_elems().map(|(k, v)| (k.clone(), v.clone())));
+                            let env = Environment::disjoint_union(&env1, &env2);
 
                             Ok(Closure {
                                 body: RichTerm::new(Term::Array(ts, ArrayAttrs { closurized: true }), pos_op_inh),
-                                env,
+                                env
                             })
                         }
                     } else {


### PR DESCRIPTION
The `disjoint_union` method recursively .. joins two environments by interleaving their HashMaps. In the worst cases this produces bloated environments but in the best cases it helps avoid reconstructing a new environment by copying elements to it.

A `debug_assert` verifying the disjoint nature would be a good idea at this point.

Using the unit tests and a hacky elapsed time measurement to compare this against the existing implementation yields:

```
extend took 17.003µs
disjoint_union took 4.2µs

extend took 109.418µs
disjoint_union took 4.628µs

extend took 7.598µs
disjoint_union took 3.541µs

extend took 15.054µs
disjoint_union took 3.003µs

extend took 15.438µs
disjoint_union took 4.023µs

extend took 12.13µs
disjoint_union took 2.965µs
```

Clearly handling environment layers is more efficient than moving around elements themselves. Still have to look into how this impacts the wider codebase. 