### PR TITLE
Backport 0.2.1 pre-release fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1174,7 +1174,7 @@ dependencies = [
 
 [[package]]
 name = "nickel-lang"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "ansi_term",
  "assert_matches",
@@ -1212,7 +1212,7 @@ dependencies = [
 
 [[package]]
 name = "nickel-lang-lsp"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -1237,7 +1237,7 @@ dependencies = [
 
 [[package]]
 name = "nickel-lang-utilities"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "codespan",
  "criterion",
@@ -1246,7 +1246,7 @@ dependencies = [
 
 [[package]]
 name = "nickel-repl"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "nickel-lang",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1174,7 +1174,7 @@ dependencies = [
 
 [[package]]
 name = "nickel-lang"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "ansi_term",
  "assert_matches",
@@ -1212,7 +1212,7 @@ dependencies = [
 
 [[package]]
 name = "nickel-lang-lsp"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -1237,7 +1237,7 @@ dependencies = [
 
 [[package]]
 name = "nickel-lang-utilities"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "codespan",
  "criterion",
@@ -1246,7 +1246,7 @@ dependencies = [
 
 [[package]]
 name = "nickel-repl"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "nickel-lang",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nickel-lang"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Nickel team"]
 license = "MIT"
 readme = "README.md"
@@ -64,7 +64,7 @@ pretty_assertions = "1.2.1"
 assert_matches = "1.5.0"
 criterion = "0.3"
 pprof = { version = "0.9.1", features = ["criterion", "flamegraph"] }
-nickel-lang-utilities = {path = "utilities", version = "0.1.0"}
+nickel-lang-utilities = {path = "utilities", version = "0.2.0"}
 similar = "2.1.0"
 
 [workspace]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nickel-lang"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Nickel team"]
 license = "MIT"
 readme = "README.md"
@@ -64,7 +64,7 @@ pretty_assertions = "1.2.1"
 assert_matches = "1.5.0"
 criterion = "0.3"
 pprof = { version = "0.9.1", features = ["criterion", "flamegraph"] }
-nickel-lang-utilities = {path = "utilities", version = "0.2.0"}
+nickel-lang-utilities = {path = "utilities", version = "0.2.1"}
 similar = "2.1.0"
 
 [workspace]

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,15 +1,13 @@
-Version 0.2  (2022-07-XX)
+Version 0.2  (2022-07-29)
 =========================
-
-Various bug fixes, language and tooling improvements.
 
 Breaking changes
 ----------------
 
-- Using a contract as part of a static type annotations will in most cases fail
+- Using a contract as part of a static type annotation will in most cases fail
   with an appropriate error message. This is a temporary limitation in order to
-  fix previously unsound behavior in the typechecker. This will likely be fixed
-  in the upcoming 0.3.x release. For more details, see issues
+  fix previously unsound behavior in the typechecker. This restriction will
+  likely be lifted in the upcoming 0.3.x release. For more details, see issues
   [#701](https://github.com/tweag/nickel/issues/701) and
   [#724](https://github.com/tweag/nickel/issues/724)
 
@@ -25,17 +23,18 @@ Fixes
 Language features
 -----------------
 
-- Merge null values together give null, and merging empty lists together gives
-  an empty list, instead of failing with a `error: non mergeable terms`
+- Merging null values together gives null, and merging empty lists together gives
+  an empty list, instead of failing with `error: non mergeable terms`
 - Add recursive let-bindings (`let rec`)
-- Add type wildcard. Use `_` in place of a type to let the typechecker fill
+- Add type wildcards. Use `_` in place of a type to let the typechecker fill
   the gap. Example: `let foo : _ = array.all ((==) 2) [1,2,3]`
 - Add `builtin.to_str` and `string.from` to convert generic values to a string
+- Re-introduce an official syntax for enum types
 
 Tooling
 -------
 
-- Add the `nickel pprint-ast` command to pretty print a parsed program (for
+- Add the `nickel pprint-ast` command to pretty print a parsed program (mostly
   debugging purpose)
 - Add the `nickel doc` command to produce markdown documentation from the
   in-code `doc` metadata
@@ -43,7 +42,7 @@ Tooling
 Documentation
 -------------
 
-- Fix various typos and use of deprecated syntax in the user manual
+- Fix various typos and remove use of deprecated syntax in the user manual
 
 Version 0.1  (2022-03-10)
 =========================

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,3 +1,50 @@
+Version 0.2  (2022-07-XX)
+=========================
+
+Various bug fixes, language and tooling improvements.
+
+Breaking changes
+----------------
+
+- Using a contract as part of a static type annotations will in most cases fail
+  with an appropriate error message. This is a temporary limitation in order to
+  fix previously unsound behavior in the typechecker. This will likely be fixed
+  in the upcoming 0.3.x release. For more details, see issues
+  [#701](https://github.com/tweag/nickel/issues/701) and
+  [#724](https://github.com/tweag/nickel/issues/724)
+
+Fixes
+-----
+
+- Fix unnecessarily restricted record contract for `record.update`
+- Fix wrong interpretation of long interpolation-like sequences `%..%{` in strings
+- Fix panic when evaluating a `switch` in specific cases
+- Fix fields without definition being assigned to `null`, instead of just being
+  marked as undefined
+
+Language features
+-----------------
+
+- Merge null values together give null, and merging empty lists together gives
+  an empty list, instead of failing with a `error: non mergeable terms`
+- Add recursive let-bindings (`let rec`)
+- Add type wildcard. Use `_` in place of a type to let the typechecker fill
+  the gap. Example: `let foo : _ = array.all ((==) 2) [1,2,3]`
+- Add `builtin.to_str` and `string.from` to convert generic values to a string
+
+Tooling
+-------
+
+- Add the `nickel pprint-ast` command to pretty print a parsed program (for
+  debugging purpose)
+- Add the `nickel doc` command to produce markdown documentation from the
+  in-code `doc` metadata
+
+Documentation
+-------------
+
+- Fix various typos and use of deprecated syntax in the user manual
+
 Version 0.1  (2022-03-10)
 =========================
 
@@ -6,46 +53,46 @@ First release! The main focus has been the design of the Nickel language itself.
 Language features
 -----------------
 
-   * Gradual type system with row types, polymorphism and type inference
-   * Contract system for data validation
-   * Merge system for recursive records that supports one level of overriding
-   * Metadata annotations (default values, documentation, etc.)
-   * Unified syntax for terms, types and contracts (RFC002)
-   * Record destructuring
- 
+- Gradual type system with row types, polymorphism and type inference
+- Contract system for data validation
+- Merge system for recursive records that supports one level of overriding
+- Metadata annotations (default values, documentation, etc.)
+- Unified syntax for terms, types and contracts (RFC002)
+- Record destructuring
+
 Tooling
 -------
 
-   * The main binary supports the following subcommands:
-      * `nickel query` to show metadata and documentation of library functions,
-        the field of a configuration, etc.
-      * `nickel export` to serialize to JSON, YAML, or TOML
-      * `nickel repl` to launch an REPL
-      * `nickel typecheck` to do typechecking without evaluating
+- The main binary supports the following subcommands:
+  - `nickel query` to show metadata and documentation of library functions,
+     the field of a configuration, etc.
+  - `nickel export` to serialize to JSON, YAML, or TOML
+  - `nickel repl` to launch an REPL
+  - `nickel typecheck` to do typechecking without evaluating
 
-   * An LSP-server is included
+- An LSP-server is included
 
 Documentation
 -------------
 
-   * User manual sections on syntax, correctness (types and contracts), and
-     merging
-   * The standard library has been documented in-code (use
-     `nickel query`/`:query` to retrieve it) 
+- User manual sections on syntax, correctness (types and contracts), and
+  merging
+- The standard library has been documented in-code (use
+     `nickel query`/`:query` to retrieve it)
 
 Known limitations
 -----------------
 
-   * The roadmap for overriding and the merge system (RFC001) has not been
-     implemented fully yet.
+- The roadmap for overriding and the merge system (RFC001) has not been
+  implemented fully yet.
 
-   * Performance has not been prioritized.
+- Performance has not been prioritized.
 
-   * Due to the use of reference counting as a memory management strategy,
-     mutually recursive record fields are currently leaking memory. This
-     shouldn't be an issue in a standard workflow.
+- Due to the use of reference counting as a memory management strategy,
+  mutually recursive record fields are currently leaking memory. This
+  shouldn't be an issue in a standard workflow.
 
-   * Standard library APIs and language features are subject to change. There
-     is no backward compatibility guarantees for this version. In general, this
-     release is meant for experimenting and getting user feedback, but isn't
-     intended to be used in production.
+- Standard library APIs and language features are subject to change. There
+  is no backward compatibility guarantees for this version. In general, this
+  release is meant for experimenting and getting user feedback, but isn't
+  intended to be used in production.

--- a/benches/mantis/deploy.ncl
+++ b/benches/mantis/deploy.ncl
@@ -55,7 +55,7 @@ fun vars =>
     logLevel | default = "INFO",
     loggers = defaultLoggers,
     job = vars.job,
-    role | [| passive, miner, backup |] = vars.role,
+    role | [| `passive, `miner, `backup |] = vars.role,
   } in
 
   let jobDefs = {

--- a/lsp/nls/Cargo.toml
+++ b/lsp/nls/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nickel-lang-lsp"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Nickel team"]
 license = "MIT"
 readme = "README.md"
@@ -31,7 +31,7 @@ lsp-types = "0.88"
 log = "0.4"
 env_logger = "0.9"
 anyhow = "1.0"
-nickel-lang = {path = "../../", version = "0.2.0"}
+nickel-lang = {path = "../../", version = "0.2.1"}
 derive_more = "0.99"
 lazy_static = "1"
 csv = "1"

--- a/lsp/nls/Cargo.toml
+++ b/lsp/nls/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nickel-lang-lsp"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Nickel team"]
 license = "MIT"
 readme = "README.md"
@@ -31,7 +31,7 @@ lsp-types = "0.88"
 log = "0.4"
 env_logger = "0.9"
 anyhow = "1.0"
-nickel-lang = {path = "../../", version = "0.1.0"}
+nickel-lang = {path = "../../", version = "0.2.0"}
 derive_more = "0.99"
 lazy_static = "1"
 csv = "1"

--- a/lsp/nls/src/linearization/completed.rs
+++ b/lsp/nls/src/linearization/completed.rs
@@ -2,7 +2,6 @@ use std::collections::HashMap;
 
 use codespan::ByteIndex;
 use nickel_lang::{
-    position::TermPos,
     term::MetaValue,
     typecheck::linearization::{LinearizationState, Scope},
 };

--- a/lsp/nls/src/linearization/mod.rs
+++ b/lsp/nls/src/linearization/mod.rs
@@ -4,8 +4,8 @@ use codespan::ByteIndex;
 use log::debug;
 use nickel_lang::{
     identifier::Ident,
-    position::{RawSpan, TermPos},
-    term::{MetaValue, RichTerm, Term, UnaryOp},
+    position::TermPos,
+    term::{MetaValue, Term, UnaryOp},
     typecheck::{
         linearization::{Linearization, Linearizer, Scope, ScopeId},
         reporting::{to_type, NameReg},

--- a/lsp/nls/src/requests/goto.rs
+++ b/lsp/nls/src/requests/goto.rs
@@ -5,7 +5,7 @@ use lsp_server::{RequestId, Response, ResponseError};
 use lsp_types::{
     GotoDefinitionParams, GotoDefinitionResponse, Location, Range, ReferenceParams, Url,
 };
-use nickel_lang::position::{RawSpan, TermPos};
+use nickel_lang::position::RawSpan;
 use serde_json::Value;
 
 use crate::{

--- a/nickel-wasm-repl/Cargo.toml
+++ b/nickel-wasm-repl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nickel-repl"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Nickel team"]
 license = "MIT"
 readme = "README.md"
@@ -11,7 +11,7 @@ keywords = ["configuration", "language", "nix", "nickel"]
 edition = "2018"
 
 [dependencies]
-nickel-lang = {default-features = false, path = "../", version = "0.2.0", features=["repl-wasm"]}
+nickel-lang = {default-features = false, path = "../", version = "0.2.1", features=["repl-wasm"]}
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/nickel-wasm-repl/Cargo.toml
+++ b/nickel-wasm-repl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nickel-repl"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Nickel team"]
 license = "MIT"
 readme = "README.md"
@@ -11,7 +11,7 @@ keywords = ["configuration", "language", "nix", "nickel"]
 edition = "2018"
 
 [dependencies]
-nickel-lang = {default-features = false, path = "../", version = "0.1.0", features=["repl-wasm"]}
+nickel-lang = {default-features = false, path = "../", version = "0.2.0", features=["repl-wasm"]}
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -339,7 +339,7 @@ impl Cache {
 
     /// Parse a source and populate the corresponding entry in the cache, or do nothing if the
     /// entry has already been parsed. This function is error tolerant: parts of the source which
-    /// result in parse errors are parsed as [`crate::term::RichTerm::Error`] and the
+    /// result in parse errors are parsed as [`crate::term::Term::ParseError`] and the
     /// corresponding error messages are collected and returned.
     ///
     /// The `Err` part of the result corresponds to non-recoverable errors.

--- a/src/term.rs
+++ b/src/term.rs
@@ -842,16 +842,16 @@ pub enum UnaryOp {
     /// Transform a string to an enum.
     EnumFromStr(),
     /// Test if a regex matches a string.
-    /// Like [`StrMatch`], this is a unary operator because we would like a way to share the
+    /// Like [`UnaryOp::StrMatch`], this is a unary operator because we would like a way to share the
     /// same "compiled regex" for many matching calls. This is done by returning functions
-    /// wrapping [`StrIsMatchCompiled`] and [`StrMatchCompiled`]
+    /// wrapping [`UnaryOp::StrIsMatchCompiled`] and [`UnaryOp::StrMatchCompiled`]
     StrIsMatch(),
     /// Match a regex on a string, and returns the captured groups together, the index of the
     /// match, etc.
     StrMatch(),
-    /// Version of `StrIsMatch` which remembers the compiled regex.
+    /// Version of [`UnaryOp::StrIsMatch`] which remembers the compiled regex.
     StrIsMatchCompiled(CompiledRegex),
-    /// Version of `StrMatch` which remembers the compiled regex.
+    /// Version of [`UnaryOp::StrMatch`] which remembers the compiled regex.
     StrMatchCompiled(CompiledRegex),
 }
 

--- a/src/typecheck/mod.rs
+++ b/src/typecheck/mod.rs
@@ -282,7 +282,12 @@ fn walk<L: Linearizer>(
     rt: &RichTerm,
 ) -> Result<(), TypecheckError> {
     let RichTerm { term: t, pos } = rt;
-    linearizer.add_term(lin, t, *pos, mk_typewrapper::dynamic());
+    linearizer.add_term(
+        lin,
+        t,
+        *pos,
+        apparent_type(t, Some(&envs), Some(state.resolver)).into(),
+    );
 
     match t.as_ref() {
         Term::ParseError

--- a/utilities/Cargo.toml
+++ b/utilities/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nickel-lang-utilities"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["The Nickel Team <nickel-lang@protonmail.com>"]
 description = "Common helper functions for the tests and benchmarks of the nickel-lang crate."
 edition = "2018"
@@ -10,6 +10,6 @@ bench = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-nickel-lang = {path = "../", version = "0.1.0"}
+nickel-lang = {path = "../", version = "0.2.0"}
 criterion = "0.3"
 codespan = "0.11"

--- a/utilities/Cargo.toml
+++ b/utilities/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nickel-lang-utilities"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["The Nickel Team <nickel-lang@protonmail.com>"]
 description = "Common helper functions for the tests and benchmarks of the nickel-lang crate."
 edition = "2018"
@@ -10,6 +10,6 @@ bench = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-nickel-lang = {path = "../", version = "0.2.0"}
+nickel-lang = {path = "../", version = "0.2.1"}
 criterion = "0.3"
 codespan = "0.11"


### PR DESCRIPTION
Merge back some pre-releases fixes made before 0.2.0 and 0.2.1 (bumping version numbers, fixing documentation and a small fix to the LSP).