### PR TITLE
Allow unused imports in LALRPOP

### DIFF
--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -7,6 +7,7 @@ use lalrpop_util::lalrpop_mod;
 lalrpop_mod!(
     #[allow(clippy::all)]
     #[allow(unused_parens)]
+    #[allow(unused_imports)]
     pub grammar);
 
 pub mod error;


### PR DESCRIPTION
This may be unwarranted, but I would like the warning to go away.

it seems that if one has a grammar with multiple top-level pub parsers. Then LALRPOP creates modules for each of them, and inlines the grammar's imports _inside each of the modules_, but still keeps the global use imports present in the final rust program.

So in our case, we end up with something like:

```rust
use imports;

mod __parse__ExtendedTerm {
  use imports;
}

mod  __parse__Term {
  use imports;
}
```

Now you could easily see where the redundant imports come from.