### PR TITLE
[CI] Add clippy check

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -50,4 +50,4 @@ jobs:
 
     - name: Run all checks
       run: |
-        nix flake check
+        nix flake check --print-build-logs

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1197,6 +1197,7 @@ dependencies = [
  "rustyline",
  "rustyline-derive",
  "serde",
+ "serde-wasm-bindgen",
  "serde_json",
  "serde_repr",
  "serde_yaml",
@@ -1866,6 +1867,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61ea8d54c77f8315140a05f4c7237403bf38b72704d031543aa1d16abbf517d1"
 dependencies = [
  "serde_derive",
+]
+
+[[package]]
+name = "serde-wasm-bindgen"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3b4c031cd0d9014307d82b8abf653c0290fbdaeb4c02d00c63cf52f728628bf"
+dependencies = [
+ "js-sys",
+ "serde",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,7 @@ rustyline-derive = { version = "0.6.0", optional = true }
 
 # The `wasm-bindgen` version is pinned (`=`) because it must be the same as `wasm-bindgen-cli` in `flake.nix`
 wasm-bindgen = { version = "=0.2.83", optional = true, features = ["serde-serialize"] }
+serde-wasm-bindgen = "0.4.5"
 js-sys = { version = "0.3", optional = true }
 serde_repr = { version = "0.1", optional = true }
 pretty = "0.11.3"

--- a/flake.nix
+++ b/flake.nix
@@ -200,8 +200,20 @@
                 pass_filenames = false;
                 entry =
                   "${pkgs.writeShellScript "clippy-hook" ''
+                    echo "CARGO_HOME"
+                    echo $CARGO_HOME
+                    echo "ls1"
+                    ls -laa
                     ${cargoHomeHookSetup}
+                    echo "CARGO_HOME"
+                    echo $CARGO_HOME
+                    echo "ls2"
+                    ls -laa
                     cargo clippy --workspace ${offlineOpts} -- --no-deps --deny warnings ${allowOpts}
+                    echo "CARGO_HOME"
+                    echo $CARGO_HOME
+                    echo "ls3"
+                    ls -laa
                   ''}";
               };
           };

--- a/flake.nix
+++ b/flake.nix
@@ -209,6 +209,7 @@
                   pass_filenames = false;
                   entry =
                     "${pkgs.writeShellScript "clippy-hook" ''
+                    export PATH="${pkgs.lib.makeLibraryPath missingSysPkgs}:$PATH"
                     ${cargoHomeHookSetup}
                     ${rust}/bin/cargo clippy --workspace ${offlineOpts} -- --no-deps --deny warnings ${allowOpts}
                   ''}";

--- a/flake.nix
+++ b/flake.nix
@@ -190,7 +190,15 @@
                 # - `stdenv` provides standard environment similarly to `mkDerivation`, including a C compiler (`cc`) required by Rust.
                 # - `cargoHome` provides Rust with the right `CARGO_HOME` environment variable to discover built dependencies.
                 cargoHomeHookSetup = pkgs.lib.optionalString (! isHook) ''
+                  echo "CARGO_HOME"
+                  echo $CARGO_HOME
+                  echo "ls11"
+                  ls -laa
                   source ${nickel.inputDerivation}
+                  echo "CARGO_HOME"
+                  echo $CARGO_HOME
+                  echo "ls12"
+                  ls -laa
                   source $stdenv/setup
                 '';
               in

--- a/lsp/nls/src/files.rs
+++ b/lsp/nls/src/files.rs
@@ -97,8 +97,7 @@ fn parse_and_typecheck(server: &mut Server, uri: Url, file_id: FileId) -> Result
 
     let diagnostics = diagnostics
         .into_iter()
-        .map(|d| lsp_types::Diagnostic::from_codespan(d, server.cache.files_mut()))
-        .flatten()
+        .flat_map(|d| lsp_types::Diagnostic::from_codespan(d, server.cache.files_mut()))
         .collect();
 
     server.notify(lsp_server::Notification::new(

--- a/lsp/nls/src/linearization/building.rs
+++ b/lsp/nls/src/linearization/building.rs
@@ -71,7 +71,7 @@ impl Building {
                 ty: UnifType::Concrete(TypeF::Dyn),
                 kind: TermKind::RecordField {
                     record,
-                    ident: ident.clone(),
+                    ident: *ident,
                     usages: Vec::new(),
                     value: ValueState::Unknown,
                 },
@@ -83,8 +83,8 @@ impl Building {
                     _ => None,
                 },
             });
-            env.insert(ident.clone(), id);
-            self.add_record_field(record, (ident.clone(), id))
+            env.insert(*ident, id);
+            self.add_record_field(record, (*ident, id))
         }
     }
 
@@ -157,7 +157,7 @@ impl Building {
             }) = parent_referenced
             {
                 debug!("parent references deferred usage");
-                unresolved.push(deferred.clone());
+                unresolved.push(deferred);
                 continue;
             }
 
@@ -171,7 +171,7 @@ impl Building {
             }) = parent_declaration
             {
                 debug!("parent references deferred usage");
-                unresolved.push(deferred.clone());
+                unresolved.push(deferred);
                 continue;
             }
 

