### PR TITLE
Don't panic when a row mismatch occurs while unifying row tails

### DIFF
--- a/src/typecheck/mod.rs
+++ b/src/typecheck/mod.rs
@@ -1494,19 +1494,22 @@ pub fn unify_rows(
                 // cases, so we delegate the work. However it returns `UnifError` instead of
                 // `RowUnifError`, hence we have a bit of wrapping and unwrapping to do. Note that
                 // since we are unifying types with a constant or a unification variable somewhere,
-                // the only unification errors that should be possible are related to constants or
-                // row constraints.
+                // the only unification errors that should be possible are related to constants,
+                // row constraints, or type mismatches.
                 (t1_tail, t2_tail) => {
                     unify(state, ctxt, t1_tail, t2_tail).map_err(|err| match err {
                         UnifError::ConstMismatch(c1, c2) => RowUnifError::ConstMismatch(c1, c2),
                         UnifError::WithConst(c1, tyw) => RowUnifError::WithConst(c1, tyw),
                         UnifError::RowConflict(id, tyw_opt, _, _) => {
                             RowUnifError::UnsatConstr(id, tyw_opt)
-                        }
+                        },
+                        UnifError::RowMismatch(id, _, _, unif_err) => {
+                            RowUnifError::RowMismatch(id, unif_err)
+                        },
                         err => panic!(
-                        "typechecker::unify_rows(): unexpected error while unifying row tails {:?}",
-                        err
-                    ),
+                            "typechecker::unify_rows(): unexpected error while unifying row tails {:?}",
+                            err
+                        ),
                     })
                 }
             }

--- a/tests/typecheck_fail.rs
+++ b/tests/typecheck_fail.rs
@@ -206,7 +206,7 @@ fn row_type_unification_variable_mismatch() {
     use nickel_lang::error::Error;
 
     // We run the example multiple times as the order in which row types
-    // are checked is not deteministic, and failures are handled differently
+    // are checked is not deterministic, and failures are handled differently
     // depending on whether they occur in the row head or tail.
     for _ in 0..10 {
         assert_matches!(

--- a/tests/typecheck_fail.rs
+++ b/tests/typecheck_fail.rs
@@ -6,6 +6,7 @@ use nickel_lang::parser::{grammar, lexer};
 use nickel_lang::term::RichTerm;
 use nickel_lang::types::{AbsType, Types};
 use nickel_lang::{typecheck, typecheck::Context};
+use nickel_lang_utilities::typecheck_fixture;
 
 fn type_check(rt: &RichTerm) -> Result<(), TypecheckError> {
     typecheck::type_check(rt, Context::new(), &mut DummyResolver {}).map(|_| ())
@@ -195,6 +196,24 @@ fn polymorphic_row_constraints() {
            (let bad = remove (remove {a = \"a\"}) in 0) : Num",
     );
     assert_row_conflict(res);
+}
+
+/// Regression test following [#841](https://github.com/tweag/nickel/issues/841).
+/// Checks that type mismatches occurring in the tail of a row type with
+/// unification variables don't cause a panic.
+#[test]
+fn row_type_unification_variable_mismatch() {
+    use nickel_lang::error::Error;
+
+    // We run the example multiple times as the order in which row types
+    // are checked is not deteministic, and failures are handled differently
+    // depending on whether they occur in the row head or tail.
+    for _ in 0..10 {
+        assert_matches!(
+            typecheck_fixture("typecheck_fail/row_type_unification_variable_mismatch.ncl"),
+            Err(Error::TypecheckError(TypecheckError::RowMismatch(..)))
+        )
+    }
 }
 
 #[test]

--- a/tests/typecheck_fail/row_type_unification_variable_mismatch.ncl
+++ b/tests/typecheck_fail/row_type_unification_variable_mismatch.ncl
@@ -1,0 +1,11 @@
+{
+  split : forall a. Array { key: Str, value: a } -> { keys: Array Str, values: Array a } = fun pairs =>
+    array.fold (fun pair acc =>
+      {
+        # Error: `pair.key` should be wrapped in an array before we concat.
+        keys = acc.keys @ pair.key,
+        values = acc.values @ [pair.value],
+      })
+      { keys = [], values = [] }
+      pairs,
+}

--- a/utilities/src/lib.rs
+++ b/utilities/src/lib.rs
@@ -19,9 +19,7 @@ pub fn eval(s: impl std::string::ToString) -> Result<Term, Error> {
 }
 
 pub fn eval_file(f: &str) -> Result<Term, Error> {
-    let path = format!("{}/../tests/{}", env!("CARGO_MANIFEST_DIR"), f);
-    let mut p = Program::new_from_file(&path)
-        .unwrap_or_else(|e| panic!("Could not create program from `{}`\n {}", path, e));
+    let mut p = program_from_test_fixture(f);
     p.eval().map(Term::from)
 }
 
@@ -31,6 +29,17 @@ pub fn parse(s: &str) -> Result<RichTerm, ParseError> {
     grammar::TermParser::new()
         .parse_term(id, lexer::Lexer::new(&s))
         .map_err(|errs| errs.errors.first().unwrap().clone())
+}
+
+pub fn typecheck_fixture(f: &str) -> Result<(), Error> {
+    let mut p = program_from_test_fixture(f);
+    p.typecheck()
+}
+
+fn program_from_test_fixture(f: &str) -> Program {
+    let path = format!("{}/../tests/{}", env!("CARGO_MANIFEST_DIR"), f);
+    Program::new_from_file(&path)
+        .unwrap_or_else(|e| panic!("Could not create program from `{}`\n {}", path, e))
 }
 
 #[derive(Clone, Copy, Eq, PartialEq, Debug)]


### PR DESCRIPTION
When unifying the tails of row types, we only handle a subset of all
possible unification errors. Previously row mismatches were not handled,
however in certain cases (such as the included test case here) we end up
trying to unify a row tail with a unification variable which resolves to
a type which doesn't match, which resulted in a panic. This commit
handles that error, preventing the panic.

This fixes #841.