### PR TITLE
[Fix] Unification of flat types (aka opaque types aka contracts)

### DIFF
--- a/src/cache.rs
+++ b/src/cache.rs
@@ -92,8 +92,8 @@ pub struct Envs {
     /// The eval environment.
     pub eval_env: eval::Environment,
     /// The typing environment, counterpart of the eval environment for typechecking. Entries are
-    /// [crate::typecheck::TypeWrapper] for the ease of interacting with the typechecker, but there
-    /// are not any unification variable in it.
+    /// [`crate::typecheck::TypeWrapper`] for the ease of interacting with the typechecker, but
+    /// there are not any unification variable in it.
     pub type_env: typecheck::Environment,
 }
 

--- a/src/repl/mod.rs
+++ b/src/repl/mod.rs
@@ -71,8 +71,8 @@ pub struct ReplImpl {
     cache: Cache,
     /// The parser, supporting toplevel let declaration.
     parser: grammar::ExtendedTermParser,
-    /// The current environment. Contain the initial environment with the stdlib, plus toplevel
-    /// declarations and loadings made inside the REPL.
+    /// The current environment (for evaluation and typing). Contain the initial environment with
+    /// the stdlib, plus toplevel declarations and loadings made inside the REPL.
     env: Envs,
     /// The initial type environment, without the toplevel declarations made inside the REPL. Used
     /// to typecheck imports in a fresh environment.
@@ -213,7 +213,14 @@ impl Repl for ReplImpl {
         for id in &pending {
             self.cache.resolve_imports(*id).unwrap();
         }
-        typecheck::env_add_term(&mut self.env.type_env, &term, &self.cache).unwrap();
+        //FIXME: use a non-empty term environment
+        typecheck::env_add_term(
+            &mut self.env.type_env,
+            &term,
+            &typecheck::eq::TermEnvironment::new(),
+            &self.cache,
+        )
+        .unwrap();
         eval::env_add_term(&mut self.env.eval_env, term.clone()).unwrap();
 
         Ok(term)

--- a/src/typecheck/reporting.rs
+++ b/src/typecheck/reporting.rs
@@ -100,8 +100,9 @@ fn cst_to_type(names: &HashMap<usize, Ident>, name_reg: &mut NameReg, c: usize) 
 
 /// Extract a concrete type corresponding to a type wrapper for error reporting.
 ///
-/// Similar to [`to_type`], excepted that free unification variables and type constants are
-/// replaced by type variables which names are determined by the `var_to_type` and `cst_to_type`.
+/// Similar [`crate::types::Types::from`], excepted that free unification variables and type
+/// constants are replaced by type variables which names are determined by the `var_to_type` and
+/// `cst_to_type`.
 ///
 /// Distinguishing occurrences of unification variables and type constants is more informative
 /// than having `Dyn` everywhere.
@@ -121,5 +122,6 @@ pub fn to_type(
             let mapped = t.map(|btyp| Box::new(to_type(table, reported_names, names, *btyp)));
             Types(mapped)
         }
+        TypeWrapper::Contract(t, _) => Types(AbsType::Flat(t)),
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -534,7 +534,7 @@ impl fmt::Display for Types {
                 }
             }
             AbsType::Sym() => write!(f, "Sym"),
-            AbsType::Flat(ref t) => write!(f, "{}", t.as_ref().shallow_repr()),
+            AbsType::Flat(ref t) => write!(f, "{}", t.pretty_print_cap(32)),
             AbsType::Var(var) => write!(f, "{}", var),
             AbsType::Forall(i, ref ty) => {
                 let mut curr: &Types = ty.as_ref();

--- a/tests/pass/typechecking.ncl
+++ b/tests/pass/typechecking.ncl
@@ -204,6 +204,43 @@ let typecheck = [
   # The (| ExportFormat) cast is only temporary, and can be removed once #671
   # (https://github.com/tweag/nickel/issues/671) is closed
   (record.update "foo" 5 {foo = 1}) : {_: Num},
+
+  # contracts_equality
+  let lib = {
+    Contract = fun label value => value,
+  } in
+  let Proxy1 = lib.Contract in
+  let Proxy2 = Proxy1 in
+  [
+    {
+      identity : lib.Contract = (null | lib.Contract),
+      foo : lib.Contract = identity,
+      bar : Proxy1 = foo,
+      baz : Proxy2 = foo,
+      baz' : Proxy2 = bar,
+
+      # composite type
+      record: {arrow: Dyn -> lib.Contract, dict: {_: Array Proxy2}} = {
+        arrow = fun _x => (_x | Proxy2),
+        dict : {_ : _} = {elt = [foo]},
+      },
+
+      # local definition
+      inline = (let InlineProxy = Proxy2 in foo : InlineProxy),
+    },
+    # the following tests were initially failing while the ones above weren't,
+    # for reasons specific to the handling of type wildcard. We keep both version to
+    # make sure that type wildcards behave correctly with respect to contract
+    # equality.
+    {
+      identity : lib.Contract = (null | lib.Contract),
+      foo : lib.Contract = identity,
+      bar : Proxy1 = foo,
+      baz : Proxy2 = foo,
+      baz' : Proxy2 = bar,
+      inline = (let InlineProxy = Proxy2 in foo : InlineProxy),
+    },
+  ],
 ] in
 
 true

--- a/tests/typecheck_fail.rs
+++ b/tests/typecheck_fail.rs
@@ -277,3 +277,20 @@ g"#
         ))
     );
 }
