### PR TITLE
[Fix] LSP freezing on some commands

### DIFF
--- a/lsp/nls/src/linearization/completed.rs
+++ b/lsp/nls/src/linearization/completed.rs
@@ -45,10 +45,7 @@ impl Completed {
     ) -> Vec<&LinearizationItem<Resolved>> {
         let empty = Vec::with_capacity(0);
         (0..scope.len())
-            .flat_map(|end| {
-                eprintln!("in scope {:?}: {:?}", scope, self.scope.get(scope));
-                self.scope.get(&scope[..=end]).unwrap_or(&empty)
-            })
+            .flat_map(|end| self.scope.get(&scope[..=end]).unwrap_or(&empty))
             .map(|id| self.get_item(*id))
             .flatten()
             .collect()

--- a/lsp/nls/src/linearization/mod.rs
+++ b/lsp/nls/src/linearization/mod.rs
@@ -412,8 +412,6 @@ impl Linearizer for AnalysisHost {
             )
             .collect();
 
-        eprintln!("Linearized {:#?}", &lin_);
-
         Linearization::new(Completed::new(lin_, scope, id_mapping))
     }
 


### PR DESCRIPTION
We noticed with @fuzzypixelz than some hover were taking ages with the LSP. It turns out debug print statement were left out. This PR fixes this problem. This is crippling enough that it mandates a new minor release.