### PR TITLE
[Refactor] Pull out Nickel test helpers in testlib.ncl

### DIFF
--- a/tests/pass/annotations.ncl
+++ b/tests/pass/annotations.ncl
@@ -1,4 +1,4 @@
-let Assert = fun l x => x || %blame% l in
+let {check, Assert, ..} = import "testlib.ncl" in
 
 [
   # left_annot_precedence
@@ -24,4 +24,4 @@ let Assert = fun l x => x || %blame% l in
   (let AssertOk = fun l t => if t == `Ok then t else %blame% l in
     switch {`Ok => true, `Err => false} `Ok | AssertOk),
 ]
-|> array.foldl (fun x y => x && y) true
+|> check

--- a/tests/pass/arrays.ncl
+++ b/tests/pass/arrays.ncl
@@ -1,4 +1,4 @@
-let Assert = fun l x => x || %blame% l in
+let {check, ..} = import "testlib.ncl" in
 
 [
   # accesses
@@ -40,4 +40,4 @@ let Assert = fun l x => x || %blame% l in
     let isZ = fun x => x == 0 in
     all isZ [0, 0, 0, 1] == false,
 ]
-|> array.foldl (fun x y => (x | Assert) && y) true
+|> check

--- a/tests/pass/basics.ncl
+++ b/tests/pass/basics.ncl
@@ -1,4 +1,4 @@
-let Assert = fun l x => x || %blame% l in
+let {check, ..} = import "testlib.ncl" in
 
 [
   # basic arithmetic
@@ -34,4 +34,4 @@ let Assert = fun l x => x || %blame% l in
   # This test checks that the terms of a switch are closured
   let x = 3 in (switch { `foo => 1, _ => x} (3 + 2)) == 3,
 ]
-|> array.foldl (fun x y => (x | Assert) && y) true
+|> check

--- a/tests/pass/builtins.ncl
+++ b/tests/pass/builtins.ncl
@@ -1,4 +1,4 @@
-let Assert = fun l x => x || %blame% l in
+let {check, ..} = import "testlib.ncl" in
 
 [
   # is_record
@@ -27,4 +27,4 @@ let Assert = fun l x => x || %blame% l in
    |> builtin.deserialize `Json
    == [3,4],
 ]
-|> array.foldl (fun x y => (x | Assert) && y) true
+|> check

--- a/tests/pass/complete.ncl
+++ b/tests/pass/complete.ncl
@@ -1,4 +1,4 @@
-let AssertEq = fun val l x => val == x || %blame% l in
+let {Assert, ..} = import "testlib.ncl" in
 
 let Y | ((Num -> Num) -> Num -> Num) -> Num -> Num = fun f => (fun x => f (x x)) (fun x => f (x x)) in
 let dec : Num -> Num = fun x => x + (-1) in
@@ -7,4 +7,4 @@ let fibo : Num -> Num = Y (fun fibo =>
   (fun x => if or (x == 0) (dec x == 0) then 1 else (fibo (dec x)) + (fibo (dec (dec x))))) in
 let val : Num = 4 in
 
-(fibo val | AssertEq 5)
+(fibo val == 5 | Assert)

--- a/tests/pass/contracts.ncl
+++ b/tests/pass/contracts.ncl
@@ -1,4 +1,4 @@
-let Assert = fun l x => x || %blame% l in
+let {check, Assert, ..} = import "testlib.ncl" in
 
 [
   let AlwaysTrue = fun l t =>
@@ -137,4 +137,4 @@ let Assert = fun l x => x || %blame% l in
     & ({baz = 1} | Id)
    == {foo = 1, bar = 1, baz = 1},
 ]
-|> array.foldl (fun x y => (x | Assert) && y) true
+|> check

--- a/tests/pass/eq.ncl
+++ b/tests/pass/eq.ncl
@@ -1,4 +1,4 @@
-let Assert = fun l x => x || %blame% l in
+let {check, ..} = import "testlib.ncl" in
 
 [
   # basic
@@ -77,4 +77,4 @@ let Assert = fun l x => x || %blame% l in
       == false
   ),
 ]
-|> array.foldl (fun x y => (x | Assert) && y) true
+|> check

--- a/tests/pass/functions.ncl
+++ b/tests/pass/functions.ncl
@@ -1,4 +1,4 @@
-let Assert = fun l x => x || %blame% l in
+let {check, ..} = import "testlib.ncl" in
 
 [
   (fun x => x) 3 == 3,
@@ -15,4 +15,4 @@ let Assert = fun l x => x || %blame% l in
     g true
     == 4,
 ]
-|> array.foldl (fun x y => (x | Assert) && y) true
+|> check

--- a/tests/pass/import.ncl
+++ b/tests/pass/import.ncl
@@ -1,3 +1,3 @@
-let Assert = fun l x => x || %blame% l in
+let {Assert, ..} = import "testlib.ncl" in
 
 (import "imported.ncl" 3 == 3 | Assert)

--- a/tests/pass/metavalues.ncl
+++ b/tests/pass/metavalues.ncl
@@ -1,4 +1,4 @@
-let Assert = fun l x => x || %blame% l in
+let {check, Assert, ..} = import "testlib.ncl" in
 
 [
   (10 | default | Num) == 10,
@@ -27,11 +27,10 @@ let Assert = fun l x => x || %blame% l in
 
   # composed
   let Even = fun l x => if x % 2 == 0 then x else %blame% l in
-    let DivBy3 = fun l x => if x % 3 ==  0 then x else %blame% l in
-    let composed = {a | Even} & {a | DivBy3} in
-    (composed & {a = 6} == {a = 6} | Assert) &&
-    (composed & {a = 12} == {a = 12} | Assert),
-
+  let DivBy3 = fun l x => if x % 3 ==  0 then x else %blame% l in
+  let composed = {a | Even} & {a | DivBy3} in
+  (composed & {a = 6} == {a = 6} | Assert) &&
+  (composed & {a = 12} == {a = 12} | Assert),
 
   # Check that the environments of contracts are correctly saved and restored when merging. See
   # issue [#117](https://github.com/tweag/nickel/issues/117)
@@ -127,4 +126,4 @@ let Assert = fun l x => x || %blame% l in
     (record.fields value == ["foo", "opt"] | Assert)
   ),
 ]
