### PR TITLE
[Refactoring] Separate walk phase during typechecking

### DIFF
--- a/benches/mantis/schemas/nomad/types.ncl
+++ b/benches/mantis/schemas/nomad/types.ncl
@@ -63,7 +63,7 @@ let time = {
       Weight | lib.contracts.Nullable (lib.contracts.AllOf [
                  num.Nat,
                  lib.contracts.GreaterEq -100,
-                 LesserEq 100])
+                 lib.contracts.LesserEq 100])
              | default = null,
       SpreadTarget | Array SpreadTargetElem
                    | default = [],
@@ -73,7 +73,7 @@ let time = {
       Value | Str,
       Percent | lib.contracts.Nullable (lib.contracts.AllOf [
                  num.PosNat,
-                 LesserEq 100])
+                 lib.contracts.LesserEq 100])
               | default = null,
     },
 
@@ -161,7 +161,7 @@ let time = {
       Spreads | Array Spread
               | default = [],
       Count | num.Nat
-            | Greater 0,
+            | lib.contracts.Greater 0,
       # TODO: Meta  [string]  string
       Name  | Str,
       RestartPolicy  | lib.contracts.Nullable json.RestartPolicy
@@ -877,7 +877,7 @@ let time = {
       check_restart | lib.contracts.Nullable stanza.check_restart
                     | default = null,
       header | {_: Array Str} | default = {},
-      body | lib.contracts.Nullable str
+      body | lib.contracts.Nullable Str
            | default = null,
       initial_status | (lib.contracts.OneOf ["passing", "warning", "critical", ""])
                      | default = "",
@@ -999,7 +999,7 @@ let time = {
       #  kill_signal: "SIGTERM"
       #}
 
-      kill_timeout | lib.contracts.Nullable duration
+      kill_timeout | lib.contracts.Nullable Duration
                    | default = null,
 
       lifecycle | lib.contracts.Nullable stanza.lifecycle

--- a/tests/pass/typechecking.ncl
+++ b/tests/pass/typechecking.ncl
@@ -13,10 +13,6 @@ let typecheck = [
   # functions
   (fun x => if x then x + 1 else 34) false,
   let id : Num -> Num = fun x => x in (id 4 : Num),
-  # the id parameter is inferred
-  (fun id => (id 4 : Num)) (fun x => x),
-  # non strict zones don't unify
-  (fun id => (id 4) + (id true: Bool)) (fun x => x),
   # contracts are opaque types
   (let AlwaysTrue = fun l t => if t then t else %blame% l in
   ((fun x => x) : AlwaysTrue -> AlwaysTrue)),


### PR DESCRIPTION
As part of refactoring the typechecker to make the different phase better separated, this PR extract a "walk" phase in a separate function. Walk mode correspond to the non-strict mode, outside of a statically typechecked block, where the typechecker simply walk the AST while looking for typed blocks (as well as saving the apparent type of bound variables).

Previously, the `unify` function used to branch on the `strict` parameter for this non-strict phase. Still, the typechecker was spinning useless fresh unification variables and calling to `unify` needlessly (that would return immediately). Separating the walk phase allowed to get rid of `unify_` and the branching in `unify`, and should offer better performances as walking is lighter and doesn't allocate garbage unification variables. The benchmarks show indeed a constant improvements in the order of a few percents up to 10%. It would be interesting to see the difference on the complete typechecking bench of #722 once it lands.