### PR TITLE
Fix testlib ignoring last test

### DIFF
--- a/tests/pass/testlib.ncl
+++ b/tests/pass/testlib.ncl
@@ -26,5 +26,5 @@
 
     But will give more precise error reporting when one test fails.
     "%m
-    = array.foldl (fun x y => (x | Assert) && y) true,
+    = array.foldl (fun acc test => (test | Assert) && acc) true,
 }


### PR DESCRIPTION
The order of the argument of `foldl` were reversed in the test library, meaning that the `Assert` contract was applied to the accumulator, and not to the current test. There is no consequence for all tests but the last one, which doesn't trigger a blame error even if it evaluates to `false`.