### PR TITLE
Fix bad lexing of enum tags

### DIFF
--- a/src/parser/grammar.lalrpop
+++ b/src/parser/grammar.lalrpop
@@ -506,23 +506,18 @@ ChunkExpr: StrChunk<RichTerm> = Interpolation <t: WithPos<Term>> "}" => StrChunk
 
 Interpolation = { "%{", "multstr %{" };
 
-StaticString: String = StringStart <s: ChunkLiteral?> StringEnd => s.unwrap_or_default();
+// A construct which looks like a string, but is generic over its delimiters.
+// Used to implement `StaticString` as well as `StringEnumTag`.
+DelimitedStaticString<Start, End>: String = Start <s: ChunkLiteral?> End => s.unwrap_or_default();
 
-EnumTag: Ident = "`" <EnumTagContent> => <>;
+StaticString = DelimitedStaticString<StringStart, StringEnd>;
 
-EnumTagContent: Ident = {
-    <Ident>,
-    <StaticString> => <>.into(),
-    // Allow tags of the form `Str, `Bool, etc. This is ad-hoc and should
-    // eventually be replaced with a proper lexing of enum tags, but this is not
-    // a trivial task. For now, to make builtin.typeof usable, we just
-    // special-case builtin types.
-    "Dyn" => "Dyn".into(),
-    "Num" => "Num".into(),
-    "Bool" => "Bool".into(),
-    "Str" => "Str".into(),
-    "Array" => "Array".into(),
-}
+StringEnumTag = DelimitedStaticString<"`\"", "\"">;
+
+EnumTag: Ident = {
+  "raw enum tag" => <>.into(),
+  <StringEnumTag> => <>.into(),
+};
 
 ChunkLiteralPart: ChunkLiteralPart<'input> = {
     "str literal" => ChunkLiteralPart::Str(<>),
@@ -565,7 +560,7 @@ UOp: UnaryOp = {
 };
 
 SwitchCase: SwitchCase = {
-    "`" <id: EnumTagContent> "=>" <t: Term> => SwitchCase::Normal(id, t),
+    <id: EnumTag> "=>" <t: Term> => SwitchCase::Normal(id, t),
     "_" "=>" <t: Term> => SwitchCase::Default(<>),
 }
 
@@ -809,6 +804,9 @@ extern {
         "multstr literal" => Token::MultiStr(MultiStringToken::Literal(<&'input str>)),
         "num literal" => Token::Normal(NormalToken::NumLiteral(<f64>)),
 
+        "raw enum tag" => Token::Normal(NormalToken::RawEnumTag(<&'input str>)),
+        "`\"" => Token::Normal(NormalToken::StrEnumTagBegin),
+
         "if" => Token::Normal(NormalToken::If),
         "then" => Token::Normal(NormalToken::Then),
         "else" => Token::Normal(NormalToken::Else),
@@ -853,7 +851,6 @@ extern {
         "|>" => Token::Normal(NormalToken::RightPipe),
         "->" => Token::Normal(NormalToken::SimpleArrow),
         "=>" => Token::Normal(NormalToken::DoubleArrow),
-        "`" => Token::Normal(NormalToken::Backtick),
         "_" => Token::Normal(NormalToken::Underscore),
         "\"" => Token::Normal(NormalToken::DoubleQuote),
         "\"%m" => Token::MultiStr(MultiStringToken::End),


### PR DESCRIPTION
Enum tag parsing previously disallowed tags whose names overlapped with language keywords (e.g. `` `if `` was rejected), while also allowing tags to have an arbitrary amount of space between the backtick and the identifier.

This commit fixes both of these issues by handling raw identifier tags and string tags in slightly different ways.

- For raw tags, the entire enum tag is now a single `RawEnumTag` token. This means that the identifier part can never be confused with a keyword during parsing, while also ensuring that there is no extra whitespace between the backtick and identifier.
- For string tags, we lex a `StringEnumTagBegin` token, which is just a backtick followed by a double quote. This puts the lexer into string mode, and we parse the remainder of the identifier as a regular static string.

Note that this means that multiline string enum tags are now rejected. Indeed we explicitly return a lexer error when we encounter a backtick followed by an attempt to open a multiline string, as without handling this case we create the possiblility for a term like `` `m%"test"%m`` to successfully parse, but with a result that is almost certainly not what the user intended.

Merging this will close #756.