### PR TITLE
Fix panic when parsing invalid use of row tails

### DIFF
--- a/src/parser/grammar.lalrpop
+++ b/src/parser/grammar.lalrpop
@@ -328,7 +328,7 @@ Atom: UniTerm = {
     Bool => UniTerm::from(Term::Bool(<>)),
     AsUniTerm<StrChunks>,
     Ident => UniTerm::from(UniTermNode::Var(<>)),
-    UniRecord => UniTerm::from(UniTermNode::Record(<>)),
+    WithPos<UniRecord> => UniTerm::from(UniTermNode::Record(<>)),
     <EnumTag> => UniTerm::from(Term::Enum(<>)),
     "[" <terms: (<Term> ",")*> <last: Term?> "]" => {
         let terms = terms

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -262,6 +262,20 @@ fn record_terms() {
     );
 }
 
+/// Regression test for [#876](https://github.com/tweag/nickel/issues/876)
+#[test]
+fn invalid_record_types() {
+    assert_matches!(
+        parse("let x | forall r. { n | Num; r } = {} in x"),
+        Err(ParseError::InvalidUniRecord(..))
+    );
+
+    assert_matches!(
+        parse("let x : forall r. { n = fun i => i; r } = {} in x"),
+        Err(ParseError::InvalidUniRecord(..))
+    );
+}
+
 #[test]
 fn string_lexing() {
     assert_eq!(


### PR DESCRIPTION
Previously Nickel would panic when parsing an expression such as:

```
let x | forall r. { k | Num; r } = {} in x
```

This was happening because the construction of the `InvalidUniRecord` error unwraps the `pos` field of the problematic `UniRecord`, but that field was never set in the parser.

This commit sets the `pos` of `UniRecord`s during parsing, thus preventing the panic.

Merging this will close #876.