### PR TITLE
Add a keywords list for use by the pretty printer

### DIFF
--- a/src/parser/lexer.rs
+++ b/src/parser/lexer.rs
@@ -33,6 +33,8 @@ use crate::parser::error::{LexicalError, ParseError};
 use logos::Logos;
 use std::ops::Range;
 
+// When adding or removing tokens that might be parsed as identifiers please update the KEYWORDS
+// list
 /// The tokens in normal mode.
 #[derive(Logos, Debug, PartialEq, Clone)]
 pub enum NormalToken<'input> {
@@ -289,6 +291,12 @@ pub enum NormalToken<'input> {
     #[regex("#[^\n]*")]
     LineComment,
 }
+
+pub const KEYWORDS: &[&str] = &[
+    "Dyn", "Num", "Bool", "Str", "Array", "if", "then", "else", "forall", "in", "let", "rec",
+    "switch", "null", "true", "false", "fun", "import", "merge", "default", "doc", "optional",
+    "priority", "force",
+];
 
 /// The tokens in string mode.
 #[derive(Logos, Debug, PartialEq, Clone)]

--- a/src/parser/lexer.rs
+++ b/src/parser/lexer.rs
@@ -33,7 +33,9 @@ use crate::parser::error::{LexicalError, ParseError};
 use logos::Logos;
 use std::ops::Range;
 
-// When adding or removing tokens that might be parsed as identifiers please update the KEYWORDS
+// **IMPORTANT**
+// When adding or removing tokens that might be parsed as identifiers,
+// please update the KEYWORDS array
 // list
 /// The tokens in normal mode.
 #[derive(Logos, Debug, PartialEq, Clone)]

--- a/src/pretty.rs
+++ b/src/pretty.rs
@@ -1,4 +1,5 @@
 use crate::destruct::{self, Destruct};
+use crate::parser::lexer::KEYWORDS;
 use crate::term::{BinaryOp, MetaValue, RichTerm, Term, UnaryOp};
 use crate::types::{AbsType, Types};
 pub use pretty::{DocAllocator, DocBuilder, Pretty};
@@ -45,7 +46,7 @@ where
 {
     fn quote_if_needed(&'a self, id: &crate::identifier::Ident) -> DocBuilder<'a, Self, A> {
         let reg = Regex::new("^_?[a-zA-Z][_a-zA-Z0-9-]*$").unwrap();
-        if reg.is_match(id.as_ref()) {
+        if reg.is_match(id.as_ref()) && !KEYWORDS.contains(&id.as_ref()) {
             self.as_string(id)
         } else {
             self.as_string(id).double_quotes()


### PR DESCRIPTION
This is a quick fix for #859. I'm not convinced it's the best approach, especially because it asks people to keep updating a list of strings as the syntax evolves. But that should be an infrequent issue.

As it is, this PR gets the pretty printer to produce parseable records even if the record field names coincide with keywords.