### PR TITLE
Migrate to the latest edition (2021)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ description = "Programmable configuration files."
 homepage = "https://nickel-lang.org"
 repository = "https://github.com/tweag/nickel"
 keywords = ["configuration", "language", "nix"]
-edition = "2018"
+edition = "2021"
 
 [[bin]]
 name = "nickel"


### PR DESCRIPTION
`cargo fix --edition` didn't find anything to do. Let's just see if the CI is happy (I haven't tried it locally, given how long it is :confused:  )