### PR TITLE
Fix LSP panicking on fields with contracts

### DIFF
--- a/src/typecheck/linearization.rs
+++ b/src/typecheck/linearization.rs
@@ -129,6 +129,12 @@ pub trait Linearizer {
     /// required or produced in parallel instances should therefore be put
     /// into the Building State `L` which is passed
     fn scope(&mut self) -> Self;
+
+    /// Create a scope for the processing of terms potentially contained in metadata (contracts
+    /// expressions in the annotations). When walking such terms, scoping behaves differently with
+    /// respect to the previous state (pending record fields, let binding, metavalue, etc.).
+    /// Mostly, the `self` linearizer keeps the state while the returned one has a clean state.
+    fn scope_meta(&mut self) -> Self;
 }
 
 /// [Linearizer] that deliberately does not maintain any state or act
@@ -146,6 +152,10 @@ where
 
     fn scope(&mut self) -> Self {
         StubHost::new()
+    }
+
+    fn scope_meta(&mut self) -> Self {
+        self.scope()
     }
 }
 


### PR DESCRIPTION
Closes #775. Since the refactoring of the typechecker with a distinct walk phase, the typechecker now also walk contracts and type annotations. This caused the LSP to panic in a lot of cases (basically, as soon as a contract is attached to a field), due to scoping issues and breaking some invariants of the LSP's linearizer.

This PR fixes the issue by adding a new proper scoping function for walking contracts (`scope_meta`) in the linearizer, which behaves the right way. This PR also removes the now deprecated code that used to (shallowly) handle contracts directly in the linearizer.