+
+#[test]
+fn locally_different_flat_types() {
+    assert_matches!(
+        type_check_expr(
+            "let lib = {Contract = fun label value => value} in
+             let foo | lib.Contract = null in
+             let lib = {Contract = fun label value => value} in
+             foo : lib.Contract"
+        ),
+        Err(TypecheckError::TypeMismatch(
+            Types(AbsType::Flat(..)),
+            Types(AbsType::Flat(..)),
+            _
+        ))
+    );
+}


### PR DESCRIPTION
Depends on #811. Closes #701. Support unification of flat types, that is contracts, by using the previously introduced type equality (#763, #771).

## Design choices

### Term environment

In order to decide equality on contracts, we need to unroll the definition of variables (in some way, to perform basic substitution), which implies to carry around local environments. In the previous PR, this term environment was defined as a mapping from  `Ident` to `&'a RichTerm`. Indeed, the AST is guaranteed to be immutable and alive during the whole duration of typechecking such that we can work on references directly, without copying anything. `'a` is then the lifetime of the original AST.

However, once we start using those references in the code of the typechecker, we suddently have to add a lot of lifetime annotations to functions and to datastructures, in a contagious way. The resulting code was quite more verbose. In the end, given that we only insert one element for each let binding, I decided that using `Rc` instead of references and to forget about lifetimes altogether was a lesser evil to keep the code clean. We can revisit this choice later, but I highly doubt it will ever make any noticeable difference regarding performances.

### Storing local environments (aka closures)

In order to correctly decide type equality, we have to store the local environment alongside contracts, at the time the contract is defined. As for evaluation, this means carrying around the equivalent of closures. One solution is to mimic what happens for evaluation, and to store an environment alongside each type in the unification table. However, this is very heavy, both in term of memory (I expect a typical codebase to use very rarely contracts as opaque types, if it does at all, but now all types must carry an environment), and in term of code changes (the unification table is used in many places).

Instead, I added a new variant to `TypeWrapper`, which stores a flat type together with an environment. Doing so, only flat types are impacted, both in performances and API changes. But we can't freely convert anymore a `Types` to a `TypeWrapper`, as we need an environment, so the `impl From<Types> for TypeWrapper` and co have been removed in favor of specific functions `from_xxx`. One drawback is that there is somehow an illegal state, `TypeWrapper::Concrete(AbsType::Flat(_))`. Indeed, an invariant that we want to maintain is that this variant is never created, and that a flat type is always represented using the new `TypeWrapper::Contract(ctr, env)`. Once again, I think this is an OK price to pay in exchange of a simple solution and localized changes.

## Recursive bindings

The term environment doesn't support recursive binding (`let rec` and records) by design. This means that the typechecker is not able to determine that within a `let lib = {Foo = ..some contract.., Bar = Foo} in ...`, `lib.Foo` and `lib.Bar` are equal (in fact, even outside of recursive bindings, the current equality checker is not willing to unroll the definition of a record field anyway).

Supporting recursive bindings would mean either:
 - leak memory, because this creates cyclic environment. This also requires the environment to have interior mutability, in order to create those cycles in the first place. If we want to avoid leaking like crazy, we can use the same trick as in #631, but that sounds complex - both in term of code and runtime cost -, and we need to do that before knowing if we will ever use such environments (if there is no type annotation involving contracts, all of this is useless).
 - use arena allocation to de-allocate the cycles at the end of the typechecking of block. This is possible but also pull in new dependencies and complexity.

Thus, unless experience prove that supporting recursive binding for deciding equality between contracts is absolutely fundamental, this PR doesn't support them for now.

## Performances

On the benchmark of typechecking the Nixpkgs list library, this PR seems to show a small but consistent performance gain over master (~ 0-3%). It's a bit surprising, as it adds complexity. But the added cost can be expected to be small, and may be hidden by other random changes due to the new memory layout or the like.

## Next

### TODO

The REPL now needs to be updated as well, as it currently doesn't update the new term environment when entering new definition. It should still function normally for most of normal usage, and will be patched in an upcoming PR.

### Follow-up

Interestingly, this PR comes close to solving #422 as well. The whole environment and substitution at type-checking time machinery is also what is needed to implement type aliases.

Another direction is to use contract equality in conjunction with lazy array contracts (#809). We can then avoid repeated contract applications on array elements when the contracts are known to be equals, which is a common situation with recursive functions.