### PR TITLE
Show call site of TermPos::unwrap on panic

### DIFF
--- a/src/position.rs
+++ b/src/position.rs
@@ -90,6 +90,7 @@ impl TermPos {
     }
 
     /// Try to unwrap the underlying span. Panic if `self` is `None`.
+    #[track_caller]
     pub fn unwrap(self) -> RawSpan {
         match self {
             TermPos::Original(x) | TermPos::Inherited(x) => x,


### PR DESCRIPTION
The LSP currently panics on some  call to `TermPos::unwrap`, but this is hard to debug, because the panic message shows the location of the call to `panic` inside `unwrap`, which is not very useful. This PR adds the `track_caller` attribute, which reports the callsite of `unwrap` instead, just as the stdlib's `Option::unwrap`.