### PR TITLE
Apply clippy lints where they make sense

### DIFF
--- a/src/bin/nickel.rs
+++ b/src/bin/nickel.rs
@@ -160,7 +160,7 @@ fn main() {
                         Error::IOError(IOError(format!(
                             "when opening or creating output file `{}`: {}",
                             output.to_string_lossy(),
-                            e.to_string()
+                            e
                         )))
                     })
                 })
@@ -170,7 +170,7 @@ fn main() {
                         Error::IOError(IOError(format!(
                             "when creating output path `{}`: {}",
                             docpath.to_string_lossy(),
-                            e.to_string()
+                            e
                         )))
                     })?;
                     let mut markdown_file = docpath.to_path_buf();
@@ -193,7 +193,7 @@ fn main() {
                         Error::IOError(IOError(format!(
                             "when opening or creating output file `{}`: {}",
                             markdown_file.to_string_lossy(),
-                            e.to_string()
+                            e
                         )))
                     })
                 })

--- a/src/destruct.rs
+++ b/src/destruct.rs
@@ -25,7 +25,7 @@ pub enum Match {
 pub enum LastMatch {
     /// The last field is a normal match. In this case the pattern is "closed" so every record
     /// fields should be matched.
-    Match(Match),
+    Match(Box<Match>),
     /// The pattern is "open" `, ..}`. Optionaly you can bind a record containing the remaining
     /// fields to an `Identifier` using the syntax `, ..y}`.
     Ellipsis(Option<Ident>),
@@ -50,12 +50,12 @@ pub enum Destruct {
 
 impl Destruct {
     /// generate the metavalue containing the contract representing this pattern.
-    pub fn as_contract(self) -> MetaValue {
+    pub fn into_contract(self) -> MetaValue {
         let label = self.label();
-        self.as_contract_with_lbl(label)
+        self.into_contract_with_lbl(label)
     }
 
-    fn as_contract_with_lbl(self, label: Label) -> MetaValue {
+    fn into_contract_with_lbl(self, label: Label) -> MetaValue {
         let open = self.is_open();
         MetaValue {
             contracts: vec![Contract {
@@ -125,7 +125,7 @@ impl Match {
                 let label = Label { span, ..label };
                 (
                     id,
-                    Term::MetaValue(MetaValue::flatten(m, d.as_contract_with_lbl(label))).into(),
+                    Term::MetaValue(MetaValue::flatten(m, d.into_contract_with_lbl(label))).into(),
                 )
             }
             Match::Assign(_id, _m, (_, _d @ Destruct::Array { .. })) => unimplemented!(),

--- a/src/error.rs
+++ b/src/error.rs
@@ -225,8 +225,8 @@ impl ParseErrors {
         ParseErrors { errors: Vec::new() }
     }
 
-    pub fn from_recoverable<'a>(
-        errs: Vec<ErrorRecovery<usize, Token<'a>, parser::error::ParseError>>,
+    pub fn from_recoverable(
+        errs: Vec<ErrorRecovery<usize, Token<'_>, parser::error::ParseError>>,
         file_id: FileId,
     ) -> Self {
         ParseErrors {
@@ -258,8 +258,7 @@ impl ToDiagnostic<FileId> for ParseErrors {
     ) -> Vec<Diagnostic<FileId>> {
         self.errors
             .iter()
-            .map(|e| e.to_diagnostic(files, contract_id))
-            .flatten()
+            .flat_map(|e| e.to_diagnostic(files, contract_id))
             .collect()
     }
 }
@@ -799,8 +798,7 @@ impl ToDiagnostic<FileId> for Error {
             Error::ParseErrors(errs) => errs
                 .errors
                 .iter()
-                .map(|e| e.to_diagnostic(files, contract_id))
-                .flatten()
+                .flat_map(|e| e.to_diagnostic(files, contract_id))
                 .collect(),
             Error::TypecheckError(err) => err.to_diagnostic(files, contract_id),
             Error::EvalError(err) => err.to_diagnostic(files, contract_id),
@@ -909,7 +907,7 @@ impl ToDiagnostic<FileId> for EvalError {
                     .with_labels(labels)
                     .with_notes(notes)];
 
-                diagnostics.push(blame_label_note(&l));
+                diagnostics.push(blame_label_note(l));
 
                 if ty_path::is_only_codom(&l.path) {
                 } else if let Some(id) = contract_id {
@@ -993,7 +991,7 @@ impl ToDiagnostic<FileId> for EvalError {
                 let mut diags = vec![Diagnostic::error()
                     .with_message(format!(
                         "missing definition for `{}`",
-                        field.unwrap_or(String::from("?"))
+                        field.unwrap_or_else(|| String::from("?"))
                     ))
                     .with_labels(labels)
                     .with_notes(vec![])];
@@ -1216,7 +1214,7 @@ impl ToDiagnostic<FileId> for ParseError {
                 ))
                 .with_labels(vec![primary(span)]),
             ParseError::InvalidUniRecord(illegal_span, tail_span, span) => Diagnostic::error()
-                .with_message(format!("invalid record literal"))
+                .with_message("invalid record literal")
                 .with_labels(vec![
                     primary(span),
                     secondary(illegal_span).with_message("can't use this record construct"),
@@ -1227,7 +1225,7 @@ impl ToDiagnostic<FileId> for ParseError {
                     String::from("Value assignements, such as `<field> = <expr>`, metadata, etc. are forbidden."),
                 ]),
             ParseError::RecursiveLetPattern(span) => Diagnostic::error()
-                .with_message(format!("recursive destructuring is not supported"))
+                .with_message("recursive destructuring is not supported")
                 .with_labels(vec![
                     primary(span),
                 ])
@@ -1474,8 +1472,7 @@ impl ToDiagnostic<FileId> for ImportError {
                 let mut diagnostic: Vec<Diagnostic<FileId>> = error
                     .errors
                     .iter()
-                    .map(|e| e.to_diagnostic(files, contract_id))
-                    .flatten()
+                    .flat_map(|e| e.to_diagnostic(files, contract_id))
                     .collect();
 
                 if let Some(span) = span_opt.as_opt_ref() {

--- a/src/eval/fixpoint.rs
+++ b/src/eval/fixpoint.rs
@@ -40,7 +40,7 @@ pub fn rec_env<'a, I: Iterator<Item = (&'a Ident, &'a RichTerm)>>(
 /// all the recursive environment. See [`crate::transform::free_vars`].
 pub fn patch_field(
     rt: &RichTerm,
-    rec_env: &Vec<(Ident, Thunk)>,
+    rec_env: &[(Ident, Thunk)],
     env: &Environment,
 ) -> Result<(), EvalError> {
     if let Term::Var(var_id) = &*rt.term {
@@ -55,7 +55,7 @@ pub fn patch_field(
                 .borrow_mut()
                 .env
                 .extend(rec_env.iter().filter(|(id, _)| deps.contains(id)).cloned()),
-            ThunkDeps::Unknown => thunk.borrow_mut().env.extend(rec_env.clone()),
+            ThunkDeps::Unknown => thunk.borrow_mut().env.extend(rec_env.iter().cloned()),
             ThunkDeps::Empty => (),
         };
     }

--- a/src/eval/lazy.rs
+++ b/src/eval/lazy.rs
@@ -255,7 +255,7 @@ impl Thunk {
     /// Return a clone of the potential field dependencies stored in a revertible thunk. See
     /// [`crate::transform::free_vars`].
     pub fn deps(&self) -> ThunkDeps {
-        self.data.borrow().deps().clone()
+        self.data.borrow().deps()
     }
 }
 

--- a/src/eval/merge.rs
+++ b/src/eval/merge.rs
@@ -503,7 +503,7 @@ fn rev_thunks<'a, I: Iterator<Item = &'a mut RichTerm>>(map: I, env: &mut Enviro
     for rt in map {
         if let Term::Var(id) = rt.as_ref() {
             // This create a fresh variable which is bound to a reverted copy of the original thunk
-            let reverted = env.get(&id).unwrap().revert();
+            let reverted = env.get(id).unwrap().revert();
             let fresh_id = fresh_var();
             env.insert(fresh_id.clone(), reverted);
             *(SharedTerm::make_mut(&mut rt.term)) = Term::Var(fresh_id);

--- a/src/eval/operation.rs
+++ b/src/eval/operation.rs
@@ -764,7 +764,7 @@ fn process_unary_operation(
                     let indent_str: String = std::iter::once('\n')
                         .chain((0..indent).map(|_| ' '))
                         .collect();
-                    s.replace("\n", &indent_str)
+                    s.replace('\n', &indent_str)
                 } else {
                     s.clone()
                 };
@@ -1059,10 +1059,9 @@ fn process_unary_operation(
                     let groups: Vec<RichTerm> = capt
                         .iter()
                         .skip(1)
-                        .map(|s_opt| {
+                        .filter_map(|s_opt| {
                             s_opt.map(|s| RichTerm::from(Term::Str(String::from(s.as_str()))))
                         })
-                        .flatten()
                         .collect();
 
                     mk_record!(
@@ -1856,7 +1855,7 @@ fn process_binary_operation(
                             ts.extend(ts1.into_iter());
                             ts.extend(ts2.into_iter());
 
-                            let mut env = env1.clone();
+                            let mut env = env1;
                             // TODO: Is there a cheaper way to "merge" two environements?
                             env.extend(env2.iter_elems().map(|(k, v)| (k.clone(), v.clone())));
 
@@ -2328,7 +2327,7 @@ fn process_nary_operation(
                         )
                     }
                 } else {
-                    Err(EvalError::InternalError(format!("The MergeContract() operator was expecting a first argument of type Label, got {}", t1.type_of().unwrap_or(String::from("<unevaluated>"))), pos_op))
+                    Err(EvalError::InternalError(format!("The MergeContract() operator was expecting a first argument of type Label, got {}", t1.type_of().unwrap_or_else(|| String::from("<unevaluated>"))), pos_op))
                 }
             }
         }

--- a/src/grammar.lalrpop
+++ b/src/grammar.lalrpop
@@ -369,7 +369,7 @@ FieldPathElem: FieldPathElem = {
 
 // Last field of a pattern
 LastMatch: LastMatch = {
-    Match => LastMatch::Match(<>),
+    Match => LastMatch::Match(Box::new(<>)),
     ".." <Ident?> => LastMatch::Ellipsis(<>),
 };
 
@@ -385,7 +385,7 @@ Destruct: Destruct = {
     <start: @L> "{" <mut matches: (<Match> ",")*> <last:LastMatch?> "}" <end: @R> => {
         let (open, rest) = match last {
 	    Some(LastMatch::Match(m)) => {
-	        matches.push(m);
+	        matches.push(*m);
 	        (false,None)
 	    },
 	    Some(LastMatch::Ellipsis(rest)) => (true, rest),

--- a/src/parser/uniterm.rs
+++ b/src/parser/uniterm.rs
@@ -164,7 +164,7 @@ impl UniRecord {
     pub fn into_type_strict(self) -> Result<Types, InvalidRecordTypeError> {
         // An open record (with an ellipsis `..` at the end) can't be translated to a record type.
         // `pos_ellipsis` should be set iff `attrs.open` is true.
-        debug_assert!((self.pos_ellipsis == TermPos::None) == !self.attrs.open);
+        debug_assert!((self.pos_ellipsis == TermPos::None) != self.attrs.open);
 
         if let Some(raw_span) = self.pos_ellipsis.into_opt() {
             return Err(InvalidRecordTypeError(TermPos::Original(raw_span)));
@@ -397,16 +397,13 @@ pub fn fix_type_vars(ty: &mut Types) {
 /// Fix the type variables of types appearing as annotations of record fields. See
 /// [`fix_type_vars`].
 pub fn fix_field_types(rt: &mut RichTerm) {
-    match SharedTerm::make_mut(&mut rt.term) {
-        Term::MetaValue(ref mut m) => {
-            if let Some(Contract { ref mut types, .. }) = m.types {
-                fix_type_vars(types);
-            }
-
-            for ctr in m.contracts.iter_mut() {
-                fix_type_vars(&mut ctr.types);
-            }
+    if let Term::MetaValue(ref mut m) = SharedTerm::make_mut(&mut rt.term) {
+        if let Some(Contract { ref mut types, .. }) = m.types {
+            fix_type_vars(types);
         }
-        _ => (),
+
+        for ctr in m.contracts.iter_mut() {
+            fix_type_vars(&mut ctr.types);
+        }
     }
 }

--- a/src/parser/utils.rs
+++ b/src/parser/utils.rs
@@ -283,7 +283,7 @@ fn merge_field(rterm1: RichTerm, rterm2: RichTerm) -> Option<RichTerm> {
             Some(RichTerm::from(Term::MetaValue(new_meta)))
         }
         (Some(meta), None) | (None, Some(meta)) => {
-            let mut new_meta = meta.clone();
+            let mut new_meta = meta;
             new_meta.value = new_value;
             Some(RichTerm::from(Term::MetaValue(new_meta)))
         }
@@ -329,7 +329,7 @@ pub fn mk_let(
     t2: RichTerm,
     span: RawSpan,
 ) -> Result<RichTerm, ParseError> {
-    let result = match pat.into() {
+    let result = match pat {
         d @ (Destruct::Record { .. } | Destruct::Array { .. }) => {
             if rec {
                 return Err(ParseError::RecursiveLetPattern(span));

--- a/src/pretty.rs
+++ b/src/pretty.rs
@@ -20,7 +20,7 @@ fn min_interpolate_sign(text: &str) -> usize {
             // be fine. But picking the maximum
             //
             // TODO: Improve the `"%*m` case if necessary.
-            if m.as_str().ends_with("{") {
+            if m.as_str().ends_with('{') {
                 d
             } else {
                 d - 1
@@ -30,7 +30,7 @@ fn min_interpolate_sign(text: &str) -> usize {
         .unwrap_or(1)
 }
 
-fn sorted_map<'a, K: Ord, V>(m: &'a HashMap<K, V>) -> Vec<(&'a K, &'a V)> {
+fn sorted_map<K: Ord, V>(m: &'_ HashMap<K, V>) -> Vec<(&'_ K, &'_ V)> {
     let mut ret: Vec<(&K, &V)> = m.iter().collect();
     ret.sort_by_key(|(k, _)| *k);
     ret
@@ -43,24 +43,24 @@ where
     Self::Doc: Clone,
     A: Clone,
 {
-    fn quote_if_needed(self: &'a Self, id: &crate::identifier::Ident) -> DocBuilder<'a, Self, A> {
+    fn quote_if_needed(&'a self, id: &crate::identifier::Ident) -> DocBuilder<'a, Self, A> {
         let reg = Regex::new("^_?[a-zA-Z][_a-zA-Z0-9-]*$").unwrap();
-        if reg.is_match(&id.to_string()) {
+        if reg.is_match(id.as_ref()) {
             self.as_string(id)
         } else {
             self.as_string(id).double_quotes()
         }
     }
 
-    fn escaped_string(self: &'a Self, s: &str) -> DocBuilder<'a, Self, A> {
+    fn escaped_string(&'a self, s: &str) -> DocBuilder<'a, Self, A> {
         let s = s
-            .replace("\\", "\\\\")
+            .replace('\\', "\\\\")
             .replace("%{", "\\%{")
-            .replace("\"", "\\\"");
+            .replace('\"', "\\\"");
         self.text(s)
     }
 
-    fn metadata(self: &'a Self, mv: &MetaValue, with_doc: bool) -> DocBuilder<'a, Self, A> {
+    fn metadata(&'a self, mv: &MetaValue, with_doc: bool) -> DocBuilder<'a, Self, A> {
         if let Some(types) = &mv.types {
             self.text(":")
                 .append(self.space())
@@ -80,14 +80,14 @@ where
                         .append(
                             self.hardline()
                                 .append(self.intersperse(
-                                    doc.lines().map(|d| self.escaped_string(&d)),
+                                    doc.lines().map(|d| self.escaped_string(d)),
                                     self.hardline().clone(),
                                 ))
                                 .double_quotes(),
                         )
                         .append(self.line())
                 })
-                .unwrap_or(self.nil())
+                .unwrap_or_else(|| self.nil())
         } else {
             self.nil()
         })
@@ -277,7 +277,7 @@ where
                     )
                     .max()
                     .unwrap_or(1);
-                let interp: String = std::iter::repeat("%").take(nb_perc).collect();
+                let interp: String = "%".repeat(nb_perc);
                 allocator
                     .intersperse(
                         chunks.iter().rev().map(|c| match c {
@@ -403,7 +403,7 @@ where
                                     .append(allocator.space())
                             })
                         })
-                        .unwrap_or(allocator.nil()),
+                        .unwrap_or_else(|| allocator.nil()),
                 )
                 .append(dst.pretty(allocator))
                 .append(if let MetaValue(ref mv) = rt.as_ref() {
@@ -468,7 +468,7 @@ where
                             .append(allocator.space())
                             .append(if let MetaValue(mv) = rt.as_ref() {
                                 allocator
-                                    .metadata(&mv, true)
+                                    .metadata(mv, true)
                                     .append(allocator.space())
                                     .append(
                                         mv.value
@@ -479,7 +479,7 @@ where
                                                     .append(allocator.space())
                                                     .append(v.pretty(allocator))
                                             })
-                                            .unwrap_or(allocator.nil()),
+                                            .unwrap_or_else(|| allocator.nil()),
                                     )
                             } else {
                                 allocator
@@ -517,7 +517,7 @@ where
                                     .append(allocator.space())
                                     .append(if let MetaValue(mv) = rt.as_ref() {
                                         allocator
-                                            .metadata(&mv, true)
+                                            .metadata(mv, true)
                                             .append(allocator.space())
                                             .append(
                                                 mv.value
@@ -528,7 +528,7 @@ where
                                                             .append(allocator.space())
                                                             .append(v.pretty(allocator))
                                                     })
-                                                    .unwrap_or(allocator.nil()),
+                                                    .unwrap_or_else(|| allocator.nil()),
                                             )
                                     } else {
                                         allocator
@@ -544,7 +544,7 @@ where
                                     .append(allocator.space())
                                     .append(if let MetaValue(mv) = rt.as_ref() {
                                         allocator
-                                            .metadata(&mv, true)
+                                            .metadata(mv, true)
                                             .append(allocator.space())
                                             .append(
                                                 mv.value
@@ -554,7 +554,7 @@ where
                                                             .text("=")
                                                             .append(v.pretty(allocator))
                                                     })
-                                                    .unwrap_or(allocator.nil()),
+                                                    .unwrap_or_else(|| allocator.nil()),
                                             )
                                     } else {
                                         allocator
@@ -602,7 +602,7 @@ where
                                 .append(allocator.space())
                                 .append(allocator.text("=>"))
                                 .append(allocator.space())
-                                .append(d.to_owned().pretty(allocator))
+                                .append(d.pretty(allocator))
                         }))
                         .nest(2)
                         .append(allocator.line_())

--- a/src/program.rs
+++ b/src/program.rs
@@ -281,7 +281,7 @@ mod doc {
     ) -> Result<(), Error> {
         match rt.term.as_ref() {
             Term::MetaValue(MetaValue { doc: Some(md), .. }) => {
-                document.append(&mut parse_documentation(header_level, arena, &md, options))
+                document.append(parse_documentation(header_level, arena, md, options))
             }
             Term::Record(map, _) | Term::RecRecord(map, _, _, _) => {
                 // Sorting fields for a determinstic output
@@ -326,12 +326,12 @@ mod doc {
                 setext,
             });
         }
-        return ast;
+        ast
     }
 
     /// Creates a codespan header of the provided string with the provided header level.
     fn mk_header<'a>(
-        ident: &String,
+        ident: &str,
         header_level: u32,
         arena: &'a Arena<AstNode<'a>>,
     ) -> &'a AstNode<'a> {
@@ -342,7 +342,7 @@ mod doc {
 
         let code = arena.alloc(AstNode::from(NodeValue::Code(NodeCode {
             num_backticks: 1,
-            literal: ident.clone().into_bytes(),
+            literal: ident.bytes().collect(),
         })));
 
         res.append(code);

--- a/src/repl/command.rs
+++ b/src/repl/command.rs
@@ -92,7 +92,7 @@ impl FromStr for Command {
     type Err = ReplError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let cmd_end = s.find(' ').unwrap_or_else(|| s.len());
+        let cmd_end = s.find(' ').unwrap_or(s.len());
         let cmd_str: String = s.chars().take(cmd_end).collect();
         let cmd: CommandType = cmd_str
             .parse()

--- a/src/repl/mod.rs
+++ b/src/repl/mod.rs
@@ -138,12 +138,7 @@ impl ReplImpl {
                 typecheck::type_check_in_env(&t, &repl_impl.env.type_env, &repl_impl.cache)?;
 
             if let Some(id) = id {
-                typecheck::Envs::env_add(
-                    &mut repl_impl.env.type_env,
-                    id.clone(),
-                    &t,
-                    &repl_impl.cache,
-                );
+                typecheck::Envs::env_add(&mut repl_impl.env.type_env, id, &t, &repl_impl.cache);
             }
 
             for id in &pending {
@@ -331,7 +326,7 @@ impl InputParser {
 
         match result {
             Ok((t, e)) if e.no_errors() => InputStatus::Complete(t),
-            Ok((_, e)) if e.errors.iter().all(|e| partial(e)) => InputStatus::Partial,
+            Ok((_, e)) if e.errors.iter().all(partial) => InputStatus::Partial,
             Ok((_, e)) => InputStatus::Failed(e),
             Err(e) if partial(&e) => InputStatus::Partial,
             Err(err) => InputStatus::Failed(err.into()),

--- a/src/term.rs
+++ b/src/term.rs
@@ -313,10 +313,9 @@ impl MetaValue {
             // If both have type annotations, the result will have the outer one as a type annotation.
             // However we still need to enforce the corresponding contract to preserve the operational
             // semantics. Thus, the inner type annotation is derelicted to a contract.
-            match inner.types.take() {
-                Some(ctr) => contracts.push(ctr),
-                _ => (),
-            };
+            if let Some(ctr) = inner.types.take() {
+                contracts.push(ctr)
+            }
         }
 
         contracts.extend(inner.contracts.into_iter());
@@ -392,9 +391,10 @@ impl Term {
             MetaValue(ref mut meta) => {
                 meta.contracts
                     .iter_mut()
-                    .for_each(|Contract { types, .. }| match types.0 {
-                        AbsType::Flat(ref mut rt) => func(rt),
-                        _ => (),
+                    .for_each(|Contract { types, .. }| {
+                        if let AbsType::Flat(ref mut rt) = types.0 {
+                            func(rt)
+                        }
                     });
                 meta.value.iter_mut().for_each(func);
             }
@@ -978,10 +978,7 @@ pub enum BinaryOp {
 
 impl BinaryOp {
     pub fn is_strict(&self) -> bool {
-        match self {
-            BinaryOp::Merge() => false,
-            _ => true,
-        }
+        !matches!(self, BinaryOp::Merge())
     }
 
     pub fn pos(&self) -> OpPos {
@@ -1065,8 +1062,7 @@ impl RichTerm {
     pub fn without_pos(mut self) -> Self {
         fn clean_pos(rt: &mut RichTerm) {
             rt.pos = TermPos::None;
-            SharedTerm::make_mut(&mut rt.term)
-                .apply_to_rich_terms(|rt: &mut RichTerm| clean_pos(rt));
+            SharedTerm::make_mut(&mut rt.term).apply_to_rich_terms(clean_pos);
         }
 
         clean_pos(&mut self);

--- a/src/term.rs
+++ b/src/term.rs
@@ -978,7 +978,10 @@ pub enum BinaryOp {
 
 impl BinaryOp {
     pub fn is_strict(&self) -> bool {
-        !matches!(self, BinaryOp::Merge())
+        match self {
+            BinaryOp::Merge() => false,
+            _ => true,
+        }
     }
 
     pub fn pos(&self) -> OpPos {

--- a/src/transform/desugar_destructuring.rs
+++ b/src/transform/desugar_destructuring.rs
@@ -84,7 +84,7 @@ pub fn desugar_with_contract(rt: RichTerm) -> RichTerm {
         with {
             Term::LetPattern(x, pat, t_, body) => {
                 let pos = body.pos;
-                let meta = pat.clone().as_contract();
+                let meta = pat.clone().into_contract();
                 let t_ = {
                     let t_pos = t_.pos;
                     RichTerm::new(
@@ -152,7 +152,7 @@ fn bind_open_field(x: Ident, pat: &Destruct, body: RichTerm) -> RichTerm {
         _ => panic!("A closed pattern can not have a rest binding"),
     };
     Term::Let(
-        var.clone(),
+        var,
         matches.iter().fold(Term::Var(x).into(), |x, m| match m {
             Match::Simple(i, _) | Match::Assign(i, _, _) => {
                 op2(DynRemove(), Term::Str(i.to_string()), x)

--- a/src/transform/free_vars.rs
+++ b/src/transform/free_vars.rs
@@ -150,9 +150,8 @@ fn collect_free_vars(rt: &mut RichTerm, free_vars: &mut HashSet<Ident>) {
         }
         Term::StrChunks(chunks) => {
             for chunk in chunks {
-                match chunk {
-                    StrChunk::Expr(t, _) => collect_free_vars(t, free_vars),
-                    _ => (),
+                if let StrChunk::Expr(t, _) = chunk {
+                    collect_free_vars(t, free_vars)
                 }
             }
         }

--- a/src/transform/mod.rs
+++ b/src/transform/mod.rs
@@ -137,10 +137,12 @@ impl Closurizable for RichTerm {
         let pos = self.pos;
 
         let thunk = match self.as_ref() {
-            Term::Var(id) if id.is_generated() => with_env.get(&id).expect(&format!(
+            Term::Var(id) if id.is_generated() => with_env.get(id).unwrap_or_else(|| {
+                panic!(
                 "Internal error(closurize) : generated identifier {} not found in the environment",
                 id
-            )),
+            )
+            }),
             _ => {
                 let closure = Closure {
                     body: self,

--- a/src/transform/share_normal_form.rs
+++ b/src/transform/share_normal_form.rs
@@ -181,18 +181,18 @@ pub fn transform_one(rt: RichTerm) -> RichTerm {
 /// duplicating any work. On the other hand, a WHNF which can contain other shareable
 /// subexpressions, such as a record, should be shared.
 fn should_share(t: &Term) -> bool {
-    !matches!(
-        t,
+    match t {
         Term::Null
-            | Term::Bool(_)
-            | Term::Num(_)
-            | Term::Str(_)
-            | Term::Lbl(_)
-            | Term::Sym(_)
-            | Term::Var(_)
-            | Term::Enum(_)
-            | Term::Fun(_, _)
-    )
+        | Term::Bool(_)
+        | Term::Num(_)
+        | Term::Str(_)
+        | Term::Lbl(_)
+        | Term::Sym(_)
+        | Term::Var(_)
+        | Term::Enum(_)
+        | Term::Fun(_, _) => false,
+        _ => true,
+    }
 }
 
 /// Bind a list of pairs `(identifier, term, binding_type)` in a term.

--- a/src/transform/share_normal_form.rs
+++ b/src/transform/share_normal_form.rs
@@ -181,18 +181,18 @@ pub fn transform_one(rt: RichTerm) -> RichTerm {
 /// duplicating any work. On the other hand, a WHNF which can contain other shareable
 /// subexpressions, such as a record, should be shared.
 fn should_share(t: &Term) -> bool {
-    match t {
+    !matches!(
+        t,
         Term::Null
-        | Term::Bool(_)
-        | Term::Num(_)
-        | Term::Str(_)
-        | Term::Lbl(_)
-        | Term::Sym(_)
-        | Term::Var(_)
-        | Term::Enum(_)
-        | Term::Fun(_, _) => false,
-        _ => true,
-    }
+            | Term::Bool(_)
+            | Term::Num(_)
+            | Term::Str(_)
+            | Term::Lbl(_)
+            | Term::Sym(_)
+            | Term::Var(_)
+            | Term::Enum(_)
+            | Term::Fun(_, _)
+    )
 }
 
 /// Bind a list of pairs `(identifier, term, binding_type)` in a term.

--- a/src/typecheck/mod.rs
+++ b/src/typecheck/mod.rs
@@ -426,7 +426,7 @@ fn walk<L: Linearizer>(
                 ..
                 } => {
                     let tyw2 = TypeWrapper::from(ty2.clone());
-                    let instantiated = instantiate_foralls(state, tyw2.clone(), ForallInst::Constant);
+                    let instantiated = instantiate_foralls(state, tyw2, ForallInst::Constant);
                     type_check_(state, envs, lin, linearizer, t, instantiated)
                 }
                 MetaValue {value: Some(t), .. } =>  walk(state, envs, lin, linearizer, t),
@@ -488,7 +488,7 @@ fn inject_pat_vars(pat: &Destruct, envs: &mut Envs) {
                 let id = bind_id.as_ref().unwrap_or(id);
                 envs.insert(id.clone(), TypeWrapper::Concrete(AbsType::Dyn()));
                 if !pat.is_empty() {
-                    inject_pat_vars(&pat, envs);
+                    inject_pat_vars(pat, envs);
                 }
             }
         });
@@ -1693,6 +1693,6 @@ fn get_wildcard_var(
 fn wildcard_vars_to_type(wildcard_vars: Vec<TypeWrapper>, table: &UnifTable) -> Wildcards {
     wildcard_vars
         .into_iter()
-        .map(|var| to_type(&table, var))
+        .map(|var| to_type(table, var))
         .collect()
 }


### PR DESCRIPTION
Quick run of `cargo clippy`.

This caught things like unnecessary `.clone()`s, and references. Though some lints suggested adding `Default` implementations for types that have a `new()` method, simply because "some users might need them", needless to say, I did not apply them as `nickel_lang` is not really a library with a public API.