### PR TITLE
Avoid recompiling regex in %str_is_match%

### DIFF
--- a/benches/mantis/lib.ncl
+++ b/benches/mantis/lib.ncl
@@ -14,8 +14,9 @@
     Smaller = fun x => contract.from_predicate (fun y => y < x),
     SmallerEq = fun x => contract.from_predicate (fun y => y <= x),
     MatchRegexp = fun regex label value =>
+      let match = string.is_match regex in
       if builtin.is_str value then
-        if string.is_match regex value then
+        if match value then
           value
         else
           contract.blame_with "no match" label

--- a/src/grammar.lalrpop
+++ b/src/grammar.lalrpop
@@ -545,6 +545,8 @@ UOp: UnaryOp = {
     "str_from" => UnaryOp::ToStr(),
     "num_from" => UnaryOp::NumFromStr(),
     "enum_from" => UnaryOp::EnumFromStr(),
+    "str_is_match" => UnaryOp::StrIsMatch(),
+    "str_match" => UnaryOp::StrMatch(),
 };
 
 SwitchCase: SwitchCase = {
@@ -722,8 +724,6 @@ BOpPre: BinaryOp = {
     "pow" => BinaryOp::Pow(),
     "str_split" => BinaryOp::StrSplit(),
     "str_contains" => BinaryOp::StrContains(),
-    "str_match" => BinaryOp::StrMatch(),
-    "str_is_match" => BinaryOp::StrIsMatch(),
     "record_insert" => BinaryOp::DynExtend(),
     "record_remove" => BinaryOp::DynRemove(),
 }

--- a/src/term.rs
+++ b/src/term.rs
@@ -845,6 +845,43 @@ pub enum UnaryOp {
     NumFromStr(),
     /// Transform a string to an enum.
     EnumFromStr(),
+    /// Test if a regex matches a string.
+    /// Like [`StrMatch`], this is a unary operator because we would like a way to share the
+    /// same "compiled regex" for many matching calls. This is done by returning functions
+    /// wrapping [`StrIsMatchCompiled`] and [`StrMatchCompiled`]
+    StrIsMatch(),
+    /// Match a regex on a string, and returns the captured groups together, the index of the
+    /// match, etc.
+    StrMatch(),
+    /// Version of `StrIsMatch` which remembers the compiled regex.
+    StrIsMatchCompiled(CompiledRegex),
+    /// Version of `StrMatch` which remembers the compiled regex.
+    StrMatchCompiled(CompiledRegex),
+}
+
+// See: https://github.com/rust-lang/regex/issues/178
+/// [`regex::Regex`] which implements [`PartialEq`].
+#[derive(Debug, Clone)]
+pub struct CompiledRegex(regex::Regex);
+
+impl PartialEq for CompiledRegex {
+    fn eq(&self, other: &Self) -> bool {
+        self.0.as_str() == other.0.as_str()
+    }
+}
+
+impl Deref for CompiledRegex {
+    type Target = regex::Regex;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl From<regex::Regex> for CompiledRegex {
+    fn from(item: regex::Regex) -> Self {
+        CompiledRegex(item)
+    }
 }
 
 /// position of a unary operator
@@ -943,11 +980,6 @@ pub enum BinaryOp {
     StrSplit(),
     /// Determine if a string is a substring of another one.
     StrContains(),
-    /// Test if a regex matches a string.
-    StrIsMatch(),
-    /// Match a regex on a string, and returns the captured groups together, the index of the
-    /// match, etc.
-    StrMatch(),
 }
 
 impl BinaryOp {

--- a/src/typecheck/operation.rs
+++ b/src/typecheck/operation.rs
@@ -172,6 +172,34 @@ pub fn get_uop_type(
             mk_typewrapper::str(),
             mk_tyw_enum!(mk_typewrapper::dynamic()),
         ),
+        // Str -> Str -> Bool
+        UnaryOp::StrIsMatch() => (
+            mk_typewrapper::str(),
+            mk_tyw_arrow!(mk_typewrapper::str(), mk_typewrapper::bool()),
+        ),
+        // Str -> Str -> {match: Str, index: Num, groups: Array Str}
+        UnaryOp::StrMatch() => (
+            mk_typewrapper::str(),
+            mk_tyw_arrow!(
+                mk_typewrapper::str(),
+                mk_tyw_record!(
+                    ("match", AbsType::Str()),
+                    ("index", AbsType::Num()),
+                    ("groups", mk_typewrapper::array(AbsType::Str()))
+                )
+            ),
+        ),
+        // Str -> Bool
+        UnaryOp::StrIsMatchCompiled(_) => (mk_typewrapper::str(), mk_typewrapper::bool()),
+        // Str -> {match: Str, index: Num, groups: Array Str}
+        UnaryOp::StrMatchCompiled(_) => (
+            mk_typewrapper::str(),
+            mk_tyw_record!(
+                ("match", AbsType::Str()),
+                ("index", AbsType::Num()),
+                ("groups", mk_typewrapper::array(AbsType::Str()))
+            ),
+        ),
     })
 }
 
