### PR TITLE
WIP: reduce closurization calls in record merging

### DIFF
--- a/src/destruct.rs
+++ b/src/destruct.rs
@@ -65,7 +65,10 @@ impl Destruct {
                             .into_iter()
                             .map(|m| m.as_meta_field())
                             .collect(),
-                        RecordAttrs { open },
+                        RecordAttrs {
+                            open,
+                            closurized: false,
+                        },
                     )
                     .into(),
                 )),

--- a/src/grammar.lalrpop
+++ b/src/grammar.lalrpop
@@ -281,7 +281,7 @@ UniRecord: UniRecord = {
         let (last_field, attrs) = match last {
             Some(RecordLastField::Field(f)) => (Some(f), Default::default()),
             Some(RecordLastField::Ellipsis) =>
-                (None, RecordAttrs { open: true }),
+                (None, RecordAttrs { open: true, closurized: false }),
             None => (None, Default::default())
         };
 

--- a/src/program.rs
+++ b/src/program.rs
@@ -425,10 +425,14 @@ mod tests {
 
         let t = eval_full("let x = 1 in let y = 1 + x in let z = {foo.bar.baz = y} in z").unwrap();
         // Records are parsed as RecRecords, so we need to build one by hand
-        let expd = mk_record!((
-            "foo",
-            mk_record!(("bar", mk_record!(("baz", Term::Num(2.0)))))
-        ));
+        let mut foo = mk_record!(("bar", mk_record!(("baz", Term::Num(2.0)))));
+        if let Term::Record(_, ref mut attrs) = SharedTerm::make_mut(&mut foo.term) {
+            attrs.closurized = true;
+        }
+        let mut expd = mk_record!(("foo", foo));
+        if let Term::Record(_, ref mut attrs) = SharedTerm::make_mut(&mut expd.term) {
+            attrs.closurized = true;
+        }
         assert_eq!(t.without_pos(), expd);
 
         // /!\ [MAY OVERFLOW STACK]

--- a/src/term.rs
+++ b/src/term.rs
@@ -196,6 +196,11 @@ pub struct ArrayAttrs {
 #[derive(Debug, Default, Eq, PartialEq, Copy, Clone)]
 pub struct RecordAttrs {
     pub open: bool,
+    /// A `closurized` record verifies the following conditions:
+    ///   - Each field value (if it exists) is a generated variable with a unique name
+    ///     (although the same variable can occur in several places, it should always refer to the same thunk anyway).
+    ///   - The environment of the record's closure only contains those generated variables.
+    pub closurized: bool,
 }
 
 /// The attributes of a let binding.
@@ -208,9 +213,13 @@ pub struct LetAttrs {
 }
 
 impl RecordAttrs {
+    /// Merge record attributes.
+    /// - The result is open if either one of the arguments is open.
+    /// - The result is closurized if both arguments are closurized.
     pub fn merge(attrs1: RecordAttrs, attrs2: RecordAttrs) -> RecordAttrs {
         RecordAttrs {
             open: attrs1.open || attrs2.open,
+            closurized: attrs1.closurized && attrs2.closurized,
         }
     }
 }


### PR DESCRIPTION
The current results aren't very impressive. On very particular loads like the following:

```
let rec generate = fun n f =>
  if n == 0 then {}
else generate (n - 1) f & { "%{f n |> string.from_num}" = null }
in
  generate 999 (fun x => x + 1)
```
I can see a speedup of about 30%, but this doesn't transfer well to benches like `mantis`, where the difference is minuscule.

I think that with record-merging, we need to closurize the merged fields to maintain the invariant "all record fields are closurized upon merging", which makes it hard to avoid some of the current calls. It's almost as if the overhead we avoid on `.closurize` calls is reintroduced by the environment manipulation.