### PR TITLE
Forbid any unification between opaque types (contracts)

### DIFF
--- a/doc/manual/typing.md
+++ b/doc/manual/typing.md
@@ -597,7 +597,7 @@ typechecker on, a contract annotation switches it back off.
 
 **Warning**: as of version 0.2.x, using contracts as types won't work in the
 majority of cases (typechecking will fail with a "can't compare contract types"
-error). This is temporary and will likely be fixed in upcoming 0.3.x. For more
+error). This is temporary and will likely be fixed in the upcoming 0.3.x release. For more
 details, see issues [#701](https://github.com/tweag/nickel/issues/701) and
 [#724](https://github.com/tweag/nickel/issues/724).
 

--- a/doc/manual/typing.md
+++ b/doc/manual/typing.md
@@ -596,7 +596,7 @@ typechecker on, a contract annotation switches it back off.
 ## Using contracts as types
 
 **Warning**: as of version 0.2.x, using contracts as types won't work in the
-majority of cases (typechecking will fail with a "can't compare contract"
+majority of cases (typechecking will fail with a "can't compare contract types"
 error). This is temporary and will likely be fixed in upcoming 0.3.x. For more
 details, see issues [#701](https://github.com/tweag/nickel/issues/701) and
 [#724](https://github.com/tweag/nickel/issues/724).

--- a/doc/manual/typing.md
+++ b/doc/manual/typing.md
@@ -595,6 +595,12 @@ typechecker on, a contract annotation switches it back off.
 
 ## Using contracts as types
 
+**Warning**: as of version 0.2.x, using contracts as types won't work in the
+majority of cases (typechecking will fail with a "can't compare contract"
+error). This is temporary and will likely be fixed in upcoming 0.3.x. For more
+details, see issues [#701](https://github.com/tweag/nickel/issues/701) and
+[#724](https://github.com/tweag/nickel/issues/724).
+
 <!-- TODO: find a good name for this section. Will need rework after merging
 types and contracts syntax -->
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1471,7 +1471,7 @@ impl ToDiagnostic<FileId> for TypecheckError {
                     Diagnostic::note()
                     .with_notes(vec![
                         String::from("Due to a temporary limitation, contracts don't mix well with static types (see https://github.com/tweag/nickel/issues/724). This error may happen when using a contract as a type annotation or when calling to a function whose type contain contracts."),
-                        String::from("As a temporary fix, please annotate the offending expression with its expected type using the pipe operator `|`. This disable static typing for the given expression."),
+                        String::from("As a temporary fix, please annotate the offending expression with its expected type using the pipe operator `|`. This disables static typing for the given expression."),
                         String::from("For example: if `foo` has type `MyContract -> Num`, rewrite `foo value + 1` as `(foo value | Num) + 1`."),
                     ])
                 ]

--- a/src/error.rs
+++ b/src/error.rs
@@ -200,7 +200,7 @@ pub enum TypecheckError {
     /// This is a temporary error due to the current limitation of checking type equality between
     /// contracts. Checking if the unification of two contracts is valid is non-trivial even in
     /// simple cases (see [#724](https://github.com/tweag/nickel/issues/724)). Currently, the
-    /// typechecker simply bails out of any attempt of contracts unification, represented by this
+    /// typechecker simply bails out of any attempt of contract unification, represented by this
     /// error.
     IncomparableFlatTypes(
         RichTerm, /* the expected flat type */

--- a/src/error.rs
+++ b/src/error.rs
@@ -197,6 +197,16 @@ pub enum TypecheckError {
         /* the error on the subtype unification */ Box<TypecheckError>,
         TermPos,
     ),
+    /// This is a temporary error due to the current limitation of checking type equality between
+    /// contracts. Checking if the unification of two contracts is valid is non-trivial even in
+    /// simple cases (see [#724](https://github.com/tweag/nickel/issues/724)). Currently, the
+    /// typechecker simply bails out of any attempt of contracts unification, represented by this
+    /// error.
+    IncomparableFlatTypes(
+        RichTerm, /* the expected flat type */
+        RichTerm, /* the inferred flat type */
+        TermPos,
+    ),
 }
 
 #[derive(Debug, PartialEq, Clone, Default)]
@@ -1448,6 +1458,23 @@ impl ToDiagnostic<FileId> for TypecheckError {
                 }
 
                 diags
+            }
+            TypecheckError::IncomparableFlatTypes(expd, actual, span_opt) => {
+                vec![Diagnostic::error()
+                    .with_message("can't compare contract types")
+                    .with_labels(mk_expr_label(span_opt))
+                    .with_notes(vec![
+                        format!("The type of the expression was expected to be `{}`", expd.as_ref().shallow_repr()),
+                        format!("The type of the expression was inferred to be `{}`", actual.as_ref().shallow_repr()),
+                        String::from("Nickel can't compare contracts during typechecking"),
+                    ]),
+                    Diagnostic::note()
+                    .with_notes(vec![
+                        String::from("Due to a temporary limitation, contracts don't mix well with static types (see https://github.com/tweag/nickel/issues/724). This error may happen when using a contract as a type annotation or when calling to a function whose type contain contracts."),
+                        String::from("As a temporary fix, please annotate the offending expression with its expected type using the pipe operator `|`. This disable static typing for the given expression."),
+                        String::from("For example: if `foo` has type `MyContract -> Num`, rewrite `foo value + 1` as `(foo value | Num) + 1`."),
+                    ])
+                ]
             }
         }
     }

--- a/src/typecheck/error.rs
+++ b/src/typecheck/error.rs
@@ -97,7 +97,7 @@ pub enum UnifError {
     WithConst(usize, TypeWrapper),
     /// A flat type, which is an opaque type corresponding to custom contracts, contained a Nickel
     /// term different from a variable. Only a variables is a legal inner term of a flat type.
-    IllformedFlatType(RichTerm),
+    IncomparableFlatTypes(RichTerm, RichTerm),
     /// A generic type was ill-formed. Currently, this happens if a `StatRecord` or `Enum` type
     /// does not contain a row type.
     IllformedType(TypeWrapper),
@@ -173,8 +173,8 @@ impl UnifError {
                 reporting::to_type(state.table, state.names, names, ty),
                 pos_opt,
             ),
-            UnifError::IllformedFlatType(rt) => {
-                TypecheckError::IllformedType(Types(AbsType::Flat(rt)))
+            UnifError::IncomparableFlatTypes(rt1, rt2) => {
+                TypecheckError::IncomparableFlatTypes(rt1, rt2, pos_opt)
             }
             UnifError::IllformedType(tyw) => TypecheckError::IllformedType(reporting::to_type(
                 state.table,

--- a/src/typecheck/mod.rs
+++ b/src/typecheck/mod.rs
@@ -1258,15 +1258,7 @@ pub fn unify(state: &mut State, mut t1: TypeWrapper, mut t2: TypeWrapper) -> Res
                     )
                 })
             }
-            (AbsType::Flat(s), AbsType::Flat(t)) => match (s.as_ref(), t.as_ref()) {
-                (Term::Var(vs), Term::Var(ts)) if vs == ts => Ok(()),
-                (Term::Var(_), Term::Var(_)) => Err(UnifError::TypeMismatch(
-                    TypeWrapper::Concrete(AbsType::Flat(s)),
-                    TypeWrapper::Concrete(AbsType::Flat(t)),
-                )),
-                (Term::Var(_), _) => Err(UnifError::IllformedFlatType(t)),
-                _ => Err(UnifError::IllformedFlatType(s)),
-            },
+            (AbsType::Flat(s), AbsType::Flat(t)) => Err(UnifError::IncomparableFlatTypes(s, t)),
             (r1, r2) if r1.is_row_type() && r2.is_row_type() => {
                 unify_rows(state, r1.clone(), r2.clone()).map_err(|err| {
                     err.into_unif_err(TypeWrapper::Concrete(r1), TypeWrapper::Concrete(r2))

--- a/tests/pass/typechecking.ncl
+++ b/tests/pass/typechecking.ncl
@@ -13,9 +13,14 @@ let typecheck = [
   # functions
   (fun x => if x then x + 1 else 34) false,
   let id : Num -> Num = fun x => x in (id 4 : Num),
+
   # contracts are opaque types
-  (let AlwaysTrue = fun l t => if t then t else %blame% l in
-  ((fun x => x) : AlwaysTrue -> AlwaysTrue)),
+  # TODO: restore the following tests once type equality for contracts is
+  # properly implemented (see https://github.com/tweag/nickel/issues/701 and
+  # https://github.com/tweag/nickel/issues/724)
+
+  # (let AlwaysTrue = fun l t => if t then t else %blame% l in
+  #  ((fun x => x) : AlwaysTrue -> AlwaysTrue)),
 
   # simple_polymorphism
   let f : forall a. a -> a = fun x => x in


### PR DESCRIPTION
Temporary band aid for #701 and fix previously unsound behavior where the typechecker would use the name of contracts to decide equality (but names are local, so the same name may refer to different definitions made at two different
locations). In waiting for a proper type equality between contracts, this PR just makes the typechecker reject any unification involving a contract with a specific error message. The example of #701 is still rejected, but the error message should at least be explicit now.

As full-fledged type equality is proving to be involved, in the meantime, this PR is intended to fix at least the cryptic error message of #701 for the 0.2.0 release.