### PR TITLE
[Fix] reset state for thunks on the stack

### DIFF
--- a/src/eval/lazy.rs
+++ b/src/eval/lazy.rs
@@ -301,4 +301,12 @@ impl ThunkUpdateFrame {
             false
         }
     }
+
+    /// Reset the state of the thunk to Suspended
+    /// Mainly used to reset the state of the vm between REPL runs
+    pub fn reset_state(self) {
+        if let Some(data) = Weak::upgrade(&self.data) {
+            data.borrow_mut().state = ThunkState::Suspended;
+        }
+    }
 }

--- a/src/eval/mod.rs
+++ b/src/eval/mod.rs
@@ -158,8 +158,7 @@ impl<R: ImportResolver> VirtualMachine<R> {
     pub fn reset(&mut self) {
         self.eval_mode = Default::default();
         self.call_stack.0.clear();
-        self.stack.reset_thunks();
-        self.stack.clear(); //Do we even need to call this at this point?
+        self.stack.reset();
     }
 
     fn set_mode(&mut self, new_mode: EvalMode) {

--- a/src/eval/mod.rs
+++ b/src/eval/mod.rs
@@ -158,8 +158,8 @@ impl<R: ImportResolver> VirtualMachine<R> {
     pub fn reset(&mut self) {
         self.eval_mode = Default::default();
         self.call_stack.0.clear();
-        reset_thunks(&mut self.stack);
-        self.stack.clear();
+        self.stack.reset_thunks();
+        self.stack.clear(); //Do we even need to call this at this point?
     }
 
     fn set_mode(&mut self, new_mode: EvalMode) {
@@ -176,10 +176,6 @@ impl<R: ImportResolver> VirtualMachine<R> {
 
     pub fn import_resolver_mut(&mut self) -> &mut R {
         &mut self.import_resolver
-    }
-
-    pub fn stack_mut(&mut self) -> &mut Stack {
-        &mut self.stack
     }
 
     /// Evaluate a Nickel term. Wrapper around [eval_closure] that starts from an empty local
@@ -764,12 +760,6 @@ pub fn env_add(env: &mut Environment, id: Ident, rt: RichTerm, local_env: Enviro
 fn update_thunks(stack: &mut Stack, closure: &Closure) {
     while let Some(thunk) = stack.pop_thunk() {
         thunk.update(closure.clone());
-    }
-}
-
-fn reset_thunks(stack: &mut Stack) {
-    while let Some(thunk) = stack.pop_thunk() {
-        thunk.reset_state();
     }
 }
 

--- a/src/eval/stack.rs
+++ b/src/eval/stack.rs
@@ -223,6 +223,20 @@ impl Stack {
         }
     }
 
+    /// Pops all items in the stack and resets the state of the thunks it encounters.
+    pub fn reset_thunks(&mut self) {
+        match self.0.pop() {
+            Some(Marker::Thunk(thunk)) => { 
+                thunk.reset_state();
+                self.reset_thunks();
+            }
+            Some(_m) => {
+                self.reset_thunks();
+            }
+            None => {}
+        }
+    }
+
     /// Try to pop an operator continuation from the top of the stack. If `None` is returned, the
     /// top element was not an operator continuation and the stack is left unchanged.
     pub fn pop_op_cont(&mut self) -> Option<(OperationCont, usize, TermPos)> {

--- a/src/eval/stack.rs
+++ b/src/eval/stack.rs
@@ -128,21 +128,12 @@ impl Stack {
         count
     }
 
-    pub fn clear(&mut self) {
-        self.0.clear();
-    }
-
     /// Pops all items in the stack and resets the state of the thunks it encounters.
-    pub fn reset_thunks(&mut self) {
-        match self.0.pop() {
-            Some(Marker::Thunk(thunk)) => {
+    pub fn reset(&mut self) {
+        while let Some(marker) = self.0.pop() {
+            if let Marker::Thunk(thunk) = marker {
                 thunk.reset_state();
-                self.reset_thunks();
             }
-            Some(_m) => {
-                self.reset_thunks();
-            }
-            None => {}
         }
     }
 

--- a/src/eval/stack.rs
+++ b/src/eval/stack.rs
@@ -226,7 +226,7 @@ impl Stack {
     /// Pops all items in the stack and resets the state of the thunks it encounters.
     pub fn reset_thunks(&mut self) {
         match self.0.pop() {
-            Some(Marker::Thunk(thunk)) => { 
+            Some(Marker::Thunk(thunk)) => {
                 thunk.reset_state();
                 self.reset_thunks();
             }

--- a/src/eval/stack.rs
+++ b/src/eval/stack.rs
@@ -132,6 +132,20 @@ impl Stack {
         self.0.clear();
     }
 
+    /// Pops all items in the stack and resets the state of the thunks it encounters.
+    pub fn reset_thunks(&mut self) {
+        match self.0.pop() {
+            Some(Marker::Thunk(thunk)) => {
+                thunk.reset_state();
+                self.reset_thunks();
+            }
+            Some(_m) => {
+                self.reset_thunks();
+            }
+            None => {}
+        }
+    }
+
     /// Count the number of arguments at the top of the stack.
     pub fn count_args(&self) -> usize {
         Stack::count(self, Marker::is_arg)
@@ -220,20 +234,6 @@ impl Stack {
                 None
             }
             _ => None,
-        }
-    }
-
-    /// Pops all items in the stack and resets the state of the thunks it encounters.
-    pub fn reset_thunks(&mut self) {
-        match self.0.pop() {
-            Some(Marker::Thunk(thunk)) => {
-                thunk.reset_state();
-                self.reset_thunks();
-            }
-            Some(_m) => {
-                self.reset_thunks();
-            }
-            None => {}
         }
     }
 


### PR DESCRIPTION
Changed `VirtualMachine::reset` to also reset the state of all thunks in the stack to `Suspended`.
Fixes #868