### PR TITLE
Rename DynRecord to Dict

### DIFF
--- a/doc/manual/typing.md
+++ b/doc/manual/typing.md
@@ -190,9 +190,7 @@ The following type constructors are available:
   pair.fst : Num
   ```
 
-- **Dynamic record**: `{_: T}`. A record whose field
-  names are statically unknown but are all of type `T`.  Typically used to model
-  dictionaries.
+- **Dictionary**: `{_: T}`. A dictionary mapping string keys to `T`.
 
   Example:
 

--- a/src/parser/grammar.lalrpop
+++ b/src/parser/grammar.lalrpop
@@ -782,7 +782,7 @@ TypeAtom: Types = {
             );
         Types(AbsType::Enum(Box::new(ty)))
     },
-    "{" "_" ":" <Types> "}" => Types(AbsType::DynRecord(Box::new(<>))),
+    "{" "_" ":" <Types> "}" => Types(AbsType::Dict(Box::new(<>))),
     "_" => {
         let id = *next_wildcard_id;
         *next_wildcard_id += 1;

--- a/src/parser/uniterm.rs
+++ b/src/parser/uniterm.rs
@@ -385,7 +385,7 @@ pub fn fix_type_vars(ty: &mut Types) {
                     fix_type_vars_aux(tail.as_mut(), bound_vars);
                 }
             }
-            AbsType::DynRecord(ref mut ty)
+            AbsType::Dict(ref mut ty)
             | AbsType::Array(ref mut ty)
             | AbsType::Enum(ref mut ty)
             | AbsType::StaticRecord(ref mut ty) => fix_type_vars_aux(ty.as_mut(), bound_vars),

--- a/src/pretty.rs
+++ b/src/pretty.rs
@@ -770,7 +770,7 @@ where
                     .braces(),
                 _ => row.pretty(allocator).braces(),
             },
-            DynRecord(ty) => allocator
+            Dict(ty) => allocator
                 .line()
                 .append(allocator.text("_"))
                 .append(allocator.space())

--- a/src/transform/free_vars.rs
+++ b/src/transform/free_vars.rs
@@ -182,7 +182,7 @@ fn collect_type_free_vars(ty: &mut Types, set: &mut HashSet<Ident>) {
         AbsType::Forall(_, ty)
         | AbsType::Enum(ty)
         | AbsType::StaticRecord(ty)
-        | AbsType::DynRecord(ty)
+        | AbsType::Dict(ty)
         | AbsType::Array(ty) => collect_type_free_vars(ty.as_mut(), set),
         AbsType::Arrow(ty1, ty2) => {
             collect_type_free_vars(ty1.as_mut(), set);

--- a/src/typecheck/eq.rs
+++ b/src/typecheck/eq.rs
@@ -409,7 +409,7 @@ fn type_eq_bounded<E: TermEnvironment>(
             | (AbsType::Bool(), AbsType::Bool())
             | (AbsType::Sym(), AbsType::Sym())
             | (AbsType::Str(), AbsType::Str()) => true,
-            (AbsType::DynRecord(tyw1), AbsType::DynRecord(tyw2))
+            (AbsType::Dict(tyw1), AbsType::Dict(tyw2))
             | (AbsType::Array(tyw1), AbsType::Array(tyw2)) => {
                 type_eq_bounded(state, tyw1, env1, tyw2, env2)
             }

--- a/src/typecheck/mk_typewrapper.rs
+++ b/src/typecheck/mk_typewrapper.rs
@@ -97,7 +97,7 @@ pub fn dyn_record<T>(ty: T) -> TypeWrapper
 where
     T: Into<TypeWrapper>,
 {
-    TypeWrapper::Concrete(AbsType::DynRecord(Box::new(ty.into())))
+    TypeWrapper::Concrete(AbsType::Dict(Box::new(ty.into())))
 }
 
 pub fn array<T>(ty: T) -> TypeWrapper

--- a/src/typecheck/mod.rs
+++ b/src/typecheck/mod.rs
@@ -487,7 +487,7 @@ fn walk_type<L: Linearizer>(
        }
        AbsType::Flat(t) => walk(state, ctxt, lin, linearizer, t),
        AbsType::Enum(ty2)
-       | AbsType::DynRecord(ty2)
+       | AbsType::Dict(ty2)
        | AbsType::StaticRecord(ty2)
        | AbsType::Array(ty2)
        | AbsType::Forall(_, ty2) => walk_type(state, ctxt, lin, linearizer, ty2),
@@ -767,8 +767,8 @@ fn type_check_<L: Linearizer>(
                 ty.clone()
             };
 
-            if let TypeWrapper::Concrete(AbsType::DynRecord(rec_ty)) = root_ty {
-                // Checking for a dynamic record
+            if let TypeWrapper::Concrete(AbsType::Dict(rec_ty)) = root_ty {
+                // Checking for a dictionaries
                 stat_map
                     .iter()
                     .try_for_each(|(_, t)| -> Result<(), TypecheckError> {
@@ -1195,8 +1195,8 @@ impl<E: TermEnvironment + Clone> GenericTypeWrapper<E> {
             Concrete(AbsType::StaticRecord(row)) => {
                 Concrete(AbsType::StaticRecord(Box::new(row.subst(id, to))))
             }
-            Concrete(AbsType::DynRecord(def_ty)) => {
-                Concrete(AbsType::DynRecord(Box::new(def_ty.subst(id, to))))
+            Concrete(AbsType::Dict(def_ty)) => {
+                Concrete(AbsType::Dict(Box::new(def_ty.subst(id, to))))
             }
             Concrete(AbsType::Array(ty)) => Concrete(AbsType::Array(Box::new(ty.subst(id, to)))),
             // Cases are spelled out instead of using a catch-all case `_ => ` to force
@@ -1412,7 +1412,7 @@ pub fn unify(
                 }
                 (tyw1, tyw2) => unify(state, ctxt, tyw1, tyw2),
             },
-            (AbsType::DynRecord(t), AbsType::DynRecord(t2)) => unify(state, &ctxt, *t, *t2),
+            (AbsType::Dict(t), AbsType::Dict(t2)) => unify(state, &ctxt, *t, *t2),
             (AbsType::Forall(i1, t1t), AbsType::Forall(i2, t2t)) => {
                 // Very stupid (slow) implementation
                 let constant_type = state.table.fresh_const();
@@ -1745,7 +1745,7 @@ fn constrain_var(state: &mut State, tyw: &TypeWrapper, p: usize) {
                 }
                 AbsType::Enum(row) => constrain_var_(state, constr, row, p),
                 AbsType::StaticRecord(row) => constrain_var_(state, constr, row, p),
-                AbsType::DynRecord(tyw) => constrain_var_(state, constr, tyw, p),
+                AbsType::Dict(tyw) => constrain_var_(state, constr, tyw, p),
             },
             TypeWrapper::Constant(_) | TypeWrapper::Contract(..) => (),
         }

--- a/src/typecheck/operation.rs
+++ b/src/typecheck/operation.rs
@@ -86,7 +86,7 @@ pub fn get_uop_type(
         // forall a b. { _ : a} -> (Str -> a -> b) -> { _ : b }
         UnaryOp::RecordMap() => {
             // Assuming f has type Str -> a -> b,
-            // this has type DynRecord(a) -> DynRecord(b)
+            // this has type Dict(a) -> Dict(b)
 
             let a = TypeWrapper::Ptr(state.table.fresh_var());
             let b = TypeWrapper::Ptr(state.table.fresh_var());


### PR DESCRIPTION
Currently, dictionaries types in Nickel are represented with something called a dynamic record: `DynRecord(Ty)` . This maps `Str` keys to the type `Ty`. This in not particularly bad, but it would be better to just have it be called a *dictionary*: `Dict(Ty)`, to better portray it's meaning.

This change renames all occurrences of `DynRecord(..)` to `Dict(..)`