### PR TITLE
Fix fold benchmarks

### DIFF
--- a/benches/arrays/fold.ncl
+++ b/benches/arrays/fold.ncl
@@ -1,34 +1,34 @@
-let letter | string.CharLiteral -> string.CharLiteral = fun n =>
-  string.char_code "a" + (n % 26)
-  |> string.char_from_code in
+let letter | Num -> string.CharLiteral = fun n =>
+  string.code "a" + (n % 26)
+  |> string.from_code in
 
 {
   right = {
     strings = {
       run = fun n =>
-        array.fold (fun x y => x ++ "a") (array.generate n (fun n => letter n))
+        array.fold (fun x acc => acc ++ x) "" (array.generate (fun n => letter n) n)
     },
     nums = {
       run = fun n =>
-        array.fold (fun x y => x*y + (x - y)) (array.generate n (fun n => n/2))
+        array.fold (fun x acc => x*acc + (x - acc)) 0 (array.generate (fun n => n/2) n)
     },
     arrays = {
       run = fun n =>
-        array.fold (fun x acc => [x] ++ acc) (array.generate n (fun n => [n]))
+        array.fold (fun x acc => acc @ [x]) [] (array.generate (fun n => [n]) n)
     },
   },
   left = {
     strings = {
       run = fun n =>
-        array.foldl (fun x y => x ++ "a") (array.generate n (fun n => letter n))
+        array.foldl (fun acc x => acc ++ x) "" (array.generate (fun n => letter n) n)
     },
     nums = {
       run = fun n =>
-        array.foldl (fun x y => x*y + (x - y)) (array.generate n (fun n => n/2))
+        array.foldl (fun acc x => x*acc + (x - acc)) 0 (array.generate (fun n => n/2) n)
     },
     arrays = {
       run = fun n =>
-        array.foldl (fun x acc => [x] ++ acc) (array.generate n (fun n => [n]))
+        array.foldl (fun acc x => acc @ [x]) [] (array.generate (fun n => [n]) n)
     },
   }
 }


### PR DESCRIPTION
It seems like the fold benchmarks weren't running at all, in that the arguments to `array.fold` are not saturated, the signature of `array.generate` is wrong, and `letter`'s contract is incorrect.

I got slowdowns of nearly 10000% after the changes.

Or am I missing something?