@@ -333,22 +361,6 @@ pub fn get_bop_type(
             mk_typewrapper::str(),
             mk_typewrapper::str(),
             mk_typewrapper::bool(),
-        ),
-        // Str -> Str -> Bool
-        BinaryOp::StrIsMatch() => (
-            mk_typewrapper::str(),
-            mk_typewrapper::str(),
-            mk_typewrapper::bool(),
-        ),
-        // Str -> Str -> {match: Str, index: Num, groups: Array Str}
-        BinaryOp::StrMatch() => (
-            mk_typewrapper::str(),
-            mk_typewrapper::str(),
-            mk_tyw_record!(
-                ("match", AbsType::Str()),
-                ("index", AbsType::Num()),
-                ("groups", mk_typewrapper::array(AbsType::Str()))
-            ),
         ),
         // Str -> Str -> Array Str
         BinaryOp::StrSplit() => (

--- a/stdlib/string.ncl
+++ b/stdlib/string.ncl
@@ -272,15 +272,33 @@
     | doc m%"
       `is_match regex str` checks if `str` matches `regex`.
 
-      Note that this function may perform better by sharing its partial application between multiple calls,
-      because in this case the underlying regular expression will only be compiled once.
-
       For example:
       ```nickel
         is_match "^\\d+$" "123" =>
           true
         is_match "\\d{4}" "123" =>
           false
+      ```
+
+      For example, in the following program, the whole call to
+      `string.is_match "[0-9]*\\.?[0-9]+ x"` is re-evaluated at each invocation of
+      `is_number`. The regexp will be recompiled 3 times in total:
+
+      ```nickel
+      let is_number = fun x => string.is_match "[0-9]*\\.?[0-9]+" x in
+      ["0", "42", "0.5"] |> array.all is_number =>
+        true
+      ```
+
+      On the other hand, in the version below, the partial application of
+      `string.is_match "[0-9]*\\.?[0-9]+"` is evaluated once, returning a
+      function capturing the compiled regexp. The regexp will only be compiled
+      once and for all:
+
+      ```nickel
+      let is_number' = string.is_match "[0-9]*\\.?[0-9]+" in
+      ["0", "42", "0.5"] |> array.all is_number' =>
+        true
       ```
       "%m
     = fun regex => %str_is_match% regex,
@@ -290,9 +308,6 @@
       `match regex str` matches `str` given `regex`. Results in the part of `str` that matched, the index of the
       first character that was part of the match in `str`, and a arrays of all capture groups if any.
 
-      Note that this function may perform better by sharing its partial application between multiple calls, 
-      because in this case the underlying regular expression will only be compiled once.
-
       For example:
       ```nickel
         match "^(\\d).*(\\d).*(\\d).*$" "5 apples, 6 pears and 0 grapes" =>
@@ -300,6 +315,10 @@
         match "3" "01234" =>
           { match = "3", index = 3, groups = [ ] }
       ```
+
+      Note that this function may perform better by sharing its partial application between multiple calls,
+      because in this case the underlying regular expression will only be compiled once (See the documentation
+      of `string.is_match` for more details).
       "%m
     = fun regex => %str_match% regex,
 

--- a/stdlib/string.ncl
+++ b/stdlib/string.ncl
@@ -41,9 +41,10 @@
       ```
       "%m
     = let pattern = m%"^[+-]?(\d+(\.\d*)?(e[+-]?\d+)?|\.\d+(e[+-]?\d+)?)$"%m in
+      let is_num_literal = %str_is_match% pattern in
       fun l s =>
         if %is_str% s then
-          if %str_is_match% s pattern then
+          if is_num_literal s then
             s
           else
             %blame% (%tag% "invalid num literal" l)
@@ -271,6 +272,9 @@
     | doc m%"
       `is_match regex str` checks if `str` matches `regex`.
 
+      Note that this function may perform better by sharing its partial application between multiple calls,
+      because in this case the underlying regular expression will only be compiled once.
+
       For example:
       ```nickel
         is_match "^\\d+$" "123" =>
@@ -279,12 +283,15 @@
           false
       ```
       "%m
-    = fun regex s => %str_is_match% s regex,
+    = fun regex => %str_is_match% regex,
 
     match : Str -> Str -> {match: Str, index: Num, groups: Array Str}
     | doc m%"
       `match regex str` matches `str` given `regex`. Results in the part of `str` that matched, the index of the
       first character that was part of the match in `str`, and a arrays of all capture groups if any.
+
+      Note that this function may perform better by sharing its partial application between multiple calls, 
+      because in this case the underlying regular expression will only be compiled once.
 
       For example:
       ```nickel
@@ -294,7 +301,7 @@
           { match = "3", index = 3, groups = [ ] }
       ```
       "%m
-    = fun regex s => %str_match% s regex,
+    = fun regex => %str_match% regex,
 
     length : Str -> Num
     | doc m%"


### PR DESCRIPTION
# Rationale

When using functions like `string.is_match regex str`, the interpreter recompiles the regular expression `regex` on every use. This is because the underlying implementation in the standard library relies on the binary operator `%str_is_match%`. After discussing this with @francois-caddet and @yannham, we can make `%str_is_match%` a unary operator which takes a (regex) string and generates a Nickel function matching on this string.

# Implementation

The above sounds straightforward, but I couldn't write it out using the current AST. In particular, our "generated" function (let's call it the matcher), would need to refer to the same compiled `Regex` and _dynamically_ call `is_match` on it. 

We _can_ use closures:

- We can force them to be `Sync + Send`, which will keep the entire AST thread safe.
- In our case, we can move the compiled regular expression into a closure and have it call `is_match` dynamically.

This comes in the form of a new `UnaryOp::FFI(<closure>)`, which means "call this Rust closure on a Nickel Term", it's an operator because this is less intrusive than adding it as a term.

# Overly-specific benchmark

```
let pattern = "^[\\w\\.-]+@([\\w-]+\\.)+[\\w-]{2,4}$" in
let Email = contract.from_predicate (string.is_match pattern) in 
[
  "nickel-lang@tweag.io",
  # -- snip --
] | Array Email
```
With a list of ~70 emails, the difference is `0.20s` vs `0.02s` on my machine, but this is a simple measure with `time`.

Even though the mantis benchmark motivated this (as it did ~20 calls to `Regex::new`), the results weren't impressive there.