### PR TITLE
[Feature] Optional fields

### DIFF
--- a/src/eval/merge.rs
+++ b/src/eval/merge.rs
@@ -241,6 +241,7 @@ pub fn merge(
                 doc: doc1,
                 types: types1,
                 contracts: contracts1,
+                opt: opt1,
                 priority: priority1,
                 value: value1,
             } = meta1;
@@ -248,6 +249,7 @@ pub fn merge(
                 doc: doc2,
                 types: types2,
                 contracts: contracts2,
+                opt: opt2,
                 priority: priority2,
                 value: value2,
             } = meta2;
@@ -345,6 +347,9 @@ pub fn merge(
                 doc,
                 types,
                 contracts,
+                // If one of the record requires this field, then it musn't be optional. The
+                // resulting field is optional iff both are.
+                opt: opt1 && opt2,
                 priority,
                 value,
             };

--- a/src/eval/mod.rs
+++ b/src/eval/mod.rs
@@ -878,5 +878,60 @@ pub fn subst(rt: RichTerm, initial_env: &Environment, env: &Environment) -> Rich
     }
 }
 
+/// Checks if the given term is a chain of nested and/or merged metavalues such that:
+///
+/// 1. At least one metavalue has the `optional` flag set
+/// 2. The final value is undefined
+///
+/// This function is used to determine if a record field is an optional field without definition,
+/// and should thus be ignored by record operations.
+///
+/// Beware: correctly checking that a value is an empty optional can incur arbitrary computations
+/// in principle, but this function is supposed to be a quick peek. It's a terminating
+/// approximation and hence is necessarily incomplete. In practice, this function is able to
+/// traverse merge expressions and follow variables links, but within a limit (in the number of
+/// variables followed).
+pub fn is_empty_optional(rt: &RichTerm, env: &Environment) -> bool {
+    fn is_empty_optional_aux(rt: &RichTerm, env: &Environment, is_opt: bool, gas: &mut u8) -> bool {
+        match rt.as_ref() {
+            Term::MetaValue(meta) => {
+                let is_opt = is_opt || meta.opt;
+
+                if let Some(ref next) = meta.value {
+                    is_empty_optional_aux(next, env, is_opt, gas)
+                } else {
+                    is_opt
+                }
+            }
+            Term::Op2(BinaryOp::Merge(), ref t1, ref t2) => {
+                // The aggregated value for is_opt must follow the same logic as in the
+                // implementation of merge: a field is optional if both operands define it as
+                // optional.
+                //
+                // Thus the resulting value is an empty optional if either:
+                // - both branch are empty optionals
+                // - a wrapping metavalue is optional (is_opt is true at this point) and both
+                // branch are empty.
+                is_empty_optional_aux(t1, env, is_opt, gas)
+                    && is_empty_optional_aux(t2, env, is_opt, gas)
+            }
+            Term::Var(id) if *gas > 0 => {
+                if let Some(closure) = env.get(id).as_ref().map(Thunk::borrow) {
+                    *gas -= 1;
+                    is_empty_optional_aux(&closure.body, &closure.env, is_opt, gas)
+                } else {
+                    false
+                }
+            }
+            _ => false,
+        }
+    }
+
+    // The total amount of gas is rather abritrary, but in any case, it ought to stay low: remember
+    // that is_empty_optional may be called on each field of a record when evaluatinog some record
+    // operations.
+    is_empty_optional_aux(rt, env, false, &mut 8)
+}
+
 #[cfg(test)]
 mod tests;

--- a/src/parser/grammar.lalrpop
+++ b/src/parser/grammar.lalrpop
@@ -108,6 +108,10 @@ AnnotAtom<TypeRule>: MetaValue = {
         doc: Some(strip_indent_doc(s)),
         ..Default::default()
     },
