### PR TITLE
Fix random order of fields in `nickel doc`

### DIFF
--- a/src/pretty.rs
+++ b/src/pretty.rs
@@ -26,7 +26,7 @@ fn min_interpolate_sign(text: &str) -> usize {
 
 fn sorted_map<'a, K: Ord, V>(m: &'a HashMap<K, V>) -> Vec<(&'a K, &'a V)> {
     let mut ret: Vec<(&K, &V)> = m.iter().collect();
-    ret.sort_by(|x, y| x.0.cmp(&y.0));
+    ret.sort_by_key(|(k, _)| *k);
     ret
 }
 

--- a/src/program.rs
+++ b/src/program.rs
@@ -283,8 +283,12 @@ mod doc {
             Term::MetaValue(MetaValue { doc: Some(md), .. }) => {
                 document.append(&mut parse_documentation(header_level, arena, &md, options))
             }
-            Term::Record(hm, _) | Term::RecRecord(hm, _, _, _) => {
-                for (ident, rt) in hm {
+            Term::Record(map, _) | Term::RecRecord(map, _, _, _) => {
+                // Sorting fields for a determinstic output
+                let mut entries: Vec<(_, _)> = map.iter().collect();
+                entries.sort_by_key(|(k, _)| *k);
+
+                for (ident, rt) in entries {
                     let header = mk_header(&ident.label, header_level + 1, arena);
                     document.append(header);
                     to_markdown(rt, header_level + 1, arena, document, options)?;

--- a/src/serialize.rs
+++ b/src/serialize.rs
@@ -102,7 +102,7 @@ where
     S: Serializer,
 {
     let mut entries: Vec<(_, _)> = map.iter().collect();
-    entries.sort_by(|(k1, _), (k2, _)| k1.cmp(k2));
+    entries.sort_by_key(|(k, _)| *k);
 
     let mut map_ser = serializer.serialize_map(Some(entries.len()))?;
     for (id, t) in entries.iter() {


### PR DESCRIPTION
Depends on #743. `nickel doc` doesn't sort the fields of records, and because Rust hashmaps are randomized, two invocations of on the same file will order fields in a different way. This PR fixes that by always sorting fields before processing them. Passing by, I replaced a few `sort_by` calls by `sort_by_key` elsewhere, which are arguably simpler.