### PR TITLE
Implement "occurs check" to prevent infinite loop during type-checking

### DIFF
--- a/src/typecheck/error.rs
+++ b/src/typecheck/error.rs
@@ -103,6 +103,9 @@ pub enum UnifError {
     DomainMismatch(TypeWrapper, TypeWrapper, Box<UnifError>),
     /// An error occurred when unifying the codomains of two arrows.
     CodomainMismatch(TypeWrapper, TypeWrapper, Box<UnifError>),
+    /// An error occurred when trying to unify to terms which have overlapping unification
+    /// variables.
+    InfiniteRecursiveType(TypeWrapper, TypeWrapper),
 }
 
 impl UnifError {
@@ -138,11 +141,13 @@ impl UnifError {
         pos_opt: TermPos,
     ) -> TypecheckError {
         match self {
-            UnifError::TypeMismatch(ty1, ty2) => TypecheckError::TypeMismatch(
-                reporting::to_type(state.table, state.names, names, ty1),
-                reporting::to_type(state.table, state.names, names, ty2),
-                pos_opt,
-            ),
+            UnifError::InfiniteRecursiveType(ty1, ty2) | UnifError::TypeMismatch(ty1, ty2) => {
+                TypecheckError::TypeMismatch(
+                    reporting::to_type(state.table, state.names, names, ty1),
+                    reporting::to_type(state.table, state.names, names, ty2),
+                    pos_opt,
+                )
+            }
             UnifError::RowMismatch(ident, tyw1, tyw2, err) => TypecheckError::RowMismatch(
                 ident,
                 reporting::to_type(state.table, state.names, names, tyw1),

--- a/src/typecheck/mod.rs
+++ b/src/typecheck/mod.rs
@@ -1355,11 +1355,9 @@ fn get_free_variables(wildcards: &Vec<TypeWrapper>, t: TypeWrapper) -> HashSet<u
 
 /// Check if the type variable `ptr` occurs in `t`
 fn occurs_check(ptr: usize, state: &State, t: TypeWrapper) -> bool {
-    let free_vars = get_free_variables(state.wildcard_vars, t);
-    let result = free_vars
+    get_free_variables(state.wildcard_vars, t)
         .iter()
-        .any(|other_ptr| state.table.root(ptr) == state.table.root(*other_ptr));
-    result
+        .any(|other_ptr| state.table.root(ptr) == state.table.root(*other_ptr))
 }
 
 /// Try to unify two types.

--- a/src/typecheck/mod.rs
+++ b/src/typecheck/mod.rs
@@ -1314,6 +1314,54 @@ fn row_add(
     }
 }
 
+/// Get the set of all unification variables in a type.
+fn get_free_variables(wildcards: &Vec<TypeWrapper>, t: TypeWrapper) -> HashSet<usize> {
+    match t {
+        TypeWrapper::Ptr(i) => HashSet::from([i]),
+        TypeWrapper::Concrete(ty) => match ty {
+            AbsType::Dyn()
+            | AbsType::Num()
+            | AbsType::Bool()
+            | AbsType::Str()
+            | AbsType::Sym()
+            | AbsType::Flat(_)
+            | AbsType::Var(_)
+            | AbsType::RowEmpty() => HashSet::new(),
+            // TODO: replace with get_wilccard_var(..)
+            AbsType::Wildcard(id) => wildcards
+                .get(id)
+                .map(|ty| get_free_variables(wildcards, ty.clone()))
+                .unwrap_or(HashSet::new()),
+            AbsType::Arrow(ty1, ty2) => {
+                let a = get_free_variables(wildcards, *ty1);
+                let b = get_free_variables(wildcards, *ty2);
+                a.union(&b).map(|i| *i).collect()
+            }
+            AbsType::Forall(_, ty)
+            | AbsType::Enum(ty)
+            | AbsType::StaticRecord(ty)
+            | AbsType::DynRecord(ty)
+            | AbsType::Array(ty) => get_free_variables(wildcards, *ty),
+            AbsType::RowExtend(_, ty_row, tail) => ty_row
+                .map(|ty| get_free_variables(wildcards, *ty))
+                .unwrap_or(HashSet::new())
+                .union(&get_free_variables(wildcards, *tail))
+                .map(|i| *i)
+                .collect(),
+        },
+        TypeWrapper::Contract(..) | TypeWrapper::Constant(_) => HashSet::new(),
+    }
+}
+
+/// Check if the type variable `ptr` occurs in `t`
+fn occurs_check(ptr: usize, state: &State, t: TypeWrapper) -> bool {
+    let free_vars = get_free_variables(state.wildcard_vars, t);
+    let result = free_vars
+        .iter()
+        .any(|other_ptr| state.table.root(ptr) == state.table.root(*other_ptr));
+    result
+}
+
 /// Try to unify two types.
 pub fn unify(
     state: &mut State,
@@ -1420,6 +1468,11 @@ pub fn unify(
             )),
         },
         (TypeWrapper::Ptr(p1), TypeWrapper::Ptr(p2)) if p1 == p2 => Ok(()),
+        (TypeWrapper::Ptr(p), tyw) | (tyw, TypeWrapper::Ptr(p))
+            if occurs_check(p, state, tyw.clone()) =>
+        {
+            Err(UnifError::InfiniteRecursiveType(TypeWrapper::Ptr(p), tyw))
+        }
         // The two following cases are not merged just to correctly distinguish between the
         // expected type (first component of the tuple) and the inferred type when reporting a row
         // unification error.

--- a/src/typecheck/mod.rs
+++ b/src/typecheck/mod.rs
@@ -1354,7 +1354,7 @@ fn get_free_variables(wildcards: &Vec<TypeWrapper>, t: TypeWrapper) -> HashSet<u
 }
 
 /// Check if the type variable `ptr` occurs in `t`
-fn occurs_check(ptr: usize, state: &State, t: TypeWrapper) -> bool {
+fn occurs_check(state: &State, ptr: usize, t: TypeWrapper) -> bool {
     get_free_variables(state.wildcard_vars, t)
         .iter()
         .any(|other_ptr| state.table.root(ptr) == state.table.root(*other_ptr))
@@ -1467,7 +1467,7 @@ pub fn unify(
         },
         (TypeWrapper::Ptr(p1), TypeWrapper::Ptr(p2)) if p1 == p2 => Ok(()),
         (TypeWrapper::Ptr(p), tyw) | (tyw, TypeWrapper::Ptr(p))
-            if occurs_check(p, state, tyw.clone()) =>
+            if occurs_check(state,p, tyw.clone()) =>
         {
             Err(UnifError::InfiniteRecursiveType(TypeWrapper::Ptr(p), tyw))
         }

--- a/src/typecheck/mod.rs
+++ b/src/typecheck/mod.rs
@@ -1314,7 +1314,7 @@ fn row_add(
     }
 }
 
-/// Checks if the "root type" of the unification variable `ptr` is also 
+/// Checks if the "root type" of the unification variable `ptr` is also
 /// the root type of any unification variable in `t`
 fn occurs_check(state: &State, ptr: usize, t: TypeWrapper) -> bool {
     match t {

--- a/src/typecheck/mod.rs
+++ b/src/typecheck/mod.rs
@@ -1318,8 +1318,8 @@ fn row_add(
 /// the root type of any unification variable in `t`
 fn occurs_check(state: &State, ptr: usize, t: TypeWrapper) -> bool {
     match t {
-        TypeWrapper::Ptr(i) if i == ptr => state.table.root(i) == state.table.root(ptr),
-        TypeWrapper::Ptr(_) => false,
+        TypeWrapper::Ptr(i) if state.table.get(i).is_none() => i == ptr,
+        TypeWrapper::Ptr(i) => occurs_check(state, ptr, state.table.root(i)),
         TypeWrapper::Contract(..) | TypeWrapper::Constant(_) => false,
         TypeWrapper::Concrete(ty) => match ty {
             AbsType::Dyn()

--- a/tests/typecheck_fail.rs
+++ b/tests/typecheck_fail.rs
@@ -310,5 +310,10 @@ fn infinite_recursive_types() {
     assert_matches!(
         type_check_expr("{g = g 0}.g : Num"),
         Err(TypecheckError::TypeMismatch(..))
+    );
+
+    assert_matches!(
+        type_check_expr("let f : (_ -> _) -> _ ->  _ = fun f x => let v = f x in [f,x] in f"),
+        Err(TypecheckError::TypeMismatch(..))
     )
 }

--- a/tests/typecheck_fail.rs
+++ b/tests/typecheck_fail.rs
@@ -294,3 +294,21 @@ fn locally_different_flat_types() {
         ))
     );
 }
+
+#[test]
+fn infinite_recursive_types() {
+    assert_matches!(
+        type_check_expr("let f :  _ = fun x => x x in f"),
+        Err(TypecheckError::TypeMismatch(..))
+    );
+
+    assert_matches!(
+        type_check_expr("let f :  _ =  fun esv es e => e esv e (es e) in f"),
+        Err(TypecheckError::TypeMismatch(..))
+    );
+
+    assert_matches!(
+        type_check_expr("{g = g 0}.g : Num"),
+        Err(TypecheckError::TypeMismatch(..))
+    )
+}


### PR DESCRIPTION
### Summary
Currently, the Nickel type-checker does not perform "occurs check" when unifying a type variable with another type . Occurs checks normally prevents us from creating "infinite" type substitutions. For example, if we want to unify a type variable `a` with another type 
`a -> b`, occurs checks prevents `a = a -> b` from being a type substitution equation. 

In Nickel, this means that programs which result in a type variable unifying with another type which includes that variable results in a stack overflow.

### Example:
```
let f :  _ = fun x => x x in f 
```
```
let f :  _ =  fun esv es e => e esv e (es e) in f
```
```
{g = g 0}.g : Num
```

### Actual output:
```
thread 'main' has overflowed its stack
fatal runtime error: stack overflow
```

### Desired output:

Nickel should give a type error, stating the exact problem in a friendly way; and maybe even "tips" on how to resolve it.
```
nickel> let f :  _ = fun x => x x 

The expression x has the inferred type a -> b. 
x cannot be the argument of x, because this will lead to the construction of the infinite type a = a -> b.
Maybe try using concrete types to guide your implementation instead of wildcards?
```

The error message generation is not *yet* like as I've described above.

Closes #277