### PR TITLE
Separate the WASM build in a wrapper crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1245,6 +1245,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "nickel-repl"
+version = "0.1.0"
+dependencies = [
+ "nickel-lang",
+]
+
+[[package]]
 name = "nix"
 version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,6 +72,7 @@ members = [
     ".",
     "lsp/nls",
     "utilities",
+    "nickel-wasm-repl",
 ]
 
 # Enable this to use flamegraphs

--- a/HACKING.md
+++ b/HACKING.md
@@ -79,12 +79,12 @@ nickel-lang-lsp 0.1.0
 ## WebAssembly REPL
 
 There is a WebAssembly (WASM) version of the REPL, which is used for the online
-playground on [nickel-lang.org][nickel-lang.org]. Using Cargo directly to build
-the WASM REPL is possible but is not a trivial procedure. The Cargo way requires
-installing new tools and patching `Cargo.toml`.
+playground on [nickel-lang.org][nickel-lang.org]. To ease the build, we use the
+`nickel-repl` located in `nickel-wasm-repl`, which just wraps and re-export
+the `nickel-lang` with the right settings for building to WebAssembly.
 
-On the other hand, Nix can do the whole build in one simple command, but
-incremental compilation is not as good as with direct usage of `cargo`.
+The Nix flake has also an output to do the whole build, but incremental
+compilation is not as good as with direct usage of `cargo`.
 
 Both methods are described below.
 
@@ -101,43 +101,15 @@ LICENSE  package.json nickel_lang_bg.js  nickel_lang_bg.wasm [..]
 ### Using Cargo
 
 1. [Install `wasm-pack`][install-wasm-pack]
-2. Add the following line to `Cargo.toml` under the `[lib]` heading:
-
-   ```diff
-   [lib]
-   +crate-type = ["cdylib", "rlib"]
-   ```
-
-3. Remove the following line from `Cargo.toml` (dependency on
-   `nickel-lang-utilities`):
-
-   ```diff
-   -nickel-lang-utilities = {path = "utilities", version = "0.1.0"}
-   ```
-
-4. Run `wasm-pack`:
+2. Run `wasm-pack` on the `nickel-repl` crate:
 
    ```shell
+   cd nickel-repl-wasm
    wasm-pack build -- --no-default-features --features repl-wasm
    ```
 
    A `pkg` directory, containing the corresponding NPM package, should now be
    available.
-5. (Optional) the generated NPM package is named `nickel`, but this name is not
-   very descriptive, and is already in use in the NPM registry. You can patch
-   the name of the NPM package using `jq` to be `nickel-repl` instead:
-
-   ```shell
-   $ jq '.name = "nickel-repl"' pkg/package.json > package.json.patched \
-     && rm -f pkg/package.json \
-     && mv package.json.patched pkg/package.json
-   ```
-
-   If you don't have `jq`, you can do it by hand: replace the `name` attribute
-   in `pkg/package.json` by `"nickel-repl"`.
-
-The `pkg` directory now contains a `nickel-repl` NPM package that can be used
-from JavaScript.
 
 # Testing
 

--- a/nickel-wasm-repl/Cargo.toml
+++ b/nickel-wasm-repl/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "nickel-repl"
+version = "0.1.0"
+authors = ["Nickel team"]
+license = "MIT"
+readme = "README.md"
+description = "WebAssembly REPL for the Nickel programming language."
+homepage = "https://nickel-lang.org"
+repository = "https://github.com/tweag/nickel"
+keywords = ["configuration", "language", "nix", "nickel"]
+edition = "2018"
+
+[dependencies]
+nickel-lang = {default-features = false, path = "../", version = "0.1.0", features=["repl-wasm"]}
+
+[lib]
+crate-type = ["cdylib", "rlib"]

--- a/nickel-wasm-repl/src/lib.rs
+++ b/nickel-wasm-repl/src/lib.rs
@@ -1,0 +1,1 @@
+pub use nickel_lang::*;


### PR DESCRIPTION
Close #695. Make a new crate that simply wraps `nickel-lang` and re-export its API, but with the right setting for being build using WASM to get rid of all the monkey patching that needed to be done before. It has worked quite straightforwardly, and greatly ease the procedure of building the WASM REPL.