### PR TITLE
LSP completion based on contract information

### DIFF
--- a/lsp/nls/src/requests/completion.rs
+++ b/lsp/nls/src/requests/completion.rs
@@ -6,7 +6,7 @@ use lsp_server::{RequestId, Response, ResponseError};
 use lsp_types::{CompletionItem, CompletionParams};
 use nickel_lang::{
     identifier::Ident,
-    term::MetaValue,
+    term::{MetaValue, RichTerm, Term},
     types::{RecordRows, RecordRowsIteratorItem, TypeF, Types},
 };
 use serde_json::Value;
@@ -93,8 +93,8 @@ fn find_fields_from_meta_value(meta_value: &MetaValue, path: &mut Vec<Ident>) ->
         .iter()
         .chain(meta_value.types.iter())
         .flat_map(|contract| match &contract.types {
-            Types(AbsType::Record(row)) => find_fields_from_type(&row, path),
-            Types(AbsType::Flat(term)) => find_fields_from_term(term, path).unwrap_or_default(),
+            Types(TypeF::Record(row)) => find_fields_from_type(&row, path),
+            Types(TypeF::Flat(term)) => find_fields_from_term(term, path).unwrap_or_default(),
             _ => Vec::new(),
         })
         .collect()

--- a/lsp/nls/src/requests/completion.rs
+++ b/lsp/nls/src/requests/completion.rs
@@ -74,7 +74,7 @@ fn find_fields_from_contract(
 ) -> Option<Vec<Ident>> {
     let item = linearization.get_item(id)?;
     match &item.meta {
-        Some(meta_value) => find_fields_from_meta_value(meta_value, path),
+        Some(meta_value) => Some(find_fields_from_meta_value(meta_value, path)),
         None => match item.kind {
             TermKind::Declaration(_, _, ValueState::Known(new_id))
             | TermKind::Usage(UsageState::Resolved(new_id)) => {
@@ -87,10 +87,7 @@ fn find_fields_from_contract(
 
 /// Find record field associated associated with a MetaValue.
 /// This can be gotten from the type or the contracts.
-fn find_fields_from_meta_value(
-    meta_value: &MetaValue,
-    path: &mut Vec<Ident>,
-) -> Option<Vec<Ident>> {
+fn find_fields_from_meta_value(meta_value: &MetaValue, path: &mut Vec<Ident>) -> Vec<Ident> {
     meta_value
         .contracts
         .iter()
@@ -100,8 +97,7 @@ fn find_fields_from_meta_value(
             Types(AbsType::Flat(term)) => find_fields_from_term(term, path).unwrap_or_default(),
             _ => Vec::new(),
         })
-        .collect::<Vec<_>>()
-        .into()
+        .collect()
 }
 
 /// Extract the fields from a given record type.
@@ -144,9 +140,9 @@ fn find_fields_from_term(term: &RichTerm, path: &mut Vec<Ident>) -> Option<Vec<I
         (Term::MetaValue(meta_value), Some(ident)) => {
             // We don't need to pop here, as the metavalue wraps the actual record
             path.push(ident);
-            find_fields_from_meta_value(meta_value, path)
+            Some(find_fields_from_meta_value(meta_value, path))
         }
-        (Term::MetaValue(meta_value), None) => find_fields_from_meta_value(meta_value, path),
+        (Term::MetaValue(meta_value), None) => Some(find_fields_from_meta_value(meta_value, path)),
         _ => None,
     }
 }

--- a/lsp/nls/src/requests/completion.rs
+++ b/lsp/nls/src/requests/completion.rs
@@ -91,18 +91,17 @@ fn find_fields_from_meta_value(
     meta_value: &MetaValue,
     path: &mut Vec<Ident>,
 ) -> Option<Vec<Ident>> {
-    Some(
-        meta_value
-            .contracts
-            .iter()
-            .chain(meta_value.types.iter())
-            .flat_map(|contract| match &contract.types {
-                Types(AbsType::Record(row)) => find_fields_from_type(&row, path),
-                Types(AbsType::Flat(term)) => find_fields_from_term(term, path).unwrap_or_default(),
-                _ => Vec::new(),
-            })
-            .collect(),
-    )
+    meta_value
+        .contracts
+        .iter()
+        .chain(meta_value.types.iter())
+        .flat_map(|contract| match &contract.types {
+            Types(AbsType::Record(row)) => find_fields_from_type(&row, path),
+            Types(AbsType::Flat(term)) => find_fields_from_term(term, path).unwrap_or_default(),
+            _ => Vec::new(),
+        })
+        .collect::<Vec<_>>()
+        .into()
 }
 
 /// Extract the fields from a given record type.

--- a/lsp/nls/src/requests/completion.rs
+++ b/lsp/nls/src/requests/completion.rs
@@ -21,11 +21,12 @@ use crate::{
     trace::{Enrich, Trace},
 };
 
-// General ideas:
+// General idea:
 // A path is the reverse of the list of identifiers that make up a record indexing operation.
 // e.g if we have a.b.c, the associated path would be vec![c, b, a]
-// Paths are used to guide the completion engine to handle nested records.
+// Paths are used to guide the completion engine to handle nested record indexing.
 // They also generalize the single record indexing case.
+// TODO: add more docs
 
 /// Find the record field associated with a particular ID in the linearization
 /// using lexical scoping rules.
@@ -57,6 +58,12 @@ fn find_fields_from_term_kind(
     }
 }
 
+// Some(MetaValue { contracts, .. }) => {
+//     contracts.iter().find_map(|contract| match &contract.types {
+//         Types(TypeF::Record(rrows)) => Some(find_fields_from_type(&rrows, path)),
+//         _ => None,
+//     })
+// }
 /// Find the record fields associated with an ID in the linearization using
 /// its contract information.
 fn find_fields_from_contract(
@@ -66,12 +73,7 @@ fn find_fields_from_contract(
 ) -> Option<Vec<Ident>> {
     let item = linearization.get_item(id)?;
     match &item.meta {
-        Some(MetaValue { contracts, .. }) => {
-            contracts.iter().find_map(|contract| match &contract.types {
-                Types(TypeF::Record(rrows)) => Some(find_fields_from_type(&rrows, path)),
-                _ => None,
-            })
-        }
+        Some(meta_value) => find_fields_from_meta_value(meta_value, path),
         None => match item.kind {
             TermKind::Declaration(_, _, ValueState::Known(new_id))
             | TermKind::Usage(UsageState::Resolved(new_id)) => {
@@ -79,6 +81,17 @@ fn find_fields_from_contract(
             }
             _ => None,
         },
+    }
+}
+
+fn find_fields_from_meta_value(
+    meta_value: &MetaValue,
+    path: &mut Vec<Ident>,
+) -> Option<Vec<Ident>> {
+    match &meta_value.contracts.first()?.types {
+        Types(AbsType::Record(row)) => Some(find_fields_from_type(&row, path)),
+        Types(AbsType::Flat(term)) => find_fields_from_term(term, path),
+        _ => None,
     }
 }
 
@@ -90,10 +103,15 @@ fn find_fields_from_type(rrows: &RecordRows, path: &mut Vec<Ident>) -> Vec<Ident
             _ => None,
         });
 
-        if let Some(Types(TypeF::Record(rrows_current))) = type_of_current {
-            find_fields_from_type(&rrows_current, path)
-        } else {
-            Vec::new()
+        match type_of_current {
+            Some(Types(TypeF::Record(rrows_current))) =>  find_fields_from_type(&rrows_current, path), 
+            Some(Types(TypeF::Flat(term))) => { 
+                match find_fields_from_term(&term, path) {
+                    Some(result) => result,
+                    None => Vec::new(),
+                }
+            }
+            _ => Vec::new()
         }
     } else {
         rrows
@@ -103,6 +121,26 @@ fn find_fields_from_type(rrows: &RecordRows, path: &mut Vec<Ident>) -> Vec<Ident
                 _ => None,
             })
             .collect::<Vec<_>>()
+    }
+}
+
+fn find_fields_from_term(term: &RichTerm, path: &mut Vec<Ident>) -> Option<Vec<Ident>> {
+    let current = path.pop();
+    match (term.as_ref(), current) {
+        (Term::Record(data) | Term::RecRecord(data, ..), None) => {
+            Some(data.fields.keys().cloned().collect())
+        }
+        (Term::Record(data) | Term::RecRecord(data, ..), Some(name)) => {
+            let term = data.fields.get(&name)?;
+            find_fields_from_term(term, path) 
+        }
+        (Term::MetaValue(meta_value), Some(ident)) => {
+            // We don't need to pop here, as meta wraps the record
+            path.push(ident);
+            find_fields_from_meta_value(meta_value, path)
+        },
+        (Term::MetaValue(meta_value), None) => find_fields_from_meta_value(meta_value, path),
+        _ => None,
     }
 }
 

