### PR TITLE
Deprecate `fresh_var` for a new method in Ident

### DIFF
--- a/src/eval/merge.rs
+++ b/src/eval/merge.rs
@@ -510,14 +510,12 @@ fn merge_closurize(
 }
 
 fn rev_thunks<'a, I: Iterator<Item = &'a mut RichTerm>>(map: I, env: &mut Environment) {
-    use crate::transform::fresh_var;
-
     for rt in map {
         if let Term::Var(id) = rt.as_ref() {
             // This create a fresh variable which is bound to a reverted copy of the original thunk
             let reverted = env.get(id).unwrap().revert();
-            let fresh_id = fresh_var();
-            env.insert(fresh_id.clone(), reverted);
+            let fresh_id = Ident::generate();
+            env.insert(fresh_id, reverted);
             *(SharedTerm::make_mut(&mut rt.term)) = Term::Var(fresh_id);
         }
         // Otherwise, if it is not a variable after the share normal form transformations, it

--- a/src/eval/merge.rs
+++ b/src/eval/merge.rs
@@ -514,7 +514,7 @@ fn rev_thunks<'a, I: Iterator<Item = &'a mut RichTerm>>(map: I, env: &mut Enviro
         if let Term::Var(id) = rt.as_ref() {
             // This create a fresh variable which is bound to a reverted copy of the original thunk
             let reverted = env.get(id).unwrap().revert();
-            let fresh_id = Ident::generate();
+            let fresh_id = Ident::fresh();
             env.insert(fresh_id, reverted);
             *(SharedTerm::make_mut(&mut rt.term)) = Term::Var(fresh_id);
         }

--- a/src/eval/operation.rs
+++ b/src/eval/operation.rs
@@ -1022,7 +1022,7 @@ fn process_unary_operation(
                 let re = regex::Regex::new(s)
                     .map_err(|err| EvalError::Other(err.to_string(), pos_op))?;
 
-                let param = Ident::generate();
+                let param = Ident::fresh();
                 let matcher = Term::Fun(
                     param.clone(),
                     RichTerm::new(
@@ -1049,7 +1049,7 @@ fn process_unary_operation(
                 let re = regex::Regex::new(s)
                     .map_err(|err| EvalError::Other(err.to_string(), pos_op))?;
 
-                let param = Ident::generate();
+                let param = Ident::fresh();
                 let matcher = Term::Fun(
                     param.clone(),
                     RichTerm::new(

--- a/src/eval/operation.rs
+++ b/src/eval/operation.rs
@@ -23,7 +23,7 @@ use crate::{
     serialize::ExportFormat,
     term::{array::Array, make as mk_term, PendingContract},
     term::{ArrayAttrs, BinaryOp, NAryOp, RichTerm, StrChunk, Term, UnaryOp},
-    transform::{apply_contracts::apply_contracts, fresh_var, Closurizable},
+    transform::{apply_contracts::apply_contracts, Closurizable},
 };
 use md5::digest::Digest;
 use simple_counter::*;
@@ -1022,7 +1022,7 @@ fn process_unary_operation(
                 let re = regex::Regex::new(s)
                     .map_err(|err| EvalError::Other(err.to_string(), pos_op))?;
 
-                let param = fresh_var();
+                let param = Ident::generate();
                 let matcher = Term::Fun(
                     param.clone(),
                     RichTerm::new(
@@ -1049,7 +1049,7 @@ fn process_unary_operation(
                 let re = regex::Regex::new(s)
                     .map_err(|err| EvalError::Other(err.to_string(), pos_op))?;
 
-                let param = fresh_var();
+                let param = Ident::generate();
                 let matcher = Term::Fun(
                     param.clone(),
                     RichTerm::new(

--- a/src/identifier.rs
+++ b/src/identifier.rs
@@ -31,7 +31,7 @@ impl Ident {
         Self::new_with_pos(label, TermPos::None)
     }
 
-    pub fn generate() -> Self {
+    pub fn fresh() -> Self {
         Self::new(format!("{}{}", GEN_PREFIX, GeneratedCounter::next()))
     }
 

--- a/src/identifier.rs
+++ b/src/identifier.rs
@@ -6,6 +6,7 @@ use std::hash::Hash;
 
 use crate::position::TermPos;
 
+simple_counter::generate_counter!(GeneratedCounter, usize);
 static INTERNER: Lazy<interner::Interner> = Lazy::new(interner::Interner::new);
 
 #[derive(Debug, Clone, Copy, Deserialize, Serialize)]
@@ -28,6 +29,10 @@ impl Ident {
 
     pub fn new(label: impl AsRef<str>) -> Self {
         Self::new_with_pos(label, TermPos::None)
+    }
+
+    pub fn generate() -> Self {
+        Self::new(format!("{}{}", GEN_PREFIX, GeneratedCounter::next()))
     }
 
     pub fn label(&self) -> &str {

--- a/src/transform/desugar_destructuring.rs
+++ b/src/transform/desugar_destructuring.rs
@@ -56,7 +56,7 @@ pub fn transform_one(rt: RichTerm) -> RichTerm {
 pub fn desugar_fun(rt: RichTerm) -> RichTerm {
     match_sharedterm! {rt.term, with {
         Term::FunPattern(x, pat, t_) if !pat.is_empty() => {
-            let x = x.unwrap_or_else(Ident::generate);
+            let x = x.unwrap_or_else(Ident::fresh);
             let t_pos = t_.pos;
             RichTerm::new(
                 Term::Fun(
@@ -109,7 +109,7 @@ pub fn desugar(rt: RichTerm) -> RichTerm {
         with {
             Term::LetPattern(x, pat, t_, body) => {
                 let pos = body.pos;
-                let x = x.unwrap_or_else(Ident::generate);
+                let x = x.unwrap_or_else(Ident::fresh);
                 RichTerm::new(
                     Term::Let(
                         x.clone(),
@@ -142,7 +142,7 @@ fn bind_open_field(x: Ident, pat: &Destruct, body: RichTerm) -> RichTerm {
             open: true,
             rest: None,
             ..
-        } => (matches, Ident::generate()),
+        } => (matches, Ident::fresh()),
         Destruct::Record {
             open: false,
             rest: None,

--- a/src/transform/desugar_destructuring.rs
+++ b/src/transform/desugar_destructuring.rs
@@ -56,7 +56,7 @@ pub fn transform_one(rt: RichTerm) -> RichTerm {
 pub fn desugar_fun(rt: RichTerm) -> RichTerm {
     match_sharedterm! {rt.term, with {
         Term::FunPattern(x, pat, t_) if !pat.is_empty() => {
-            let x = x.unwrap_or_else(super::fresh_var);
+            let x = x.unwrap_or_else(Ident::generate);
             let t_pos = t_.pos;
             RichTerm::new(
                 Term::Fun(
@@ -109,7 +109,7 @@ pub fn desugar(rt: RichTerm) -> RichTerm {
         with {
             Term::LetPattern(x, pat, t_, body) => {
                 let pos = body.pos;
-                let x = x.unwrap_or_else(super::fresh_var);
+                let x = x.unwrap_or_else(Ident::generate);
                 RichTerm::new(
                     Term::Let(
                         x.clone(),
@@ -142,7 +142,7 @@ fn bind_open_field(x: Ident, pat: &Destruct, body: RichTerm) -> RichTerm {
             open: true,
             rest: None,
             ..
-        } => (matches, super::fresh_var()),
+        } => (matches, Ident::generate()),
         Destruct::Record {
             open: false,
             rest: None,

--- a/src/transform/mod.rs
+++ b/src/transform/mod.rs
@@ -8,10 +8,6 @@ use crate::{
     types::{AbsType, Types, UnboundTypeVariableError},
 };
 
-use simple_counter::*;
-
-generate_counter!(FreshVarCounter, usize);
-
 pub mod apply_contracts;
 pub mod desugar_destructuring;
 pub mod free_vars;
@@ -69,9 +65,7 @@ pub fn transform_no_free_vars(
 #[deprecated = "use [Ident::generate] instead"]
 /// Generate a new fresh variable which do not clash with user-defined variables.
 pub fn fresh_var() -> Ident {
-    use crate::identifier::GEN_PREFIX;
-
-    format!("{}{}", GEN_PREFIX, FreshVarCounter::next()).into()
+    Ident::generate()
 }
 
 /// Structures which can be packed together with their environment as a closure.

--- a/src/transform/mod.rs
+++ b/src/transform/mod.rs
@@ -62,12 +62,6 @@ pub fn transform_no_free_vars(
         .unwrap())
 }
 
-#[deprecated = "use [Ident::generate] instead"]
-/// Generate a new fresh variable which do not clash with user-defined variables.
-pub fn fresh_var() -> Ident {
-    Ident::fresh()
-}
-
 /// Structures which can be packed together with their environment as a closure.
 ///
 /// The typical implementer is [`crate::term::RichTerm`], but structures containing

--- a/src/transform/mod.rs
+++ b/src/transform/mod.rs
@@ -65,7 +65,7 @@ pub fn transform_no_free_vars(
 #[deprecated = "use [Ident::generate] instead"]
 /// Generate a new fresh variable which do not clash with user-defined variables.
 pub fn fresh_var() -> Ident {
-    Ident::generate()
+    Ident::fresh()
 }
 
 /// Structures which can be packed together with their environment as a closure.
@@ -128,7 +128,7 @@ impl Closurizable for RichTerm {
         // affect the invariant mentioned above, because the share normal form must ensure that the
         // fields of a record all contain generated variables (or constant), but never
         // user-supplied variables.
-        let var = Ident::generate();
+        let var = Ident::fresh();
         let pos = self.pos;
 
         let thunk = match self.as_ref() {

--- a/src/transform/mod.rs
+++ b/src/transform/mod.rs
@@ -66,6 +66,7 @@ pub fn transform_no_free_vars(
         .unwrap())
 }
 
+#[deprecated = "use [Ident::generate] instead"]
 /// Generate a new fresh variable which do not clash with user-defined variables.
 pub fn fresh_var() -> Ident {
     use crate::identifier::GEN_PREFIX;

--- a/src/transform/mod.rs
+++ b/src/transform/mod.rs
@@ -134,7 +134,7 @@ impl Closurizable for RichTerm {
         // affect the invariant mentioned above, because the share normal form must ensure that the
         // fields of a record all contain generated variables (or constant), but never
         // user-supplied variables.
-        let var = fresh_var();
+        let var = Ident::generate();
         let pos = self.pos;
 
         let thunk = match self.as_ref() {

--- a/src/transform/share_normal_form.rs
+++ b/src/transform/share_normal_form.rs
@@ -27,7 +27,6 @@
 //!
 //! Newly introduced variables begin with a special character to avoid clashing with user-defined
 //! variables.
-use super::fresh_var;
 use crate::{
     identifier::Ident,
     match_sharedterm,
@@ -56,7 +55,7 @@ pub fn transform_one(rt: RichTerm) -> RichTerm {
                     .into_iter()
                     .map(|(id, t)| {
                         if should_share(&t.term) {
-                            let fresh_var = fresh_var();
+                            let fresh_var = Ident::generate();
                             let pos_t = t.pos;
                             bindings.push((fresh_var.clone(), t, BindingType::Normal));
                             (id, RichTerm::new(Term::Var(fresh_var), pos_t))
@@ -106,7 +105,7 @@ pub fn transform_one(rt: RichTerm) -> RichTerm {
                         // CHANGE THIS CONDITION CAREFULLY. Doing so can break the post-condition
                         // explained above.
                         if !t.as_ref().is_constant() {
-                            let fresh_var = fresh_var();
+                            let fresh_var = Ident::generate();
                             let pos_t = t.pos;
                             let field_deps = deps.as_ref().and_then(|deps| deps.stat_fields.get(&id)).cloned();
                             let is_non_rec = (&field_deps).as_ref().map(|deps| deps.is_empty()).unwrap_or(false);
@@ -125,7 +124,7 @@ pub fn transform_one(rt: RichTerm) -> RichTerm {
                     .enumerate()
                     .map(|(index, (id_t, t))| {
                         if !t.as_ref().is_constant() {
-                            let fresh_var = fresh_var();
+                            let fresh_var = Ident::generate();
                             let pos_t = t.pos;
                             let field_deps = deps.as_ref().and_then(|deps| deps.dyn_fields.get(index)).cloned();
                             let btype = mk_binding_type(field_deps);
@@ -146,7 +145,7 @@ pub fn transform_one(rt: RichTerm) -> RichTerm {
                     .into_iter()
                     .map(|t| {
                         if should_share(&t.term) {
-                            let fresh_var = fresh_var();
+                            let fresh_var = Ident::generate();
                             let pos_t = t.pos;
                             bindings.push((fresh_var.clone(), t, BindingType::Normal));
                             RichTerm::new(Term::Var(fresh_var), pos_t)
@@ -160,7 +159,7 @@ pub fn transform_one(rt: RichTerm) -> RichTerm {
             },
             Term::MetaValue(meta) if meta.value.as_ref().map(|t| should_share(&t.term)).unwrap_or(false) => {
                     let mut meta = meta;
-                    let fresh_var = fresh_var();
+                    let fresh_var = Ident::generate();
                     let t = meta.value.take().unwrap();
                     meta.value
                         .replace(RichTerm::new(Term::Var(fresh_var.clone()), t.pos));

--- a/src/transform/share_normal_form.rs
+++ b/src/transform/share_normal_form.rs
@@ -55,7 +55,7 @@ pub fn transform_one(rt: RichTerm) -> RichTerm {
                     .into_iter()
                     .map(|(id, t)| {
                         if should_share(&t.term) {
-                            let fresh_var = Ident::generate();
+                            let fresh_var = Ident::fresh();
                             let pos_t = t.pos;
                             bindings.push((fresh_var.clone(), t, BindingType::Normal));
                             (id, RichTerm::new(Term::Var(fresh_var), pos_t))
@@ -105,7 +105,7 @@ pub fn transform_one(rt: RichTerm) -> RichTerm {
                         // CHANGE THIS CONDITION CAREFULLY. Doing so can break the post-condition
                         // explained above.
                         if !t.as_ref().is_constant() {
-                            let fresh_var = Ident::generate();
+                            let fresh_var = Ident::fresh();
                             let pos_t = t.pos;
                             let field_deps = deps.as_ref().and_then(|deps| deps.stat_fields.get(&id)).cloned();
                             let is_non_rec = (&field_deps).as_ref().map(|deps| deps.is_empty()).unwrap_or(false);
@@ -124,7 +124,7 @@ pub fn transform_one(rt: RichTerm) -> RichTerm {
                     .enumerate()
                     .map(|(index, (id_t, t))| {
                         if !t.as_ref().is_constant() {
-                            let fresh_var = Ident::generate();
+                            let fresh_var = Ident::fresh();
                             let pos_t = t.pos;
                             let field_deps = deps.as_ref().and_then(|deps| deps.dyn_fields.get(index)).cloned();
                             let btype = mk_binding_type(field_deps);
@@ -145,7 +145,7 @@ pub fn transform_one(rt: RichTerm) -> RichTerm {
                     .into_iter()
                     .map(|t| {
                         if should_share(&t.term) {
-                            let fresh_var = Ident::generate();
+                            let fresh_var = Ident::fresh();
                             let pos_t = t.pos;
                             bindings.push((fresh_var.clone(), t, BindingType::Normal));
                             RichTerm::new(Term::Var(fresh_var), pos_t)
@@ -159,7 +159,7 @@ pub fn transform_one(rt: RichTerm) -> RichTerm {
             },
             Term::MetaValue(meta) if meta.value.as_ref().map(|t| should_share(&t.term)).unwrap_or(false) => {
                     let mut meta = meta;
-                    let fresh_var = Ident::generate();
+                    let fresh_var = Ident::fresh();
                     let t = meta.value.take().unwrap();
                     meta.value
                         .replace(RichTerm::new(Term::Var(fresh_var.clone()), t.pos));


### PR DESCRIPTION
Depends on #835 

The concept came from a comment from @yannham:

	I wonder if we couldn't do something a bit cleaner here, by avoiding allocating a string at all for generated symbols, by:
		- having a method to print a symbol as a number (Symbol::to_string())
	    - move the method to create a fresh identifiers to Ident, which would set generated to true in this case
	    - if label() is called, just return format!("{}{}", GEN_PREFIX, symbol.
	I can see that the last one may be problematic because label return a &str. But at least we can move the code to create a fresh generated identifier into Ident and handle generated in a less fragile way (rather than relying on the presence of some character).

Here, we deprecated the method `fresh_var`, responsible for creating new `Ident` with a generated label, and created a method directly inside `Ident`.