### PR TITLE
[Fix] Fix types-vs-contracts manual page not found on the website

### DIFF
--- a/doc/manual/types-vs-contracts.md
+++ b/doc/manual/types-vs-contracts.md
@@ -1,5 +1,5 @@
 ---
-slug: type-vs-contract
+slug: types-vs-contracts
 ---
 
 # Type vs contract: when to?
@@ -83,7 +83,7 @@ let Schema = {
 ## Computation (compound expressions)
 
 Some expressions are neither immediate data nor functions. Take for example the
-function application `array.map (fun s => "http://#{s}/index") servers`.
+function application `array.map (fun s => "http://%{s}/index") servers`.
 Usually, you should do **nothing**.
 
 - *Inside configuration: nothing*. The function or operator you are using should


### PR DESCRIPTION
Closes #736 (at least, on the nickel side: we then need to update the flake on the nickel-lang repo).