### PR TITLE
[Refactor] Introduce `RecordBase` to share common fields between `Record` and `RecRecord` terms

### DIFF
--- a/lsp/nls/src/linearization/mod.rs
+++ b/lsp/nls/src/linearization/mod.rs
@@ -5,7 +5,7 @@ use log::debug;
 use nickel_lang::{
     identifier::Ident,
     position::TermPos,
-    term::{MetaValue, Term, UnaryOp},
+    term::{record::RecordData, MetaValue, Term, UnaryOp},
     typecheck::{
         linearization::{Linearization, Linearizer, Scope, ScopeId},
         reporting::{to_type, NameReg},
@@ -292,7 +292,7 @@ impl Linearizer for AnalysisHost {
                     }
                 }
             }
-            Term::Record(fields, _) | Term::RecRecord(fields, ..) => {
+            Term::Record(RecordData { fields, .. }) | Term::RecRecord(fields, ..) => {
                 lin.push(LinearizationItem {
                     id,
                     pos,

--- a/lsp/nls/src/linearization/mod.rs
+++ b/lsp/nls/src/linearization/mod.rs
@@ -5,7 +5,7 @@ use log::debug;
 use nickel_lang::{
     identifier::Ident,
     position::TermPos,
-    term::{record::RecordData, MetaValue, Term, UnaryOp},
+    term::{MetaValue, Term, UnaryOp},
     typecheck::{
         linearization::{Linearization, Linearizer, Scope, ScopeId},
         reporting::{to_type, NameReg},
@@ -292,7 +292,7 @@ impl Linearizer for AnalysisHost {
                     }
                 }
             }
-            Term::Record(RecordData { fields, .. }) | Term::RecRecord(fields, ..) => {
+            Term::Record(record) | Term::RecRecord(record, ..) => {
                 lin.push(LinearizationItem {
                     id,
                     pos,
@@ -302,8 +302,8 @@ impl Linearizer for AnalysisHost {
                     meta: self.meta.take(),
                 });
 
-                lin.register_fields(fields, id, self.scope.clone(), &mut self.env);
-                let mut field_names = fields.keys().cloned().collect::<Vec<_>>();
+                lin.register_fields(&record.fields, id, self.scope.clone(), &mut self.env);
+                let mut field_names = record.fields.keys().cloned().collect::<Vec<_>>();
                 field_names.sort_unstable();
 
                 self.record_fields =

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -578,11 +578,12 @@ impl Cache {
                                 CacheError::Error(ImportError::ParseErrors(err.into(), pos))
                             })?;
                         }
-                        Term::RecRecord(ref mut map, ref mut dyn_fields, ..) => {
-                            let map_res: Result<_, UnboundTypeVariableError> = std::mem::take(map)
-                                .into_iter()
-                                .map(|(id, t)| Ok((id, transform::transform(t, wildcards)?)))
-                                .collect();
+                        Term::RecRecord(ref mut record, ref mut dyn_fields, ..) => {
+                            let map_res: Result<_, UnboundTypeVariableError> =
+                                std::mem::take(&mut record.fields)
+                                    .into_iter()
+                                    .map(|(id, t)| Ok((id, transform::transform(t, wildcards)?)))
+                                    .collect();
 
                             let dyn_fields_res: Result<_, UnboundTypeVariableError> =
                                 std::mem::take(dyn_fields)
@@ -595,7 +596,7 @@ impl Cache {
                                     })
                                     .collect();
 
-                            *map = map_res.map_err(|err| {
+                            record.fields = map_res.map_err(|err| {
                                 CacheError::Error(ImportError::ParseErrors(err.into(), pos))
                             })?;
                             *dyn_fields = dyn_fields_res.map_err(|err| {

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -4,6 +4,7 @@ use crate::error::{Error, ImportError, ParseError, ParseErrors, TypecheckError};
 use crate::parser::lexer::Lexer;
 use crate::position::TermPos;
 use crate::stdlib as nickel_stdlib;
+use crate::term::record::RecordData;
 use crate::term::{RichTerm, SharedTerm, Term};
 use crate::transform::import_resolution;
 use crate::typecheck::type_check;
@@ -567,12 +568,13 @@ impl Cache {
                     let pos = term.pos;
 
                     match SharedTerm::make_mut(&mut term.term) {
-                        Term::Record(ref mut map, _) => {
-                            let map_res: Result<_, UnboundTypeVariableError> = std::mem::take(map)
-                                .into_iter()
-                                .map(|(id, t)| Ok((id, transform::transform(t, wildcards)?)))
-                                .collect();
-                            *map = map_res.map_err(|err| {
+                        Term::Record(RecordData { ref mut fields, .. }) => {
+                            let map_res: Result<_, UnboundTypeVariableError> =
+                                std::mem::take(fields)
+                                    .into_iter()
+                                    .map(|(id, t)| Ok((id, transform::transform(t, wildcards)?)))
+                                    .collect();
+                            *fields = map_res.map_err(|err| {
                                 CacheError::Error(ImportError::ParseErrors(err.into(), pos))
                             })?;
                         }

--- a/src/deserialize.rs
+++ b/src/deserialize.rs
@@ -75,7 +75,7 @@ impl<'de> serde::Deserializer<'de> for RichTerm {
                 variant: v.into_label(),
                 rich_term: None,
             }),
-            Term::Record(v, _) => visit_record(v, visitor),
+            Term::Record(record) => visit_record(record.fields, visitor),
             Term::Array(v, _) => visit_array(v, visitor),
             Term::MetaValue(_) => visitor.visit_unit(),
             other => Err(RustDeserializationError::UnimplementedType {
@@ -120,8 +120,8 @@ impl<'de> serde::Deserializer<'de> for RichTerm {
     {
         let (variant, rich_term) = match unwrap_term(self)? {
             Term::Enum(ident) => (ident.into_label(), None),
-            Term::Record(v, _) => {
-                let mut iter = v.into_iter();
+            Term::Record(record) => {
+                let mut iter = record.fields.into_iter();
                 let (variant, value) = match iter.next() {
                     Some(v) => v,
                     None => {
@@ -296,7 +296,7 @@ impl<'de> serde::Deserializer<'de> for RichTerm {
         V: Visitor<'de>,
     {
         match unwrap_term(self)? {
-            Term::Record(v, _) => visit_record(v, visitor),
+            Term::Record(record) => visit_record(record.fields, visitor),
             other => Err(RustDeserializationError::InvalidType {
                 expected: "Record".to_string(),
                 occurred: other.type_of().unwrap_or_else(|| "Other".to_string()),
@@ -316,7 +316,7 @@ impl<'de> serde::Deserializer<'de> for RichTerm {
     {
         match unwrap_term(self)? {
             Term::Array(v, _) => visit_array(v, visitor),
-            Term::Record(v, _) => visit_record(v, visitor),
+            Term::Record(record) => visit_record(record.fields, visitor),
             other => Err(RustDeserializationError::InvalidType {
                 expected: "Record".to_string(),
                 occurred: other.type_of().unwrap_or_else(|| "Other".to_string()),
@@ -524,7 +524,7 @@ impl<'de> VariantAccess<'de> for VariantDeserializer {
         V: Visitor<'de>,
     {
         match self.rich_term.map(unwrap_term) {
-            Some(Ok(Term::Record(v, _))) => visit_record(v, visitor),
+            Some(Ok(Term::Record(record))) => visit_record(record.fields, visitor),
             Some(Ok(other)) => Err(RustDeserializationError::InvalidType {
                 expected: "Array variant".to_string(),
                 occurred: other.type_of().unwrap_or_else(|| "Other".to_string()),

--- a/src/destruct.rs
+++ b/src/destruct.rs
@@ -61,14 +61,13 @@ impl Destruct {
         MetaValue {
             contracts: vec![Contract {
                 types: Types(AbsType::Flat(
-                    Term::Record(RecordData {
-                        fields: self
-                            .inner()
+                    Term::Record(RecordData::new(
+                        self.inner()
                             .into_iter()
                             .map(|m| m.as_meta_field())
                             .collect(),
-                        attrs: RecordAttrs { open },
-                    })
+                        RecordAttrs { open },
+                    ))
                     .into(),
                 )),
                 label,

--- a/src/destruct.rs
+++ b/src/destruct.rs
@@ -4,6 +4,7 @@
 use crate::identifier::Ident;
 use crate::label::Label;
 use crate::position::RawSpan;
+use crate::term::record::RecordData;
 use crate::term::{Contract, MetaValue, RecordAttrs, RichTerm, Term};
 use crate::types::{AbsType, Types};
 
@@ -60,13 +61,14 @@ impl Destruct {
         MetaValue {
             contracts: vec![Contract {
                 types: Types(AbsType::Flat(
-                    Term::Record(
-                        self.inner()
+                    Term::Record(RecordData {
+                        fields: self
+                            .inner()
                             .into_iter()
                             .map(|m| m.as_meta_field())
                             .collect(),
-                        RecordAttrs { open },
-                    )
+                        attrs: RecordAttrs { open },
+                    })
                     .into(),
                 )),
                 label,

--- a/src/eval/merge.rs
+++ b/src/eval/merge.rs
@@ -432,10 +432,7 @@ pub fn merge(
 
             Ok(Closure {
                 body: RichTerm::new(
-                    Term::Record(RecordData {
-                        fields: m,
-                        attrs: RecordAttrs::merge(attrs1, attrs2),
-                    }),
+                    Term::Record(RecordData::new(m, RecordAttrs::merge(attrs1, attrs2))),
                     final_pos,
                 ),
                 env,

--- a/src/eval/merge.rs
+++ b/src/eval/merge.rs
@@ -362,9 +362,7 @@ pub fn merge(
         }
         // Merge put together the fields of records, and recursively merge
         // fields that are present in both terms
-        (Term::Record(r1), Term::Record(r2)) => {
-            let mut m1 = r1.fields;
-            let mut m2 = r2.fields;
+        (Term::Record(mut r1), Term::Record(mut r2)) => {
             /* Terms inside m1 and m2 may capture variables of resp. env1 and env2.  Morally, we
              * need to store closures, or a merge of closures, inside the resulting record.  We use
              * the same trick as in the evaluation of the operator DynExtend, and replace each such
@@ -373,22 +371,19 @@ pub fn merge(
             // Merging recursive record is the one operation that may override recursive fields. To
             // have the recursive fields depend on the updated values, we need to revert the thunks
             // first.
-            rev_thunks(m1.values_mut(), &mut env1);
-            rev_thunks(m2.values_mut(), &mut env2);
+            rev_thunks(r1.fields.values_mut(), &mut env1);
+            rev_thunks(r2.fields.values_mut(), &mut env2);
 
             // We save the original fields before they are potentially merged in order to patch
             // their environment in the final record (cf `fixpoint::patch_fields`). Note that we
             // are only cloning shared terms (`Rc`s) here.
-            let m1_values: Vec<_> = m1.values().cloned().collect();
-            let m2_values: Vec<_> = m2.values().cloned().collect();
+            let m1_values: Vec<_> = r1.fields.values().cloned().collect();
+            let m2_values: Vec<_> = r2.fields.values().cloned().collect();
 
-            let (left, center, right) = hashmap::split(m1, m2);
-
-            let attrs1 = r1.attrs;
-            let attrs2 = r2.attrs;
+            let (left, center, right) = hashmap::split(r1.fields, r2.fields);
 
             match mode {
-                MergeMode::Contract(mut lbl) if !attrs2.open && !left.is_empty() => {
+                MergeMode::Contract(mut lbl) if !r2.attrs.open && !left.is_empty() => {
                     let fields: Vec<String> =
                         left.keys().map(|field| format!("`{}`", field)).collect();
                     let plural = if fields.len() == 1 { "" } else { "s" };
@@ -432,7 +427,7 @@ pub fn merge(
 
             Ok(Closure {
                 body: RichTerm::new(
-                    Term::Record(RecordData::new(m, RecordAttrs::merge(attrs1, attrs2))),
+                    Term::Record(RecordData::new(m, RecordAttrs::merge(r1.attrs, r2.attrs))),
                     final_pos,
                 ),
                 env,

--- a/src/eval/mod.rs
+++ b/src/eval/mod.rs
@@ -399,10 +399,7 @@ impl<R: ImportResolver> VirtualMachine<R> {
                     self.stack.push_arg(
                         Closure {
                             body: RichTerm::new(
-                                Term::Record(RecordData {
-                                    fields: cases.clone(),
-                                    attrs: Default::default(),
-                                }),
+                                Term::Record(RecordData::with_fields(cases.clone())),
                                 pos,
                             ),
                             env: env.clone(),

--- a/src/eval/mod.rs
+++ b/src/eval/mod.rs
@@ -844,28 +844,12 @@ pub fn subst(rt: RichTerm, initial_env: &Environment, env: &Environment) -> Rich
             RichTerm::new(Term::Sealed(i, t, lbl), pos)
         }
         Term::Record(record) => {
-            let fields = record.fields
-                .into_iter()
-                .map(|(id, t)| {
-                    (
-                        id,
-                        subst(t, initial_env, env),
-                    )
-                })
-                .collect();
+            let record = record.map_fields(|_, t| subst(t, initial_env, env));
 
-            RichTerm::new(Term::Record(RecordData { fields, attrs: record.attrs }), pos)
+            RichTerm::new(Term::Record(record), pos)
         }
         Term::RecRecord(record, dyn_fields, deps) => {
-            let fields = record.fields
-                .into_iter()
-                .map(|(id, t)| {
-                    (
-                        id,
-                        subst(t, initial_env, env),
-                    )
-                })
-                .collect();
+            let record = record.map_fields(|_, t| subst(t, initial_env, env));
 
             let dyn_fields = dyn_fields
                 .into_iter()
@@ -877,7 +861,7 @@ pub fn subst(rt: RichTerm, initial_env: &Environment, env: &Environment) -> Rich
                 })
                 .collect();
 
-            RichTerm::new(Term::RecRecord(RecordData { fields, attrs: record.attrs }, dyn_fields, deps), pos)
+            RichTerm::new(Term::RecRecord(record, dyn_fields, deps), pos)
         }
         Term::Array(ts, attrs) => {
             let ts = ts

--- a/src/eval/operation.rs
+++ b/src/eval/operation.rs
@@ -1896,7 +1896,7 @@ impl<R: ImportResolver> VirtualMachine<R> {
                                 match fields.insert(Ident::from(id), as_var) {
                                     Some(t) if !is_empty_optional(&t, &env2) => Err(EvalError::Other(format!("$[ .. ]: tried to extend record with the field {}, but it already exists", id), pos_op)),
                                     _ => Ok(Closure {
-                                        body: Term::Record(RecordData { fields, attrs: record.attrs }).into(),
+                                        body: Term::Record(RecordData::new(fields, record.attrs)).into(),
                                         env: env2,
                                     }),
                                 }
@@ -1936,7 +1936,7 @@ impl<R: ImportResolver> VirtualMachine<R> {
                                         id,
                                         String::from("(-$)"),
                                         RichTerm::new(
-                                            Term::Record(RecordData { fields, attrs: record.attrs }),
+                                            Term::Record(RecordData::new(fields, record.attrs)),
                                             pos2,
                                         ),
                                         pos_op,
@@ -1945,7 +1945,7 @@ impl<R: ImportResolver> VirtualMachine<R> {
                                 else {
                                     Ok(Closure {
                                         body: RichTerm::new(
-                                            Term::Record(RecordData { fields, attrs: record.attrs }), pos_op_inh
+                                            Term::Record(RecordData::new(fields, record.attrs)), pos_op_inh
                                         ),
                                         env: env2,
                                     })

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -212,16 +212,16 @@ fn record_terms() {
     assert_eq!(
         parse_without_pos("{ a = 1, b = 2, c = 3}"),
         RecRecord(
-            record::RecordData {
-                fields: vec![
+            record::RecordData::new(
+                vec![
                     (Ident::from("a"), Num(1.).into()),
                     (Ident::from("b"), Num(2.).into()),
                     (Ident::from("c"), Num(3.).into()),
                 ]
                 .into_iter()
                 .collect(),
-                attrs: Default::default(),
-            },
+                Default::default(),
+            ),
             Vec::new(),
             None,
         )
@@ -231,15 +231,15 @@ fn record_terms() {
     assert_eq!(
         parse_without_pos("{ a = 1, \"%{123}\" = (if 4 then 5 else 6), d = 42}"),
         RecRecord(
-            record::RecordData {
-                fields: vec![
+            record::RecordData::new(
+                vec![
                     (Ident::from("a"), Num(1.).into()),
                     (Ident::from("d"), Num(42.).into()),
                 ]
                 .into_iter()
                 .collect(),
-                attrs: Default::default(),
-            },
+                Default::default(),
+            ),
             vec![(
                 StrChunks(vec![StrChunk::expr(RichTerm::from(Num(123.)))]).into(),
                 mk_app!(mk_term::op1(UnaryOp::Ite(), Num(4.)), Num(5.), Num(6.))
@@ -252,15 +252,15 @@ fn record_terms() {
     assert_eq!(
         parse_without_pos("{ a = 1, \"\\\"%}%\" = 2}"),
         RecRecord(
-            record::RecordData {
-                fields: vec![
+            record::RecordData::new(
+                vec![
                     (Ident::from("a"), Num(1.).into()),
                     (Ident::from("\"%}%"), Num(2.).into()),
                 ]
                 .into_iter()
                 .collect(),
-                attrs: Default::default(),
-            },
+                Default::default(),
+            ),
             Vec::new(),
             None,
         )

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -4,7 +4,7 @@ use crate::identifier::Ident;
 use crate::parser::error::ParseError as InternalParseError;
 use crate::term::make as mk_term;
 use crate::term::Term::*;
-use crate::term::{BinaryOp, RichTerm, StrChunk, UnaryOp};
+use crate::term::{record, BinaryOp, RichTerm, StrChunk, UnaryOp};
 use crate::{mk_app, mk_switch};
 use assert_matches::assert_matches;
 use codespan::Files;
@@ -212,15 +212,17 @@ fn record_terms() {
     assert_eq!(
         parse_without_pos("{ a = 1, b = 2, c = 3}"),
         RecRecord(
-            vec![
-                (Ident::from("a"), Num(1.).into()),
-                (Ident::from("b"), Num(2.).into()),
-                (Ident::from("c"), Num(3.).into()),
-            ]
-            .into_iter()
-            .collect(),
+            record::RecordData {
+                fields: vec![
+                    (Ident::from("a"), Num(1.).into()),
+                    (Ident::from("b"), Num(2.).into()),
+                    (Ident::from("c"), Num(3.).into()),
+                ]
+                .into_iter()
+                .collect(),
+                attrs: Default::default(),
+            },
             Vec::new(),
-            Default::default(),
             None,
         )
         .into()
@@ -229,17 +231,19 @@ fn record_terms() {
     assert_eq!(
         parse_without_pos("{ a = 1, \"%{123}\" = (if 4 then 5 else 6), d = 42}"),
         RecRecord(
-            vec![
-                (Ident::from("a"), Num(1.).into()),
-                (Ident::from("d"), Num(42.).into()),
-            ]
-            .into_iter()
-            .collect(),
+            record::RecordData {
+                fields: vec![
+                    (Ident::from("a"), Num(1.).into()),
+                    (Ident::from("d"), Num(42.).into()),
+                ]
+                .into_iter()
+                .collect(),
+                attrs: Default::default(),
+            },
             vec![(
                 StrChunks(vec![StrChunk::expr(RichTerm::from(Num(123.)))]).into(),
                 mk_app!(mk_term::op1(UnaryOp::Ite(), Num(4.)), Num(5.), Num(6.))
             )],
-            Default::default(),
             None,
         )
         .into()
@@ -248,14 +252,16 @@ fn record_terms() {
     assert_eq!(
         parse_without_pos("{ a = 1, \"\\\"%}%\" = 2}"),
         RecRecord(
-            vec![
-                (Ident::from("a"), Num(1.).into()),
-                (Ident::from("\"%}%"), Num(2.).into()),
-            ]
-            .into_iter()
-            .collect(),
+            record::RecordData {
+                fields: vec![
+                    (Ident::from("a"), Num(1.).into()),
+                    (Ident::from("\"%}%"), Num(2.).into()),
+                ]
+                .into_iter()
+                .collect(),
+                attrs: Default::default(),
+            },
             Vec::new(),
-            Default::default(),
             None,
         )
         .into()

--- a/src/parser/utils.rs
+++ b/src/parser/utils.rs
@@ -255,11 +255,7 @@ pub fn elaborate_field_path(
         FieldPathElem::Ident(id) => {
             let mut fields = HashMap::new();
             fields.insert(id, acc);
-            Term::Record(RecordData {
-                fields,
-                attrs: Default::default(),
-            })
-            .into()
+            Term::Record(RecordData::with_fields(fields)).into()
         }
         FieldPathElem::Expr(exp) => {
             let static_access = match exp.term.as_ref() {
@@ -281,11 +277,7 @@ pub fn elaborate_field_path(
                 let id = Ident::new_with_pos(static_access, exp.pos);
                 let mut fields = HashMap::new();
                 fields.insert(id, acc);
-                Term::Record(RecordData {
-                    fields,
-                    attrs: Default::default(),
-                })
-                .into()
+                Term::Record(RecordData::with_fields(fields)).into()
             } else {
                 let empty = Term::Record(RecordData {
                     fields: HashMap::new(),

--- a/src/parser/utils.rs
+++ b/src/parser/utils.rs
@@ -361,14 +361,7 @@ where
         }
     });
 
-    Term::RecRecord(
-        RecordData {
-            fields: static_fields,
-            attrs,
-        },
-        dynamic_fields,
-        None,
-    )
+    Term::RecRecord(RecordData::new(static_fields, attrs), dynamic_fields, None)
 }
 
 /// Merge two fields by performing the merge of both their value and MetaValue if any.

--- a/src/pretty.rs
+++ b/src/pretty.rs
@@ -470,10 +470,10 @@ where
             },
             Var(id) => allocator.as_string(id),
             Enum(id) => allocator.text("`").append(allocator.quote_if_needed(id)),
-            Record(fields, attr) => allocator
+            Record(record) => allocator
                 .line()
                 .append(allocator.intersperse(
-                    sorted_map(fields).iter().map(|&(id, rt)| {
+                    sorted_map(&record.fields).iter().map(|&(id, rt)| {
                         allocator
                             .quote_if_needed(id)
                             .append(allocator.space())
@@ -502,7 +502,7 @@ where
                     }),
                     allocator.line(),
                 ))
-                .append(if attr.open {
+                .append(if record.attrs.open {
                     allocator.line().append(allocator.text(".."))
                 } else {
                     allocator.nil()

--- a/src/pretty.rs
+++ b/src/pretty.rs
@@ -512,15 +512,14 @@ where
                 .group()
                 .braces(),
             RecRecord(
-                fields,
+                record,
                 dyn_fields, /* field whose name is defined by interpolation */
-                attr,
-                _deps, /* dependency tracking between fields. None before the free var pass */
+                _deps,      /* dependency tracking between fields. None before the free var pass */
             ) => allocator
                 .line()
                 .append(
                     allocator.intersperse(
-                        sorted_map(fields)
+                        sorted_map(&record.fields)
                             .iter()
                             .map(|&(id, rt)| {
                                 allocator
@@ -579,7 +578,7 @@ where
                         allocator.line(),
                     ),
                 )
-                .append(if attr.open {
+                .append(if record.attrs.open {
                     allocator.line().append(allocator.text(".."))
                 } else {
                     allocator.nil()

--- a/src/program.rs
+++ b/src/program.rs
@@ -256,6 +256,7 @@ where
 mod doc {
     use crate::cache::Cache;
     use crate::error::{Error, IOError};
+    use crate::term::record::RecordData;
     use crate::term::{MetaValue, RichTerm, Term};
     use codespan::FileId;
     use comrak::arena_tree::NodeEdge;
@@ -300,9 +301,9 @@ mod doc {
             Term::MetaValue(MetaValue { doc: Some(md), .. }) => {
                 document.append(parse_documentation(header_level, arena, md, options))
             }
-            Term::Record(map, _) | Term::RecRecord(map, _, _, _) => {
+            Term::Record(RecordData { fields, .. }) | Term::RecRecord(fields, _, _, _) => {
                 // Sorting fields for a determinstic output
-                let mut entries: Vec<(_, _)> = map.iter().collect();
+                let mut entries: Vec<(_, _)> = fields.iter().collect();
                 entries.sort_by_key(|(k, _)| *k);
 
                 for (ident, rt) in entries {

--- a/src/program.rs
+++ b/src/program.rs
@@ -256,7 +256,6 @@ where
 mod doc {
     use crate::cache::Cache;
     use crate::error::{Error, IOError};
-    use crate::term::record::RecordData;
     use crate::term::{MetaValue, RichTerm, Term};
     use codespan::FileId;
     use comrak::arena_tree::NodeEdge;
@@ -301,9 +300,9 @@ mod doc {
             Term::MetaValue(MetaValue { doc: Some(md), .. }) => {
                 document.append(parse_documentation(header_level, arena, md, options))
             }
-            Term::Record(RecordData { fields, .. }) | Term::RecRecord(fields, _, _, _) => {
+            Term::Record(record) | Term::RecRecord(record, _, _) => {
                 // Sorting fields for a determinstic output
-                let mut entries: Vec<(_, _)> = fields.iter().collect();
+                let mut entries: Vec<(_, _)> = record.fields.iter().collect();
                 entries.sort_by_key(|(k, _)| *k);
 
                 for (ident, rt) in entries {

--- a/src/repl/query_print.rs
+++ b/src/repl/query_print.rs
@@ -191,8 +191,8 @@ fn write_query_result_<R: QueryPrinter>(
     ) -> io::Result<()> {
         writeln!(out)?;
         match t {
-            Term::Record(map, _) if !map.is_empty() => {
-                let mut fields: Vec<_> = map.keys().collect();
+            Term::Record(record) if !record.fields.is_empty() => {
+                let mut fields: Vec<_> = record.fields.keys().collect();
                 fields.sort();
                 renderer.write_fields(out, fields.into_iter())
             }

--- a/src/repl/query_print.rs
+++ b/src/repl/query_print.rs
@@ -196,8 +196,8 @@ fn write_query_result_<R: QueryPrinter>(
                 fields.sort();
                 renderer.write_fields(out, fields.into_iter())
             }
-            Term::RecRecord(map, dyn_fields, ..) if !map.is_empty() => {
-                let mut fields: Vec<_> = map.keys().collect();
+            Term::RecRecord(record, dyn_fields, ..) if !record.fields.is_empty() => {
+                let mut fields: Vec<_> = record.fields.keys().collect();
                 fields.sort();
                 let dynamic = Ident::from("<dynamic>");
                 fields.extend(dyn_fields.iter().map(|_| &dynamic));

--- a/src/repl/rustyline_frontend.rs
+++ b/src/repl/rustyline_frontend.rs
@@ -53,8 +53,8 @@ pub fn repl(histfile: PathBuf) -> Result<(), InitError> {
                 let cmd = line.chars().skip(1).collect::<String>().parse::<Command>();
                 let result = match cmd {
                     Ok(Command::Load(path)) => repl.load(&path).map(|term| match term.as_ref() {
-                        Term::Record(map, _) => {
-                             println!("Loaded {} symbol(s) in the environment.", map.len())
+                        Term::Record(record) => {
+                             println!("Loaded {} symbol(s) in the environment.", record.fields.len())
                         }
                         Term::RecRecord(map, dyn_fields, ..) => {
                             if !dyn_fields.is_empty() {

--- a/src/repl/rustyline_frontend.rs
+++ b/src/repl/rustyline_frontend.rs
@@ -56,12 +56,12 @@ pub fn repl(histfile: PathBuf) -> Result<(), InitError> {
                         Term::Record(record) => {
                              println!("Loaded {} symbol(s) in the environment.", record.fields.len())
                         }
-                        Term::RecRecord(map, dyn_fields, ..) => {
+                        Term::RecRecord(record, dyn_fields, ..) => {
                             if !dyn_fields.is_empty() {
                                 println!("Warning: loading dynamic fields is currently not supported. {} symbols ignored", dyn_fields.len());
                             }
 
-                            println!("Loaded {} symbol(s) in the environment.", map.len())
+                            println!("Loaded {} symbol(s) in the environment.", record.fields.len())
                         }
                         _ => (),
                     }),

--- a/src/serialize.rs
+++ b/src/serialize.rs
@@ -123,10 +123,7 @@ where
     D: Deserializer<'de>,
 {
     let fields = HashMap::deserialize(deserializer)?;
-    Ok(RecordData {
-        fields,
-        attrs: Default::default(),
-    })
+    Ok(RecordData::with_fields(fields))
 }
 
 /// Serialize for an Array. Required to hide the internal attributes.

--- a/src/serialize.rs
+++ b/src/serialize.rs
@@ -2,8 +2,7 @@
 use crate::{
     error::SerializationError,
     eval::{self, is_empty_optional},
-    identifier::Ident,
-    term::{array::Array, ArrayAttrs, MetaValue, RecordAttrs, RichTerm, Term},
+    term::{array::Array, record::RecordData, ArrayAttrs, MetaValue, RichTerm, Term},
 };
 
 use serde::{
@@ -97,15 +96,12 @@ where
 
 /// Serializer for a record. Serialize fields in alphabetical order to get a deterministic output
 /// (by default, `HashMap`'s randomness implies a randomized order of fields in the output).
-pub fn serialize_record<S>(
-    map: &HashMap<Ident, RichTerm>,
-    _attrs: &RecordAttrs,
-    serializer: S,
-) -> Result<S::Ok, S::Error>
+pub fn serialize_record<S>(record: &RecordData, serializer: S) -> Result<S::Ok, S::Error>
 where
     S: Serializer,
 {
-    let mut entries: Vec<(_, _)> = map
+    let mut entries: Vec<(_, _)> = record
+        .fields
         .iter()
         // Filtering out optional fields without a definition. All variable should have been
         // substituted at this point, so we pass an empty environment.
@@ -122,14 +118,15 @@ where
 }
 
 /// Deserialize for a record. Required to set the record attributes to default.
-pub fn deserialize_record<'de, D>(
-    deserializer: D,
-) -> Result<(HashMap<Ident, RichTerm>, RecordAttrs), D::Error>
+pub fn deserialize_record<'de, D>(deserializer: D) -> Result<RecordData, D::Error>
 where
     D: Deserializer<'de>,
 {
-    let map: HashMap<Ident, RichTerm> = HashMap::deserialize(deserializer)?;
-    Ok((map, Default::default()))
+    let fields = HashMap::deserialize(deserializer)?;
+    Ok(RecordData {
+        fields,
+        attrs: Default::default(),
+    })
 }
 
 /// Serialize for an Array. Required to hide the internal attributes.
@@ -196,8 +193,11 @@ pub fn validate(format: ExportFormat, t: &RichTerm) -> Result<(), SerializationE
             Null if format == ExportFormat::Json || format == ExportFormat::Yaml => Ok(()),
             Null => Err(SerializationError::UnsupportedNull(format, t.clone())),
             Bool(_) | Num(_) | Str(_) | Enum(_) => Ok(()),
-            Record(map, _) => {
-                map.iter().try_for_each(|(_, t)| validate(format, t))?;
+            Record(record) => {
+                record
+                    .fields
+                    .iter()
+                    .try_for_each(|(_, t)| validate(format, t))?;
                 Ok(())
             }
             Array(array, _) => {

--- a/src/term.rs
+++ b/src/term.rs
@@ -460,23 +460,10 @@ pub mod record {
         where
             F: FnMut(Ident, RichTerm) -> RichTerm,
         {
-            self.filter_map_fields(|id, t| Some(f(id, t)))
-        }
-
-        /// Returns the record resulting from applying the provided function
-        /// to each field, and removing any field for which the function returns
-        /// None.
-        ///
-        /// Note that `f` is taken as `mut` in order to allow it to mutate
-        /// external state while iterating.
-        pub fn filter_map_fields<F>(self, mut f: F) -> Self
-        where
-            F: FnMut(Ident, RichTerm) -> Option<RichTerm>,
-        {
             let fields = self
                 .fields
                 .into_iter()
-                .filter_map(|(id, t)| f(id, t).map(|t| (id, t)))
+                .map(|(id, t)| (id, f(id, t)))
                 .collect();
             RecordData { fields, ..self }
         }

--- a/src/term.rs
+++ b/src/term.rs
@@ -417,6 +417,18 @@ impl ArrayAttrs {
     }
 }
 
+pub mod record {
+    use super::{RecordAttrs, RichTerm};
+    use crate::identifier::Ident;
+    use std::collections::HashMap;
+
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct RecordData {
+        pub fields: HashMap<Ident, RichTerm>,
+        pub attrs: RecordAttrs,
+    }
+}
+
 #[derive(Debug, Default, Eq, PartialEq, Copy, Clone)]
 pub struct RecordAttrs {
     pub open: bool,

--- a/src/term.rs
+++ b/src/term.rs
@@ -434,6 +434,14 @@ pub mod record {
         pub fields: HashMap<Ident, RichTerm>,
         pub attrs: RecordAttrs,
     }
+
+    impl RecordData {
+        /// A record with the provided fields & the default set of attributes.
+        pub fn with_fields(fields: HashMap<Ident, RichTerm>) -> Self {
+            let attrs = Default::default();
+            RecordData { fields, attrs }
+        }
+    }
 }
 
 #[derive(Debug, Default, Eq, PartialEq, Copy, Clone)]

--- a/src/transform/free_vars.rs
+++ b/src/transform/free_vars.rs
@@ -100,8 +100,8 @@ fn collect_free_vars(rt: &mut RichTerm, free_vars: &mut HashSet<Ident>) {
             }
         }
         Term::Sealed(_, t, _) => collect_free_vars(t, free_vars),
-        Term::Record(map, _) => {
-            for t in map.values_mut() {
+        Term::Record(record) => {
+            for t in record.fields.values_mut() {
                 collect_free_vars(t, free_vars);
             }
         }

--- a/src/transform/free_vars.rs
+++ b/src/transform/free_vars.rs
@@ -105,15 +105,15 @@ fn collect_free_vars(rt: &mut RichTerm, free_vars: &mut HashSet<Ident>) {
                 collect_free_vars(t, free_vars);
             }
         }
-        Term::RecRecord(map, dyn_fields, _, deps) => {
-            let rec_fields: HashSet<Ident> = map.keys().cloned().collect();
+        Term::RecRecord(record, dyn_fields, deps) => {
+            let rec_fields: HashSet<Ident> = record.fields.keys().cloned().collect();
             let mut fresh = HashSet::new();
             let mut new_deps = RecordDeps {
-                stat_fields: HashMap::with_capacity(map.len()),
+                stat_fields: HashMap::with_capacity(record.fields.len()),
                 dyn_fields: Vec::with_capacity(dyn_fields.len()),
             };
 
-            for (id, t) in map.iter_mut() {
+            for (id, t) in record.fields.iter_mut() {
                 fresh.clear();
 
                 collect_free_vars(t, &mut fresh);

--- a/src/transform/share_normal_form.rs
+++ b/src/transform/share_normal_form.rs
@@ -31,7 +31,7 @@ use crate::{
     identifier::Ident,
     match_sharedterm,
     position::TermPos,
-    term::{BindingType, LetAttrs, RichTerm, Term},
+    term::{record::RecordData, BindingType, LetAttrs, RichTerm, Term},
 };
 
 use std::{collections::HashSet, rc::Rc};
@@ -48,10 +48,10 @@ pub fn transform_one(rt: RichTerm) -> RichTerm {
     let pos = rt.pos;
     match_sharedterm! {rt.term,
         with {
-            Term::Record(map, attrs) => {
-                let mut bindings = Vec::with_capacity(map.len());
+            Term::Record(RecordData { fields, attrs }) => {
+                let mut bindings = Vec::with_capacity(fields.len());
 
-                let map = map
+                let fields = fields
                     .into_iter()
                     .map(|(id, t)| {
                         if should_share(&t.term) {
@@ -65,7 +65,7 @@ pub fn transform_one(rt: RichTerm) -> RichTerm {
                     })
                     .collect();
 
-                with_bindings(Term::Record(map, attrs), bindings, pos)
+                with_bindings(Term::Record(RecordData { fields, attrs }), bindings, pos)
             },
             Term::RecRecord(map, dyn_fields, attrs, deps) => {
                 // When a recursive record is evaluated, all fields need to be turned to closures

--- a/src/transform/share_normal_form.rs
+++ b/src/transform/share_normal_form.rs
@@ -67,7 +67,7 @@ pub fn transform_one(rt: RichTerm) -> RichTerm {
 
                 with_bindings(Term::Record(RecordData { fields, attrs }), bindings, pos)
             },
-            Term::RecRecord(map, dyn_fields, attrs, deps) => {
+            Term::RecRecord(record, dyn_fields, deps) => {
                 // When a recursive record is evaluated, all fields need to be turned to closures
                 // anyway (see the corresponding case in `eval::eval()`), which is what the share
                 // normal form transformation does. This is why the test is more lax here than for
@@ -82,7 +82,7 @@ pub fn transform_one(rt: RichTerm) -> RichTerm {
                 // fields of recursive records contain either a constant or a *generated* variable,
                 // but never a user-supplied variable directly (the former starts with a special
                 // marker). See comments inside [`crate::RichTerm::closurize`] for more details.
-                let mut bindings = Vec::with_capacity(map.len());
+                let mut bindings = Vec::with_capacity(record.fields.len());
 
                 fn mk_binding_type(field_deps: Option<HashSet<Ident>>) -> BindingType {
                     // If the fields has an empty set of dependencies, we can eschew the
@@ -99,7 +99,7 @@ pub fn transform_one(rt: RichTerm) -> RichTerm {
                     }
                 }
 
-                let map = map
+                let static_fields = record.fields
                     .into_iter()
                     .map(|(id, t)| {
                         // CHANGE THIS CONDITION CAREFULLY. Doing so can break the post-condition
@@ -136,7 +136,7 @@ pub fn transform_one(rt: RichTerm) -> RichTerm {
                     })
                     .collect();
 
-                with_bindings(Term::RecRecord(map, dyn_fields, attrs, deps), bindings, pos)
+                with_bindings(Term::RecRecord(RecordData { fields: static_fields, attrs: record.attrs }, dyn_fields, deps), bindings, pos)
             },
             Term::Array(ts, attrs) => {
                 let mut bindings = Vec::with_capacity(ts.len());

--- a/src/typecheck/eq.rs
+++ b/src/typecheck/eq.rs
@@ -268,8 +268,15 @@ fn contract_eq_bounded<E: TermEnvironment>(
                         .unwrap_or(false)
                 })
         }
-        (Record(m1, attrs1), Record(m2, attrs2)) => {
-            map_eq(contract_eq_bounded, state, m1, env1, m2, env2) && attrs1 == attrs2
+        (Record(r1), Record(r2)) => {
+            map_eq(
+                contract_eq_bounded,
+                state,
+                &r1.fields,
+                env1,
+                &r2.fields,
+                env2,
+            ) && r1.attrs == r2.attrs
         }
         (RecRecord(m1, dyn_fields1, attrs1, _), RecRecord(m2, dyn_fields2, attrs2, _)) =>
         // We only compare records whose field structure is statically known (i.e. without dynamic

--- a/src/typecheck/eq.rs
+++ b/src/typecheck/eq.rs
@@ -278,14 +278,21 @@ fn contract_eq_bounded<E: TermEnvironment>(
                 env2,
             ) && r1.attrs == r2.attrs
         }
-        (RecRecord(m1, dyn_fields1, attrs1, _), RecRecord(m2, dyn_fields2, attrs2, _)) =>
+        (RecRecord(r1, dyn_fields1, _), RecRecord(r2, dyn_fields2, _)) =>
         // We only compare records whose field structure is statically known (i.e. without dynamic
         // fields).
         {
             dyn_fields1.is_empty()
                 && dyn_fields2.is_empty()
-                && map_eq(contract_eq_bounded, state, m1, env1, m2, env2)
-                && attrs1 == attrs2
+                && map_eq(
+                    contract_eq_bounded,
+                    state,
+                    &r1.fields,
+                    env1,
+                    &r2.fields,
+                    env2,
+                )
+                && r1.attrs == r2.attrs
         }
         (Array(ts1, attrs1), Array(ts2, attrs2)) => {
             ts1.len() == ts2.len()

--- a/src/typecheck/mod.rs
+++ b/src/typecheck/mod.rs
@@ -51,7 +51,7 @@ use crate::{
     environment::Environment as GenericEnvironment,
     error::TypecheckError,
     identifier::Ident,
-    term::{record::RecordData, Contract, MetaValue, RichTerm, StrChunk, Term, TraverseOrder},
+    term::{Contract, MetaValue, RichTerm, StrChunk, Term, TraverseOrder},
     types::{AbsType, RowIterator, RowIteratorItem, Types},
     {mk_tyw_arrow, mk_tyw_enum, mk_tyw_enum_row, mk_tyw_record, mk_tyw_row},
 };
@@ -112,8 +112,11 @@ pub fn mk_initial_ctxt(initial_env: &Vec<RichTerm>) -> Result<Context, EnvBuildE
     let bindings = initial_env
         .iter()
         .map(|rt| {
-            if let Term::RecRecord(rec, ..) = rt.as_ref() {
-                Ok(rec.iter().map(|(id, rt)| (id.clone(), rt.clone())))
+            if let Term::RecRecord(record, ..) = rt.as_ref() {
+                Ok(record
+                    .fields
+                    .iter()
+                    .map(|(id, rt)| (id.clone(), rt.clone())))
             } else {
                 Err(EnvBuildError::NotARecord(rt.clone()))
             }
@@ -146,8 +149,8 @@ pub fn env_add_term(
     let RichTerm { term, pos } = rt;
 
     match term.as_ref() {
-        Term::Record(RecordData { fields, .. }) | Term::RecRecord(fields, ..) => {
-            for (id, t) in fields {
+        Term::Record(record) | Term::RecRecord(record, ..) => {
+            for (id, t) in &record.fields {
                 let tyw: TypeWrapper = TypeWrapper::from_apparent_type(
                     apparent_type(t.as_ref(), Some(env), Some(resolver)),
                     term_env,
@@ -384,8 +387,8 @@ fn walk<L: Linearizer>(
 
             walk(state, ctxt, lin, linearizer, exp)
         }
-        Term::RecRecord(stat_map, dynamic, ..) => {
-            for (id, field) in stat_map.iter() {
+        Term::RecRecord(record, dynamic, ..) => {
+            for (id, field) in record.fields.iter() {
                 let binding_type = binding_type(
                     state,
                     field.as_ref(),
@@ -399,7 +402,7 @@ fn walk<L: Linearizer>(
             // We don't bind the fields in the term environment used to check for contract
             // equality. See the `Let` case above for more details on why such recursive bindings
             // are currently ignored.
-            stat_map
+            record.fields
                 .iter()
                 .map(|(_, t)| t)
                 .chain(dynamic.iter().map(|(_, t)| t))
@@ -723,17 +726,18 @@ fn type_check_<L: Linearizer>(
         }
         // If some fields are defined dynamically, the only potential type that works is `{_ : a}`
         // for some `a`
-        Term::RecRecord(stat_map, dynamic, ..) if !dynamic.is_empty() => {
+        Term::RecRecord(record, dynamic, ..) if !dynamic.is_empty() => {
             let ty_dyn = state.table.fresh_unif_var();
 
-            for id in stat_map.keys() {
+            for id in record.fields.keys() {
                 ctxt.type_env.insert(id.clone(), ty_dyn.clone());
                 linearizer.retype_ident(lin, id, ty_dyn.clone())
             }
 
             // We don't bind the fields in the term environment used to check for contract. See
             // `Let` case in `walk`.
-            stat_map
+            record
+                .fields
                 .iter()
                 .try_for_each(|(_, t)| -> Result<(), TypecheckError> {
                     type_check_(
@@ -749,12 +753,12 @@ fn type_check_<L: Linearizer>(
             unify(state, &ctxt, ty, mk_typewrapper::dyn_record(ty_dyn))
                 .map_err(|err| err.into_typecheck_err(state, rt.pos))
         }
-        Term::Record(RecordData { fields, .. }) | Term::RecRecord(fields, ..) => {
+        Term::Record(record) | Term::RecRecord(record, ..) => {
             // For recursive records, we look at the apparent type of each field and bind it in
             // ctxt before actually typechecking the content of fields.
             // Fields defined by interpolation are ignored.
             if let Term::RecRecord(..) = t.as_ref() {
-                for (id, rt) in fields {
+                for (id, rt) in &record.fields {
                     let tyw = binding_type(state, rt.as_ref(), &ctxt, true);
                     ctxt.type_env.insert(id.clone(), tyw.clone());
                     linearizer.retype_ident(lin, id, tyw);
@@ -769,7 +773,8 @@ fn type_check_<L: Linearizer>(
 
             if let TypeWrapper::Concrete(AbsType::Dict(rec_ty)) = root_ty {
                 // Checking for a dictionary
-                fields
+                record
+                    .fields
                     .iter()
                     .try_for_each(|(_, t)| -> Result<(), TypecheckError> {
                         type_check_(
@@ -782,7 +787,7 @@ fn type_check_<L: Linearizer>(
                         )
                     })
             } else {
-                let row = fields.iter().try_fold(
+                let row = record.fields.iter().try_fold(
                     mk_tyw_row!(),
                     |acc, (id, field)| -> Result<TypeWrapper, TypecheckError> {
                         // In the case of a recursive record, new types (either type variables or
@@ -1079,8 +1084,8 @@ pub fn infer_record_type(t: &Term, term_env: &SimpleTermEnvironment) -> TypeWrap
             contracts,
             ..
         }) if contracts.is_empty() => infer_record_type(rt.as_ref(), term_env),
-        Term::Record(RecordData { fields, .. }) | Term::RecRecord(fields, ..) => {
-            AbsType::Record(Box::new(TypeWrapper::Concrete(fields.iter().fold(
+        Term::Record(record) | Term::RecRecord(record, ..) => {
+            AbsType::Record(Box::new(TypeWrapper::Concrete(record.fields.iter().fold(
                 AbsType::RowEmpty(),
                 |r, (id, rt)| {
                     AbsType::RowExtend(

--- a/src/types.rs
+++ b/src/types.rs
@@ -54,7 +54,7 @@ use crate::{
     identifier::Ident,
     mk_app, mk_fun,
     term::make as mk_term,
-    term::{RichTerm, Term, TraverseOrder},
+    term::{record::RecordData, RichTerm, Term, TraverseOrder},
 };
 
 use std::{collections::HashMap, fmt};
@@ -375,7 +375,10 @@ impl Types {
                     ),
                 };
 
-                let rec = RichTerm::from(Term::Record(fcs, Default::default()));
+                let rec = RichTerm::from(Term::Record(RecordData {
+                    fields: fcs,
+                    attrs: Default::default(),
+                }));
 
                 mk_app!(contract::record(), rec, tail)
             }

--- a/src/types.rs
+++ b/src/types.rs
@@ -375,10 +375,7 @@ impl Types {
                     ),
                 };
 
-                let rec = RichTerm::from(Term::Record(RecordData {
-                    fields: fcs,
-                    attrs: Default::default(),
-                }));
+                let rec = RichTerm::from(Term::Record(RecordData::with_fields(fcs)));
 
                 mk_app!(contract::record(), rec, tail)
             }

--- a/tests/free_vars.rs
+++ b/tests/free_vars.rs
@@ -35,7 +35,7 @@ fn check_dyn_vars(expr: &str, expected: Vec<Vec<&str>>) -> bool {
     free_vars::transform(&mut rt);
 
     match rt.term.into_owned() {
-        Term::RecRecord(_, dyns, _, deps) => {
+        Term::RecRecord(_, dyns, deps) => {
             let deps = deps.unwrap();
             dyns.len() == deps.dyn_fields.len() && dyn_free_vars_incl(&deps.dyn_fields, expected)
         }
@@ -48,13 +48,14 @@ fn check_stat_vars(expr: &str, expected: HashMap<&str, Vec<&str>>) -> bool {
     free_vars::transform(&mut rt);
 
     match rt.term.into_owned() {
-        Term::RecRecord(map, _, _, deps) => {
+        Term::RecRecord(record, _, deps) => {
             let deps = deps.unwrap();
             println!(
                 "-- comparing {:#?} **AND* {:#?}",
                 deps.stat_fields, expected
             );
-            map.len() == deps.stat_fields.len() && stat_free_vars_incl(&deps.stat_fields, expected)
+            record.fields.len() == deps.stat_fields.len()
+                && stat_free_vars_incl(&deps.stat_fields, expected)
         }
         _ => panic!("{} hasn't been parsed as a record", expr),
     }


### PR DESCRIPTION
### Why is this needed?

As part of refactoring record contracts with polymorphic tails, we're going to introduce an `Option<Box<Term>>` field to both `Record`s and `RecRecord`s which will hold the sealed portion of records passed through contracts with polymorphic tails (see [this issue](https://github.com/tweag/nickel/issues/201) for more info, in particular the section "Coarse sealing built-in"). 

To make this simpler, this PR groups together the existing common fields into a `RecordBase` struct. It also introduces two functions on this type to avoid the need for consumers to destructure & then rebuild `RecordBase`s everywhere. 

### Notes

- Both `map_fields` and `filter_map_fields` take their function parameter as `mut`. This is because in certain places we build up additional state while iterating (e.g. by pushing the `Ident`s into a `Vec`). I _think_ it's reasonable to do this, but would appreciate other opinions in case there's something I missed.

### Recommendation for reviewers

Each commit is self-contained & passes the whole test suite. Several also have extra detail in the commit messages. As such I'd recommend reviewing commit-by-commit rather than trying to review the whole PR as a single unit.