### PR TITLE
Unified environment interface for contract equality checking

### DIFF
--- a/src/repl/mod.rs
+++ b/src/repl/mod.rs
@@ -217,7 +217,7 @@ impl Repl for ReplImpl {
         typecheck::env_add_term(
             &mut self.env.type_env,
             &term,
-            &typecheck::eq::TermEnvironment::new(),
+            &typecheck::eq::SimpleTermEnvironment::new(),
             &self.cache,
         )
         .unwrap();


### PR DESCRIPTION
Preliminary work for the follow-up of #766, which is to fix the contract equality checking during an REPL session. This PR is also required more generally in order to use contract equality checking during evaluation, for example to eliminate redundant contract applications at runtime when merging lazy array contracts.

This PR abstracts over the `TermEnvironment`, that is currently a concrete data structure used by the typechecker, by turning it into a trait. The trait is then implemented by `SimpleTermEnvironment` (formerly `TermEnvironment`) and the eval environment (`eval::Environment`). This change requires to add a bunch of generic parameters, in particular on the contract equality checking functions and for the formerly `TypeWrapper`, but the change are hopefully reasonably localized.

Because the eval environment returns thunks, and not direct references to terms and environments, the interface of `TermEnvironment` has to reverse the control flow and take a continuation instead of returning references, as opposed to e.g. `SimpleTermEnvironment::get`.