### PR TITLE
Add support for nested record completion in the LSP

### DIFF
--- a/lsp/nls/src/requests/completion.rs
+++ b/lsp/nls/src/requests/completion.rs
@@ -313,11 +313,9 @@ pub fn handle_completion(
 
 #[cfg(test)]
 mod tests {
-    use nickel_lang::position::TermPos;
-
-    use crate::linearization::Environment;
-
     use super::*;
+    use crate::linearization::Environment;
+    use nickel_lang::position::TermPos;
     use std::collections::{HashMap, HashSet};
 
     #[test]
@@ -389,12 +387,12 @@ mod tests {
         ));
         let ty = Types(AbsType::RowExtend(
             Ident::from("b"),
-            Some(Box::new(ty)),
+            Some(Box::new(Types(AbsType::Record(Box::new(ty))))),
             Box::new(Types(AbsType::RowEmpty())),
         ));
         let ty = Types(AbsType::RowExtend(
             Ident::from("a"),
-            Some(Box::new(ty)),
+            Some(Box::new(Types(AbsType::Record(Box::new(ty))))),
             Box::new(Types(AbsType::RowEmpty())),
         ));
         let mut path = vec![Ident::from("b"), Ident::from("a")];

--- a/lsp/nls/src/requests/completion.rs
+++ b/lsp/nls/src/requests/completion.rs
@@ -87,16 +87,13 @@ fn find_fields_from_type(ty: &Box<Types>, path: &mut Vec<Ident>) -> Vec<Ident> {
     let current = path.pop();
     ty.iter_as_rows()
         .flat_map(|item| match (item, current) {
-            (RowIteratorItem::Row(ident, Some(ty)), Some(current)) if current == *ident => {
-                if let Types(AbsType::Record(ty)) = ty {
-                    find_fields_from_type(ty, path)
-                } else {
-                    find_fields_from_type(&Box::new(ty.clone()), path)
-                }
+            (RowIteratorItem::Row(ident, Some(Types(AbsType::Record(ty)))), Some(current))
+                if current == *ident =>
+            {
+                find_fields_from_type(ty, path)
             }
-            (RowIteratorItem::Row(..), Some(_)) => Vec::new(),
             (RowIteratorItem::Row(ident, _), None) => vec![ident.clone()],
-            (RowIteratorItem::Tail(..), _) => Vec::new(),
+            _ => Vec::new(),
         })
         .collect::<Vec<_>>()
 }

--- a/lsp/nls/src/requests/completion.rs
+++ b/lsp/nls/src/requests/completion.rs
@@ -134,7 +134,7 @@ fn get_identifiers_before_field(text: &str) -> Option<Vec<String>> {
         .rev()
         .collect();
 
-    get_identifier_path(&text[..])
+    get_identifier_path(&text.as_str())
 }
 
 fn remove_duplicates(items: &Vec<CompletionItem>) -> Vec<CompletionItem> {

--- a/lsp/nls/src/requests/completion.rs
+++ b/lsp/nls/src/requests/completion.rs
@@ -83,7 +83,7 @@ fn find_fields_from_contract(
 }
 
 /// Extract the fields from a given record type.
-fn find_fields_from_type(ty: &Box<Types>, path: &mut Vec<Ident>) -> Vec<Ident> {
+fn find_fields_from_type(ty: &Types, path: &mut Vec<Ident>) -> Vec<Ident> {
     let current = path.pop();
     ty.iter_as_rows()
         .flat_map(|item| match (item, current) {
@@ -109,14 +109,13 @@ lazy_static! {
 /// Get the string chunks that make up an identifier path.
 fn get_identifier_path(text: &str) -> Option<Vec<String>> {
     // skip any `.` at the end of the text
-    let text: String = text
-        .chars()
-        .rev()
-        .skip_while(|c| *c == '.') // skip . (if any)
-        .collect::<String>()
-        .chars()
-        .rev()
-        .collect();
+    let text = {
+        let mut text = String::from(text);
+        while text.ends_with('.') {
+            text.pop();
+        }
+        text
+    };
 
     let result: Vec<_> = RE_SPACE.split(text.as_ref()).map(String::from).collect();
     if result.is_empty() {
@@ -347,7 +346,7 @@ mod tests {
             (
                 r##"let me : _ = { name = "foo", time = 1800, a.b.c.d = 10 } in
                     me.ca.cb"##,
-                vec!["me", "a", "b"],
+                vec!["me", "ca", "cb"],
             ),
         ];
         for (input, expected) in tests {

--- a/lsp/nls/src/requests/completion.rs
+++ b/lsp/nls/src/requests/completion.rs
@@ -80,6 +80,20 @@ lazy_static! {
     // This regexp must be the reverse of the regexp in the lexer (nickel_lang::parser::lexer)
     // to correctly parse identifiers.
     static ref RE: regex::Regex = regex::Regex::new(r"[_a-zA-Z0-9-']*[a-zA-Z]_?").unwrap();
+    static ref RE_SPACE: regex::Regex = regex::Regex::new(r"\s+").unwrap();
+}
+
+/// Get the string chunks that make up an identifier path
+fn get_identifier_path(text: &str) -> Option<Vec<String>> {
+    let result: Vec<_> = RE_SPACE.split(text).map(String::from).collect();
+    let path = result
+        .iter()
+        .rev()
+        .cloned()
+        .collect::<Vec<_>>()
+        .get(0)
+        .cloned()?;
+    Some(path.split(".").map(String::from).collect())
 }
 
 /// Get the identifier before the `.`, for record completion.

--- a/lsp/nls/src/requests/completion.rs
+++ b/lsp/nls/src/requests/completion.rs
@@ -300,6 +300,25 @@ mod tests {
     use std::collections::{HashMap, HashSet};
 
     #[test]
+    fn test_get_identifier_path() {
+        let tests = [
+            ("let person = {} in \n    a.b.c.d", vec!["a", "b", "c", "d"]),
+            ("   ab.dec", vec!["ab", "dec"]),
+            (
+                r##"let name = { sdf.clue.add.bar = 10 } in
+            name.sdf.clue.add.bar"##,
+                vec!["name", "sdf", "clue", "add", "bar"],
+            ),
+        ];
+        for (input, expected) in tests {
+            let actual = get_identifier_path(input);
+            let expected: Option<Vec<_>> =
+                Some(expected.iter().cloned().map(String::from).collect());
+            assert_eq!(actual, expected)
+        }
+    }
+
+    #[test]
     fn test_remove_duplicates() {
         fn completion_item(names: Vec<&str>) -> Vec<CompletionItem> {
             names

--- a/lsp/nls/src/requests/completion.rs
+++ b/lsp/nls/src/requests/completion.rs
@@ -194,6 +194,8 @@ fn get_completion_identifiers(
             // empty should return none
             if let Some(path) = get_identifier_path(source) {
                 let mut path: Vec<_> = path.iter().rev().cloned().map(Ident::from).collect();
+                // unwrap is safe here because we are guaranteed by `get_identifier_path`
+                // that it will return a non-empty vector
                 let name = path.pop().unwrap();
                 if let Some(id) = item.env.get(&name).copied() {
                     collect_record_info(linearization, item, id, &mut path)
@@ -210,6 +212,8 @@ fn get_completion_identifiers(
             // we also want to give completion based on <record path> in this case.
             if let Some(path) = get_identifiers_before_field(source) {
                 let mut path: Vec<_> = path.iter().rev().cloned().map(Ident::from).collect();
+                // unwrap is safe here because we are guaranteed by `get_identifiers_before_field`
+                // that it will return a non-empty vector
                 let name = path.pop().unwrap();
                 if let Some(id) = item.env.get(&name).copied() {
                     collect_record_info(linearization, item, id, &mut path)

--- a/lsp/nls/src/requests/completion.rs
+++ b/lsp/nls/src/requests/completion.rs
@@ -118,14 +118,11 @@ fn get_identifier_path(text: &str) -> Option<Vec<String>> {
     };
 
     let result: Vec<_> = RE_SPACE.split(text.as_ref()).map(String::from).collect();
-    if result.is_empty() {
-        return None;
-    }
     let path = result.iter().rev().next().cloned()?;
     Some(path.split(".").map(String::from).collect())
 }
 
-/// Get the identifier before `.<text>` for record completion.
+/// Get the identifiers before `.<text>` for record completion.
 fn get_identifiers_before_field(text: &str) -> Option<Vec<String>> {
     // Skip `<text>`
     let text: String = text

--- a/lsp/nls/src/requests/completion.rs
+++ b/lsp/nls/src/requests/completion.rs
@@ -25,6 +25,7 @@ use crate::{
 // A path is the reverse of the list of identifiers that make up a record indexing operation.
 // e.g if we have a.b.c, the associated path would be vec![c, b, a]
 // Paths are used to guide the completion engine to handle nested records.
+// They also generalize the single record indexing case.
 
 /// Find the record field associated with a particular ID in the linearization
 /// using lexical scoping rules.

--- a/lsp/nls/src/requests/completion.rs
+++ b/lsp/nls/src/requests/completion.rs
@@ -342,6 +342,11 @@ mod tests {
             ),
             ("name.class", vec!["name", "class"]),
             ("number", vec!["number"]),
+            ("", vec![""]), // maybe return an empty vector in this case?
+            (
+                r##"let x = {"fo京o" = {bar = 42}} in x."fo京o".foo"##,
+                vec!["x", "\"fo京o\"", "foo"],
+            ),
         ];
         for (input, expected) in tests {
             let actual = get_identifier_path(input);


### PR DESCRIPTION
This improves the LSP completion by adding support for nested records. 

This addresses item `2a` in #877 