### PR TITLE
[Feature] Merge priorities

### DIFF
--- a/doc/manual/merging.md
+++ b/doc/manual/merging.md
@@ -254,16 +254,64 @@ final record:
 ## Merging record with metadata
 
 Metadata can be attached to values thanks to the `|` operator. Metadata
-currently includes contract annotations, default value, and documentation. We
-describe in this section how metadata interacts with merging.
+currently includes contract annotations, default value, merge priority, and
+documentation. We describe in this section how metadata interacts with merging.
 
-### Default values
+### Merge priorities
+
+Priorities are specified using the `priority` annotation, followed by a number
+literal. There are also two other special priorities, the bottom priority, specified
+using the `default` annotation, and the top priority, specified using the
+`force` annotation.
+
+Priorities dictate which values take precedence over the other values. By
+default, values are given the priority `0`. Values with the same priority are
+recursively merged as specified in this document, which can mean failure if the
+values can't be meaningfully merged:
+
+```text
+nickel>{foo | default = 1} & {foo = 2}
+error: non mergeable terms
+  ┌─ repl-input-1:1:8
+  │
+1 │ {foo = 1} & {foo = 2}
+  │        ^           ^ with this expression
+  │        │
+  │        cannot merge this expression
+  │
+  = Both values have the same merge priority but they can't be combined
+```
+
+On the other hand, if the priorities differ, this value with highest priority
+silently erases the other in the final result:
+
+```text
+nickel>{foo | priority 1 = 1} & {foo = 2}
+{ foo = 1 }
+
+nickel>{foo | priority -1 = 1} & {foo = 2}
+{ foo = 2 }
+```
+
+The priorities are ordered in the following way:
+
+- bottom is the lowest priority
+- numeral priorities are ordered as usual numbers (priorities can be any valid Nickel
+  number, including fractions and negative values)
+- top is the highest priority
+
+#### Default values
 
 A `default` annotation can be used to provide a base value, but let it be
 overridable through merging. For example, `{foo | default = 1} & {foo = 2}`
-evaluates to `{foo = 2}`. Without the default value, this merge would have
-failed with a `non mergeable fields` error, because merging being symmetric, it
-doesn't know how to combine `1` and `2` in a generic and meaningful way.
+evaluates to `{foo = 2}`. Default values are just a special case of priorities,
+being the lowest possible one.
+
+#### Forcing values
+
+Dually, values with the `force` annotation are given the highest priority. Such
+a value can never be overriden, and will either take precedence over another
+values or be tentatively combined if merged with another forcing value.
 
 #### Specification
 
@@ -283,10 +331,6 @@ same on both side:
            left & right  if p(left) = p(right)
 }
 ```
-
-Currently, there are only two priorities, `normal` (by default, when nothing is
-specified) and the `default` one, with `default < normal`. We plan to add more
-in the future (see [RFC001](https://github.com/tweag/nickel/blob/c21cf280dc610821fceed4c2caafedb60ce7177c/rfcs/001-overriding.md#priorities)).
 
 #### Example
 

--- a/doc/manual/syntax.md
+++ b/doc/manual/syntax.md
@@ -12,7 +12,7 @@ alphanumeric characters, `_` (underscores) or `'` (single quotes). For example,
 
 ## Simple values
 
-There are four basic kind of values in Nickel :
+There are four basic kinds of values in Nickel :
 
 1. numeric values
 2. boolean values