--- a/lsp/nls/src/requests/completion.rs
+++ b/lsp/nls/src/requests/completion.rs
@@ -115,10 +115,7 @@ fn find_fields_from_type(rrows: &RecordRows, path: &mut Vec<Ident>) -> Vec<Ident
         match type_of_current {
             Some(Types(TypeF::Record(rrows_current))) =>  find_fields_from_type(&rrows_current, path), 
             Some(Types(TypeF::Flat(term))) => { 
-                match find_fields_from_term(&term, path) {
-                    Some(result) => result,
-                    None => Vec::new(),
-                }
+                find_fields_from_term(&term, path).unwrap_or_default()
             }
             _ => Vec::new()
         }

--- a/lsp/nls/src/requests/completion.rs
+++ b/lsp/nls/src/requests/completion.rs
@@ -96,12 +96,11 @@ fn find_fields_from_meta_value(
             .contracts
             .iter()
             .chain(meta_value.types.iter())
-            .filter_map(|contract| match &contract.types {
-                Types(AbsType::Record(row)) => Some(find_fields_from_type(&row, path)),
-                Types(AbsType::Flat(term)) => find_fields_from_term(term, path),
-                _ => None,
+            .flat_map(|contract| match &contract.types {
+                Types(AbsType::Record(row)) => find_fields_from_type(&row, path),
+                Types(AbsType::Flat(term)) => find_fields_from_term(term, path).unwrap_or_default(),
+                _ => Vec::new(),
             })
-            .flatten()
             .collect(),
     )
 }

--- a/lsp/nls/src/requests/completion.rs
+++ b/lsp/nls/src/requests/completion.rs
@@ -59,12 +59,6 @@ fn find_fields_from_term_kind(
     }
 }
 
-// Some(MetaValue { contracts, .. }) => {
-//     contracts.iter().find_map(|contract| match &contract.types {
-//         Types(TypeF::Record(rrows)) => Some(find_fields_from_type(&rrows, path)),
-//         _ => None,
-//     })
-// }
 /// Find the record fields associated with an ID in the linearization using
 /// its contract information.
 fn find_fields_from_contract(
@@ -109,11 +103,13 @@ fn find_fields_from_type(rrows: &RecordRows, path: &mut Vec<Ident>) -> Vec<Ident
         });
 
         match type_of_current {
-            Some(Types(TypeF::Record(rrows_current))) =>  find_fields_from_type(&rrows_current, path), 
-            Some(Types(TypeF::Flat(term))) => { 
+            Some(Types(TypeF::Record(rrows_current))) => {
+                find_fields_from_type(&rrows_current, path)
+            }
+            Some(Types(TypeF::Flat(term))) => {
                 find_fields_from_term(&term, path).unwrap_or_default()
             }
-            _ => Vec::new()
+            _ => Vec::new(),
         }
     } else {
         rrows


### PR DESCRIPTION
This change allows the LSP to give record completion using the contract information available. 

Fixes item `3` in #877