### PR TITLE
Pretty print the optional metavalue annotation

### DIFF
--- a/src/pretty.rs
+++ b/src/pretty.rs
@@ -99,6 +99,11 @@ where
             }),
             self.line().clone(),
         ))
+        .append(if mv.opt {
+            self.line().append(self.text("| optional"))
+        } else {
+            self.nil()
+        })
         .append(if mv.priority == crate::term::MergePriority::Bottom {
             self.line().append(self.text("| default"))
         } else {


### PR DESCRIPTION
The pretty printer used to ignore the optional annotation for metavalues.