--- a/lsp/nls/src/linearization/building.rs
+++ b/lsp/nls/src/linearization/building.rs
@@ -46,12 +46,12 @@ impl Building {
     }
 
     pub(super) fn inform_declaration(&mut self, declaration: ID, value: ID) {
-        match self.linearization.get_mut(declaration) {
-            Some(LinearizationItem {
-                kind: TermKind::Declaration(_, _, value_state),
-                ..
-            }) => *value_state = ValueState::Known(value),
-            _ => (),
+        if let Some(LinearizationItem {
+            kind: TermKind::Declaration(_, _, value_state),
+            ..
+        }) = self.linearization.get_mut(declaration)
+        {
+            *value_state = ValueState::Known(value)
         }
     }
 

--- a/lsp/nls/src/linearization/interface.rs
+++ b/lsp/nls/src/linearization/interface.rs
@@ -22,7 +22,7 @@ impl ResolutionState for Resolved {}
 /// 3. Records, listing their fields
 /// 4. wildcard (Structure) for any other kind of term.
 /// Can be extended later to represent Contracts, Records, etc.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum TermKind {
     Declaration(Ident, Vec<ID>, ValueState),
     Usage(UsageState),
@@ -36,7 +36,7 @@ pub enum TermKind {
     Structure,
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ValueState {
     Unknown,
     Known(ID),
@@ -52,7 +52,7 @@ impl ValueState {
 }
 /// Some usages cannot be fully resolved in a first pass (i.e. recursive record fields)
 /// In these cases we defer the resolution to a second pass during linearization
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum UsageState {
     Unbound,
     Resolved(ID),

--- a/lsp/nls/src/linearization/mod.rs
+++ b/lsp/nls/src/linearization/mod.rs
@@ -168,7 +168,7 @@ impl Linearizer for AnalysisHost {
                                 id: id_gen.get_and_advance(),
 
                                 ty: ty.clone(),
-                                pos: ident.pos.clone(),
+                                pos: ident.pos,
                                 kind: TermKind::Structure,
                                 meta: self.meta.take(),
                             });
@@ -227,7 +227,7 @@ impl Linearizer for AnalysisHost {
                             id: id_gen.get_and_advance(),
 
                             ty: ty.clone(),
-                            pos: ident.pos.clone(),
+                            pos: ident.pos,
                             kind: TermKind::Structure,
                             meta: self.meta.take(),
                         });
@@ -357,7 +357,7 @@ impl Linearizer for AnalysisHost {
             .iter()
             .filter_map(|item| match &item.kind {
                 TermKind::Usage(UsageState::Deferred { parent, child }) => {
-                    Some((item.id, *parent, child.clone()))
+                    Some((item.id, *parent, *child))
                 }
                 _ => None,
             })

--- a/lsp/nls/src/linearization/mod.rs
+++ b/lsp/nls/src/linearization/mod.rs
@@ -120,7 +120,7 @@ impl Linearizer for AnalysisHost {
                     pos
                 });
 
-                for field in lin.linearization.get_mut(record + offset).into_iter() {
+                if let Some(field) = lin.linearization.get_mut(record + offset) {
                     debug!("{:?}", field.kind);
                     let usage_offset = if matches!(term, Term::Var(_)) {
                         debug!(
@@ -387,7 +387,7 @@ impl Linearizer for AnalysisHost {
                 id_mapping.insert(*id, index);
             });
 
-        fn transform_wildcard(wildcars: &Vec<Types>, t: Types) -> Types {
+        fn transform_wildcard(wildcars: &[Types], t: Types) -> Types {
             match t {
                 Types(TypeF::Wildcard(i)) => wildcars.get(i).unwrap_or(&t).clone(),
                 _ => t,

--- a/lsp/nls/src/requests/completion.rs
+++ b/lsp/nls/src/requests/completion.rs
@@ -339,10 +339,10 @@ pub fn handle_completion(
         Some(item) => {
             debug!("found closest item: {:?}", item);
 
-            let trigger = params.context.as_ref().and_then(|context| {
-                context
-                    .trigger_character.as_deref()
-            });
+            let trigger = params
+                .context
+                .as_ref()
+                .and_then(|context| context.trigger_character.as_deref());
 
             let in_scope =
                 get_completion_identifiers(&text[..start], trigger, linearization, item)?;

--- a/lsp/nls/src/requests/completion.rs
+++ b/lsp/nls/src/requests/completion.rs
@@ -44,7 +44,7 @@ fn find_fields_from_term_kind(
             } else {
                 let name = path.pop()?;
                 let new_id = fields.get(&name)?;
-                find_fields_from_term_kind(&linearization, *new_id, path)
+                find_fields_from_term_kind(linearization, *new_id, path)
             }
         }
         TermKind::RecordField {
@@ -72,7 +72,7 @@ fn find_fields_from_contract(
         None => match item.kind {
             TermKind::Declaration(_, _, ValueState::Known(new_id))
             | TermKind::Usage(UsageState::Resolved(new_id)) => {
-                find_fields_from_contract(&linearization, new_id, path)
+                find_fields_from_contract(linearization, new_id, path)
             }
             _ => None,
         },
@@ -187,7 +187,7 @@ fn get_identifiers_before_field(text: &str) -> Option<Vec<String>> {
         .rev()
         .collect();
 
-    get_identifier_path(&text.as_str())
+    get_identifier_path(text.as_str())
 }
 
 fn remove_duplicates(items: &Vec<CompletionItem>) -> Vec<CompletionItem> {
@@ -219,11 +219,11 @@ fn collect_record_info(
                     Some((find_fields_from_type(&rrows, path), item.ty.clone()))
                 }
                 (TermKind::Declaration(_, _, ValueState::Known(body_id)), _) if id == item.id => {
-                    match find_fields_from_contract(&linearization, *body_id, path) {
+                    match find_fields_from_contract(linearization, *body_id, path) {
                         // Get record fields from contract metadata
                         Some(fields) => Some((fields, item.ty.clone())),
                         // Get record fields from lexical scoping
-                        None => find_fields_from_term_kind(&linearization, id, path)
+                        None => find_fields_from_term_kind(linearization, id, path)
                             .map(|idents| (idents, item.ty.clone())),
                     }
                 }
@@ -280,7 +280,7 @@ fn get_completion_identifiers(
                     .iter()
                     .filter_map(|i| match i.kind {
                         TermKind::Declaration(ref ident, _, _) => {
-                            Some((vec![ident.clone()], i.ty.clone()))
+                            Some((vec![*ident], i.ty.clone()))
                         }
                         _ => None,
                     })
@@ -341,9 +341,7 @@ pub fn handle_completion(
 
             let trigger = params.context.as_ref().and_then(|context| {
                 context
-                    .trigger_character
-                    .as_ref()
-                    .map(|trigger| trigger.as_str())
+                    .trigger_character.as_deref()
             });
 
             let in_scope =

--- a/lsp/nls/src/requests/completion.rs
+++ b/lsp/nls/src/requests/completion.rs
@@ -172,7 +172,7 @@ fn get_identifier_path(text: &str) -> Option<Vec<String>> {
             String::from(name)
         }
     }
-    Some(path.split(".").map(remove_quotes).collect())
+    Some(path.split('.').map(remove_quotes).collect())
 }
 
 /// Get the identifiers before `.<text>` for record completion.

--- a/lsp/nls/src/requests/completion.rs
+++ b/lsp/nls/src/requests/completion.rs
@@ -87,7 +87,7 @@ fn find_fields_from_meta_value(meta_value: &MetaValue, path: &mut Vec<Ident>) ->
         .iter()
         .chain(meta_value.types.iter())
         .flat_map(|contract| match &contract.types {
-            Types(TypeF::Record(row)) => find_fields_from_type(&row, path),
+            Types(TypeF::Record(row)) => find_fields_from_type(row, path),
             Types(TypeF::Flat(term)) => find_fields_from_term(term, path).unwrap_or_default(),
             _ => Vec::new(),
         })
@@ -115,7 +115,7 @@ fn find_fields_from_type(rrows: &RecordRows, path: &mut Vec<Ident>) -> Vec<Ident
         rrows
             .iter()
             .filter_map(|item| match item {
-                RecordRowsIteratorItem::Row(row) => Some(row.id.clone()),
+                RecordRowsIteratorItem::Row(row) => Some(row.id),
                 _ => None,
             })
             .collect::<Vec<_>>()

--- a/lsp/nls/src/requests/goto.rs
+++ b/lsp/nls/src/requests/goto.rs
@@ -45,7 +45,7 @@ pub fn handle_to_definition(
 
     let item = linearization.item_at(&locator);
 
-    if item == None {
+    if item.is_none() {
         server.reply(Response::new_ok(id, Value::Null));
         return Ok(());
     }
@@ -108,7 +108,7 @@ pub fn handle_to_usages(
 
     let item = linearization.item_at(&locator);
 
-    if item == None {
+    if item.is_none() {
         server.reply(Response::new_ok(id, Value::Null));
         return Ok(());
     }

--- a/lsp/nls/src/requests/goto.rs
+++ b/lsp/nls/src/requests/goto.rs
@@ -57,19 +57,18 @@ pub fn handle_to_definition(
     let location = match item.kind {
         TermKind::Usage(UsageState::Resolved(usage_id)) => {
             let definition = linearization.get_item(usage_id).unwrap();
-            let location = match definition.pos.unwrap() {
-                RawSpan {
-                    start: ByteIndex(start),
-                    end: ByteIndex(end),
-                    src_id,
-                } => Location {
-                    uri: Url::parse(&server.cache.name(src_id).to_string_lossy()).unwrap(),
-                    range: Range::from_codespan(
-                        &src_id,
-                        &(start as usize..end as usize),
-                        server.cache.files(),
-                    ),
-                },
+            let RawSpan {
+                start: ByteIndex(start),
+                end: ByteIndex(end),
+                src_id,
+            } = definition.pos.unwrap();
+            let location = Location {
+                uri: Url::parse(&server.cache.name(src_id).to_string_lossy()).unwrap(),
+                range: Range::from_codespan(
+                    &src_id,
+                    &(start as usize..end as usize),
+                    server.cache.files(),
+                ),
             };
             Some(location)
         }

--- a/lsp/nls/src/requests/hover.rs
+++ b/lsp/nls/src/requests/hover.rs
@@ -44,7 +44,7 @@ pub fn handle(
 
     Trace::enrich(&id, linearization);
 
-    if item == None {
+    if item.is_none() {
         server.reply(Response::new_ok(id, Value::Null));
         return Ok(());
     }

--- a/lsp/nls/src/server.rs
+++ b/lsp/nls/src/server.rs
@@ -25,7 +25,7 @@ use crate::{
     trace::Trace,
 };
 
-pub const DOT_COMPL_TRIGGER: &'static str = ".";
+pub const DOT_COMPL_TRIGGER: &str = ".";
 
 pub struct Server {
     pub connection: Connection,

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -917,7 +917,7 @@ impl Cache {
     /// Generate the initial typing context from the list of `file_ids` corresponding to the
     /// standard library parts.
     pub fn mk_type_ctxt(&self) -> Result<typecheck::Context, CacheError<Void>> {
-        let stdlib_terms_vec =
+        let stdlib_terms_vec: Vec<RichTerm> =
             self.stdlib_ids
                 .as_ref()
                 .map_or(Err(CacheError::NotParsed), |ids| {

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -202,7 +202,7 @@ impl<E> CacheError<E> {
 /// retrieved from the cache.
 ///
 /// See [ImportResolver::resolve].
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum ResolvedTerm {
     FromFile {
         path: PathBuf, /* the loaded path */
@@ -1030,7 +1030,7 @@ impl ImportResolver for Cache {
         };
 
         self.parse_multi(file_id, format)
-            .map_err(|err| ImportError::ParseErrors(err.into(), *pos))?;
+            .map_err(|err| ImportError::ParseErrors(err, *pos))?;
 
         Ok((ResolvedTerm::FromFile { path: path_buf }, file_id))
     }

--- a/src/deserialize.rs
+++ b/src/deserialize.rs
@@ -47,7 +47,7 @@ macro_rules! deserialize_number_round {
 }
 
 /// An error occurred during deserialization to Rust.
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub enum RustDeserializationError {
     InvalidType { expected: String, occurred: String },
     MissingValue,

--- a/src/environment.rs
+++ b/src/environment.rs
@@ -101,7 +101,7 @@ impl<K: Hash + Eq, V: PartialEq> Environment<K, V> {
         let mut env: Vec<NonNull<HashMap<K, V>>> = self
             .iter_layers()
             // SAFETY: all NonNull::new_unchecked comes from pointers created from Rc, so cannot be null
-            .map(|hmap| unsafe { NonNull::new_unchecked(Rc::as_ptr(&hmap) as *mut _) })
+            .map(|hmap| unsafe { NonNull::new_unchecked(Rc::as_ptr(hmap) as *mut _) })
             .collect();
         // SAFETY: by design, env cannot be empty, and coming from an Rc, it is well aligned and initialized
         let current_map = unsafe { env.pop().unwrap().as_ref() }.iter();
@@ -297,7 +297,7 @@ mod tests {
         env_base.insert(1, 'a');
         assert_eq!(env_base.iter_layers().count(), 1);
         assert_eq!(env_base.iter_layers().next().unwrap().get(&1), Some(&'a'));
-        assert_eq!(env_base.iter_layers().skip(1).next(), None);
+        assert_eq!(env_base.iter_layers().nth(1), None);
         let _ = env_base.clone();
         assert_eq!(env_base.iter_layers().count(), 1);
         env_base.insert(2, 'b');
@@ -336,8 +336,8 @@ mod tests {
         env2.insert(1, 'y');
         assert_eq!(env_base.iter_elems().count(), 3);
         assert_eq!(env2.iter_elems().count(), 3);
-        assert_eq!(env_base.iter_elems().skip(2).next(), Some((&1, &'z')));
-        assert_eq!(env2.iter_elems().skip(2).next(), Some((&1, &'y')));
+        assert_eq!(env_base.iter_elems().nth(2), Some((&1, &'z')));
+        assert_eq!(env2.iter_elems().nth(2), Some((&1, &'y')));
 
         let mut iter_elems_base = env_base.iter_elems();
         let _ = iter_elems_base.next();

--- a/src/error.rs
+++ b/src/error.rs
@@ -208,7 +208,7 @@ pub enum TypecheckError {
     ),
 }
 
-#[derive(Debug, PartialEq, Clone, Default)]
+#[derive(Debug, PartialEq, Eq, Clone, Default)]
 pub struct ParseErrors {
     pub errors: Vec<ParseError>,
 }
@@ -273,7 +273,7 @@ impl ToDiagnostic<FileId> for ParseErrors {
 }
 
 /// An error occurring during parsing.
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub enum ParseError {
     /// Unexpected end of file.
     UnexpectedEOF(FileId, /* tokens expected by the parser */ Vec<String>),
@@ -348,11 +348,11 @@ pub enum SerializationError {
 }
 
 /// A general I/O error, occurring when reading a source file or writing an export.
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub struct IOError(pub String);
 
 /// An error occurring during an REPL session.
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub enum ReplError {
     UnknownCommand(String),
     MissingArg {
@@ -1269,7 +1269,7 @@ impl ToDiagnostic<FileId> for TypecheckError {
             TypecheckError::UnboundIdentifier(ident, pos_opt) =>
             // Use the same diagnostic as `EvalError::UnboundIdentifier` for consistency.
                 {
-                    EvalError::UnboundIdentifier(ident.clone(), *pos_opt)
+                    EvalError::UnboundIdentifier(*ident, *pos_opt)
                         .to_diagnostic(files, contract_id)
                 }
             TypecheckError::MissingRow(ident, expd, actual, span_opt) =>
@@ -1365,7 +1365,7 @@ impl ToDiagnostic<FileId> for TypecheckError {
                 // nested field (e.g. `pkg.subpkg1.meta.url`) and only show once the row mismatch
                 // error followed by the underlying error.
                 let mut err = (*err_).clone();
-                let mut path = vec![ident.clone()];
+                let mut path = vec![*ident];
 
                 while let TypecheckError::RowMismatch(id_next, _, _, next, _) = *err {
                     path.push(id_next);

--- a/src/error.rs
+++ b/src/error.rs
@@ -320,7 +320,7 @@ pub enum ParseError {
 }
 
 /// An error occurring during the resolution of an import.
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub enum ImportError {
     /// An IO error occurred during an import.
     IOError(

--- a/src/eval/callstack.rs
+++ b/src/eval/callstack.rs
@@ -219,6 +219,11 @@ impl CallStack {
         self.0.len()
     }
 
+    /// Return whether the callstack is empty.
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
     /// Truncate the callstack at a certain size. Used e.g. to quickly drop the elements introduced
     /// during the strict evaluation of the operand of a primitive operator. Wrapper for
     /// `callstack.0.truncate(len)`.

--- a/src/eval/callstack.rs
+++ b/src/eval/callstack.rs
@@ -9,7 +9,7 @@ use crate::{
 use codespan::FileId;
 
 /// A call stack, saving the history of function calls.
-#[derive(PartialEq, Clone, Default, Debug)]
+#[derive(PartialEq, Eq, Clone, Default, Debug)]
 pub struct CallStack(pub Vec<StackElem>);
 
 /// Basic description of a function call. Used for error reporting.
@@ -181,7 +181,7 @@ impl CallStack {
                         Some(CallDescr {
                             head: ref mut head @ None,
                             span: span_call,
-                        }) if pos.unwrap() <= *span_call => *head = Some(id.clone()),
+                        }) if pos.unwrap() <= *span_call => *head = Some(*id),
                         _ => (),
                     };
                 }

--- a/src/eval/fixpoint.rs
+++ b/src/eval/fixpoint.rs
@@ -15,8 +15,8 @@ pub fn rec_env<'a, I: Iterator<Item = (&'a Ident, &'a RichTerm)>>(
                 let thunk = env
                     .get(var_id)
                     .cloned()
-                    .ok_or_else(|| EvalError::UnboundIdentifier(var_id.clone(), rt.pos))?;
-                Ok((id.clone(), thunk))
+                    .ok_or(EvalError::UnboundIdentifier(*var_id, rt.pos))?;
+                Ok((*id, thunk))
             }
             _ => {
                 // If we are in this branch, `rt` must be a constant after the share normal form
@@ -26,7 +26,7 @@ pub fn rec_env<'a, I: Iterator<Item = (&'a Ident, &'a RichTerm)>>(
                     body: rt.clone(),
                     env: Environment::new(),
                 };
-                Ok((id.clone(), Thunk::new(closure, IdentKind::Let)))
+                Ok((*id, Thunk::new(closure, IdentKind::Let)))
             }
         })
         .collect()
@@ -48,7 +48,7 @@ pub fn patch_field(
         let mut thunk = env
             .get(var_id)
             .cloned()
-            .ok_or_else(|| EvalError::UnboundIdentifier(var_id.clone(), rt.pos))?;
+            .ok_or(EvalError::UnboundIdentifier(*var_id, rt.pos))?;
 
         let deps = thunk.deps();
 

--- a/src/eval/merge.rs
+++ b/src/eval/merge.rs
@@ -384,7 +384,11 @@ pub fn merge(
             let m1_values: Vec<_> = r1.fields.values().cloned().collect();
             let m2_values: Vec<_> = r2.fields.values().cloned().collect();
 
-            let hashmap::SplitResult{left, center, right} = hashmap::split(r1.fields, r2.fields);
+            let hashmap::SplitResult {
+                left,
+                center,
+                right,
+            } = hashmap::split(r1.fields, r2.fields);
 
             match mode {
                 MergeMode::Contract(mut lbl) if !r2.attrs.open && !left.is_empty() => {
@@ -534,16 +538,13 @@ pub mod hashmap {
     pub struct SplitResult<K, V1, V2> {
         pub left: HashMap<K, V1>,
         pub center: HashMap<K, (V1, V2)>,
-        pub right: HashMap<K, V2>
+        pub right: HashMap<K, V2>,
     }
 
     /// Split two hashmaps m1 and m2 in three parts (left,center,right), where left holds bindings
     /// `(key,value)` where key is not in `m2.keys()`, right is the dual (keys of m2 that are not
     /// in m1), and center holds bindings for keys that are both in m1 and m2.
-    pub fn split<K, V1, V2>(
-        m1: HashMap<K, V1>,
-        m2: HashMap<K, V2>,
-    ) -> SplitResult<K, V1, V2>
+    pub fn split<K, V1, V2>(m1: HashMap<K, V1>, m2: HashMap<K, V2>) -> SplitResult<K, V1, V2>
     where
         K: std::hash::Hash + Eq,
     {
@@ -559,7 +560,11 @@ pub mod hashmap {
             }
         }
 
-        SplitResult{left, center, right}
+        SplitResult {
+            left,
+            center,
+            right,
+        }
     }
 
     #[cfg(test)]
@@ -572,7 +577,11 @@ pub mod hashmap {
             let m2 = HashMap::<isize, isize>::new();
 
             m1.insert(1, 1);
-            let (mut left, center, right) = split(m1, m2);
+            let SplitResult {
+                mut left,
+                center,
+                right,
+            } = split(m1, m2);
 
             if left.remove(&1) == Some(1)
                 && left.is_empty()
@@ -591,7 +600,11 @@ pub mod hashmap {
             let mut m2 = HashMap::new();
 
             m2.insert(1, 1);
-            let (left, center, mut right) = split(m1, m2);
+            let SplitResult {
+                left,
+                center,
+                mut right,
+            } = split(m1, m2);
 
             if right.remove(&1) == Some(1)
                 && right.is_empty()
@@ -613,7 +626,11 @@ pub mod hashmap {
 
             m1.insert(1, 1);
             m2.insert(1, 2);
-            let (left, mut center, right) = split(m1, m2);
+            let SplitResult {
+                left,
+                mut center,
+                right,
+            } = split(m1, m2);
 
             if center.remove(&1) == Some((1, 2))
                 && center.is_empty()
@@ -637,7 +654,11 @@ pub mod hashmap {
             m1.insert(2, 1);
             m2.insert(1, -1);
             m2.insert(3, -1);
-            let (mut left, mut center, mut right) = split(m1, m2);
+            let SplitResult {
+                mut left,
+                mut center,
+                mut right,
+            } = split(m1, m2);
 
             if left.remove(&2) == Some(1)
                 && center.remove(&1) == Some((1, -1))

--- a/src/eval/mod.rs
+++ b/src/eval/mod.rs
@@ -336,8 +336,7 @@ impl<R: ImportResolver> VirtualMachine<R> {
                             thunk.set_evaluated();
                         }
                     }
-                    self.call_stack
-                        .enter_var(thunk.ident_kind(), *x, pos);
+                    self.call_stack.enter_var(thunk.ident_kind(), *x, pos);
                     thunk.into_closure()
                 }
                 Term::App(t1, t2) => {

--- a/src/eval/operation.rs
+++ b/src/eval/operation.rs
@@ -621,7 +621,7 @@ impl<R: ImportResolver> VirtualMachine<R> {
                             // As for `ArrayMap` (see above), we closurize the content of fields
                             let record = record.map_fields_without_optionals(&env, |id, t| {
                                 let pos = t.pos.into_inherited();
-                                
+
                                 mk_app!(f_as_var.clone(), mk_term::string(id.label()), t)
                                     .closurize(&mut shared_env, env.clone())
                                     .with_pos(pos)
@@ -1152,7 +1152,7 @@ impl<R: ImportResolver> VirtualMachine<R> {
                                     pos_field: t.pos,
                                     pos_access: pos_op,
                                 });
-                                
+
                                 mk_term::op1(UnaryOp::Force(stack_elem), t)
                                     .closurize(&mut shared_env, env.clone())
                             });
@@ -2813,7 +2813,11 @@ fn eq(env: &mut Environment, c1: Closure, c2: Closure) -> EqResult {
         (Term::SealingKey(s1), Term::SealingKey(s2)) => EqResult::Bool(s1 == s2),
         (Term::Enum(id1), Term::Enum(id2)) => EqResult::Bool(id1 == id2),
         (Term::Record(r1), Term::Record(r2)) => {
-            let merge::hashmap::SplitResult{left, center, right} = merge::hashmap::split(r1.fields, r2.fields);
+            let merge::hashmap::SplitResult {
+                left,
+                center,
+                right,
+            } = merge::hashmap::split(r1.fields, r2.fields);
 
             // As for other record operations, we ignore optional fields without a definition.
             if !left.values().all(|rt| is_empty_optional(rt, &env1))

--- a/src/eval/operation.rs
+++ b/src/eval/operation.rs
@@ -500,7 +500,7 @@ impl<R: ImportResolver> VirtualMachine<R> {
                             .into_iter()
                             // Ignore optional fields without definitions.
                             .filter_map(|(_, t)| {
-                                (!is_empty_optional(&t, &env)).then(|| t)
+                                (!is_empty_optional(&t, &env)).then_some(t)
                             })
                             .collect();
                         Ok(Closure {
@@ -621,10 +621,10 @@ impl<R: ImportResolver> VirtualMachine<R> {
                             // As for `ArrayMap` (see above), we closurize the content of fields
                             let record = record.map_fields_without_optionals(&env, |id, t| {
                                 let pos = t.pos.into_inherited();
-                                let map_app = mk_app!(f_as_var.clone(), mk_term::string(id.label()), t)
+                                
+                                mk_app!(f_as_var.clone(), mk_term::string(id.label()), t)
                                     .closurize(&mut shared_env, env.clone())
-                                    .with_pos(pos);
-                                map_app
+                                    .with_pos(pos)
                             });
 
                             Ok(Closure {
@@ -1024,7 +1024,7 @@ impl<R: ImportResolver> VirtualMachine<R> {
 
                     let param = Ident::fresh();
                     let matcher = Term::Fun(
-                        param.clone(),
+                        param,
                         RichTerm::new(
                             Term::Op1(
                                 UnaryOp::StrIsMatchCompiled(re.into()),
@@ -1051,7 +1051,7 @@ impl<R: ImportResolver> VirtualMachine<R> {
 
                     let param = Ident::fresh();
                     let matcher = Term::Fun(
-                        param.clone(),
+                        param,
                         RichTerm::new(
                             Term::Op1(
                                 UnaryOp::StrMatchCompiled(re.into()),
@@ -1147,14 +1147,14 @@ impl<R: ImportResolver> VirtualMachine<R> {
 
                             let record = record.map_fields_without_optionals(&env, |id, t| {
                                 let stack_elem = Some(callstack::StackElem::Field {
-                                    id: id.clone(),
+                                    id,
                                     pos_record: pos,
                                     pos_field: t.pos,
                                     pos_access: pos_op,
                                 });
-                                let forced = mk_term::op1(UnaryOp::Force(stack_elem), t)
-                                    .closurize(&mut shared_env, env.clone());
-                                forced
+                                
+                                mk_term::op1(UnaryOp::Force(stack_elem), t)
+                                    .closurize(&mut shared_env, env.clone())
                             });
 
                             let terms = record.fields.clone().into_values();
@@ -2009,7 +2009,7 @@ impl<R: ImportResolver> VirtualMachine<R> {
 
                                 let mut env = env1.clone();
                                 // TODO: Is there a cheaper way to "merge" two environements?
-                                env.extend(env2.iter_elems().map(|(k, v)| (k.clone(), v.clone())));
+                                env.extend(env2.iter_elems().map(|(k, v)| (*k, v.clone())));
 
                                 // We have two sets of contracts from the LHS and RHS arrays.
                                 // - Common contracts between the two sides can be put into
@@ -2614,7 +2614,7 @@ impl PushPriority {
     fn push_into_record(&self, record: RecordData, env: &Environment, pos: TermPos) -> Closure {
         let mut new_env = Environment::new();
 
-        let record = record.map_fields_without_optionals(&env, |_, rt| {
+        let record = record.map_fields_without_optionals(env, |_, rt| {
             // There is a subtlety with respect to overriding here. Take:
             //
             // ```nickel
@@ -2664,7 +2664,7 @@ impl PushPriority {
             };
 
             let fresh_id = Ident::fresh();
-            new_env.insert(fresh_id.clone(), thunk);
+            new_env.insert(fresh_id, thunk);
             RichTerm::new(Term::Var(fresh_id), pos)
         });
 
@@ -2816,8 +2816,8 @@ fn eq(env: &mut Environment, c1: Closure, c2: Closure) -> EqResult {
             let (left, center, right) = merge::hashmap::split(r1.fields, r2.fields);
 
             // As for other record operations, we ignore optional fields without a definition.
-            if !left.values().all(|rt| is_empty_optional(&rt, &env1))
-                || !right.values().all(|rt| is_empty_optional(&rt, &env2))
+            if !left.values().all(|rt| is_empty_optional(rt, &env1))
+                || !right.values().all(|rt| is_empty_optional(rt, &env2))
             {
                 EqResult::Bool(false)
             } else if center.is_empty() {

--- a/src/eval/operation.rs
+++ b/src/eval/operation.rs
@@ -2813,7 +2813,7 @@ fn eq(env: &mut Environment, c1: Closure, c2: Closure) -> EqResult {
         (Term::SealingKey(s1), Term::SealingKey(s2)) => EqResult::Bool(s1 == s2),
         (Term::Enum(id1), Term::Enum(id2)) => EqResult::Bool(id1 == id2),
         (Term::Record(r1), Term::Record(r2)) => {
-            let (left, center, right) = merge::hashmap::split(r1.fields, r2.fields);
+            let merge::hashmap::SplitResult{left, center, right} = merge::hashmap::split(r1.fields, r2.fields);
 
             // As for other record operations, we ignore optional fields without a definition.
             if !left.values().all(|rt| is_empty_optional(rt, &env1))

--- a/src/eval/tests.rs
+++ b/src/eval/tests.rs
@@ -20,7 +20,7 @@ fn parse(s: &str) -> Option<RichTerm> {
     let id = Files::new().add("<test>", String::from(s));
 
     grammar::TermParser::new()
-        .parse_term(id, lexer::Lexer::new(&s))
+        .parse_term(id, lexer::Lexer::new(s))
         .map(RichTerm::without_pos)
         .map_err(|err| println!("{:?}", err))
         .ok()
@@ -35,7 +35,7 @@ fn identity_over_values() {
     assert_eq!(Ok(boolean.clone()), eval_no_import(boolean.into()));
 
     let lambda = mk_fun!("x", mk_app!(mk_term::var("x"), mk_term::var("x")));
-    assert_eq!(Ok(lambda.as_ref().clone()), eval_no_import(lambda.into()));
+    assert_eq!(Ok(lambda.as_ref().clone()), eval_no_import(lambda));
 }
 
 #[test]
@@ -230,8 +230,7 @@ fn interpolation_simple() {
                 BinaryOp::StrConcat(),
                 mk_term::string(", "),
                 mk_term::string("World!"),
-            )
-            .into(),
+            ),
         ),
         StrChunk::Literal(String::from(" How")),
         StrChunk::expr(mk_term::if_then_else(

--- a/src/eval/tests.rs
+++ b/src/eval/tests.rs
@@ -225,13 +225,11 @@ fn imports() {
 fn interpolation_simple() {
     let mut chunks = vec![
         StrChunk::Literal(String::from("Hello")),
-        StrChunk::expr(
-            mk_term::op2(
-                BinaryOp::StrConcat(),
-                mk_term::string(", "),
-                mk_term::string("World!"),
-            ),
-        ),
+        StrChunk::expr(mk_term::op2(
+            BinaryOp::StrConcat(),
+            mk_term::string(", "),
+            mk_term::string("World!"),
+        )),
         StrChunk::Literal(String::from(" How")),
         StrChunk::expr(mk_term::if_then_else(
             Term::Bool(true),

--- a/src/identifier.rs
+++ b/src/identifier.rs
@@ -89,6 +89,12 @@ where
     }
 }
 
+// False-positive Clippy error: if we apply this suggestion,
+// we end up with an implementation of `From<Ident> for String`.
+// Then setting `F = Ident` in the implementation above gives
+// `From<Ident> for Ident` which is incoherent with the
+// blanket implementation of `From<T> for T`.
+#[allow(clippy::from_over_into)]
 impl Into<String> for Ident {
     fn into(self) -> String {
         self.into_label()

--- a/src/label.rs
+++ b/src/label.rs
@@ -48,7 +48,7 @@ pub mod ty_path {
     };
 
     /// An element of a path type.
-    #[derive(Debug, Clone, PartialEq)]
+    #[derive(Debug, Clone, PartialEq, Eq)]
     pub enum Elem {
         Domain,
         Codomain,

--- a/src/parser/error.rs
+++ b/src/parser/error.rs
@@ -1,6 +1,6 @@
 use crate::{identifier::Ident, position::RawSpan};
 
-#[derive(Clone, PartialEq, Debug)]
+#[derive(Clone, PartialEq, Eq, Debug)]
 pub enum LexicalError {
     /// A closing brace '}' does not match an opening brace '{'.
     UnmatchedCloseBrace(usize),
@@ -12,7 +12,7 @@ pub enum LexicalError {
     Generic(usize, usize),
 }
 
-#[derive(Clone, PartialEq, Debug)]
+#[derive(Clone, PartialEq, Eq, Debug)]
 pub enum ParseError {
     /// A specific lexical error
     Lexical(LexicalError),

--- a/src/parser/lexer.rs
+++ b/src/parser/lexer.rs
@@ -322,7 +322,7 @@ pub const KEYWORDS: &[&str] = &[
 ];
 
 /// The tokens in string mode.
-#[derive(Logos, Debug, PartialEq, Clone)]
+#[derive(Logos, Debug, PartialEq, Eq, Clone)]
 pub enum StringToken<'input> {
     #[error]
     Error,
@@ -344,7 +344,7 @@ pub enum StringToken<'input> {
 }
 
 /// The tokens in multiline string mode.
-#[derive(Logos, Debug, PartialEq, Clone)]
+#[derive(Logos, Debug, PartialEq, Eq, Clone)]
 pub enum MultiStringToken<'input> {
     #[error]
     Error,

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -13,7 +13,7 @@ fn parse(s: &str) -> Result<RichTerm, ParseError> {
     let id = Files::new().add("<test>", String::from(s));
 
     super::grammar::TermParser::new()
-        .parse_term(id, Lexer::new(&s))
+        .parse_term(id, Lexer::new(s))
         .map_err(|errs| errs.errors.first().unwrap().clone())
 }
 

--- a/src/parser/uniterm.rs
+++ b/src/parser/uniterm.rs
@@ -390,7 +390,7 @@ impl VarKindCell {
 
     /// Return the current var_kind.
     pub fn var_kind(&self) -> VarKind {
-        (*self.0.borrow()).var_kind
+        self.0.borrow().var_kind
     }
 }
 
@@ -473,8 +473,8 @@ impl FixTypeVars for Types {
             | TypeF::Flat(_)
             | TypeF::Wildcard(_) => (),
             TypeF::Arrow(ref mut s, ref mut t) => {
-                (&mut *s).fix_type_vars_env(bound_vars.clone());
-                (&mut *t).fix_type_vars_env(bound_vars);
+                (*s).fix_type_vars_env(bound_vars.clone());
+                (*t).fix_type_vars_env(bound_vars);
             }
             TypeF::Var(ref mut id) => {
                 if let Some(cell) = bound_vars.get(id) {
@@ -498,14 +498,14 @@ impl FixTypeVars for Types {
                 // We span a new VarKindCell and put it in the environment. The recursive calls to
                 // fix_type_vars will fill this cell with the correct kind, which we get afterwards
                 // to set the right value for `var_kind`.
-                bound_vars.insert(var.clone(), VarKindCell::new());
-                (&mut *body).fix_type_vars_env(bound_vars.clone());
+                bound_vars.insert(*var, VarKindCell::new());
+                (*body).fix_type_vars_env(bound_vars.clone());
                 // unwrap(): we just inseted a value for `var` above, and environment can never
                 // delete values.
                 *var_kind = bound_vars.get(var).unwrap().var_kind();
             }
             TypeF::Dict(ref mut ty) | TypeF::Array(ref mut ty) => {
-                (&mut *ty).fix_type_vars_env(bound_vars)
+                (*ty).fix_type_vars_env(bound_vars)
             }
             TypeF::Enum(ref mut erows) => erows.fix_type_vars_env(bound_vars),
             TypeF::Record(ref mut rrows) => rrows.fix_type_vars_env(bound_vars),

--- a/src/pretty.rs
+++ b/src/pretty.rs
@@ -402,8 +402,7 @@ where
                 .text("let")
                 .append(allocator.space())
                 .append(
-                    opt_id
-                        .clone()
+                    (*opt_id)
                         .map(|id| {
                             allocator.as_string(id).append(if dst.is_empty() {
                                 allocator.nil()

--- a/src/repl/mod.rs
+++ b/src/repl/mod.rs
@@ -272,7 +272,7 @@ impl Repl for ReplImpl {
         // We need to `traverse` the term, in case the type depends on inner terms that also contain wildcards
         let term = term
             .traverse(
-                &mut |rt: RichTerm, _| -> Result<RichTerm, std::convert::Infallible> {
+                &|rt: RichTerm, _| -> Result<RichTerm, std::convert::Infallible> {
                     Ok(transform::substitute_wildcards::transform_one(
                         rt, &wildcards,
                     ))

--- a/src/repl/mod.rs
+++ b/src/repl/mod.rs
@@ -150,7 +150,7 @@ impl ReplImpl {
             if let Some(id) = id {
                 typecheck::env_add(
                     &mut repl_impl.env.type_ctxt.type_env,
-                    id.clone(),
+                    id,
                     &t,
                     &repl_impl.env.type_ctxt.term_env,
                     repl_impl.vm.import_resolver(),
@@ -192,9 +192,9 @@ impl ReplImpl {
                 Ok(eval_function(&mut self.vm, t, &self.env.eval_env)?.into())
             }
             ExtendedTerm::ToplevelLet(id, t) => {
-                let t = prepare(self, Some(id.clone()), t)?;
+                let t = prepare(self, Some(id), t)?;
                 let local_env = self.env.eval_env.clone();
-                eval::env_add(&mut self.env.eval_env, id.clone(), t, local_env);
+                eval::env_add(&mut self.env.eval_env, id, t, local_env);
                 Ok(EvalResult::Bound(id))
             }
         }

--- a/src/repl/simple_frontend.rs
+++ b/src/repl/simple_frontend.rs
@@ -99,7 +99,7 @@ pub fn serialize<R: Repl>(
 ) -> Result<InputResult, InputError> {
     repl.eval_full(input)
         .and_then(|eval_res| match eval_res {
-            EvalResult::Evaluated(t) => serialize::to_string(format, &t.into())
+            EvalResult::Evaluated(t) => serialize::to_string(format, &t)
                 .map(InputResult::Success)
                 .map_err(Error::from),
             EvalResult::Bound(_) => Ok(InputResult::Success(String::new())),

--- a/src/repl/wasm_frontend.rs
+++ b/src/repl/wasm_frontend.rs
@@ -162,7 +162,7 @@ impl WasmInitResult {
     /// Make a `WasmInitResult` result from an `InputError`.
     fn error(mut state: ReplState, error: InputError) -> Self {
         WasmInitResult {
-            msg: err_to_string(&mut state.0.cache_mut(), &error),
+            msg: err_to_string(state.0.cache_mut(), &error),
             tag: WasmResultTag::Error,
             state,
         }
@@ -278,7 +278,7 @@ pub fn diags_to_string(cache: &mut Cache, diags: &Vec<Diagnostic<FileId>>) -> St
     diags
         .iter()
         .try_for_each(|d| {
-            codespan_reporting::term::emit(&mut buffer, &config, cache.files_mut(), &d)
+            codespan_reporting::term::emit(&mut buffer, &config, cache.files_mut(), d)
         })
         .unwrap();
 

--- a/src/repl/wasm_frontend.rs
+++ b/src/repl/wasm_frontend.rs
@@ -209,13 +209,13 @@ impl WasmInputResult {
         WasmInputResult {
             msg,
             tag: WasmResultTag::Error,
-            errors: JsValue::from_serde(&errors).unwrap(),
+            errors: serde_wasm_bindgen::to_value(&errors).unwrap(),
         }
     }
 
     /// Generate a serializable empty list.
     fn empty_errors() -> JsValue {
-        JsValue::from_serde(&Vec::<WasmErrorDiagnostic>::new()).unwrap()
+        serde_wasm_bindgen::to_value(&Vec::<WasmErrorDiagnostic>::new()).unwrap()
     }
 }
 
@@ -271,7 +271,7 @@ impl TryInto<ExportFormat> for WasmExportFormat {
 }
 
 /// Render error diagnostics as a string.
-pub fn diags_to_string(cache: &mut Cache, diags: &Vec<Diagnostic<FileId>>) -> String {
+pub fn diags_to_string(cache: &mut Cache, diags: &[Diagnostic<FileId>]) -> String {
     let mut buffer = Ansi::new(Cursor::new(Vec::new()));
     let config = codespan_reporting::term::Config::default();
 

--- a/src/serialize.rs
+++ b/src/serialize.rs
@@ -225,7 +225,7 @@ where
             .map_err(|err| SerializationError::Other(err.to_string())),
         ExportFormat::Yaml => serde_yaml::to_writer(writer, &rt)
             .map_err(|err| SerializationError::Other(err.to_string())),
-        ExportFormat::Toml => toml::Value::try_from(&rt)
+        ExportFormat::Toml => toml::Value::try_from(rt)
             .map_err(|err| SerializationError::Other(err.to_string()))
             .and_then(|v| {
                 write!(writer, "{}", v).map_err(|err| SerializationError::Other(err.to_string()))
@@ -249,7 +249,7 @@ pub fn to_string(format: ExportFormat, rt: &RichTerm) -> Result<String, Serializ
         ExportFormat::Yaml => {
             serde_yaml::to_string(&rt).map_err(|err| SerializationError::Other(err.to_string()))
         }
-        ExportFormat::Toml => toml::Value::try_from(&rt)
+        ExportFormat::Toml => toml::Value::try_from(rt)
             .map(|v| format!("{}", v))
             .map_err(|err| SerializationError::Other(err.to_string())),
         ExportFormat::Raw => match rt.as_ref() {

--- a/src/term.rs
+++ b/src/term.rs
@@ -1678,7 +1678,7 @@ impl RichTerm {
                     .into_iter()
                     .map(|ctr| {
                         let Contract {types, label} = ctr;
-                        types.traverse(&mut f_on_type, state, order).map(|types| Contract { types, label })
+                        types.traverse(&f_on_type, state, order).map(|types| Contract { types, label })
                     })
                     .collect();
                 let contracts = contracts?;
@@ -1687,7 +1687,7 @@ impl RichTerm {
                     .types
                     .map(|ctr| {
                         let Contract {types, label} = ctr;
-                        types.traverse(&mut f_on_type, state, order).map(|types| Contract { types, label })
+                        types.traverse(&f_on_type, state, order).map(|types| Contract { types, label })
                     })
                     .transpose()?;
 

--- a/src/term.rs
+++ b/src/term.rs
@@ -266,7 +266,7 @@ pub mod array {
 
             // This condition is the same as `!Rc::is_unique(&mut self.inner)`, but that function
             // is not public.
-            if Rc::strong_count(&mut self.inner) != 1 || Rc::weak_count(&mut self.inner) != 0 {
+            if Rc::strong_count(&self.inner) != 1 || Rc::weak_count(&self.inner) != 0 {
                 self.inner = self.iter().cloned().collect::<Rc<[_]>>();
             }
 
@@ -516,6 +516,11 @@ pub struct PriorityIsNaN;
 
 // The following impl are ok because `NumeralPriority(NaN)` can't be constructed.
 impl Eq for NumeralPriority {}
+
+// We can't derive `Ord` because there is an `f64` inside
+// but it is actually an `Ord` because `NaN` is forbidden.
+// See `TryFrom` smart constructor.
+#[allow(clippy::derive_ord_xor_partial_ord)]
 impl Ord for NumeralPriority {
     fn cmp(&self, other: &Self) -> Ordering {
         // Ok: NaN is forbidden

--- a/src/transform/desugar_destructuring.rs
+++ b/src/transform/desugar_destructuring.rs
@@ -60,7 +60,7 @@ pub fn desugar_fun(rt: RichTerm) -> RichTerm {
             let t_pos = t_.pos;
             RichTerm::new(
                 Term::Fun(
-                    x.clone(),
+                    x,
                     RichTerm::new(Term::LetPattern(None, pat, Term::Var(x).into(), t_), t_pos /* TODO: should we use rt.pos? */),
                 ),
                 rt.pos,
@@ -112,9 +112,9 @@ pub fn desugar(rt: RichTerm) -> RichTerm {
                 let x = x.unwrap_or_else(Ident::fresh);
                 RichTerm::new(
                     Term::Let(
-                        x.clone(),
+                        x,
                         t_,
-                        destruct_term(x.clone(), &pat, bind_open_field(x, &pat, body)),
+                        destruct_term(x, &pat, bind_open_field(x, &pat, body)),
                         Default::default(),
                     ),
                     pos,
@@ -136,7 +136,7 @@ fn bind_open_field(x: Ident, pat: &Destruct, body: RichTerm) -> RichTerm {
             open: true,
             rest: Some(x),
             ..
-        } => (matches, x.clone()),
+        } => (matches, *x),
         Destruct::Record {
             matches,
             open: true,
@@ -172,8 +172,8 @@ fn destruct_term(x: Ident, pat: &Destruct, body: RichTerm) -> RichTerm {
         Destruct::Record { matches, .. } => matches.iter().fold(body, move |t, m| match m {
             Match::Simple(id, _) => RichTerm::new(
                 Term::Let(
-                    id.clone(),
-                    op1(StaticAccess(id.clone()), Term::Var(x.clone())),
+                    *id,
+                    op1(StaticAccess(*id), Term::Var(x)),
                     t,
                     Default::default(),
                 ),
@@ -181,9 +181,9 @@ fn destruct_term(x: Ident, pat: &Destruct, body: RichTerm) -> RichTerm {
             ),
             Match::Assign(f, _, (id, pat)) => desugar(RichTerm::new(
                 Term::LetPattern(
-                    id.clone(),
+                    *id,
                     pat.clone(),
-                    op1(StaticAccess(f.clone()), Term::Var(x.clone())),
+                    op1(StaticAccess(*f), Term::Var(x)),
                     t,
                 ),
                 pos,

--- a/src/transform/desugar_destructuring.rs
+++ b/src/transform/desugar_destructuring.rs
@@ -180,12 +180,7 @@ fn destruct_term(x: Ident, pat: &Destruct, body: RichTerm) -> RichTerm {
                 pos,
             ),
             Match::Assign(f, _, (id, pat)) => desugar(RichTerm::new(
-                Term::LetPattern(
-                    *id,
-                    pat.clone(),
-                    op1(StaticAccess(*f), Term::Var(x)),
-                    t,
-                ),
+                Term::LetPattern(*id, pat.clone(), op1(StaticAccess(*f), Term::Var(x)), t),
                 pos,
             )),
         }),

--- a/src/transform/free_vars.rs
+++ b/src/transform/free_vars.rs
@@ -27,7 +27,7 @@ impl CollectFreeVars for RichTerm {
     fn collect_free_vars(&mut self, free_vars: &mut HashSet<Ident>) {
         match SharedTerm::make_mut(&mut self.term) {
             Term::Var(id) => {
-                free_vars.insert(id.clone());
+                free_vars.insert(*id);
             }
             Term::ParseError(_)
             | Term::Null
@@ -124,7 +124,7 @@ impl CollectFreeVars for RichTerm {
                     t.collect_free_vars(&mut fresh);
                     new_deps
                         .stat_fields
-                        .insert(id.clone(), &fresh & &rec_fields);
+                        .insert(*id, &fresh & &rec_fields);
 
                     free_vars.extend(&fresh - &rec_fields);
                 }

--- a/src/transform/free_vars.rs
+++ b/src/transform/free_vars.rs
@@ -122,9 +122,7 @@ impl CollectFreeVars for RichTerm {
                     fresh.clear();
 
                     t.collect_free_vars(&mut fresh);
-                    new_deps
-                        .stat_fields
-                        .insert(*id, &fresh & &rec_fields);
+                    new_deps.stat_fields.insert(*id, &fresh & &rec_fields);
 
                     free_vars.extend(&fresh - &rec_fields);
                 }

--- a/src/transform/import_resolution.rs
+++ b/src/transform/import_resolution.rs
@@ -44,9 +44,7 @@ where
 
     // If an import is resolved, then stack it.
     let transformed = rt.traverse(
-        &mut |rt: RichTerm,
-              state: &mut ImportsResolutionState<R>|
-         -> Result<RichTerm, ImportError> {
+        &|rt: RichTerm, state: &mut ImportsResolutionState<R>| -> Result<RichTerm, ImportError> {
             let rt = transform_one(rt, state.resolver, &state.parent)?;
 
             if let Term::ResolvedImport(file_id) = rt.term.as_ref() {

--- a/src/transform/mod.rs
+++ b/src/transform/mod.rs
@@ -35,7 +35,7 @@ pub fn transform_no_free_vars(
     wildcards: Option<&Wildcards>,
 ) -> Result<RichTerm, UnboundTypeVariableError> {
     let rt = rt.traverse(
-        &mut |mut rt: RichTerm, _| -> Result<RichTerm, UnboundTypeVariableError> {
+        &|mut rt: RichTerm, _| -> Result<RichTerm, UnboundTypeVariableError> {
             // Start by substituting any wildcard with its inferred type
             if let Some(wildcards) = wildcards {
                 rt = substitute_wildcards::transform_one(rt, wildcards);
@@ -52,7 +52,7 @@ pub fn transform_no_free_vars(
 
     Ok(rt
         .traverse(
-            &mut |rt: RichTerm, _| -> Result<RichTerm, ()> {
+            &|rt: RichTerm, _| -> Result<RichTerm, ()> {
                 let rt = share_normal_form::transform_one(rt);
                 Ok(rt)
             },

--- a/src/transform/mod.rs
+++ b/src/transform/mod.rs
@@ -141,7 +141,7 @@ impl Closurizable for RichTerm {
             }
         };
 
-        env.insert(var.clone(), thunk);
+        env.insert(var, thunk);
         RichTerm::new(Term::Var(var), pos.into_inherited())
     }
 }

--- a/src/transform/share_normal_form.rs
+++ b/src/transform/share_normal_form.rs
@@ -55,7 +55,7 @@ pub fn transform_one(rt: RichTerm) -> RichTerm {
                     if should_share(&t.term) {
                         let fresh_var = Ident::fresh();
                         let pos_t = t.pos;
-                        bindings.push((fresh_var.clone(), t, BindingType::Normal));
+                        bindings.push((fresh_var, t, BindingType::Normal));
                         RichTerm::new(Term::Var(fresh_var), pos_t)
                     } else {
                         t
@@ -88,7 +88,7 @@ pub fn transform_one(rt: RichTerm) -> RichTerm {
                     // rather that the dependencies haven't been computed. In the latter
                     // case, we must be conservative and assume the field is potentially
                     // recursive.
-                    let is_non_rec = (&field_deps).as_ref().map(|deps| deps.is_empty()).unwrap_or(false);
+                    let is_non_rec = field_deps.as_ref().map(|deps| deps.is_empty()).unwrap_or(false);
                     if is_non_rec {
                         BindingType::Normal
                     } else {
@@ -103,9 +103,9 @@ pub fn transform_one(rt: RichTerm) -> RichTerm {
                         let fresh_var = Ident::fresh();
                         let pos_t = t.pos;
                         let field_deps = deps.as_ref().and_then(|deps| deps.stat_fields.get(&id)).cloned();
-                        let is_non_rec = (&field_deps).as_ref().map(|deps| deps.is_empty()).unwrap_or(false);
+                        let is_non_rec = field_deps.as_ref().map(|deps| deps.is_empty()).unwrap_or(false);
                         let btype = mk_binding_type(field_deps);
-                        bindings.push((fresh_var.clone(), t, btype));
+                        bindings.push((fresh_var, t, btype));
 
                         RichTerm::new(Term::Var(fresh_var), pos_t)
                     } else {
@@ -122,7 +122,7 @@ pub fn transform_one(rt: RichTerm) -> RichTerm {
                             let pos_t = t.pos;
                             let field_deps = deps.as_ref().and_then(|deps| deps.dyn_fields.get(index)).cloned();
                             let btype = mk_binding_type(field_deps);
-                            bindings.push((fresh_var.clone(), t, btype));
+                            bindings.push((fresh_var, t, btype));
                             (id_t, RichTerm::new(Term::Var(fresh_var), pos_t))
                         } else {
                             (id_t, t)
@@ -141,7 +141,7 @@ pub fn transform_one(rt: RichTerm) -> RichTerm {
                         if should_share(&t.term) {
                             let fresh_var = Ident::fresh();
                             let pos_t = t.pos;
-                            bindings.push((fresh_var.clone(), t, BindingType::Normal));
+                            bindings.push((fresh_var, t, BindingType::Normal));
                             RichTerm::new(Term::Var(fresh_var), pos_t)
                         } else {
                             t
@@ -156,7 +156,7 @@ pub fn transform_one(rt: RichTerm) -> RichTerm {
                     let fresh_var = Ident::fresh();
                     let t = meta.value.take().unwrap();
                     meta.value
-                        .replace(RichTerm::new(Term::Var(fresh_var.clone()), t.pos));
+                        .replace(RichTerm::new(Term::Var(fresh_var), t.pos));
                     let inner = RichTerm::new(Term::MetaValue(meta), pos);
                     let attrs = LetAttrs {
                         binding_type: BindingType::Normal,

--- a/src/transform/substitute_wildcards.rs
+++ b/src/transform/substitute_wildcards.rs
@@ -51,7 +51,7 @@ fn get_wildcard_type(wildcards: &Wildcards, id: usize) -> Types {
 /// Recursively substitutes wildcards for their inferred type inside a given type.
 fn substitute_wildcards_recursively(ty: Types, wildcards: &Wildcards) -> Types {
     ty.traverse::<_, _, Infallible>(
-        &mut |ty, _| {
+        &|ty, _| {
             if let Types(TypeF::Wildcard(id)) = ty {
                 Ok(get_wildcard_type(wildcards, id))
             } else {

--- a/src/typecheck/eq.rs
+++ b/src/typecheck/eq.rs
@@ -114,7 +114,7 @@ impl From<eval::Environment> for SimpleTermEnvironment {
             .map(|(id, thunk)| {
                 let borrowed = thunk.borrow();
                 (
-                    id.clone(),
+                    *id,
                     (
                         borrowed.body.clone(),
                         SimpleTermEnvironment::from(borrowed.env.clone()),

--- a/src/typecheck/eq.rs
+++ b/src/typecheck/eq.rs
@@ -386,7 +386,7 @@ fn rows_as_set(erows: &UnifEnumRows) -> Option<HashSet<Ident>> {
     let set: Option<HashSet<_>> = erows
         .iter()
         .map(|item| match item {
-            UnifEnumRowsIteratorItem::Row(id) => Some(id.clone()),
+            UnifEnumRowsIteratorItem::Row(id) => Some(*id),
             _ => None,
         })
         .collect();

--- a/src/typecheck/mod.rs
+++ b/src/typecheck/mod.rs
@@ -601,10 +601,7 @@ pub fn mk_initial_ctxt(initial_env: &[RichTerm]) -> Result<Context, EnvBuildErro
         .iter()
         .map(|rt| {
             if let Term::RecRecord(record, ..) = rt.as_ref() {
-                Ok(record
-                    .fields
-                    .iter()
-                    .map(|(id, rt)| (*id, rt.clone())))
+                Ok(record.fields.iter().map(|(id, rt)| (*id, rt.clone())))
             } else {
                 Err(EnvBuildError::NotARecord(rt.clone()))
             }

--- a/src/typecheck/mod.rs
+++ b/src/typecheck/mod.rs
@@ -595,7 +595,7 @@ pub enum EnvBuildError {
 }
 
 /// Populate the initial typing environment from a `Vec` of parsed files.
-pub fn mk_initial_ctxt(initial_env: &Vec<RichTerm>) -> Result<Context, EnvBuildError> {
+pub fn mk_initial_ctxt(initial_env: &[RichTerm]) -> Result<Context, EnvBuildError> {
     // Collect the bindings for each module, clone them and flatten the result to a single list.
     let bindings = initial_env
         .iter()

--- a/src/typecheck/operation.rs
+++ b/src/typecheck/operation.rs
@@ -48,7 +48,7 @@ pub fn get_uop_type(
             let row = UnifEnumRows::UnifVar(row_var_id);
 
             let domain = mk_tyw_enum!(; row.clone());
-            let codomain = mk_tyw_enum!(id.clone(); row);
+            let codomain = mk_tyw_enum!(*id; row);
 
             // The codomain is the only type which can impose a constraint on the fresh row
             // unification variable, namely that it can't contain `id`.
@@ -66,7 +66,7 @@ pub fn get_uop_type(
             let rows = state.table.fresh_rrows_uvar();
             let res = state.table.fresh_type_uvar();
 
-            (mk_tyw_record!((id.clone(), res.clone()); rows), res)
+            (mk_tyw_record!((*id, res.clone()); rows), res)
         }
         // forall a b. Array a -> (a -> b) -> Array b
         UnaryOp::ArrayMap() => {

--- a/src/typecheck/reporting.rs
+++ b/src/typecheck/reporting.rs
@@ -68,7 +68,7 @@ fn select_uniq(name_reg: &mut NameReg, mut name: String, id: usize) -> Ident {
     }
 
     let ident = Ident::from(name);
-    name_reg.reg.insert(id, ident.clone());
+    name_reg.reg.insert(id, ident);
     ident
 }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -669,9 +669,7 @@ fn get_var_contract(
     id: &Ident,
     pol: bool,
 ) -> Result<RichTerm, UnboundTypeVariableError> {
-    let (pos, neg) = vars
-        .get(id)
-        .ok_or(UnboundTypeVariableError(*id))?;
+    let (pos, neg) = vars.get(id).ok_or(UnboundTypeVariableError(*id))?;
     if pol {
         Ok(pos.clone())
     } else {
@@ -724,10 +722,7 @@ impl EnumRows {
             RichTerm::from(Term::Switch(
                 mk_term::var(value_arg),
                 cases,
-                Some(mk_app!(
-                    contract::enum_fail(),
-                    mk_term::var(label_arg)
-                )),
+                Some(mk_app!(contract::enum_fail(), mk_term::var(label_arg))),
             ))
         };
         let case = mk_fun!(label_arg, value_arg, case_body);
@@ -735,7 +730,7 @@ impl EnumRows {
         Ok(mk_app!(contract::enums(), case))
     }
 
-    pub fn iter<'a>(&'a self) -> EnumRowsIterator<'a, EnumRows> {
+    pub fn iter(&self) -> EnumRowsIterator<EnumRows> {
         EnumRowsIterator { erows: Some(self) }
     }
 }
@@ -807,7 +802,7 @@ impl RecordRows {
         }
     }
 
-    pub fn iter<'a>(&'a self) -> RecordRowsIterator<'a, Types, RecordRows> {
+    pub fn iter(&self) -> RecordRowsIterator<Types, RecordRows> {
         RecordRowsIterator {
             rrows: Some(self),
             ty: std::marker::PhantomData,

--- a/tests/free_vars.rs
+++ b/tests/free_vars.rs
@@ -10,7 +10,7 @@ use nickel_lang_utilities::parse;
 // }
 
 fn free_vars_eq(free_vars: &HashSet<Ident>, expected: Vec<&str>) -> bool {
-    let expected_set: HashSet<Ident> = expected.into_iter().map(|s| Ident::from(s)).collect();
+    let expected_set: HashSet<Ident> = expected.into_iter().map(Ident::from).collect();
     *free_vars == expected_set
 }
 

--- a/utilities/src/lib.rs
+++ b/utilities/src/lib.rs
@@ -27,7 +27,7 @@ pub fn parse(s: &str) -> Result<RichTerm, ParseError> {
     let id = Files::new().add("<test>", String::from(s));
 
     grammar::TermParser::new()
-        .parse_term(id, lexer::Lexer::new(&s))
+        .parse_term(id, lexer::Lexer::new(s))
         .map_err(|errs| errs.errors.first().unwrap().clone())
 }
 

--- a/utilities/src/lib.rs
+++ b/utilities/src/lib.rs
@@ -59,7 +59,7 @@ pub struct Bench<'b> {
 }
 
 impl<'b> Bench<'b> {
-    pub fn bench(
+    pub fn new(
         name: &'b str,
         base_dir: &'b str,
         subpath: &'b str,


### PR DESCRIPTION
Add a clippy check to the CI (and flake checks, and pre commit hooks). The CI disables two rules that, in our experience, don't always make sense to implement. This PR doesn't disable them on the whole crate because sometimes they are justified, so we don't want to silence them either when a contributor is running clippy locally: we just avoid having them blocking the CI.

* Add Clippy to the CI run
* Add a Clippy pre-commit hook
* CI logs are fully visible in Github Action
* All Clippy errors and warnings are fixed (most automatically via `clippy --fix`, some manually)