### PR TITLE
Replace `Scope` with `Environment` in the LSP

### DIFF
--- a/lsp/nls/src/linearization/building.rs
+++ b/lsp/nls/src/linearization/building.rs
@@ -4,10 +4,7 @@ use log::debug;
 use nickel_lang::{
     identifier::Ident,
     term::{MetaValue, RichTerm, Term},
-    typecheck::{
-        linearization::{LinearizationState, Scope},
-        TypeWrapper,
-    },
+    typecheck::{linearization::LinearizationState, TypeWrapper},
     types::AbsType,
 };
 
@@ -24,25 +21,13 @@ use super::{
 #[derive(Default)]
 pub struct Building {
     pub linearization: Vec<LinearizationItem<Unresolved>>,
-    pub scope: HashMap<Scope, Vec<ID>>,
 }
 
 pub type ID = usize;
 
 impl Building {
     pub(super) fn push(&mut self, item: LinearizationItem<Unresolved>) {
-        self.scope
-            .remove(&item.scope)
-            .map(|mut s| {
-                s.push(item.id);
-                s
-            })
-            .or_else(|| Some(vec![item.id]))
-            .into_iter()
-            .for_each(|l| {
-                self.scope.insert(item.scope.clone(), l);
-            });
-        self.linearization.push(item);
+        self.linearization.push(item)
     }
 
     pub(super) fn add_usage(&mut self, decl: usize, usage: usize) {
@@ -74,7 +59,6 @@ impl Building {
         &mut self,
         record_fields: &HashMap<Ident, RichTerm>,
         record: usize,
-        scope: Scope,
         env: &mut Environment,
     ) {
         for (ident, value) in record_fields.iter() {
@@ -91,7 +75,6 @@ impl Building {
                     usages: Vec::new(),
                     value: ValueState::Unknown,
                 },
-                scope: scope.clone(),
                 meta: match value.term.as_ref() {
                     Term::MetaValue(meta @ MetaValue { .. }) => Some(MetaValue {
                         value: None,

--- a/lsp/nls/src/linearization/completed.rs
+++ b/lsp/nls/src/linearization/completed.rs
@@ -1,10 +1,7 @@
 use std::collections::HashMap;
 
 use codespan::ByteIndex;
-use nickel_lang::{
-    term::MetaValue,
-    typecheck::linearization::{LinearizationState, Scope},
-};
+use nickel_lang::{term::MetaValue, typecheck::linearization::LinearizationState};
 
 use super::{
     building::ID,
@@ -15,19 +12,16 @@ use super::{
 #[derive(Debug, Default)]
 pub struct Completed {
     pub linearization: Vec<LinearizationItem<Resolved>>,
-    scope: HashMap<Scope, Vec<usize>>,
     id_to_index: HashMap<ID, usize>,
 }
 
 impl Completed {
     pub fn new(
         linearization: Vec<LinearizationItem<Resolved>>,
-        scope: HashMap<Scope, Vec<usize>>,
         id_to_index: HashMap<ID, usize>,
     ) -> Self {
         Self {
             linearization,
-            scope,
             id_to_index,
         }
     }
@@ -40,14 +34,12 @@ impl Completed {
 
     pub fn get_in_scope(
         &self,
-        LinearizationItem { scope, .. }: &LinearizationItem<Resolved>,
+        LinearizationItem { env, .. }: &LinearizationItem<Resolved>,
     ) -> Vec<&LinearizationItem<Resolved>> {
-        let empty = Vec::with_capacity(0);
-        (0..scope.len())
-            .flat_map(|end| self.scope.get(&scope[..=end]).unwrap_or(&empty))
-            .map(|id| self.get_item(*id))
-            .flatten()
-            .collect()
+        env.iter()
+            .map(|(_, id)| self.get_item(*id))
+            .collect::<Option<Vec<_>>>()
+            .unwrap_or(Vec::new())
     }
 
     /// Finds the index of a linearization item for a given location

--- a/lsp/nls/src/requests/completion.rs
+++ b/lsp/nls/src/requests/completion.rs
@@ -339,7 +339,6 @@ mod tests {
                 pos: TermPos::None,
                 ty: Types(AbsType::Dyn()),
                 kind,
-                scope: Vec::new(),
                 meta: None,
             }
         }
@@ -350,8 +349,7 @@ mod tests {
                 .enumerate()
                 .map(|(index, id)| (id, index))
                 .collect();
-            let scope = HashMap::new();
-            Completed::new(linearization, scope, id_to_index)
+            Completed::new(linearization, id_to_index)
         }
 
         // ids is an array of the ids from this linearization


### PR DESCRIPTION
This is the final clean up of the work started in #867 to remove the `Scope` data structure, and replace it completely with an `Environment`