### PR TITLE
Enable markdown linting for doc

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,10 @@
+{
+    "default": true,
+    "MD013": {
+        "code_blocks": false,
+        "tables": false
+    },
+    "MD024": {
+        "allow_different_nesting": true
+    }
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,4 +94,3 @@ aspects to consider when working on Nickel:
 [tweag]: https://www.tweag.io
 [rfcs]: ./rfcs/
 [matrix-nickel]: https://matrix.to/#/#nickel-lang:matrix.org
-[nickel-lang.org]: https://nickel-lang.org

--- a/HACKING.md
+++ b/HACKING.md
@@ -1,5 +1,4 @@
-The Nickel developer guide
-==========================
+# The Nickel developer guide
 
 There are two ways to set up a development environment for Nickel: using
 [Nix][nix], or directly via your preferred system package manager. Nix is able
@@ -12,12 +11,14 @@ itself_. The reason is that incremental compilation for Rust and Nix is not
 there yet, and incremental rebuilds using only Nix are going to be painfully
 long.
 
-# Content
+## Content
 
 The Nickel repository consist in 3 crates:
 
-- `nickel-lang` (path: `.`). The main crate containing the interpreter as a library as well as the `nickel` binary.
-- `nickel-lang-lsp` (path: `lsp/nls/`). the Nickel Language Server (NLS), an LSP server for Nickel.
+- `nickel-lang` (path: `.`). The main crate containing the interpreter as a
+  library as well as the `nickel` binary.
+- `nickel-lang-lsp` (path: `lsp/nls/`). the Nickel Language Server (NLS), an LSP
+  server for Nickel.
 - `nickel-lang-utilities`: (path: `utilities/`). An auxiliary crate regrouping
    helpers for tests and benchmarks. Not required to build `nickel` itself.
 
@@ -26,9 +27,9 @@ Other noteworthy items:
 - The user manual in `doc/manual/`, as a bunch of markdown files.
 - A VSCode extension for NLS in `lsp/client-extension/`.
 
-# Setup a development environment
+## Setup a development environment
 
-## Using Nix
+### Using Nix
 
 To set up a development environment using a recent Nix (>= 2.4):
 
@@ -37,12 +38,12 @@ To set up a development environment using a recent Nix (>= 2.4):
    in a shell with all the required tool to hack on Nickel (`rust`, `cargo`,
    etc.)
 
-## Without Nix
+### Without Nix
 
 Otherwise, you can install the Rust toolchain separately: follow the
 instructions of the [Rust installation guide][install-rust].
 
-# Building
+## Building
 
 You can build all crates at once:
 
@@ -54,7 +55,7 @@ $ ./target/debug/nls --version
 nickel-lang-lsp 0.1.0
 ```
 
-## Nickel
+### Nickel
 
 To only build the main crate `nickel-lang`, run:
 
@@ -64,7 +65,7 @@ $ ./target/debug/nickel --version
 nickel-lang 0.1.0
 ```
 
-## NLS (nickel-lang-lsp)
+### NLS (nickel-lang-lsp)
 
 To build NLS separately, the LSP server for Nickel, build the `nickel-lang-lsp` crate:
 
@@ -76,7 +77,7 @@ nickel-lang-lsp 0.1.0
 
 (Alternatively, you can run `cargo build` directly inside `lsp/nls/`).
 
-## WebAssembly REPL
+### WebAssembly REPL
 
 There is a WebAssembly (WASM) version of the REPL, which is used for the online
 playground on [nickel-lang.org][nickel-lang.org]. To ease the build, we use the
@@ -88,7 +89,7 @@ compilation is not as good as with direct usage of `cargo`.
 
 Both methods are described below.
 
-### Using Nix
+#### Using Nix
 
 At the root of the repository:
 
@@ -98,7 +99,7 @@ $ ls result/nickel-repl
 LICENSE  package.json nickel_lang_bg.js  nickel_lang_bg.wasm [..]
 ```
 
-### Using Cargo
+#### Using Cargo
 
 1. [Install `wasm-pack`][install-wasm-pack]
 2. Run `wasm-pack` on the `nickel-repl` crate:
@@ -111,7 +112,7 @@ LICENSE  package.json nickel_lang_bg.js  nickel_lang_bg.wasm [..]
    A `pkg` directory, containing the corresponding NPM package, should now be
    available.
 
-# Testing
+## Testing
 
 Tests are run via `cargo test`. They are two types of tests:
 
@@ -147,7 +148,7 @@ fn non_mergeable() {
 }
 ```
 
-# Benchmarking
+## Benchmarking
 
 If your change is likely to impact performance, it is recommended to run the
 benchmark suite on master and on your branch to assess any performance changes.
@@ -156,7 +157,7 @@ Please report your findings in the description of the PR.
 The benchmark suite is located in the `benches/` directory. To run it:
 
 ```shell
-$ cargo bench
+cargo bench
 ```
 
 Note that a full run takes some time, up to a dozen of minutes. You can run

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ configuration, be it for a single app, a machine, whole infrastructure, or a
 build system.
 
 The motivating use cases are in particular:
+
 - The [Nix package manager](https://nixos.org/): Nix is a declarative package
     manager using its own language for specifying packages. Nickel is an
     evolution of the Nix language, while trying to overcome some of its
@@ -66,7 +67,7 @@ The motivating use cases are in particular:
     a specification of the dependency graph.
 
 Most aforementioned projects have their own bespoke configuration language. See
-[Related projects and inspirations](#Related-projects-and-inspirations). In
+[Related projects and inspirations](#related-projects-and-inspirations). In
 general, application-specific languages might suffer from feature creep, lack of
 abstractions or just feel ad hoc. Nickel buys you more for less.
 
@@ -81,39 +82,46 @@ the `nickel-lang` crate documentation).
 ### Run
 
 1. Start Nickel
-   * with [flake-enabled](https://nixos.wiki/wiki/Flakes) Nix directly
+
+   - with [flake-enabled](https://nixos.wiki/wiki/Flakes) Nix directly
      with `nix run nickel` (which pulls it from the global flakes
      registry), or with `nix run github:tweag/nickel` (which pulls it
      from the repo). You can use [our binary cache](https://nickel.cachix.org) to
      prevent rebuilding a lot of packages. You pass in arguments with
      an extra `--` as in `nix run nickel -- repl`,
-   * with `./nickel`, after [building](#Build) this repo, depending on the
+   - with `./nickel`, after [building](#build) this repo, depending on the
      location of the executable and passing in arguments directly,
-   * or with `cargo run` after [building](#Build), passing in arguments with
+   - or with `cargo run` after [building](#build), passing in arguments with
      an extra `--` as in `cargo run -- -f program.ncl`.
 
 2. Run your first program:
-  ```console
-  $ ./nickel <<< 'let x = 2 in x + x'
-  4
-  ```
-  Or load it from a file:
-  ```console
-  $ echo 'let s = "world" in "Hello, " ++ s' > program.ncl
-  $ ./nickel -f program.ncl
-  "Hello, world"
-  ```
+
+    ```console
+    $ ./nickel <<< 'let x = 2 in x + x'
+    4
+    ```
+
+    Or load it from a file:
+
+    ```console
+    $ echo 'let s = "world" in "Hello, " ++ s' > program.ncl
+    $ ./nickel -f program.ncl
+    "Hello, world"
+    ```
+
 3. Start a REPL:
-  ```console
-  $ ./nickel repl
-  nickel> let x = 2 in x + x
-  4
 
-  nickel>
-  ```
-  Use `:help` for a list of available commands.
+    ```console
+    $ ./nickel repl
+    nickel> let x = 2 in x + x
+    4
 
+    nickel>
+    ```
+
+    Use `:help` for a list of available commands.
 4. Export your configuration to JSON, YAML or TOML:
+
   ```console
   $ ./nickel export --format json <<< '{foo = "Hello, world!"}'
   {
@@ -126,38 +134,46 @@ for help about a specific subcommand.
 
 #### Editor Setup
 
-Nickel has syntax highlighting plugins for Vim/Neovim, and VSCode.
-In-editor diagnostics, type hints, and auto-completion are provided by the Nickel Language Server.
-Please follow [this guide](https://github.com/tweag/nickel/tree/master/lsp) to setup syntax highlighting and NLS.
+Nickel has syntax highlighting plugins for Vim/Neovim, and VSCode. In-editor
+diagnostics, type hints, and auto-completion are provided by the Nickel Language
+Server. Please follow
+[this guide](https://github.com/tweag/nickel/tree/master/lsp) to setup syntax
+highlighting and NLS.
 
 ### Build
 
 [rust-guide]: https://doc.rust-lang.org/cargo/getting-started/installation.html
 
 1. Download build dependencies:
+
    - **With Nix**: If you have [Nix](https://nixos.org/nix) installed:
+
      ```console
-     $ nix-shell shell.nix
+     nix-shell shell.nix
      ```
+
      to be dropped in a shell, ready to build. You can use [our binary
-     cache](https://nickel.cachix.org) to prevent rebuilding a lot of
-     packages.
+     cache](https://nickel.cachix.org) to prevent rebuilding a lot of packages.
    - **Without Nix**: otherwise, follow [this guide][rust-guide] to install Rust
      and Cargo first.
+
 1. Build Nickel:
+
    ```console
-   $ cargo build
+   cargo build
    ```
+
    And voilà! Generated files are placed in `target/debug`.
 1. *(optional)* make a symbolic link to the executable:
+
   ```console
-  $ ln -S nickel target/debug/nickel
+  ln -S nickel target/debug/nickel
   ```
 
 ### Tests
 
 ```console
-$ cargo test
+cargo test
 ```
 
 ### Documentation
@@ -169,9 +185,11 @@ repository as a collection of Markdown files in `doc/manual`.
 To get the documentation of the `nickel-lang` codebase itself:
 
 1. Build the doc:
-  ```console
-  $ cargo doc --no-deps
-  ```
+
+    ```console
+    cargo doc --no-deps
+    ```
+
 2. Open the file `target/doc/nickel/index.html` in your browser.
 
 ### Examples

--- a/benches/mantis/README.md
+++ b/benches/mantis/README.md
@@ -1,15 +1,17 @@
+# Mantis bench
+
 This bench is a copy of [nickel-mantis-ops](https://github.com/tweag/nickel-mantis-ops)
 by @yannham
 
-# Mantis Ops in Nickel
+## Mantis Ops in Nickel
 
 This is a tentative to convert the [mantis ops repo of
 IOHK](https://github.com/input-output-hk/mantis-ops) from CUE to Nickel, as a
 dogfooding exercise. This repo tries to respect the same file hierarchy than the
 original one, whenever possible.
 
-## Example invocation
+### Example invocation
 
-```
+```console
 nickel export <<< 'import "deploy.ncl" {namespace="mantis-staging", job="miner"}'
 ```

--- a/doc/manual/contracts.md
+++ b/doc/manual/contracts.md
@@ -1,6 +1,7 @@
 ---
 slug: contracts
 ---
+
 # Contracts in Nickel
 
 (For the motivation behind contracts and a high-level overview of contracts and
@@ -32,7 +33,7 @@ are performed:
 2. Check that the result is a number.
 3. If it is, return the expression unchanged. Otherwise, raise an error.
 
-```
+```text
 $ nickel repl
 nickel>1 + 1 | Num
 2
@@ -72,8 +73,8 @@ A custom contract is a function of two arguments:
   `contract.blame_with` when the contract isn't satisfied.
 - The value being checked.
 
-Upon success, the contract must return the original value. We will see the reason why
-in the [laziness](#laziness) section. To signal failure, we use
+Upon success, the contract must return the original value. We will see the
+reason why in the [laziness](#laziness) section. To signal failure, we use
 `contract.blame` or its variant `contract.blame_with` that takes an additional
 error message as a parameter. `blame` immediately aborts the execution and
 reports a contract violation error.
@@ -82,7 +83,7 @@ In `IsFoo`, we first test if the value is a string, and then if it is equal to
 `"foo"`, in which case the contract succeeds. Otherwise, the contract fails with
 appropriate error messages. Let us try:
 
-```
+```text
 nickel>1 | IsFoo
 error: contract broken by a value [not a string].
 [..]
@@ -254,7 +255,7 @@ existing contracts seamlessly as building blocks for new contracts.
 
 If we export this example to json, we get:
 
-```
+```console
 $ nickel -f config.ncl export
 error: contract broken by a value.
    ┌─ :1:1
@@ -302,7 +303,7 @@ Additionally to defining the contracts of fields, record contract can also
 attach metadata (see [merging](./merging.md)) to fields, such as a documentation
 or default value:
 
-```
+```text
 nickel>let MyConfig = {
     foo | doc "This documentation will propagate to the final value!"
         | Str
@@ -326,7 +327,7 @@ nickel>:query config.foo
 
 By default, record contracts are closed, meaning that additional fields are forbidden:
 
-```
+```text
 nickel>let Contract = {foo | Str}
 nickel>{foo = "a", bar = 1} | Contract
 error: contract broken by a value [extra field `bar`].
@@ -336,7 +337,7 @@ error: contract broken by a value [extra field `bar`].
 If you want to allow additional fields, append `, ..` after the last field
 definition to define an open contract:
 
-```
+```text
 nickel>let Contract = {foo | Str, ..}
 nickel>{foo = "a", bar = 1} | Contract
 { foo = <contract,value="a">, bar = 1}
@@ -350,7 +351,7 @@ contract or a normal value. If a field is defined both in the contract and the
 checked value, the two definitions will be merged in the final result. For
 example:
 
-```
+```text
 nickel>let Secure = {
   must_be_very_secure | Bool = true,
   data | Str,
@@ -388,7 +389,7 @@ fields: thus, the contract `{bar | Str}` attached to `foo` will actually behave
 as an open contract, even if you didn't use `..`. This is usually not what you
 want:
 
-```
+```text
 nickel>let ContractPipe = {
   sub_field | {foo | Str}
 }
@@ -418,7 +419,7 @@ as contracts. In fact, any type constructor of the
 An array contract checks that the value is an array and applies the parameter
 contract to each element:
 
-```
+```text
 nickel>let VeryBig = contract.from_predicate (fun value =>
   builtin.is_num value
   && value >= 1000)
@@ -474,7 +475,7 @@ have a bug that you need to fix.
 The interpreter automatically performs book-keeping for functions contracts in
 order to make this caller/callee distinction:
 
-```
+```text
 nickel>let add_semi | Str -> Str = fun x => x ++ ";" in
 add_semi 1
 error: contract broken by the caller.
@@ -492,7 +493,7 @@ The beauty of function contracts is that they gracefully scale to higher-order
 functions as well. Higher-order functions are functions that take other
 functions as parameters. Here is an example:
 
-```
+```text
 nickel>let apply_fun | (Num -> Num) -> Num = fun f => f 0 in
 apply_fun (fun x => "a")
 error: contract broken by the caller.
@@ -540,7 +541,7 @@ information on a large configuration without having to actually evaluate
 everything. We will use a dummy failing expression `1 + "a"` to observe where
 evaluation takes place:
 
-```
+```text
 nickel>let config = {fail = 1 + "a", data | doc "Some information" = 42}
 nickel>:query config.data
 * value: 42
@@ -629,7 +630,7 @@ value and continues with the second argument (here, our wrapped `value`).
 
 Let us see if we indeed preserved laziness:
 
-```
+```text
 nickel>let config | NumBoolDict = {
     "1" = 1 + "a", # Same as our previous "fail"
     "0" | doc "Some information" = true,
@@ -642,7 +643,7 @@ nickel>:query config."0"
 Yes! Our contract doesn't unduly cause the evaluation of the field `"1"`. Does
 it check anything, though?
 
-```
+```text
 nickel>let config | NumBoolDict = {
   not_a_number = false,
   "0" | doc "Some information" = false,

--- a/doc/manual/cookbook.md
+++ b/doc/manual/cookbook.md
@@ -19,7 +19,8 @@ obliterate the types, making your library basically unusable inside typed code.
 ### Example
 
 DON'T
-```
+
+```nickel
 {
   foo :  Num -> Num = fun x => x + 1,
   bar : Num -> Num = foo,
@@ -27,7 +28,8 @@ DON'T
 ```
 
 BUT DO
-```
+
+```nickel
 {
   foo = fun x => x + 1,
   bar = foo,
@@ -41,13 +43,14 @@ Alternatively, you can repeat your types both at the function level and at the
 record level. It makes code more navigable and `query`-friendly, but at the
 expense of repetition and duplicated contract checks. It is also currently
 required for polymorphic functions because of [the following
-bug](https://github.com/tweag/nickel/issues/360). A better solution will
-probably be implemented in the future: type holes (TODO: MAY ACTUALLY BE AVAILABLE FOR RELEASE)
+bug](https://github.com/tweag/nickel/issues/360).
 
-(NOT YET POSSIBLE)
-```
-{
-  foo : Num -> Num = fun x => x + 1,
-  bar : Num -> Num = foo,
-} : _
-```
+<!-- # Note: we already have type wildcard, but they don't "export" the inferred type. -->
+<!-- A better solution will probably be implemented in the future: type wildcard (TODO: -->
+<!--  -->
+<!-- ```nickel -->
+<!-- { -->
+<!--   foo : Num -> Num = fun x => x + 1, -->
+<!--   bar : Num -> Num = foo, -->
+<!-- } : _ -->
+<!-- ``` -->

--- a/doc/manual/correctness.md
+++ b/doc/manual/correctness.md
@@ -73,7 +73,7 @@ of properties that can be checked for, such as:
 
 Both types and contracts are enforced in a similar way, using an annotation:
 
-```
+```text
 $ nickel repl
 nickel> 1 + 1.5 : Num
 2.5
@@ -106,7 +106,7 @@ difference between types and contracts in practice.
 Say we need a function to convert an array of key-value pairs to an array of keys
 and an array of values. Let's call it `split`:
 
-```
+```text
 nickel> split [{key = "foo", value = 1}, {key = "bar", value = 2}]
 {keys = ["foo", "bar"], values = [1, 2]}
 
@@ -146,9 +146,10 @@ split [{key = "foo", value = 1}, {key = "bar", value = 2}]
 
 We want to ensure that the callers to `split` pass an array
 verifying:
- - elements are records with a `key` field and a `value` field
- - keys are strings
- - values can be anything, but must all have the same type
+
+- elements are records with a `key` field and a `value` field
+- keys are strings
+- values can be anything, but must all have the same type
 
 We also want to make sure our implementation correctly returns a value which is
 a record with a field `keys` that is an array of strings, and a field `values`
@@ -189,18 +190,20 @@ function contract for `split` has the following limitations:
   potentially back into unhelpful dynamic type errors. Evaluating `config.ncl`
   indeed reports the following error:
 
-        error: Type error
-        ┌─ repl-input-12:6:27
-        │
-      6 │         keys = acc.keys @ pair.key,
-        │                           ^^^^^^^^ This expression has type Str, but Array was expected
-        │
-        ┌─ repl-input-13:1:45
-        │
-      1 │ lib.split [{key = "foo", value = 1}, {key = "bar", value = 2}]
-        │                                             ----- evaluated to this
-        │
-        = @, 2nd operand
+     ```text
+     error: Type error
+       ┌─ repl-input-12:6:27
+       │
+     6 │         keys = acc.keys @ pair.key,
+       │                           ^^^^^^^^ This expression has type Str, but Array was expected
+       │
+       ┌─ repl-input-13:1:45
+       │
+     1 │ lib.split [{key = "foo", value = 1}, {key = "bar", value = 2}]
+       │                                             ----- evaluated to this
+       │
+       = @, 2nd operand
+     ```
 
   This error is not very helpful to the caller. It points to inside the
   implementation of `split`, and to the `key = "bar"` part of the argument,
@@ -223,7 +226,7 @@ correctly reported.
 What's more, intermediate values are also typechecked. Evaluating or just
 typechecking `lib.ncl` already reports an error:
 
-```
+```text
 error: Incompatible rows declaration
   ┌─ repl-input-14:9:7
   │
@@ -285,7 +288,7 @@ let level = 1 in
 
 We get:
 
-```
+```text
 error: incompatible types
   ┌─ repl-input-0:3:26
   │
@@ -317,7 +320,7 @@ let level = 4 in
 
 This correctly reports an error, and even gives the computed offending value:
 
-```
+```text
 error: contract broken by a value.
   ┌─ :1:1
   │

--- a/doc/manual/introduction.md
+++ b/doc/manual/introduction.md
@@ -52,6 +52,7 @@ configuration, be it for a single app, a machine, whole infrastructure, or a
 build system.
 
 The motivating use cases are in particular:
+
 - The [Nix package manager](https://nixos.org/): Nix is a declarative package
     manager using its own language for specifying packages. Nickel is an
     evolution of the Nix language, while trying to overcome some of its

--- a/doc/manual/merging.md
+++ b/doc/manual/merging.md
@@ -31,9 +31,9 @@ following situations:
 - [Merging two records without common fields](#simple-merge-(no-common-fields))
 - [Merging records with common fields](#recursive-merge-(with-common-fields))
 - [Merging records with metadata](#merging-record-with-metadata)
-  * [Default values](#default-values)
-  * [Contracts](#contracts)
-  * [Documentation](#documentation)
+  - [Default values](#default-values)
+  - [Contracts](#contracts)
+  - [Documentation](#documentation)
 - [Recursive overriding](#recursive-overriding)
 
 ## Simple merge (no common fields)
@@ -46,7 +46,7 @@ to `{foo = 1, bar = "bar", baz = false}`.
 
 Technically, if we write the left operand as:
 
-```
+```text
 left = {
   field_left_1 = value_left_1,
   ..,
@@ -56,7 +56,7 @@ left = {
 
 And the right operand as:
 
-```
+```text
 right {
   field_right_1 = value_right_1,
   ..,
@@ -66,7 +66,7 @@ right {
 
 Then the merge `left & right` evaluates to the record:
 
-```
+```text
 {
   field_left_1 = value_left_1,
   ..,
@@ -161,7 +161,7 @@ unless one of the following condition hold:
 
 ### Specification
 
-```
+```text
 left = {
   field_left_1 = value_left_1,
   ..,
@@ -174,7 +174,7 @@ left = {
 
 And the right operand as:
 
-```
+```text
 right {
   field_right_1 = value_right_1,
   ..,
@@ -188,7 +188,7 @@ right {
 Where the `field_left_i` and `field_right_j` are distinct for all `i` and `j`.
 Then the merge `left & right` evaluates to the record:
 
-```
+```text
 {
   field_left_1 = value_left_1,
   ..,
@@ -204,7 +204,7 @@ Then the merge `left & right` evaluates to the record:
 
 For two values `v1` and `v2`, if at least one value is not a record, then
 
-```
+```text
 v1 & v2 = v1    if (type_of(v1) is Num, Bool, Str, Enum or v1 == null)
                    AND v1 == v2
           _|_   otherwise (indicates failure)
@@ -271,7 +271,7 @@ recursively merged, if the priorities are the same. Without loss of generality,
 we consider the simple case of two records with only one field, which is the
 same on both side:
 
-```
+```text
 {common = left} & {common = right}
 = {
   common = left          if p(left) > p(right)
@@ -308,7 +308,7 @@ Because merging is meant to be symmetric, Nickel is unable to know which value
 to pick between `enabled = true` and `enabled = false` for the firewall, and
 thus fail:
 
-```
+```text
 error: non mergeable terms
   ┌─ repl-input-0:2:22
   │
@@ -426,7 +426,7 @@ let GreaterThan
 
 This fails at evaluation:
 
-```
+```text
 error: contract broken by a value.
 [..]
    ┌─ repl-input-1:16:19
@@ -440,7 +440,6 @@ note:
 13 │     port | GreaterThan 1024
    │            ^^^^^^^^^^^^^^^^ bound here
 ```
-
 
 ### Documentation
 
@@ -458,9 +457,10 @@ config.ncl query foo` on:
 }
 ```
 
-Will print `"Some documentation"` as expected. If both sides have documentation, the behavior
-is unspecified, as merging two distinct blobs of text doesn't make sense
-in general. Currently, Nickel will randomly keeps one of the two in practice.
+Will print `"Some documentation"` as expected. If both sides have documentation,
+the behavior is unspecified, as merging two distinct blobs of text doesn't make
+sense in general. Currently, Nickel will randomly keeps one of the two in
+practice.
 
 ## Recursive overriding
 
@@ -500,8 +500,9 @@ here, `input` -- will also be updated automatically*. For example, `base_config
 }
 ```
 
-Currently, one can only override a field that has been marked as default beforehand. A
-more ergonomic way of overriding is planned, and described in [RFC001][rfc001].
+Currently, one can only override a field that has been marked as default
+beforehand. A more ergonomic way of overriding is planned, and described in
+[RFC001][rfc001].
 
 ### Example
 

--- a/doc/manual/syntax.md
+++ b/doc/manual/syntax.md
@@ -6,20 +6,24 @@ slug: syntax
 
 ## Identifiers
 
-Nickel identifiers start with an alphabetic character, followed by zero or more alphanumeric characters, `_` (underscores) or `'` (single quotes). For example, `this-isn't-invalid` is a valid identifier.
+Nickel identifiers start with an alphabetic character, followed by zero or more
+alphanumeric characters, `_` (underscores) or `'` (single quotes). For example,
+`this-isn't-invalid` is a valid identifier.
 
 ## Simple values
 
 There are four basic kind of values in Nickel :
- 1. numeric values
- 2. boolean values
- 3. strings
- 4. enum tags
+
+1. numeric values
+2. boolean values
+3. strings
+4. enum tags
 
 ### Numeric values
 
-Nickel has a support for numbers, positive and negative, with or without decimals.
-Internally, those numbers are stored as 64-bits floating point numbers, following the IEEE 754 standard.
+Nickel has a support for numbers, positive and negative, with or without
+decimals. Internally, those numbers are stored as 64-bits floating point
+numbers, following the IEEE 754 standard.
 
 Examples:
 
@@ -40,9 +44,9 @@ There are a some predefined operators for working with numbers :
 | /        | The division operator                                | `1 / 2 = 0.5` |
 | %        | The modulo operator (returns the *signed* remainder) | `5 % 3 = 2`   |
 
-> **Remark about the `-` operator:**
-> Since `-` can be used inside an identifier, the subtraction operators **needs** to be surrounded by spaces:
-> write `a - b`, not `a-b`. `1-2` works as expected, because `1` and `2` are no identifiers.
+> **Remark about the `-` operator:** Since `-` can be used inside an identifier,
+> the subtraction operators **needs** to be surrounded by spaces: write `a - b`,
+> not `a-b`. `1-2` works as expected, because `1` and `2` aren't identifiers.
 
 Numbers can be compared using the following operators :
 | Operator | Description      | Example   |
@@ -68,11 +72,14 @@ In the table below, you will find the operators sorted from highest to lowest pr
 
 The boolean values in Nickel are denoted `true` and `false`.
 
-Nickel features the classical boolean operators *AND* (&&), *OR* (||) and *NOT* (!).
-The _AND_ and _OR_ operators are lazy in the evaluation of the second argument: for example, in `exp1 && exp2`, `exp2` is only evaluated if `exp1` evaluates to `false`.
+Nickel features the classical boolean operators *AND* (&&), *OR* (||) and *NOT*
+(!). The *AND* and *OR* operators are lazy in the evaluation of the second
+argument: for example, in `exp1 && exp2`, `exp2` is only evaluated if `exp1`
+evaluates to `false`.
 
 Examples:
-```
+
+```text
 > true && false
 false
 
@@ -85,15 +92,17 @@ false
 
 ### Strings
 
-Nickel can work with sequences of characters, or strings.
-Strings are enclosed by `" ... "` for a single line string or by `m%" ... "%m` for a multiline string.
-They can be concatenated with the operator `++`.
-Strings must be UTF-8 valid.
+Nickel can work with sequences of characters, or strings. Strings are enclosed
+by `" ... "` for a single line string or by `m%" ... "%m` for a multiline
+string. They can be concatenated with the operator `++`. Strings must be UTF-8
+valid.
 
-The string interpolation syntax is `"%{ < expression that evaluates to a string > }"`.
+The string interpolation syntax is
+`"%{ < expression that evaluates to a string > }"`.
 
 Examples:
-```
+
+```text
 > "Hello, World!"
 "Hello, World!"
 
@@ -115,10 +124,13 @@ error: Type error
 "The number 5."
 ```
 
-Multiline strings are useful to write indented lines. The indentation is stripped from the beginning of the first line, and first and last lines are ignored if they are empty or contain only spaces.
+Multiline strings are useful to write indented lines. The indentation is
+stripped from the beginning of the first line, and first and last lines are
+ignored if they are empty or contain only spaces.
 
 Example:
-```
+
+```text
 > m%"
 This line has no indentation.
   This line is indented.
@@ -134,7 +146,8 @@ This line has no more indentation."
 The only special sequence in a multiline string is the string interpolation.
 
 Examples:
-```
+
+```text
 > m%"Multiline\nString?"%m
 "Multiline\nString?"
 
@@ -143,10 +156,13 @@ Examples:
 String"
 ```
 
-A multiline string can be introduced and closed by multiple `%` signs, as long as this amount is equal. If you want to use string interpolation, you must use the same amount of `%` as in the delimiters.
+A multiline string can be introduced and closed by multiple `%` signs, as long
+as this amount is equal. If you want to use string interpolation, you must use
+the same amount of `%` as in the delimiters.
 
 Examples:
-```
+
+```text
 > m%%"Hello World"%%m
 "Hello World"
 
@@ -160,9 +176,10 @@ Examples:
 "Hello World"
 ```
 
-Multiline strings are "indentation-aware". This means that one could use an indented string interpolation and the indentation would behave as expected:
+Multiline strings are "indentation-aware". This means that one could use an
+indented string interpolation and the indentation would behave as expected:
 
-```
+```text
 > let log = m%"
 if log:
   print("log:", s)
@@ -185,8 +202,8 @@ def concat(str_array, log=false):
 
 #### Enum tags
 
-Enumeration tags are used to express finite alternatives. They are formed
-by writing a backtick `` ` `` followed by any valid identifier. For example,
+Enumeration tags are used to express finite alternatives. They are formed by
+writing a backtick `` ` `` followed by any valid identifier. For example,
 `builtin.serialize` takes an export format as a first argument, which is an enum
 tag among `` `Json ``, `` `Toml `` or `` `Yaml `` (as of version 0.1):
 
@@ -220,10 +237,12 @@ enforce that only valid tags are passed to a function within a typed block. See
 
 ## Equality
 
-Operators `==` and `!=` are used to compare values. Two values of different types are never equal: that is, `==` doesn't perform implicit conversions.
+Operators `==` and `!=` are used to compare values. Two values of different
+types are never equal: that is, `==` doesn't perform implicit conversions.
 
 Examples:
-```
+
+```text
 > 1 == 1
 true
 
@@ -243,13 +262,15 @@ false
 false
 ```
 
-
 ## Composite values
 
 ### Array
-An array is a sequence of values. They are delimited by `[` and `]`, and elements are separated with `,`.
+
+An array is a sequence of values. They are delimited by `[` and `]`, and
+elements are separated with `,`.
 
 Examples:
+
 ```nickel
 [1, 2, 3]
 ["Hello", "World"]
@@ -258,20 +279,24 @@ Examples:
 ```
 
 Arrays can be concatenated with the operator `@`:
-```
+
+```text
 > [1] @ [2, 3]
 [ 1, 2, 3 ]
 ```
 
 ### Record
-Records are key-value storage, or in Nickel terms, field-value storage. They are delimited by `{` and `}`, and elements are separated with `,`.
-Field-value elements are noted as `field = value`.
-The fields are strings, but can be written without quotes `"` if they respect identifiers syntax. Values can be of any type.
-Elements inside a record are unordered.
-Two records can be _merged_ together using the operator `&`. The reader can find
-more information about merging in the [section on merging](./merging.md).
+
+Records are key-value storage, or in Nickel terms, field-value storage. They are
+delimited by `{` and `}`, and elements are separated with `,`. Field-value
+elements are noted as `field = value`. The fields are strings, but can be
+written without quotes `"` if they respect identifiers syntax. Values can be of
+any type. Elements inside a record are unordered. Two records can be *merged*
+together using the operator `&`. The reader can find more information about
+merging in the [section on merging](./merging.md).
 
 Examples:
+
 ```nickel
 {}
 {a = 3}
@@ -280,7 +305,8 @@ Examples:
 ```
 
 Accessing a record field can be done using the `.` operator :
-```
+
+```text
 > { a = 1, b = 5 }.a
 1
 
@@ -291,8 +317,10 @@ error: Missing field
 "one"
 ```
 
-It is possible to write records of records via the *piecewise syntax*, where we separate fields by dots:
-```
+It is possible to write records of records via the *piecewise syntax*, where we
+separate fields by dots:
+
+```text
 > { a = { b = 1 } }
 { a = { b = 1 } }
 
@@ -303,8 +331,10 @@ It is possible to write records of records via the *piecewise syntax*, where we 
 { a = { b = 1, c = 2 }, b = 3 }
 ```
 
-When fields are enclosed with double quotes (`"`), you can use string interpolation to create or access fields:
-```
+When fields are enclosed with double quotes (`"`), you can use string
+interpolation to create or access fields:
+
+```text
 > let k = "a" in { "%{k}" = 1 }
 { a = 1 }
 
@@ -315,10 +345,13 @@ When fields are enclosed with double quotes (`"`), you can use string interpolat
 ## Constructs
 
 ### If-Then-Else
-This construct allows conditional branching in your code. You can use it as `if <bool expr> then <expr> else <expr>`.
+
+This construct allows conditional branching in your code. You can use it as
+`if <bool expr> then <expr> else <expr>`.
 
 Examples:
-```
+
+```text
 > if true then "TRUE :)" else "false :("
 "TRUE :)"
 
@@ -333,11 +366,15 @@ Examples:
 ```
 
 ### Let-In
-Let-in allows the binding of an expression. It is used as `let <rec?> <ident> = <expr> in <expr>`.
-The `rec` keyword in Let-in constructs allows the let binding to become recursive, enabling the use of the `<ident>` within the first `<expr>`.
+
+Let-in allows the binding of an expression. It is used as
+`let <rec?> <ident> = <expr> in <expr>`. The `rec` keyword in Let-in constructs
+allows the let binding to become recursive, enabling the use of the `<ident>`
+within the first `<expr>`.
 
 Examples:
-```
+
+```text
 > let r = { a = "a", b = "b" } in r.a
 "a"
 
@@ -353,17 +390,23 @@ true
 > let rec fib = fun n => if n <= 2 then 1 else fib (n - 1) + fib (n - 2) in fib 9
 34
 
-> let rec repeat = fun n x => if n <= 0 then [] else repeat (n - 1) x @ [x] in repeat 3 "foo"
+> let rec repeat = fun n x => if n <= 0 then [] else repeat (n - 1) x @ [x] in
+repeat 3 "foo"
 ["foo", "foo", "foo"]
 ```
 
 ## Functions
-A function is declared using the `fun` keyword, then arguments separated with spaces, and finally an arrow `=>` to add the body of the function.
-To call a function, just add the arguments after it separated with spaces.
-Functions in Nickel are curried, meaning that a function taking multiple arguments is actually a function that takes a single argument and returns a function taking the rest of the arguments, until it is applied.
+
+A function is declared using the `fun` keyword, then arguments separated with
+spaces, and finally an arrow `=>` to add the body of the function. To call a
+function, just add the arguments after it separated with spaces. Functions in
+Nickel are curried, meaning that a function taking multiple arguments is
+actually a function that takes a single argument and returns a function taking
+the rest of the arguments, until it is applied.
 
 Examples:
-```
+
+```text
 > (fun a b => a + b) 1 2
 3
 
@@ -376,10 +419,12 @@ let add = fun a b => a + b in add 1 2
 3
 ```
 
-All existing infix operators in Nickel can be turned into functions by putting them inside parentheses.
+All existing infix operators in Nickel can be turned into functions by putting
+them inside parentheses.
 
 Examples:
-```
+
+```text
 > 1 + 2
 3
 
@@ -398,11 +443,13 @@ Examples:
 [ 1, 2, 3, 4, 5 ]
 ```
 
-Functions might be composed using the *pipe operator*. The pipe operator allows for a function application `f x` to be written as `x |> f`.
-This operator is left-associative, so `x |> f |> g` will be interpreted as `g (f x)`.
+Functions might be composed using the *pipe operator*. The pipe operator allows
+for a function application `f x` to be written as `x |> f`. This operator is
+left-associative, so `x |> f |> g` will be interpreted as `g (f x)`.
 
 Examples:
-```
+
+```text
 > "Hello World" |> string.split " "
 ["Hello", "World"]
 
@@ -419,10 +466,12 @@ Examples:
 ```
 
 ## Typing
-To give a type to a value, we write it with `< value > : < type >`.
-More information on typing in the relevant document.
+
+To give a type to a value, we write it with `< value > : < type >`. More
+information on typing in the relevant document.
 
 Examples:
+
 ```nickel
 5 : Num
 "Hello" : Str
@@ -438,12 +487,14 @@ let r : { _ : Num } = { a = 1, b = 2 }
 ```
 
 ## Metadata
-Metadata are used to attach contracts (more information in relevant documentation), documentation or priority to values.
-A metadata is introduced with the syntax `<value> | <metadata>`. Multiple metadata can be chained.
 
+Metadata are used to attach contracts (more information in relevant
+documentation), documentation or priority to values. A metadata is introduced
+with the syntax `<value> | <metadata>`. Multiple metadata can be chained.
 
 Examples:
-```
+
+```text
 > 5 | Num
 5
 
@@ -466,9 +517,9 @@ error: Blame error: contract broken by a value.
 3
 ```
 
-Adding documentation can be done with `| doc < string >`.
-Examples:
-```
+Adding documentation can be done with `| doc < string >`. Examples:
+
+```text
 > 5 | doc "The number five"
 5
 
@@ -481,11 +532,13 @@ Examples:
 true
 ```
 
-Record contracts can set default values using the `default` metadata:
-It is noted as `| default = < default value >`.
-This is especially useful when merging records (more about this in the dedicated document about merge).
+Record contracts can set default values using the `default` metadata: It is
+noted as `| default = < default value >`. This is especially useful when merging
+records (more about this in the dedicated document about merge).
+
 Examples:
-```
+
+```text
 > let Ais2ByDefault = { a | default = 2 } in
   {} | Ais2ByDefault
 { a = 2 }

--- a/doc/manual/types-vs-contracts.md
+++ b/doc/manual/types-vs-contracts.md
@@ -40,6 +40,7 @@ What to do depends on the context:
     for the sake of clarity.
 
     Example:
+
     ```nickel
     let foo : Num =
       let addTwo = fun x => x + 2 in
@@ -60,6 +61,7 @@ Types are not adding much for configuration data, while contracts are more
 flexible and expressive.
 
 Example:
+
 ```nickel
 let Schema = {
   name | Str

--- a/doc/manual/typing.md
+++ b/doc/manual/typing.md
@@ -44,7 +44,7 @@ example:
 `version` is a string, and can't be added to a number. If we try to export this
 configuration using `nickel export`, we get a reasonable error message:
 
-```
+```text
 error: Type error
   ┌─ repl-input-3:8:16
   │
@@ -68,7 +68,8 @@ filter (fun x => if x % 2 == 0 then x else null) [1,2,3,4,5,6]
 ```
 
 Result:
-```
+
+```text
 error: Type error
   ┌─ repl-input-11:2:32
   │
@@ -102,6 +103,7 @@ annotation. We will refer to such an annotated expression as a *statically typed
 block*.
 
 Example:
+
 ```nickel
 # Let binding
 let f : Num -> Bool = fun x => x % 2 == 0 in
@@ -126,7 +128,8 @@ filter (fun x => if x % 2 == 0 then x else null) [1,2,3,4,5,6]) : Array Num
 ```
 
 Result:
-```
+
+```text
 error: Incompatible types
   ┌─ repl-input-12:3:37
   │
@@ -170,24 +173,29 @@ The following type constructors are available:
 - **Array**: `Array T`. An array of elements of type `T`.
 
   Example:
+
   ```nickel
   let x : Array (Array Num) = [[1,2], [3,4]] in
   array.flatten x : Array Num
   ```
+
 - **Record**: `{field1: T1, .., fieldn: Tn}`. A record whose field
   names are known statically as `field1`, .., `fieldn`, respectively of type
   `T1`, .., `Tn`.
 
   Example:
+
   ```nickel
   let pair : {fst: Num, snd: Str} = {fst = 1, snd = "a"} in
   pair.fst : Num
   ```
+
 - **Dynamic record**: `{_: T}`. A record whose field
   names are statically unknown but are all of type `T`.  Typically used to model
   dictionaries.
 
   Example:
+
   ```nickel
   let occurrences : {_: Num} = {a = 1, b = 3, c = 0} in
   record.map (fun char count => count + 1) occurrences : {_ : Num}
@@ -200,6 +208,7 @@ The following type constructors are available:
   able to detect incomplete matches, for example.
 
   Example:
+
   ```nickel
   let protocol : [| `http, `ftp, `sftp |] = `http in
   (switch {
@@ -209,10 +218,12 @@ The following type constructors are available:
   } protocol) : Num
   ```
 
-- **Arrow (function)**: `S -> T`. A function taking arguments of type `S` and returning a value of
-  type `T`. For multi-parameters functions, just iterate the arrow constructor.
+- **Arrow (function)**: `S -> T`. A function taking arguments of type `S` and
+  returning a value of type `T`. For multi-parameters functions, just iterate
+  the arrow constructor.
 
   Example:
+
   ```nickel
   {
     incr : Num -> Num = fun x => x + 1,
@@ -285,7 +296,8 @@ result) : Array Num
 ```
 
 Result:
-```
+
+```text
 error: Incompatible types
   ┌─ repl-input-35:2:37
   │
@@ -332,7 +344,7 @@ let r3 = {may = 1300, june = 400, total = may + june} in
 }) : {partial1: Num, partial2: Num}
 ```
 
-```
+```text
 error: Type error: extra row `sept`
   ┌─ repl-input-40:8:23
   │
@@ -368,6 +380,7 @@ let r3 = {may = 1300, june = 400, total = may + june} in
 ```
 
 Result:
+
 ```nickel
 {partial1 = 570, partial2 = 1770}
 ```
@@ -438,7 +451,8 @@ array.filter (fun x => if x % 2 == 0 then x else null) [1,2,3,4,5,6]
 ```
 
 Result:
-```
+
+```text
 error: Blame error: contract broken by the caller.
   ┌─ :1:17
   │
@@ -475,11 +489,11 @@ We call `filter` from a dynamically typed location, but still get a spot-on
 error. To precisely avoid dynamically code injecting values of the wrong type
 inside statically typed blocks via function calls, the interpreter protects said
 blocks by a contract. Contracts form a principled runtime verification scheme.
-Please refer to the [dedicated manual section](./contracts.md) for more details, but
-for now, you can just remember that *any type annotation* (wherever it is) gives
-rise at runtime to a corresponding contract application. In other words, `foo:
-T` and `foo | T` (here `|` is contract application, not the row tail separator)
-behave exactly the same at *runtime*.
+Please refer to the [dedicated manual section](./contracts.md) for more details,
+but for now, you can just remember that *any type annotation* (wherever it is)
+gives rise at runtime to a corresponding contract application. In other words,
+`foo: T` and `foo | T` (here `|` is contract application, not the row tail
+separator) behave exactly the same at *runtime*.
 
 Thanks to this guard, you can statically type your library functions and use
 them from dynamically typed code while still enjoying good error messages.
@@ -496,7 +510,8 @@ let x = 0 + 1 in
 ```
 
 Result:
-```
+
+```text
 error: Incompatible types
   ┌─ repl-input-6:1:6
   │
@@ -514,6 +529,7 @@ evaluates to a number but is rejected by the typechecker because it uses dynamic
 idioms. In this case, we can trade a type annotation for a contract application:
 
 Example:
+
 ```nickel
 let x | Num = if true then 0 else "a" in
 (1 + x : Num)
@@ -544,7 +560,8 @@ because of the type mismatch between the if branches:
 ```
 
 Result:
-```
+
+```text
 error: Incompatible types
   ┌─ repl-input-46:1:27
   │
@@ -556,10 +573,9 @@ error: Incompatible types
   = These types are not compatible
 ```
 
-**Apparent type**
-
-As a side note, annotations are not always needed to use dynamically typed code
-inside a statically typed block. The following example is accepted:
+**Apparent type**: As a side note, annotations are not always needed to use
+dynamically typed code inside a statically typed block. The following example is
+accepted:
 
 ```nickel
 let x = 1 in
@@ -597,8 +613,9 @@ typechecker on, a contract annotation switches it back off.
 
 **Warning**: as of version 0.2.x, using contracts as types won't work in the
 majority of cases (typechecking will fail with a "can't compare contract types"
-error). This is temporary and will likely be fixed in the upcoming 0.3.x release. For more
-details, see issues [#701](https://github.com/tweag/nickel/issues/701) and
+error). This is temporary and will likely be fixed in the upcoming 0.3.x
+release. For more details, see issues
+[#701](https://github.com/tweag/nickel/issues/701) and
 [#724](https://github.com/tweag/nickel/issues/724).
 
 <!-- TODO: find a good name for this section. Will need rework after merging
@@ -621,7 +638,8 @@ let Port = contract.from_predicate (fun value =>
 But this program is unfortunately rejected by the typechecker:
 
 Result:
-```
+
+```text
 error: Incompatible types
   ┌─ repl-input-0:7:2
   │

--- a/examples/README.md
+++ b/examples/README.md
@@ -11,15 +11,19 @@ data!
 
 ### From the command line
 
-- *Base values*: some examples just return numbers, strings or booleans. You can run them directly:
-    ```
+- *Base values*: some examples just return numbers, strings or booleans. You can
+  run them directly:
+
+    ```console
     $ nickel -f fibonacci.ncl
-    Done: Num(55.0)
+    55
     ```
-- *Configurations*: some return records representing configuration. Because of laziness, Nickel
-    won't currently print any readable result as is. Please use the `export`
-    subcommand to see the result serialized as JSON:
-    ```
+
+- *Configurations*: some return records representing configuration. Nickel won't
+  currently print a very readable result as is. Please use the `export`
+  subcommand to see the result serialized as JSON:
+
+    ```console
     $ nickel -f merge-main.ncl export
     {
       "firewall": {
@@ -30,7 +34,7 @@ data!
     Alternatively, you can query a configuration or a sub-element to get
     a list of attributes or the documentation:
 
-    ```
+    ```console
     $ nickel -f record-contract.ncl query kind
       • contract: <ReplicationController, ReplicaSet, Pod>
       • value: `ReplicationController
@@ -41,38 +45,41 @@ data!
 
 First start the REPL:
 
-```
+```console
 $ nickel repl
 nickel>
 ```
 
 - Just import a file directly to evaluate it:
-    ```
+
+    ```text
     nickel> import "fibonacci.ncl"
     55
 
     nickel>
     ```
+
 - Use `builtin.serialize` to have the same behavior as the `export` subcommand
   and print the result as JSON:
 
-  ```
-  nickel> builtin.serialize `Json (import "merge-main.ncl")
-  "{
-      \"firewall\": {
-      ...
-  }"
+    ```text
+    nickel> builtin.serialize `Json (import "merge-main.ncl")
+    "{
+        \"firewall\": {
+        ...
+    }"
 
-  nickel>
-  ```
+    nickel>
+    ```
+
 - Use `:query` to retrieve information and documentation about a field:
 
-  ```
-  nickel>let config = import "record-contract.ncl"
-  nickel>:query config.kind
-  • contract: <ReplicationController, ReplicaSet, Pod>
-  • value: `ReplicationController
-  • documentation: The kind of the element being configured.
+    ```text
+    nickel>let config = import "record-contract.ncl"
+    nickel>:query config.kind
+    • contract: <ReplicationController, ReplicaSet, Pod>
+    • value: `ReplicationController
+    • documentation: The kind of the element being configured.
 
-  nickel>
-  ```
+    nickel>
+    ```

--- a/examples/arrays/README.md
+++ b/examples/arrays/README.md
@@ -1,4 +1,4 @@
-# Arrays 
+# Arrays
 
 This example shows how to write generic, statically typed functions in Nickel.
 The code is illustrative: in practice, you should use the array stdlib functions
@@ -6,8 +6,8 @@ The code is illustrative: in practice, you should use the array stdlib functions
 
 ## Run
 
-```
-$ nickel -f arrays.ncl export
+```console
+nickel -f arrays.ncl export
 ```
 
 ## Playground
@@ -19,7 +19,7 @@ Another aspect is how Nickel guard typed function from untyped code by using
 contracts: at the end of the example, you can provide wrong arguments in the
 calls to `my_array_lib.map` or `my_array_lib.fold` to see contracts error appear:
 
-```
+```diff
 -    let l = my_array_lib.map (fun x => x+1) [1, 2, 3, 4, 5, 6] in
 +    let l = my_array_lib.map [1, 2, 3, 4, 5, 6] (fun x => x+1) in
 ```

--- a/examples/config-gcc/README.md
+++ b/examples/config-gcc/README.md
@@ -5,8 +5,8 @@ invocation of the `gcc` compiler.
 
 ## Run
 
-```
-$ nickel -f config-gcc.ncl export
+```console
+nickel -f config-gcc.ncl export
 ```
 
 ## Contracts

--- a/examples/fibonacci/README.md
+++ b/examples/fibonacci/README.md
@@ -5,6 +5,6 @@ exponential version of fibonacci: don't call it on a big value!
 
 ## Run
 
-```
-$ nickel -f fibonacci.ncl
+```console
+nickel -f fibonacci.ncl
 ```

--- a/examples/merge/README.md
+++ b/examples/merge/README.md
@@ -6,6 +6,6 @@ code to run lies in `main.ncl`. The default value `firewall.enabled` defined in
 
 ## Run
 
-```
-$ nickel -f main.ncl export
+```console
+nickel -f main.ncl export
 ```

--- a/examples/polymorphism/README.md
+++ b/examples/polymorphism/README.md
@@ -8,8 +8,8 @@ polymorphic types for you.
 
 ## Run
 
-```
-$ nickel -f polymorphism.ncl
+```console
+nickel -f polymorphism.ncl
 ```
 
 ## Playground

--- a/examples/record-contract/README.md
+++ b/examples/record-contract/README.md
@@ -7,8 +7,8 @@ configuration.
 
 ## Run
 
-```
-$ nickel -f record-contract.ncl export
+```console
+nickel -f record-contract.ncl export
 ```
 
 ## Playground

--- a/examples/simple-contracts/README.md
+++ b/examples/simple-contracts/README.md
@@ -16,9 +16,9 @@ Bool` and use `contract.fromPred` to obtain the corresponding contracts.
 
 ## Run
 
-```
-$ nickel -f simple-contract-bool.ncl
-$ nickel -f simple-contract-div.ncl
+```console
+nickel -f simple-contract-bool.ncl
+nickel -f simple-contract-div.ncl
 ```
 
 ## Playground

--- a/flake.nix
+++ b/flake.nix
@@ -170,6 +170,10 @@
               };
               markdownlint = {
                 enable = true;
+                excludes = [
+                  "notes/(.+)\\.md$"
+                  "^RELEASES\\.md$"
+                ];
               };
             };
           };
@@ -326,7 +330,7 @@
           name = channel;
           value = buildNickel { inherit channel; isDevShell = true; };
         }
-      ));
+        ));
 
       checks = {
         # wasm-opt can take long: eschew optimizations in checks

--- a/lsp/README.md
+++ b/lsp/README.md
@@ -30,27 +30,32 @@ the following commands.
 - *Global installation*: if you want to use `nls` on a regular basis, this is
   what you want to do. To have `nickel` and `nls` available globally, add them
   into your profile:
-  ```
-  nix profile install github:tweag/nickel
-  ```
+
+    ```console
+    nix profile install github:tweag/nickel
+    ```
+
 - *Shell*: Try out for the time of a session. To be dropped in a shell with the
   `nickel` and `nls` commands available, run:
-  ```
-  nix shell github:tweag/nickel
-  ```
+
+    ```console
+    nix shell github:tweag/nickel
+    ```
+
 - *Local build*: if you just wand to build `nickel`
-  and `nls` without installing them:
-  ```
-  # The executables will be placed in ./result/bin/
-  nix build github:tweag/nickel
-  ```
+  and `nls` without installing them (the executables will be placed in
+  ./result/bin/):
+
+    ```shell
+    nix build github:tweag/nickel
+    ```
 
 ### Using Nix (without flakes)
 
 Alternatively, you can install `nickel` and `nls` globally on older Nix versions
 without flakes via `nix-env`:
 
-```
+```console
 git clone https://github.com/tweag/nickel.git
 cd nickel
 nix-env -f . -i
@@ -61,7 +66,7 @@ nix-env -f . -i
 If you already have a working [`cargo`](https://doc.rust-lang.org/cargo/)
 installation, you can make `nls` available globally without Nix:
 
-```
+```console
 cargo install nickel-lang-lsp
 ```
 
@@ -82,35 +87,43 @@ your editor.
 #### Build the extension
 
 NLS is currently not available through the vscode marketplace, but this
-repository includes an extension that can be built locally via Nix (cf []()
-about the Nix setup).
+repository includes an extension that can be built locally via Nix (see the
+section about the Nix setup).
 
-- One-liner (using the [`jq`](https://stedolan.github.io/jq/) command):
-  ```
+- One-liner (using the [jq](https://stedolan.github.io/jq/) command):
+
+  ```console
   code --install-extension $(nix build ./\#vscodeExtension --no-link --json | jq ".[0].outputs.vsix")
   ```
+
 - In two steps, going via VSCode:
   - Build with Nix:
-    ```
-    nix build github:tweag/nickel#vscodeExtension.vsix
-    ```
-  - Then, in VSCode, use `Extension: Install from VSIX` in the vscode command
+
+      ```console
+      nix build github:tweag/nickel#vscodeExtension.vsix
+      ```
+
+  - Then, in VSCode, use "Extension: Install from VSIX" in the vscode command
     palette and choose `./result-vsix/nls-client.vsix`.
 
 #### Configuration
 
-The VS Code extension offers three configuration options: 
+The VS Code extension offers three configuration options:
 
 - `nls.server.path`: Path to nickel language server
 - `nls.server.trace`: Enables performance tracing to the given file
-- `nls.server.debugLog`: Logs the communication between VS Code and the language server.
+- `nls.server.debugLog`: Logs the communication between VS Code and the language
+  server.
 
 ### (Neo)Vim
 
-Before proceeding install the [Nickel syntax highlighting plugin](https://github.com/nickel-lang/vim-nickel) using your Vim plugin manager.
-Without this plugin your LSP client may not start NLS on nickel source files.
+Before proceeding install the [Nickel syntax highlighting
+plugin](https://github.com/nickel-lang/vim-nickel) using your Vim plugin
+manager. Without this plugin your LSP client may not start NLS on nickel source
+files.
 
 With Vim-Plug:
+
 ```vim
 Plug 'nickel-lang/vim-nickel'
 ```
@@ -128,24 +141,25 @@ require('lspconfig')["nickel_ls"].setup {}
 
 #### With Coc.nvim
 
-Add an `nickel_ls` entry to your configuration. Type `:CocConfig` in Neovim (or edit `coc-settings.json`) and add:
+Add an `nickel_ls` entry to your configuration. Type `:CocConfig` in Neovim (or
+edit `coc-settings.json`) and add:
 
-```
+```jsonc
 {
   "languageserver": {
-    # Your other language servers configuration
-    # ...,
+    // Your other language servers configuration
+    // ...,
     "nickel_ls": {
       "command": "nls",
-      # You can enable performance tracing with:
-      # "command": "nls --trace <file>",
+      // You can enable performance tracing with:
+      // "command": "nls --trace <file>",
       "rootPatterns": [
         ".git"
       ],
       "filetypes": [
         "ncl"
       ]
-    },
+    }
   }
 }
 ```

--- a/rfcs/002-merge-types-terms-syntax.md
+++ b/rfcs/002-merge-types-terms-syntax.md
@@ -37,8 +37,8 @@ is different from the standard typed functional language. We have to:
   exists in the language.
 
 Thus, we can precisely give a meaning to a type `1 + 1` (`#(1 + 1)`) and to a
-term such as `forall a. a -> a` (`§(forall a. a -> a)`). Why we propose to do so is
-explained in the next section.
+term such as `forall a. a -> a` (`§(forall a. a -> a)`). Why we propose to do so
+is explained in the next section.
 
 ## Motivation
 
@@ -98,6 +98,7 @@ that we could just write:
 Which looks more natural all while having a reasonable semantics.
 
 ## Notations
+
 We use the following notations throughout this document:
 
 - `Term` is the subset of the current syntax that includes terms: records,
@@ -228,9 +229,9 @@ complex, whenever possible.
 - Recall that `! : Term + Type -> UniTerm` is the embedding of the current
   syntax to the new unified syntax (erasing `#` and `§`, and changing `|` for
   tails to `;`)
-- In the following, `~` is some flavour of operational equivalence. We won't prove the rules.
-  Those are rather design guidelines. In consequence, we also restrain from
-  giving a formal definition for `~`.
+- In the following, `~` is some flavour of operational equivalence. We won't
+  prove the rules. Those are rather design guidelines. In consequence, we also
+  restrain from giving a formal definition for `~`.
 
 The `term` and `type` functions must satisfy the following coherence laws:
 
@@ -300,7 +301,7 @@ typechecking but fails at runtime on the failure of merging `1` and `2`.
 Because of those issues, **we propose to only translate as types records that
 are already record types in the current syntax**. That is:
 
-```
+```text
 type({f1: t1, .., fn : tn}) = {f1: type(t1), .., fn: type(tn)}
 type({...}) = #term({...}) otherwise
 ```
@@ -313,11 +314,11 @@ possible improvements.
 There is currently no general type application per se, but a special casing for
 `List Foo`, which is a parametrized type. **We propose to keep ground types as
 reserved keywords and special lexemes of the language** for now: it makes things
-simpler as we don't have to ask ourselves what `let List = 1 in [] : List Num` should be
-interpreted as. That way, we can also special case the application of the list
-type and translate an application as a term otherwise:
+simpler as we don't have to ask ourselves what `let List = 1 in [] : List Num`
+should be interpreted as. That way, we can also special case the application of
+the list type and translate an application as a term otherwise:
 
-```
+```text
 type(a b) = List type(f)   if a == List
           = #term(a b)     otherwise (= #term(a) term(b))
 ```
@@ -360,7 +361,7 @@ or not. We sidestep this question as an external implementation detail, assuming
 here that there is a predicate `is_type_var` available during the translation.
 We can now set:
 
-```
+```text
 type(var x) = x   if is_type_var(x)
 type(var x) = #x  otherwise
 ```
@@ -379,7 +380,7 @@ types in the current syntax. It turns out we could extract record types from
 some record contracts too, that often hold the same information. The typical
 example is contracts of the form:
 
-```
+```nickel
 {
   foo | #Contract1,
   bar | #{baz | Str},
@@ -448,7 +449,7 @@ benefit in allowing it would be to capture type variables, as in
 We can even imagine the typechecker being able to evaluate function application,
 to be able to do something like:
 
-```
+```nickel
 let Pair = fun a b => {fst: a, snd: b} in
 fst : forall a b. Pair a b -> a = ...
 ```


### PR DESCRIPTION
What started as a non-trivial enterprise, adding markdown linting checks to the CI, was actually very easy to do thanks to pre-commit-hooks.nix. This PR:

- makes a pass on the various markdown documentation to appease the linter
- adds a configuration file for markdownlint to customize a couple rules
- enables markdown linting in pre-commit-hooks.nix, which has the effect of running the linter as part of the checks of the flake (and hence, on the CI).