@@ -532,9 +532,14 @@ Adding documentation can be done with `| doc < string >`. Examples:
 true
 ```
 
-Record contracts can set default values using the `default` metadata: It is
-noted as `| default = < default value >`. This is especially useful when merging
-records (more about this in the dedicated document about merge).
+Metadata can also set merge priorities using the following annotations:
+
+- `default` gives the lowest priority (default values)
+- `priority NN`, where `NN` is a number literal, gives a numeral priority
+- `force` gives the highest priority
+
+If there is no priority specified, `priority 0` is given by default. See more
+about this in the dedicated section on merging.
 
 Examples:
 
@@ -552,4 +557,13 @@ Examples:
 
 > {foo | default = 1, bar = foo + 1} & {foo = 2}
 { foo = 2, bar = 3 }
+
+> {foo | force = 1, bar = foo + 1} & {foo = 2}
+{ bar = 2, foo = 1 }
+
+> {foo | priority 10 = 1} & {foo | priority 8 = 2} & {foo = 3}
+{ foo = 1 }
+
+> {foo | priority -1 = 1} & {foo = 2}
+{ foo = 2 }
 ```

--- a/examples/merge-priorities/README.md
+++ b/examples/merge-priorities/README.md
@@ -1,0 +1,12 @@
+# Merge priorities
+
+This example is a variant of the merge example that makes use of merge
+priorities. The code to run lies in `main.ncl`. The default value
+`firewall.enabled` defined in `security.ncl` is overwritten in the final
+configuration.
+
+## Run
+
+```console
+nickel -f main.ncl export
+```

--- a/examples/merge-priorities/main.ncl
+++ b/examples/merge-priorities/main.ncl
@@ -1,0 +1,20 @@
+# Merge several blocks into one final configuration. In a real world case, one
+# would also want contracts to validate the shape of the data.
+let server = import "server.ncl" in
+let security = import "security.ncl" in
+# Disabling firewall in the final result
+server & security & {
+  #As opposed to the simple merge example, this would now fail
+  #firewall.enabled = false
+
+  firewall.open_ports | priority 10 = [80],
+  firewall.type = "superiptables",
+  server.host.ip = "89.22.11.01",
+
+  # this will only be selected if no values with higher priority (or no priority
+  # annotation, which is the same as priority 0) is ever defined
+  # because there's a definite value below, this won't be selected.
+  server.host.name | priority -1 = "hello-world.backup.com",
+} & {
+  server.host.name = "hello-world.main.com",
+}

--- a/examples/merge-priorities/security.ncl
+++ b/examples/merge-priorities/security.ncl
@@ -1,0 +1,8 @@
+{
+  server.host.options | priority 10 = "TLS",
+
+  # force make it impossible to override this value with false
+  firewall.enabled | force = true,
+  firewall.type | default = "iptables",
+  firewall.open_ports | priority 5 = [21, 80, 443],
+}

