### PR TITLE
Rename StaticRecord  to Record

### DIFF
--- a/src/label.rs
+++ b/src/label.rs
@@ -140,7 +140,7 @@ pub mod ty_path {
                     _ => panic!(),
                 }
             }
-            (AbsType::StaticRecord(rows), Some(Elem::Field(ident))) => {
+            (AbsType::Record(rows), Some(Elem::Field(ident))) => {
                 // initial "{"
                 let mut start_offset = 1;
                 // middle ": " between the field name and the type

--- a/src/parser/uniterm.rs
+++ b/src/parser/uniterm.rs
@@ -234,7 +234,7 @@ impl UniRecord {
                     }
                 },
             )?;
-        Ok(Types(AbsType::StaticRecord(Box::new(ty))))
+        Ok(Types(AbsType::Record(Box::new(ty))))
     }
 
     pub fn with_pos(mut self, pos: TermPos) -> Self {
@@ -388,7 +388,7 @@ pub fn fix_type_vars(ty: &mut Types) {
             AbsType::Dict(ref mut ty)
             | AbsType::Array(ref mut ty)
             | AbsType::Enum(ref mut ty)
-            | AbsType::StaticRecord(ref mut ty) => fix_type_vars_aux(ty.as_mut(), bound_vars),
+            | AbsType::Record(ref mut ty) => fix_type_vars_aux(ty.as_mut(), bound_vars),
         }
     }
 

--- a/src/pretty.rs
+++ b/src/pretty.rs
@@ -761,7 +761,7 @@ where
                     .append(curr.to_owned().pretty(allocator))
             }
             Enum(row) => row.pretty(allocator).enclose("[|", "|]"),
