### PR TITLE
Maintain a term environment during an REPL session

### DIFF
--- a/benches/stdlib.rs
+++ b/benches/stdlib.rs
@@ -6,7 +6,7 @@ use nickel_lang::cache::{Cache, ErrorTolerance};
 pub fn typecheck_stdlib(c: &mut Criterion) {
     let mut cache = Cache::new(ErrorTolerance::Strict);
     cache.load_stdlib().unwrap();
-    let type_env = cache.mk_type_env().unwrap();
+    let type_env = cache.mk_type_ctxt().unwrap();
     c.bench_function("typecheck stdlib", |b| {
         b.iter_batched(
             || cache.clone(),

--- a/lsp/nls/src/cache.rs
+++ b/lsp/nls/src/cache.rs
@@ -14,7 +14,7 @@ pub trait CacheExt {
     fn typecheck_with_analysis(
         &mut self,
         file_id: FileId,
-        initial_env: &typecheck::Environment,
+        initial_ctxt: &typecheck::Context,
         lin_cache: &mut HashMap<FileId, Completed>,
     ) -> Result<CacheOp<()>, CacheError<TypecheckError>>;
 }
@@ -35,7 +35,7 @@ impl CacheExt for Cache {
     fn typecheck_with_analysis<'a>(
         &mut self,
         file_id: FileId,
-        initial_env: &typecheck::Environment,
+        initial_ctxt: &typecheck::Context,
         lin_cache: &mut HashMap<FileId, Completed>,
     ) -> Result<CacheOp<()>, CacheError<TypecheckError>> {
         if !self.terms_mut().contains_key(&file_id) {
@@ -50,7 +50,7 @@ impl CacheExt for Cache {
         } else if *state >= EntryState::Parsed {
             let host = AnalysisHost::new();
             let (_, linearized) =
-                typecheck::type_check_linearize(term, initial_env.clone(), self, host)?;
+                typecheck::type_check_linearize(term, initial_ctxt.clone(), self, host)?;
             self.update_state(file_id, EntryState::Typechecked);
             lin_cache.insert(file_id, linearized);
             Ok(CacheOp::Done(()))

--- a/lsp/nls/src/files.rs
+++ b/lsp/nls/src/files.rs
@@ -72,7 +72,7 @@ pub fn handle_save(server: &mut Server, params: DidChangeTextDocumentParams) -> 
 fn typecheck(server: &mut Server, file_id: FileId) -> Result<CacheOp<()>, Vec<Diagnostic<FileId>>> {
     server
         .cache
-        .typecheck_with_analysis(file_id, &server.initial_env, &mut server.lin_cache)
+        .typecheck_with_analysis(file_id, &server.initial_ctxt, &mut server.lin_cache)
         .map_err(|error| match error {
             CacheError::Error(tc_error) => tc_error.to_diagnostic(server.cache.files_mut(), None),
             CacheError::NotParsed => unreachable!(),

--- a/lsp/nls/src/server.rs
+++ b/lsp/nls/src/server.rs
@@ -17,7 +17,7 @@ use lsp_types::{
 };
 
 use nickel_lang::cache::{Cache, ErrorTolerance};
-use nickel_lang::typecheck::Environment;
+use nickel_lang::typecheck::Context;
 
 use crate::{
     linearization::completed::Completed,
@@ -29,7 +29,7 @@ pub struct Server {
     pub connection: Connection,
     pub cache: Cache,
     pub lin_cache: HashMap<FileId, Completed>,
-    pub initial_env: Environment,
+    pub initial_ctxt: Context,
 }
 
 impl Server {
@@ -61,13 +61,13 @@ impl Server {
     pub fn new(connection: Connection) -> Server {
         let mut cache = Cache::new(ErrorTolerance::Tolerant);
         cache.load_stdlib().unwrap();
-        let initial_env = cache.mk_type_env().unwrap();
+        let initial_ctxt = cache.mk_type_ctxt().unwrap();
         let lin_cache = HashMap::new();
         Server {
             connection,
             cache,
             lin_cache,
-            initial_env,
+            initial_ctxt,
         }
     }
 

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -86,18 +86,12 @@ pub enum ErrorTolerance {
     Strict,
 }
 
-/// wrapping eval environment with typing environment
+/// The different environments maintained during the REPL session for evaluation and typechecking.
 #[derive(Debug, Clone)]
 pub struct Envs {
     /// The eval environment.
     pub eval_env: eval::Environment,
     /// The typing context.
-    ///
-    /// The typing context includes the typing environment, counterpart of the eval environment for
-    /// typechecking. Entries are of type [`crate::typecheck::TypeWrapper`] for the ease of
-    /// interacting with the typechecker, but there are not any unification variable in it.
-    ///
-    /// The context also includes the term environment, used to check for contract equality.
     pub type_ctxt: typecheck::Context,
 }
 

--- a/src/program.rs
+++ b/src/program.rs
@@ -71,8 +71,11 @@ impl Program {
     /// Retrieve the parsed term and typecheck it, and generate a fresh initial environment. Return
     /// both.
     fn prepare_eval(&mut self) -> Result<(RichTerm, eval::Environment), Error> {
-        let Envs { eval_env, type_env } = self.cache.prepare_stdlib()?;
-        self.cache.prepare(self.main_id, &type_env)?;
+        let Envs {
+            eval_env,
+            type_ctxt,
+        } = self.cache.prepare_stdlib()?;
+        self.cache.prepare(self.main_id, &type_ctxt)?;
         Ok((self.cache.get(self.main_id).unwrap(), eval_env))
     }
 
@@ -104,7 +107,7 @@ impl Program {
     pub fn typecheck(&mut self) -> Result<(), Error> {
         self.cache.parse(self.main_id)?;
         self.cache.load_stdlib()?;
-        let initial_env = self.cache.mk_type_env().expect("program::typecheck(): stdlib has been loaded but was not found in cache on mk_types_env()");
+        let initial_env = self.cache.mk_type_ctxt().expect("program::typecheck(): stdlib has been loaded but was not found in cache on mk_types_env()");
         self.cache
             .resolve_imports(self.main_id)
             .map_err(|cache_err| {
@@ -181,7 +184,7 @@ pub fn query(
     initial_env: &Envs,
     path: Option<String>,
 ) -> Result<Term, Error> {
-    cache.prepare(file_id, &initial_env.type_env)?;
+    cache.prepare(file_id, &initial_env.type_ctxt)?;
 
     let t = if let Some(p) = path {
         // Parsing `y.path`. We `seq` it to force the evaluation of the underlying value,

--- a/src/typecheck/eq.rs
+++ b/src/typecheck/eq.rs
@@ -84,6 +84,17 @@ impl TermEnvironment for SimpleTermEnvironment {
     }
 }
 
+impl std::iter::FromIterator<(Ident, (RichTerm, SimpleTermEnvironment))> for SimpleTermEnvironment {
+    fn from_iter<T>(iter: T) -> Self
+    where
+        T: IntoIterator<Item = (Ident, (RichTerm, SimpleTermEnvironment))>,
+    {
+        SimpleTermEnvironment(
+            GenericEnvironment::<Ident, (RichTerm, SimpleTermEnvironment)>::from_iter(iter),
+        )
+    }
+}
+
 impl TermEnvironment for eval::Environment {
     fn get_then<F, T>(&self, id: &Ident, f: F) -> T
     where

--- a/src/typecheck/mod.rs
+++ b/src/typecheck/mod.rs
@@ -81,7 +81,11 @@ pub type Environment = GenericEnvironment<Ident, TypeWrapper>;
 /// Mapping from wildcard ID to inferred type
 pub type Wildcards = Vec<Types>;
 
-/// A structure holding the typing context, that is, scoped, environment-like data.
+/// The typing context is a structure holding the scoped, environment-like data structures required
+/// to perform typechecking.
+///
+/// The typing context currently includes the typing environment, counterpart of the eval
+/// environment for typechecking, and the term environment.
 #[derive(Debug, PartialEq, Clone)]
 pub struct Context {
     pub type_env: Environment,

--- a/tests/typecheck_fail.rs
+++ b/tests/typecheck_fail.rs
@@ -5,10 +5,10 @@ use nickel_lang::error::TypecheckError;
 use nickel_lang::parser::{grammar, lexer};
 use nickel_lang::term::RichTerm;
 use nickel_lang::types::{AbsType, Types};
-use nickel_lang::{typecheck, typecheck::Environment};
+use nickel_lang::{typecheck, typecheck::Context};
 
 fn type_check(rt: &RichTerm) -> Result<(), TypecheckError> {
-    typecheck::type_check(rt, Environment::new(), &mut DummyResolver {}).map(|_| ())
+    typecheck::type_check(rt, Context::new(), &mut DummyResolver {}).map(|_| ())
 }
 
 fn type_check_expr(s: impl std::string::ToString) -> Result<(), TypecheckError> {

--- a/utilities/src/lib.rs
+++ b/utilities/src/lib.rs
@@ -118,7 +118,10 @@ impl<'b> Bench<'b> {
 
 pub fn bench_terms<'r>(rts: Vec<Bench<'r>>) -> Box<dyn Fn(&mut Criterion) + 'r> {
     let mut cache = Cache::new(ErrorTolerance::Strict);
-    let Envs { eval_env, type_env } = cache.prepare_stdlib().unwrap();
+    let Envs {
+        eval_env,
+        type_ctxt,
+    } = cache.prepare_stdlib().unwrap();
     Box::new(move |c: &mut Criterion| {
         rts.iter().for_each(|bench| {
             let t = bench.term();
@@ -133,9 +136,9 @@ pub fn bench_terms<'r>(rts: Vec<Bench<'r>>) -> Box<dyn Fn(&mut Criterion) + 'r> 
                     },
                     |(mut c_local, id, t)| {
                         if bench.eval_mode == EvalMode::TypeCheck {
-                            c_local.typecheck(id, &type_env).unwrap();
+                            c_local.typecheck(id, &type_ctxt).unwrap();
                         } else {
-                            c_local.prepare(id, &type_env).unwrap();
+                            c_local.prepare(id, &type_ctxt).unwrap();
                             eval::eval(t, &eval_env, &mut c_local).unwrap();
                         }
                     },
@@ -186,7 +189,7 @@ macro_rules! ncl_bench_group {
             let mut c: criterion::Criterion<_> = $config
                 .configure_from_args();
             let mut cache = Cache::new(ErrorTolerance::Strict);
-            let Envs {eval_env, type_env} = cache.prepare_stdlib().unwrap();
+            let Envs {eval_env, type_ctxt} = cache.prepare_stdlib().unwrap();
             $(
                 let bench = $crate::ncl_bench!$b;
                 let t = bench.term();
@@ -205,9 +208,9 @@ macro_rules! ncl_bench_group {
                         },
                         |(mut c_local, id, t)| {
                             if bench.eval_mode == $crate::EvalMode::TypeCheck {
-                                c_local.typecheck(id, &type_env).unwrap();
+                                c_local.typecheck(id, &type_ctxt).unwrap();
                             } else {
-                                c_local.prepare(id, &type_env).unwrap();
+                                c_local.prepare(id, &type_ctxt).unwrap();
                                 eval(t, &eval_env, &mut c_local).unwrap();
                             }
                         },


### PR DESCRIPTION
Follow up of #766 and #834. Correctly check for contract equality during an REPL session, by providing an initial context (typing environment + term environment), instead of just a typing environment, to various typechecking.

Sadly, we don't really use the machinery introduced in #834, because that would require to use `GenericTypeWrapper<E>` instead of `TypeWrapper` in a lot of places inside the `typecheck` module, which is a verbose and heavy change. Thus we somehow maintain two environments which contain the same information but in slightly different form (`eval_env` and `term_env`), but the overhead is expected to be insignificant and it lets the meat of the `typecheck` module untouched.

Depends on #834