+    "|" "optional" => MetaValue {
+        opt: true,
+        ..Default::default()
+    },
     ":" <l: @L> <ty: TypeRule> <r: @R> => MetaValue {
         types: Some(Contract {types: ty.clone(), label: mk_label(ty, src_id, l, r)}),
         ..Default::default()
@@ -871,6 +875,7 @@ extern {
         "merge" => Token::Normal(NormalToken::Merge),
         "default" => Token::Normal(NormalToken::Default),
         "doc" => Token::Normal(NormalToken::Doc),
+        "optional" => Token::Normal(NormalToken::Optional),
 
         "hash" => Token::Normal(NormalToken::OpHash),
         "serialize" => Token::Normal(NormalToken::Serialize),

--- a/src/parser/grammar.lalrpop
+++ b/src/parser/grammar.lalrpop
@@ -97,32 +97,20 @@ AsUniTerm<Rule>: UniTerm = <l: @L> <ut: Rule> <r: @R> =>
 // `FixedType` (see `FixedType` and `parser::utils::fix_type_vars`).
 AnnotAtom<TypeRule>: MetaValue = {
     "|" <l: @L> <ty: TypeRule> <r: @R> => MetaValue {
-        doc: None,
-        types: None,
         contracts: vec![Contract {types: ty.clone(), label: mk_label(ty, src_id, l, r)}],
-        priority: Default::default(),
-        value: None,
+        ..Default::default()
     },
     "|" "default" => MetaValue {
-        doc: None,
-        types: None,
-        contracts: Vec::new(),
         priority: MergePriority::Default,
-        value: None
+        ..Default::default()
     },
     "|" "doc" <s: StaticString> => MetaValue {
         doc: Some(strip_indent_doc(s)),
-        types: None,
-        contracts: Vec::new(),
-        priority: Default::default(),
-        value: None,
+        ..Default::default()
     },
     ":" <l: @L> <ty: TypeRule> <r: @R> => MetaValue {
-        doc: None,
         types: Some(Contract {types: ty.clone(), label: mk_label(ty, src_id, l, r)}),
-        contracts: Vec::new(),
-        priority: Default::default(),
-        value: None,
+        ..Default::default()
     },
 };
 

--- a/src/parser/lexer.rs
+++ b/src/parser/lexer.rs
@@ -210,6 +210,8 @@ pub enum NormalToken<'input> {
     Default,
     #[token("doc")]
     Doc,
+    #[token("optional")]
+    Optional,
 
     #[token("%hash%")]
     OpHash,

--- a/src/parser/uniterm.rs
+++ b/src/parser/uniterm.rs
@@ -210,6 +210,7 @@ impl UniRecord {
                                         doc: None,
                                         types: Some(ctrt),
                                         contracts,
+                                        opt: false,
                                         priority: MergePriority::Normal,
                                         value: None,
                                     }) if contracts.is_empty() => Ok(Types(AbsType::RowExtend(

--- a/tests/pass/metavalues.ncl
+++ b/tests/pass/metavalues.ncl
@@ -52,5 +52,79 @@ let Assert = fun l x => x || %blame% l in
   ((def & ctr_num & def2).a == 2 | Assert) &&
   # value/contract-default <- contract/contract-default
   ((val & (ctr_num & def)).a == 1 | Assert)),
+
+  # optionals
+  let Contract = {foo | Num, opt | Str | optional} in
+  let value | Contract = {foo = 1} in
+  (
+    (value == {foo = 1} | Assert) &&
+    (builtin.serialize `Json value
+      == builtin.serialize `Json {foo = 1}
+      | Assert) &&
+    (record.has_field "foo" value | Assert) &&
+    (!(record.has_field "opt" value) | Assert) &&
+    (record.values value == [1] | Assert) &&
+    (record.fields value == ["foo"] | Assert)
+  ),
+
+  # Although unintuitive, we have to:
+  # 1. Make Contract open (the `..` at the end)
+  # 2. Repeat foo in `{foo = 1, baz = false}` with the same value
+  # All of this because of #710 (https://github.com/tweag/nickel/issues/710). We
+  # may get rid of both once the merge semantics is clarified.
+  let Contract = {foo | Num, opt | Str | optional, ..} in
+  let with_ctr | Contract = {foo = 1} in
+  let value | Contract = with_ctr & {foo = 1, baz = false} in
+  (
+    (value == {foo = 1, baz = false} | Assert) &&
+    (builtin.serialize `Json value
+      == builtin.serialize `Json {foo = 1, baz = false}
+      | Assert) &&
+    (record.has_field "foo" value | Assert) &&
+    (record.has_field "baz" value | Assert) &&
+    (!(record.has_field "opt" value) | Assert) &&
+    (record.values value == [false, 1] | Assert) &&
+    (record.fields value == ["baz", "foo"] | Assert)
+  ),
+
+  let Contract = {foo | Num, opt | Str | optional} in
+  let value | Contract = {foo = 1 + 0, opt = "a" ++ "b"} in
+  (
+    (value == {foo = 1, opt = "ab"} | Assert) &&
+    (builtin.serialize `Json value
+      == builtin.serialize `Json {foo = 1, opt = "ab"}
+      | Assert) &&
+    (record.has_field "foo" value | Assert) &&
+    (record.has_field "opt" value | Assert) &&
+    (record.values value == [1, "ab"] | Assert) &&
+    (record.fields value == ["foo", "opt"] | Assert)
+  ),
+
+  let Contract = {foo | Num, opt | Str | optional} in
+  let with_ctr | Contract = {foo = 0.5 + 0.5} in
+  # Same as above: we have to repeat `foo` with the same value because of #710
+  let value = with_ctr & {foo = 1, opt = "a" ++ "b"} in
+  (
+    (value == {foo = 1, opt = "ab"} | Assert) &&
+    (builtin.serialize `Json value
+      == builtin.serialize `Json {foo = 1, opt = "ab"}
+      | Assert) &&
+    (record.has_field "foo" value | Assert) &&
+    (record.has_field "opt" value | Assert) &&
+    (record.values value == [1, "ab"] | Assert) &&
+    (record.fields value == ["foo", "opt"] | Assert)
+  ),
+
+  let Contract = {foo | Num, opt | Str | optional} in
+  let with_ctr | Contract = {foo = 0.5 + 0.5} in
+  # Same as above: we have to repeat `foo` with the same value because of #710
+  # opt is required by the right hand side of the merge: it's still undefined,
+  # but should be visible
+  let value = with_ctr & {foo = 1, opt} in
+  (
+    (record.has_field "foo" value | Assert) &&
+    (record.has_field "opt" value | Assert) &&
+    (record.fields value == ["foo", "opt"] | Assert)
+  ),
 ]
 |> array.foldl (fun x y => (x | Assert) && y) true


### PR DESCRIPTION
# Optional fields

Closes #373.

## Overview

This PR adds the keyword `optional` (subject to bikeshed) to the metadata syntax to describe a field that may be filled, but is not required.

The general guideline for the semantics of optional fields is that an optional field without definition should be transparent to all record operations, and serialization. Once it get merged with a definition, or with the same field without definition but that is not optional, it acts like a normal field.

In particular, an empty optional field won't appear when calling to `record.fields` and will return false when calling to `record.has_field`. The rationale is that we don't want `record.has_field "foo" r` to return `true` on an empty optional field and then have `r.foo` to fail. We may want functions like `fields_all` or `fields_optional` that include empty optional fields later, but I don't see an obvious usage for now (dynamic contract inspection/building, maybe?), so let's wait for someone to actually ask for them.

## Deciding "is an empty optional"

The way we handle metadata in Nickel is by nature very dynamic: any value can have metadata, and in principle we can't fetch the full metadata of an expression, or decide properties like "is it defined" without performing a form of evaluation, which can involve arbitrary computations. We can have nested metadata, etc.

This means that deciding "is this field an empty optional" is potentially arbitrary long, and causes the evaluation of the field, which sounds bad. For example, `record.fields` requires to decide "is empty optional" on each field, to filter the list. It feels more natural to store this information at the field level, as a simple flag, and update upon merge, such that we have a direct access in constant time to this property for any given field.

## Solution implemented in this PR

However, this would make optional fields quite special, without a good reason. The same dilemma applies to many other metadata. This is why I think we should have a general reflection for metadata (should they only be allowed on record fields and stored there, basically), instead of special casing optional. In the meantime, this PR uses an heuristics to try to detect quickly an empty optional, which I hope will be more than enough for most concrete cases (indeed, while it may be arbitrarily complex to detect in theory, the natural use of optional fields should stay rather simple). The lack of optional fields have been limiting in several experimentation already, when trying to write contracts for concrete use-cases, so in my humble opinion, it's better than nothing to have them with some limitations now, and potentially make them better later, rather than waiting for a restructuring of metadata.