-|> array.foldl (fun x y => (x | Assert) && y) true
+|> check

--- a/tests/pass/overriding.ncl
+++ b/tests/pass/overriding.ncl
@@ -1,4 +1,4 @@
-let Assert = contract.from_predicate function.id in
+let {check, ..} = import "testlib.ncl" in
 
 [
   {foo | default = 1} & {foo = 2} == {foo = 2},
@@ -71,4 +71,4 @@ let Assert = contract.from_predicate function.id in
   ({foo | default = 1, bar = foo} & {foo = 2}).bar == 2,
   ({foo | default = 1, bar = foo, baz = bar} & {foo = 2}).baz == 2,
 ]
-|> array.foldl (fun next acc => (next | Assert) && acc) true
+|> check

--- a/tests/pass/quote_in_identifier.ncl
+++ b/tests/pass/quote_in_identifier.ncl
@@ -1,3 +1,3 @@
-let Assert = fun l x => x || %blame% l in
+let {Assert, ..} = import "testlib.ncl" in
 
 let this-isn't-invalid = true in this-isn't-invalid | Assert

--- a/tests/pass/record-defs.ncl
+++ b/tests/pass/record-defs.ncl
@@ -1,4 +1,4 @@
-let Assert = fun l x => x || %blame% l in
+let {check, ..} = import "testlib.ncl" in
 
 [
   # piecewise_definitions
@@ -40,4 +40,4 @@ let Assert = fun l x => x || %blame% l in
   let x = "foo" in {"%{x}" = bar, bar = 1} == {foo = 1, bar = 1},
   ({"%foo"."%bar".baz = other + 1, other = 0}."%foo"."%bar".baz == 1),
 ]
