### PR TITLE
Return environment items by reference

### DIFF
--- a/lsp/nls/src/linearization/mod.rs
+++ b/lsp/nls/src/linearization/mod.rs
@@ -263,12 +263,12 @@ impl Linearizer for AnalysisHost {
                     pos: ident.pos,
                     ty: TypeWrapper::Concrete(AbsType::Dyn()),
                     scope: self.scope.clone(),
-                    kind: TermKind::Usage(UsageState::from(self.env.get(ident))),
+                    kind: TermKind::Usage(UsageState::from(self.env.get(ident).copied())),
                     meta: self.meta.take(),
                 });
 
                 if let Some(referenced) = self.env.get(ident) {
-                    lin.add_usage(referenced, root_id)
+                    lin.add_usage(*referenced, root_id)
                 }
 
                 if let Some(chain) = self.access.take() {
@@ -467,7 +467,7 @@ impl Linearizer for AnalysisHost {
         if let Some(item) = self
             .env
             .get(ident)
-            .and_then(|index| lin.linearization.get_mut(index))
+            .and_then(|index| lin.linearization.get_mut(*index))
         {
             debug!("retyping {:?} to {:?}", ident, new_type);
             item.ty = new_type;

--- a/src/eval/fixpoint.rs
+++ b/src/eval/fixpoint.rs
@@ -14,6 +14,7 @@ pub fn rec_env<'a, I: Iterator<Item = (&'a Ident, &'a RichTerm)>>(
             Term::Var(ref var_id) => {
                 let thunk = env
                     .get(var_id)
+                    .cloned()
                     .ok_or_else(|| EvalError::UnboundIdentifier(var_id.clone(), rt.pos))?;
                 Ok((id.clone(), thunk))
             }
@@ -46,6 +47,7 @@ pub fn patch_field(
     if let Term::Var(var_id) = &*rt.term {
         let mut thunk = env
             .get(var_id)
+            .cloned()
             .ok_or_else(|| EvalError::UnboundIdentifier(var_id.clone(), rt.pos))?;
 
         let deps = thunk.deps();

--- a/src/eval/mod.rs
+++ b/src/eval/mod.rs
@@ -342,6 +342,7 @@ where
                 let mut thunk = env
                     .get(x)
                     .or_else(|| initial_env.get(x))
+                    .cloned()
                     .ok_or_else(|| EvalError::UnboundIdentifier(x.clone(), pos))?;
                 std::mem::drop(env); // thunk may be a 1RC pointer
 
@@ -954,7 +955,7 @@ pub fn is_empty_optional(rt: &RichTerm, env: &Environment) -> bool {
                     && is_empty_optional_aux(t2, env, is_opt, gas)
             }
             Term::Var(id) if *gas > 0 => {
-                if let Some(closure) = env.get(id).as_ref().map(Thunk::borrow) {
+                if let Some(closure) = env.get(id).map(Thunk::borrow) {
                     *gas -= 1;
                     is_empty_optional_aux(&closure.body, &closure.env, is_opt, gas)
                 } else {

--- a/src/transform/mod.rs
+++ b/src/transform/mod.rs
@@ -137,7 +137,7 @@ impl Closurizable for RichTerm {
         let pos = self.pos;
 
         let thunk = match self.as_ref() {
-            Term::Var(id) if id.is_generated() => with_env.get(id).unwrap_or_else(|| {
+            Term::Var(id) if id.is_generated() => with_env.get(id).cloned().unwrap_or_else(|| {
                 panic!(
                 "Internal error(closurize) : generated identifier {} not found in the environment",
                 id

--- a/src/typecheck/mod.rs
+++ b/src/typecheck/mod.rs
@@ -676,6 +676,7 @@ fn type_check_<L: Linearizer>(
             let x_ty = ctxt
                 .type_env
                 .get(x)
+                .cloned()
                 .ok_or_else(|| TypecheckError::UnboundIdentifier(x.clone(), *pos))?;
 
             let instantiated = instantiate_foralls(state, x_ty, ForallInst::Ptr);
@@ -755,7 +756,7 @@ fn type_check_<L: Linearizer>(
                         // annotations) have already be determined and put in the typing
                         // ctxtironment, and we need to use the same.
                         let ty = if let Term::RecRecord(..) = t.as_ref() {
-                            ctxt.type_env.get(id).unwrap()
+                            ctxt.type_env.get(id).cloned().unwrap()
                         } else {
                             state.table.fresh_unif_var()
                         };
@@ -1010,7 +1011,7 @@ pub fn apparent_type(
             ApparentType::Approximated(Types(AbsType::Array(Box::new(Types(AbsType::Dyn())))))
         }
         Term::Var(id) => env
-            .and_then(|envs| envs.get(id))
+            .and_then(|envs| envs.get(id).cloned())
             .map(ApparentType::FromEnv)
             .unwrap_or(ApparentType::Approximated(Types(AbsType::Dyn()))),
         Term::ResolvedImport(f) => {


### PR DESCRIPTION
The previous API of `Environment::get` was returning an owned value. This doesn't correspond to the usual API for Rust containers. This PR changes the API to return a reference instead, and let the caller decide to clone the value or not.

Preliminary step required to continue the todos left after #766.