### PR TITLE
Fix `ln -S` mistake in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ highlighting and NLS.
 1. *(optional)* make a symbolic link to the executable:
 
   ```console
-  ln -S nickel target/debug/nickel
+  ln --symbolic target/debug/nickel
   ```
 
 ### Tests


### PR DESCRIPTION
The option was `-S` (suffix) rather than `-s` (symbolic).

Also, switching to the explicit option name for clarity