### PR TITLE
Improve error messages to differentiate between flat types and static types

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -1327,21 +1327,27 @@ impl ToDiagnostic<FileId> for TypecheckError {
                     ])]
             ,
             TypecheckError::TypeMismatch(expd, actual, span_opt) => {
-                fn get_note(ty: &Types) -> String {
+                fn addendum(ty: &Types) -> String {
                     if ty.0.is_flat() {
-                        String::from("the term")
+                        String::from(" (a contract)")
                     } else {
-                        String::from("a type expression")
+                        String::from("")
                     }
                 }
+                let last_note = if expd.0.is_flat() ^ actual.0.is_flat() {
+                    String::from("Static types and contracts are not compatible")
+                } else {
+                    String::from("These types are not compatible")
+                };
+
                 vec![
                     Diagnostic::error()
                         .with_message("incompatible types")
                         .with_labels(mk_expr_label(span_opt))
                         .with_notes(vec![
-                            format!("Expected an expression typed by {} `{}`", get_note(expd), expd),
-                            format!("Inferred this expression to be typed by {} `{}`", get_note(actual), actual),
-                            String::from("These types are not compatible"),
+                            format!("The type of the expression was expected to be `{}`{}", expd, addendum(expd)),
+                            format!("The type of the expression was inferred to be `{}`{}", actual, addendum(actual)),
+                            last_note,
                         ])]
             }
             TypecheckError::RowKindMismatch(ident, expd, actual, span_opt) => {

--- a/src/error.rs
+++ b/src/error.rs
@@ -1326,17 +1326,24 @@ impl ToDiagnostic<FileId> for TypecheckError {
                         format!("Maybe you forgot to put a `forall {}.` somewhere in the enclosing type ?", ident),
                     ])]
             ,
-            TypecheckError::TypeMismatch(expd, actual, span_opt) =>
+            TypecheckError::TypeMismatch(expd, actual, span_opt) => {
+                fn get_note(ty: &Types) -> String {
+                    if ty.0.is_flat_type() {
+                        String::from("the term")
+                    } else {
+                        String::from("a type expression")
+                    }
+                }
                 vec![
                     Diagnostic::error()
                         .with_message("incompatible types")
                         .with_labels(mk_expr_label(span_opt))
                         .with_notes(vec![
-                            format!("The type of the expression was expected to be `{}`", expd),
-                            format!("The type of the expression was inferred to be `{}`", actual),
+                            format!("Expected an expression typed by {} `{}`", get_note(expd), expd),
+                            format!("Inferred this expression to be typed by {} `{}`", get_note(actual), actual),
                             String::from("These types are not compatible"),
                         ])]
-            ,
+            }
             TypecheckError::RowKindMismatch(ident, expd, actual, span_opt) => {
                 let (expd_str, actual_str) = match (expd, actual) {
                     (Some(_), None) => ("an enum type", "a record type"),

--- a/src/error.rs
+++ b/src/error.rs
@@ -1327,17 +1327,17 @@ impl ToDiagnostic<FileId> for TypecheckError {
                     ])]
             ,
             TypecheckError::TypeMismatch(expd, actual, span_opt) => {
-                fn addendum(ty: &Types) -> String {
+                fn addendum(ty: &Types) -> &str {
                     if ty.0.is_flat() {
-                        String::from(" (a contract)")
+                        " (a contract)"
                     } else {
-                        String::from("")
+                        ""
                     }
                 }
                 let last_note = if expd.0.is_flat() ^ actual.0.is_flat() {
-                    String::from("Static types and contracts are not compatible")
+                    "Static types and contracts are not compatible"
                 } else {
-                    String::from("These types are not compatible")
+                    "These types are not compatible"
                 };
 
                 vec![
@@ -1347,7 +1347,7 @@ impl ToDiagnostic<FileId> for TypecheckError {
                         .with_notes(vec![
                             format!("The type of the expression was expected to be `{}`{}", expd, addendum(expd)),
                             format!("The type of the expression was inferred to be `{}`{}", actual, addendum(actual)),
-                            last_note,
+                            String::from(last_note),
                         ])]
             }
             TypecheckError::RowKindMismatch(ident, expd, actual, span_opt) => {

--- a/src/error.rs
+++ b/src/error.rs
@@ -1328,7 +1328,7 @@ impl ToDiagnostic<FileId> for TypecheckError {
             ,
             TypecheckError::TypeMismatch(expd, actual, span_opt) => {
                 fn get_note(ty: &Types) -> String {
-                    if ty.0.is_flat_type() {
+                    if ty.0.is_flat() {
                         String::from("the term")
                     } else {
                         String::from("a type expression")

--- a/src/types.rs
+++ b/src/types.rs
@@ -153,7 +153,7 @@ impl<Ty> AbsType<Ty> {
     }
 
     /// Determine if a type is a type defined by a Nickel term.
-    pub fn is_flat_type(&self) -> bool {
+    pub fn is_flat(&self) -> bool {
         matches!(self, AbsType::Flat(_))
     }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -152,6 +152,11 @@ impl<Ty> AbsType<Ty> {
         )
     }
 
+    /// Determine if a type is a type defined by a Nickel term.
+    pub fn is_flat_type(&self) -> bool {
+        matches!(self, AbsType::Flat(_))
+    }
+
     pub fn is_wildcard(&self) -> bool {
         matches!(self, AbsType::Wildcard(_))
     }


### PR DESCRIPTION
Depending if type is flat or not, print a different note in the error.

fix #718 