-|> array.foldl (fun x y => (x | Assert) && y) true
+|> check

--- a/tests/pass/records.ncl
+++ b/tests/pass/records.ncl
@@ -1,4 +1,4 @@
-let Assert = fun l x => x || %blame% l in
+let {check, ..} = import "testlib.ncl" in
 
 [
   # accesses
@@ -116,4 +116,4 @@ let Assert = fun l x => x || %blame% l in
   } in
   data.name == "hijack",
 ]
-|> array.foldl (fun x y => (x | Assert) && y) true
+|> check

--- a/tests/pass/recursive_let.ncl
+++ b/tests/pass/recursive_let.ncl
@@ -1,7 +1,7 @@
-let Assert = fun l x => x || %blame% l in
+let {check, ..} = import "testlib.ncl" in
 
 [
   let rec f = fun n => if n == 0 then n else f (n - 1) in f 10 == 0,
   let rec fib = fun n => if n == 0 || n == 1 then 1 else fib (n - 1) + fib (n - 2) in fib 5 == 8,
 ]
-|> array.foldl (fun x y => (x | Assert) && y) true
+|> check

--- a/tests/pass/serialize.ncl
+++ b/tests/pass/serialize.ncl
@@ -1,4 +1,4 @@
-let Assert = fun l x => x || %blame% l in
+let {check, ..} = import "testlib.ncl" in
 
 let assertSerInv = fun x =>
     let assertAux = fun format x =>
@@ -62,4 +62,4 @@ let assertDeserInv = fun x =>
   let ext = {foo = {some = {}}} in
   assertSerInv (base & ext),
 ]
-|> array.foldl (fun x y => (x | Assert) && y) true
+|> check

--- a/tests/pass/strings.ncl
+++ b/tests/pass/strings.ncl
@@ -1,4 +1,4 @@
-let Assert = fun l x => x || %blame% l in
+let {check, ..} = import "testlib.ncl" in
 
 [
   # interpolation
@@ -25,4 +25,4 @@ let Assert = fun l x => x || %blame% l in
   let b = "x" in m%"a%%{b}c"%m == "a%xc",
   m%"%Hel%%{"1"}lo%%%{"2"}"%m == "%Hel%1lo%%2",
 ]
-|> array.foldl (fun x y => (x | Assert) && y) true
+|> check

--- a/tests/pass/testlib.ncl
+++ b/tests/pass/testlib.ncl
@@ -1,0 +1,30 @@
+{
+  Assert | doc m%"
+    A contract that checks if its argument is the boolean true.
+
+    We could get by just using arrays of boolean tests and `array.all`.
+
+    However, we apply this contract to each test instead because it provides
+    fine-grained error reporting, pinpointoing the exact expression that failed
+    in an array of tests, as opposed to the pure boolean solution.
+    "%m
+    = fun l x => x || %blame% l,
+  # We can't use a static type because x | Assert is not of type bool.
+  # We could use additional contracts to make it work but it's not worth the
+  # hassle.
+  check | doc m%"
+    unchecked type: Array Bool -> Bool
+
+    Check an array of tests. Apply the `Assert` contract on each element of the
+    given array.
+
+    `check tests` It is semantically equivalent to
+
+    ```nickel
+    (array.all function.id tests) | Assert
+    ```
+
+    But will give more precise error reporting when one test fails.
+    "%m
+    = array.foldl (fun x y => (x | Assert) && y) true,
+}

--- a/tests/pass/types.ncl
+++ b/tests/pass/types.ncl
@@ -1,4 +1,4 @@
-let Assert = fun l x => x || %blame% l in
+let {Assert, ..} = import "testlib.ncl" in
 
 (let plus : Num -> Num -> Num = fun x => fun y => x + y in
  plus (54 : Num) (6 : Num) == 60 | Assert)


### PR DESCRIPTION
A couple functions are defined and used again and again throughout tests on the Nickel side. This PR puts them in a separate file that is then imported in each test, avoiding having to redefine them each time.