-            StaticRecord(row) => match &row.0 {
+            Record(row) => match &row.0 {
                 AbsType::Var(id) => allocator
                     .space()
                     .append(allocator.text(";"))

--- a/src/transform/free_vars.rs
+++ b/src/transform/free_vars.rs
@@ -181,7 +181,7 @@ fn collect_type_free_vars(ty: &mut Types, set: &mut HashSet<Ident>) {
         | AbsType::Wildcard(_) => (),
         AbsType::Forall(_, ty)
         | AbsType::Enum(ty)
-        | AbsType::StaticRecord(ty)
+        | AbsType::Record(ty)
         | AbsType::Dict(ty)
         | AbsType::Array(ty) => collect_type_free_vars(ty.as_mut(), set),
         AbsType::Arrow(ty1, ty2) => {

--- a/src/typecheck/eq.rs
+++ b/src/typecheck/eq.rs
@@ -422,7 +422,7 @@ fn type_eq_bounded<E: TermEnvironment>(
                 let rows2 = rows_as_set(tyw2);
                 rows1.is_some() && rows2.is_some() && rows1 == rows2
             }
-            (AbsType::StaticRecord(tyw1), AbsType::StaticRecord(tyw2)) => {
+            (AbsType::Record(tyw1), AbsType::Record(tyw2)) => {
                 fn type_eq_bounded_wrapper<E: TermEnvironment>(
                     state: &mut State,
                     tyw1: &&GenericTypeWrapper<E>,

--- a/src/typecheck/mk_typewrapper.rs
+++ b/src/typecheck/mk_typewrapper.rs
@@ -77,7 +77,7 @@ macro_rules! mk_tyw_enum {
 macro_rules! mk_tyw_record {
     ($(($ids:expr, $tys:expr)),* $(; $tail:expr)?) => {
         $crate::typecheck::TypeWrapper::Concrete(
-            $crate::types::AbsType::StaticRecord(
+            $crate::types::AbsType::Record(
                 Box::new(mk_tyw_row!($(($ids, $tys)),* $(; $tail)?))
             )
         )

--- a/src/typecheck/mod.rs
+++ b/src/typecheck/mod.rs
@@ -488,7 +488,7 @@ fn walk_type<L: Linearizer>(
        AbsType::Flat(t) => walk(state, ctxt, lin, linearizer, t),
        AbsType::Enum(ty2)
        | AbsType::Dict(ty2)
-       | AbsType::StaticRecord(ty2)
+       | AbsType::Record(ty2)
        | AbsType::Array(ty2)
        | AbsType::Forall(_, ty2) => walk_type(state, ctxt, lin, linearizer, ty2),
     }
@@ -1079,7 +1079,7 @@ pub fn infer_record_type(t: &Term, term_env: &SimpleTermEnvironment) -> TypeWrap
             contracts,
             ..
         }) if contracts.is_empty() => infer_record_type(rt.as_ref(), term_env),
-        Term::Record(rec, ..) | Term::RecRecord(rec, ..) => AbsType::StaticRecord(Box::new(
+        Term::Record(rec, ..) | Term::RecRecord(rec, ..) => AbsType::Record(Box::new(
             TypeWrapper::Concrete(rec.iter().fold(AbsType::RowEmpty(), |r, (id, rt)| {
                 AbsType::RowExtend(
                     id.clone(),
@@ -1192,8 +1192,8 @@ impl<E: TermEnvironment + Clone> GenericTypeWrapper<E> {
                 Box::new(rest.subst(id, to)),
             )),
             Concrete(AbsType::Enum(row)) => Concrete(AbsType::Enum(Box::new(row.subst(id, to)))),
-            Concrete(AbsType::StaticRecord(row)) => {
-                Concrete(AbsType::StaticRecord(Box::new(row.subst(id, to))))
+            Concrete(AbsType::Record(row)) => {
+                Concrete(AbsType::Record(Box::new(row.subst(id, to))))
             }
             Concrete(AbsType::Dict(def_ty)) => {
                 Concrete(AbsType::Dict(Box::new(def_ty.subst(id, to))))
@@ -1393,7 +1393,7 @@ pub fn unify(
                 }
                 (tyw1, tyw2) => unify(state, ctxt, tyw1, tyw2),
             },
-            (AbsType::StaticRecord(tyw1), AbsType::StaticRecord(tyw2)) => match (*tyw1, *tyw2) {
+            (AbsType::Record(tyw1), AbsType::Record(tyw2)) => match (*tyw1, *tyw2) {
                 (TypeWrapper::Concrete(r1), TypeWrapper::Concrete(r2))
                     if r1.is_row_type() && r2.is_row_type() =>
                 {
@@ -1744,7 +1744,7 @@ fn constrain_var(state: &mut State, tyw: &TypeWrapper, p: usize) {
                     constrain_var_(state, constr, rest, p)
                 }
                 AbsType::Enum(row) => constrain_var_(state, constr, row, p),
-                AbsType::StaticRecord(row) => constrain_var_(state, constr, row, p),
+                AbsType::Record(row) => constrain_var_(state, constr, row, p),
                 AbsType::Dict(tyw) => constrain_var_(state, constr, tyw, p),
             },
             TypeWrapper::Constant(_) | TypeWrapper::Contract(..) => (),

--- a/src/types.rs
+++ b/src/types.rs
@@ -18,7 +18,7 @@
 //!
 //! The type systems feature structural records with row-polymorphism.
 //!
-//! ## Static records (row types)
+//! ## Records (row types)
 //!
 //! A row type for a record is a linked list of pairs `(id, type)` indicating the name and the type
 //! of each field. Row-polymorphism means that the tail of this list can be a type variable which
@@ -94,7 +94,7 @@ pub enum AbsType<Ty> {
     /// An enum type, wrapping a row type for enums.
     Enum(Ty /* Row */),
     /// A record type, wrapping a row type for records.
-    StaticRecord(Ty /* Row */),
+    Record(Ty /* Row */),
     /// A dictionary type.
     // Dict will only have a default type, this is simpler for now, I don't think we lose much
     Dict(Ty),
@@ -129,7 +129,7 @@ impl<Ty> AbsType<Ty> {
                 Ok(AbsType::RowExtend(id, t1_mapped, f(t2)?))
             }
             AbsType::Enum(t) => Ok(AbsType::Enum(f(t)?)),
-            AbsType::StaticRecord(t) => Ok(AbsType::StaticRecord(f(t)?)),
+            AbsType::Record(t) => Ok(AbsType::Record(f(t)?)),
             AbsType::Dict(t) => Ok(AbsType::Dict(f(t)?)),
             AbsType::Array(t) => Ok(AbsType::Array(f(t)?)),
             AbsType::Wildcard(i) => Ok(AbsType::Wildcard(i)),
@@ -347,7 +347,7 @@ impl Types {
 
                 mk_app!(contract::enums(), case)
             }
-            AbsType::StaticRecord(ref ty) => {
+            AbsType::Record(ref ty) => {
                 fn form(
                     sy: &mut i32,
                     pol: bool,
@@ -471,10 +471,10 @@ impl Types {
                 .traverse(f, state, order)
                 .map(Box::new)
                 .map(AbsType::Enum),
-            AbsType::StaticRecord(ty_inner) => (*ty_inner)
+            AbsType::Record(ty_inner) => (*ty_inner)
                 .traverse(f, state, order)
                 .map(Box::new)
-                .map(AbsType::StaticRecord),
+                .map(AbsType::Record),
             AbsType::Dict(ty_inner) => (*ty_inner)
                 .traverse(f, state, order)
                 .map(Box::new)
@@ -544,7 +544,7 @@ impl fmt::Display for Types {
                 write!(f, ". {}", curr)
             }
             AbsType::Enum(row) => write!(f, "[|{}|]", row),
-            AbsType::StaticRecord(row) => write!(f, "{{{}}}", row),
+            AbsType::Record(row) => write!(f, "{{{}}}", row),
             AbsType::Dict(ty) => write!(f, "{{_: {}}}", ty),
             AbsType::RowEmpty() => Ok(()),
             AbsType::RowExtend(id, ty_opt, tail) => {


### PR DESCRIPTION
This change has a similar rationale as #869: Currently, the name for record types is `StaticRecord`, and this can be a bit confusing, so renaming it to `Record` would be better. 