### PR TITLE
Simplify and improve the builtin enum contract

### DIFF
--- a/src/stdlib.rs
+++ b/src/stdlib.rs
@@ -46,7 +46,8 @@ pub mod contract {
     generate_accessor!(func);
     generate_accessor!(forall_var);
     generate_accessor!(fail);
-    generate_accessor!(row_extend);
+    generate_accessor!(enums);
+    generate_accessor!(enum_fail);
     generate_accessor!(record);
     generate_accessor!(dyn_record);
     generate_accessor!(record_extend);

--- a/stdlib/contract.ncl
+++ b/stdlib/contract.ncl
@@ -27,11 +27,14 @@
       else
           %seal% sy t,
 
-  "$row_extend" = fun contr case l t =>
-      if (case t) then
-          t
+  "$enums" = fun case l t =>
+      if %typeof% t == `Enum then
+          %assume% case l t
       else
-          %assume% contr l t,
+          %blame% (%tag% "not an enum tag" l),
+
+  "$enum_fail" = fun l =>
+      %blame% (%tag% "tag not included in the enum type" l),
 
   "$record" = fun cont l t =>
       if %typeof% t == `Record then


### PR DESCRIPTION
The enum contract was implemented in a heavy way, in a form of continuation passing style. This was:

1. Inefficient: for an enum of type of size 5, we may have to call 5 times a simple function that is a wrapper around an "if x == `tag", and 5 times the the continuation.
2. Unsound: type variable in tail position are wrapped in a polymorphic contract, making the catch-all case of a switch unusable in a typed setting.
3. Unhelpful: the error message in case of contract violation could be very obscure, pointing to the inner code of this generated chain of function applications.

This PR, rather than encoding the row - represented as linked list - as a chain of function applications, builds a dictionary out of the enum types and generates a corresponding switch. Checking is now constant time (indexing in a hashmap), and if the enum type has a tail, the contract doesn't even check the tag at all.

As an illustration, here is the contract associated to ``[| `foo, `bar, `baz |]``, before this PR:

```nickel
($row_extend
    ($row_extend
    ($row_extend $fail (fun x => switch {`baz => true, _ => false} x))
    (fun x => switch {`bar => true, _ => false} x))
    (fun x => switch {`foo => true, _ => false} x))
    # <label>
    )
```

And now:

```nickel
($enums
    (fun l x => switch {`bar => x, `baz => x, `foo => x, _ => $enum_fail l} x))
    # <label>
    )
```

Beside general improvement, the motivation for this PR is that the unsound behavior of the current implementation is blocking #802.