### PR TITLE
Nix with parsed and transpiled with let shadowing:

### DIFF
--- a/src/conversion.rs
+++ b/src/conversion.rs
@@ -16,6 +16,7 @@ pub struct State {
     pub file_id: FileId,
     /// Variables in scope.
     pub env: HashSet<String>,
+    pub with: Vec<RichTerm>,
 }
 
 pub trait ToNickel: Sized {
@@ -24,6 +25,7 @@ pub trait ToNickel: Sized {
         let state = State {
             file_id,
             env: HashSet::new(),
+            with: Vec::new(),
         };
         self.translate(&state)
     }

--- a/src/nix.rs
+++ b/src/nix.rs
@@ -1,6 +1,7 @@
 use crate::cache::Cache;
 use crate::conversion::State;
 pub use crate::conversion::ToNickel;
+use crate::identifier::Ident;
 use crate::mk_app;
 use crate::parser::utils::mk_span;
 use crate::term::make::{self, if_then_else};
@@ -142,7 +143,22 @@ impl ToNickel for rnix::SyntaxNode {
                 "true" => Term::Bool(true),
                 "false" => Term::Bool(false),
                 "null" => Term::Null,
-                id => Term::Var(id.into()),
+                id => {
+                    if state.env.contains(id) || state.with.is_empty() {
+                        Term::Var(id.into())
+                    } else {
+                        Term::App(
+                            mk_app!(
+                                make::op1(
+                                    UnaryOp::StaticAccess("with".into()),
+                                    Term::Var("compat".into()),
+                                ),
+                                Term::Array(state.with.clone(), Default::default())
+                            ),
+                            Term::Str(id.into()).into(),
+                        )
+                    }
+                }
             }
             .into(),
             ParsedType::LegacyLet(_) => panic!("Legacy let form is not supported"), // Probably useless to suport it in a short term.
@@ -154,6 +170,25 @@ impl ToNickel for rnix::SyntaxNode {
                 use crate::identifier::Ident;
                 let mut destruct_vec = Vec::new();
                 let mut fields = HashMap::new();
+                let env = state
+                    .env
+                    .union(
+                        &n.entries()
+                            .map(|kv| {
+                                types::Ident::cast(kv.key().unwrap().path().next().unwrap())
+                                    .unwrap()
+                                    .as_str()
+                                    .to_string()
+                            })
+                            .collect(),
+                    )
+                    .map(|e| e.clone())
+                    .collect();
+                let state = State {
+                    env,
+                    file_id: state.file_id.clone(),
+                    with: state.with.clone(),
+                };
                 for kv in n.entries() {
                     // In `let` blocks, the key is suposed to be a single ident so `Path` exactly one
                     // element.
@@ -167,7 +202,7 @@ impl ToNickel for rnix::SyntaxNode {
                         ),
                         s => s.into(),
                     };
-                    let rt = kv.value().unwrap().translate(state);
+                    let rt = kv.value().unwrap().translate(&state);
                     destruct_vec.push(destruct::Match::Simple(id.clone(), Default::default()));
                     fields.insert(id.into(), rt);
                 }
@@ -180,10 +215,19 @@ impl ToNickel for rnix::SyntaxNode {
                         span,
                     },
                     Term::RecRecord(fields, vec![], Default::default(), None),
-                    n.body().unwrap().translate(state),
+                    n.body().unwrap().translate(&state),
                 )
             }
-            ParsedType::With(n) => unimplemented!(),
+            ParsedType::With(n) => {
+                let State { file_id, env, with } = state;
+                let mut with = with.clone();
+                with.push(n.namespace().unwrap().translate(state));
+                n.body().unwrap().translate(&State {
+                    file_id: file_id.clone(),
+                    env: env.clone(),
+                    with,
+                })
+            }
 
             ParsedType::Lambda(n) => {
                 let arg = n.arg().unwrap();

--- a/src/stdlib.rs
+++ b/src/stdlib.rs
@@ -16,10 +16,13 @@ pub const RECORD: (&str, &str) = ("<stdlib/record>", include_str!("../stdlib/rec
 pub const STRING: (&str, &str) = ("<stdlib/string>", include_str!("../stdlib/string.ncl"));
 pub const NUM: (&str, &str) = ("<stdlib/num>", include_str!("../stdlib/num.ncl"));
 pub const FUNCTION: (&str, &str) = ("<stdlib/function>", include_str!("../stdlib/function.ncl"));
+pub const COMPAT: (&str, &str) = ("<stdlib/compat>", include_str!("../stdlib/compat.ncl"));
 
 /// Return the list `(name, source_code)` of all the stdlib modules.
 pub fn modules() -> Vec<(&'static str, &'static str)> {
-    vec![BUILTIN, CONTRACT, ARRAY, RECORD, STRING, NUM, FUNCTION]
+    vec![
+        BUILTIN, CONTRACT, ARRAY, RECORD, STRING, NUM, FUNCTION, COMPAT,
+    ]
 }
 
 /// Accessors to the builtin contracts.

--- a/stdlib/compat.ncl
+++ b/stdlib/compat.ncl
@@ -1,0 +1,12 @@
+{
+compat | doc "Nix compatibility layer. should not be used by Nickel program."
+= {
+  with: Array {_: Dyn} -> Str -> Dyn
+  = fun envs field => (
+    array.fold (fun prev current =>
+      if record.has_field field current
+      then current
+      else prev
+  ) {} envs)."%{field}"
+}
+}


### PR DESCRIPTION
First impl of the nix with keyword.
Shadowing by Outer `let ... in` blocks is working.
Will add functions and rec-records shadowing in a later PR.
Many clones are performed but it will be fixed in a code cleaning PR.