--- a/examples/merge-priorities/server.ncl
+++ b/examples/merge-priorities/server.ncl
@@ -1,0 +1,5 @@
+{
+  server.host.ip | default = "182.168.1.1",
+  server.host.port | default = 80,
+  server.host.name | default = "hello-world.net",
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -1116,7 +1116,10 @@ impl ToDiagnostic<FileId> for EvalError {
 
                 vec![Diagnostic::error()
                     .with_message("non mergeable terms")
-                    .with_labels(labels)]
+                    .with_labels(labels)
+                    .with_notes(vec![String::from(
+                        "Both values have the same merge priority but they can't be combined",
+                    )])]
             }
             EvalError::UnboundIdentifier(ident, span_opt) => vec![Diagnostic::error()
                 .with_message("unbound identifier")

--- a/src/eval/tests.rs
+++ b/src/eval/tests.rs
@@ -102,7 +102,7 @@ fn mk_default(t: RichTerm) -> Term {
     use crate::term::MergePriority;
 
     let mut meta = MetaValue::from(t);
-    meta.priority = MergePriority::Default;
+    meta.priority = MergePriority::Bottom;
     Term::MetaValue(meta)
 }
 

--- a/src/parser/grammar.lalrpop
+++ b/src/parser/grammar.lalrpop
@@ -108,7 +108,7 @@ AnnotAtom<TypeRule>: MetaValue = {
         priority: MergePriority::Top,
         ..Default::default()
     },
-    "|" "priority" <"num literal"> => MetaValue {
+    "|" "priority" <SignedNumLiteral> => MetaValue {
         // unwrap(): a literal can't be NaN
         priority: MergePriority::Numeral(NumeralPriority::try_from(<>).unwrap()),
         ..Default::default()
@@ -786,6 +786,14 @@ TypeAtom: Types = {
         Types(AbsType::Wildcard(id))
     },
 }
+
+SignedNumLiteral: f64 = <sign: "-"?> <value: "num literal"> => {
+    if sign.is_some() {
+        -value
+    } else {
+        value
+    }
+};
 
 extern {
     type Location = usize;

--- a/src/parser/grammar.lalrpop
+++ b/src/parser/grammar.lalrpop
@@ -104,6 +104,10 @@ AnnotAtom<TypeRule>: MetaValue = {
         priority: MergePriority::Default,
         ..Default::default()
     },
+    "|" "priority" <"num literal"> => MetaValue {
+        priority: MergePriority::Default,
+        ..Default::default()
+    },
     "|" "doc" <s: StaticString> => MetaValue {
         doc: Some(strip_indent_doc(s)),
         ..Default::default()
@@ -879,6 +883,7 @@ extern {
         "default" => Token::Normal(NormalToken::Default),
         "doc" => Token::Normal(NormalToken::Doc),
         "optional" => Token::Normal(NormalToken::Optional),
+        "priority" => Token::Normal(NormalToken::Priority),
 
         "hash" => Token::Normal(NormalToken::OpHash),
         "serialize" => Token::Normal(NormalToken::Serialize),

--- a/src/parser/grammar.lalrpop
+++ b/src/parser/grammar.lalrpop
@@ -60,7 +60,7 @@ use crate::{
     term::{
         BinaryOp, RichTerm, Term, UnaryOp, StrChunk, MetaValue,
         MergePriority, Contract, NAryOp, RecordAttrs, SharedTerm,
-        make as mk_term},
+        NumeralPriority, make as mk_term},
     types::{Types, AbsType},
     position::TermPos,
     label::Label,
@@ -101,11 +101,12 @@ AnnotAtom<TypeRule>: MetaValue = {
         ..Default::default()
     },
     "|" "default" => MetaValue {
-        priority: MergePriority::Default,
+        priority: MergePriority::Bottom,
         ..Default::default()
     },
     "|" "priority" <"num literal"> => MetaValue {
-        priority: MergePriority::Default,
+        // unwrap(): a literal can't be NaN
+        priority: MergePriority::Numeral(NumeralPriority::try_from(<>).unwrap()),
         ..Default::default()
     },
     "|" "doc" <s: StaticString> => MetaValue {
@@ -431,7 +432,7 @@ Match: Match = {
 
 // A default annotation in a pattern.
 DefaultAnnot: MetaValue = "?" <t: Term> => MetaValue {
-    priority: MergePriority::Default,
+    priority: MergePriority::Bottom,
     value: Some(t),
     ..Default::default()
 };

--- a/src/parser/grammar.lalrpop
+++ b/src/parser/grammar.lalrpop
@@ -876,7 +876,6 @@ extern {
         "map" => Token::Normal(NormalToken::Map),
         "generate" => Token::Normal(NormalToken::ArrayGen),
         "elem_at" => Token::Normal(NormalToken::ElemAt),
-        "merge" => Token::Normal(NormalToken::Merge),
         "default" => Token::Normal(NormalToken::Default),
         "doc" => Token::Normal(NormalToken::Doc),
         "optional" => Token::Normal(NormalToken::Optional),

--- a/src/parser/grammar.lalrpop
+++ b/src/parser/grammar.lalrpop
@@ -104,6 +104,10 @@ AnnotAtom<TypeRule>: MetaValue = {
         priority: MergePriority::Bottom,
         ..Default::default()
     },
+    "|" "force" => MetaValue {
+        priority: MergePriority::Top,
+        ..Default::default()
+    },
     "|" "priority" <"num literal"> => MetaValue {
         // unwrap(): a literal can't be NaN
         priority: MergePriority::Numeral(NumeralPriority::try_from(<>).unwrap()),
@@ -537,7 +541,7 @@ UOp: UnaryOp = {
     "record_map" => UnaryOp::RecordMap(),
     "seq" => UnaryOp::Seq(),
     "deep_seq" => UnaryOp::DeepSeq(None),
-    "force" => UnaryOp::Force(None),
+    "op force" => UnaryOp::Force(None),
     "head" => UnaryOp::ArrayHead(),
     "tail" => UnaryOp::ArrayTail(),
     "length" => UnaryOp::ArrayLength(),
@@ -854,7 +858,7 @@ extern {
         "typeof" => Token::Normal(NormalToken::Typeof),
         "assume" => Token::Normal(NormalToken::Assume),
         "array_lazy_assume" => Token::Normal(NormalToken::ArrayLazyAssume),
-        "force" => Token::Normal(NormalToken::Force),
+        "op force" => Token::Normal(NormalToken::OpForce),
         "blame" => Token::Normal(NormalToken::Blame),
         "chng_pol" => Token::Normal(NormalToken::ChangePol),
         "polarity" => Token::Normal(NormalToken::Polarity),
@@ -882,6 +886,7 @@ extern {
         "generate" => Token::Normal(NormalToken::ArrayGen),
         "elem_at" => Token::Normal(NormalToken::ElemAt),
         "default" => Token::Normal(NormalToken::Default),
+        "force" => Token::Normal(NormalToken::Force),
         "doc" => Token::Normal(NormalToken::Doc),
         "optional" => Token::Normal(NormalToken::Optional),
         "priority" => Token::Normal(NormalToken::Priority),

--- a/src/parser/lexer.rs
+++ b/src/parser/lexer.rs
@@ -208,8 +208,6 @@ pub enum NormalToken<'input> {
     ElemAt,
     #[token("%generate%")]
     ArrayGen,
-    #[token("merge")]
-    Merge,
     #[token("default")]
     Default,
     #[token("doc")]

--- a/src/parser/lexer.rs
+++ b/src/parser/lexer.rs
@@ -214,6 +214,8 @@ pub enum NormalToken<'input> {
     Doc,
     #[token("optional")]
     Optional,
+    #[token("priority")]
+    Priority,
 
     #[token("%hash%")]
     OpHash,

--- a/src/parser/lexer.rs
+++ b/src/parser/lexer.rs
@@ -186,7 +186,7 @@ pub enum NormalToken<'input> {
     #[token("%deep_seq%")]
     DeepSeq,
     #[token("%force%")]
-    Force,
+    OpForce,
     #[token("%head%")]
     Head,
     #[token("%tail%")]
@@ -216,6 +216,8 @@ pub enum NormalToken<'input> {
     Optional,
     #[token("priority")]
     Priority,
+    #[token("force")]
+    Force,
 
     #[token("%hash%")]
     OpHash,

--- a/src/parser/uniterm.rs
+++ b/src/parser/uniterm.rs
@@ -211,7 +211,7 @@ impl UniRecord {
                                         types: Some(ctrt),
                                         contracts,
                                         opt: false,
-                                        priority: MergePriority::Normal,
+                                        priority: MergePriority::Neutral,
                                         value: None,
                                     }) if contracts.is_empty() => Ok(Types(AbsType::RowExtend(
                                         id,

--- a/src/pretty.rs
+++ b/src/pretty.rs
@@ -99,7 +99,7 @@ where
             }),
             self.line().clone(),
         ))
-        .append(if mv.priority == crate::term::MergePriority::Default {
+        .append(if mv.priority == crate::term::MergePriority::Bottom {
             self.line().append(self.text("| default"))
         } else {
             self.nil()
@@ -207,7 +207,7 @@ where
                                 MetaValue {
                                     types,
                                     contracts,
-                                    priority: crate::term::MergePriority::Default,
+                                    priority: crate::term::MergePriority::Bottom,
                                     value: Some(value),
                                     ..
                                 } => allocator

--- a/src/repl/query_print.rs
+++ b/src/repl/query_print.rs
@@ -235,7 +235,7 @@ fn write_query_result_<R: QueryPrinter>(
 
             match &meta {
                 MetaValue {
-                    priority: MergePriority::Default,
+                    priority: MergePriority::Bottom,
                     value: Some(t),
                     ..
                 } if selected_attrs.default => {
@@ -243,10 +243,11 @@ fn write_query_result_<R: QueryPrinter>(
                     found = true;
                 }
                 MetaValue {
-                    priority: MergePriority::Normal,
+                    priority: MergePriority::Numeral(n),
                     value: Some(t),
                     ..
                 } if selected_attrs.value => {
+                    renderer.write_metadata(out, "priority", &format!("{}", n))?;
                     renderer.write_metadata(out, "value", &t.as_ref().shallow_repr())?;
                     found = true;
                 }

--- a/tests/pass.rs
+++ b/tests/pass.rs
@@ -127,3 +127,8 @@ fn recursive_let() {
 fn quote_in_indentifier() {
     check_file("quote_in_identifier.ncl")
 }
+
+#[test]
+fn priorities() {
+    check_file("priorities.ncl")
+}

--- a/tests/pass/priorities.ncl
+++ b/tests/pass/priorities.ncl
@@ -1,0 +1,41 @@
+let {Assert, ..} =  import "testlib.ncl" in
+
+let block1 = {
+  foo | default = 1,
+  bar = 1,
+  baz | force = 1,
+  x | priority 10 = 1,
+  y | priority -5 = 1,
+  z | priority 0 = 1,
+  d | default = 1,
+} in
+
+let block2 = {
+  foo | priority -10 = 2,
+  bar | priority 10 = 2,
+  baz = 2,
+  x | priority 11 = 2,
+  y  = 2,
+  z | priority 10 = 2,
+
+} in 
+
+let block3 = {
+  foo | priority -10.1 = 3,
+  bar | default = 3,
+  baz | priority 1000 = 3,
+  x | priority 12 = 3,
+  y | priority -1 = 3,
+  z | priority 50 = 3,
+} in
+
+block1 & block2 & block3
+== {
+  foo = 2,
+  bar = 2,
+  baz = 1,
+  x = 3,
+  y = 2,
+  z = 3,
+  d = 1,
+} | Assert

--- a/tests/records_fail.rs
+++ b/tests/records_fail.rs
@@ -43,6 +43,22 @@ fn non_mergeable_piecewise() {
 }
 
 #[test]
+fn non_mergeable_prio() {
+    assert_matches!(
+        eval("({a.b | priority 0 = 1, a = {b = 2}}).a.b"),
+        Err(Error::EvalError(EvalError::MergeIncompatibleArgs(..)))
+    );
+    assert_matches!(
+        eval("({a | force = false} & {a | force = true}).a"),
+        Err(Error::EvalError(EvalError::MergeIncompatibleArgs(..)))
+    );
+    assert_matches!(
+        eval("({foo.bar | priority -10 = false, foo.bar | priority -10 = true}).foo.bar"),
+        Err(Error::EvalError(EvalError::MergeIncompatibleArgs(..)))
+    );
+}
+
+#[test]
 fn dynamic_not_recursive() {
     assert_matches!(
         eval("let x = \"foo\" in {\"%{x}\" = 1, bar = foo}.bar"),


### PR DESCRIPTION
Depends on #198. Implement merge priorities as of [RFC001](https://github.com/tweag/nickel/blob/master/rfcs/001-overriding.md). The special operator `default rec` and `force rec` are not implemented in this PR but left as future work.