### PR TITLE
Double quote simple strings in the pretty printer

### DIFF
--- a/src/pretty.rs
+++ b/src/pretty.rs
@@ -261,7 +261,7 @@ where
             Null => allocator.text("null"),
             Bool(v) => allocator.as_string(v),
             Num(v) => allocator.as_string(v),
-            Str(v) => allocator.escaped_string(v),
+            Str(v) => allocator.escaped_string(v).double_quotes(),
             StrChunks(chunks) => {
                 let multiline = chunks.len() > 1;
                 let nb_perc = chunks

--- a/tests/pretty.rs
+++ b/tests/pretty.rs
@@ -1,5 +1,5 @@
 use nickel_lang::pretty::*;
-use nickel_lang::term::RichTerm;
+use nickel_lang::term::{RichTerm, StrChunk, Term};
 use nickel_lang_utilities::parse;
 use pretty::BoxAllocator;
 
@@ -137,4 +137,12 @@ fn importing() {
 #[test]
 fn overriding() {
     check_file("overriding.ncl");
+}
+
+#[test]
+fn str_vs_strchunks() {
+    assert_eq!(
+        pretty(&Term::Str("string".to_string()).into()),
+        pretty(&Term::StrChunks(vec![StrChunk::Literal("string".to_string())]).into())
+    );
 }


### PR DESCRIPTION
The pretty printer neglected to double quote strings appearing as `Term::Str` in terms. This change adds double quoting together with a test to ensure parity with `StrChunks` pretty printing.