### PR TITLE
Refactor/eval cache

### DIFF
--- a/src/bin/nickel.rs
+++ b/src/bin/nickel.rs
@@ -1,5 +1,6 @@
 //! Entry point of the program.
 use nickel_lang::error::{Error, IOError};
+use nickel_lang::eval::cache::CBNCache;
 use nickel_lang::program::Program;
 use nickel_lang::repl::query_print;
 #[cfg(feature = "repl")]
@@ -14,6 +15,8 @@ use std::{
 // use std::ffi::OsStr;
 use directories::BaseDirs;
 use structopt::StructOpt;
+
+type EC = CBNCache;
 
 /// Command-line options and subcommands.
 #[derive(StructOpt, Debug)]
@@ -211,7 +214,7 @@ fn main() {
 }
 
 fn export(
-    program: &mut Program,
+    program: &mut Program<EC>,
     format: Option<ExportFormat>,
     output: Option<PathBuf>,
 ) -> Result<(), Error> {

--- a/src/error.rs
+++ b/src/error.rs
@@ -1084,7 +1084,7 @@ mod blame_error {
         // If we have a reference to the thunk that was being tested, we can try to show
         // more information about the final, evaluated value that is responsible for the
         // blame.
-        if let Some(ref thunk) = blame_label.arg_thunk {
+        if let Some(ref thunk) = blame_label.arg_idx {
             let mut val = thunk.get_owned().body;
 
             match (val.pos, blame_label.arg_pos.as_opt_ref(), contract_id) {

--- a/src/eval/cache.rs
+++ b/src/eval/cache.rs
@@ -1,0 +1,97 @@
+use std::fmt::Debug;
+
+use super::{
+    lazy::{BlackholedError, Thunk, ThunkState, ThunkUpdateFrame},
+    IdentKind,
+};
+use crate::{eval::Closure, identifier::Ident, term::BindingType};
+
+pub trait Cache: Clone {
+    type UpdateIndex; // Temporary: we won't really need that once an alternative caching mechanism gets implemented
+
+    fn get(&self, idx: CacheIndex) -> Closure;
+    fn get_update_index(
+        &mut self,
+        idx: &mut CacheIndex,
+    ) -> Result<Option<Self::UpdateIndex>, BlackholedError>;
+    fn add(&mut self, clos: Closure, kind: IdentKind, bty: BindingType) -> CacheIndex;
+    fn patch<F: FnOnce(&mut Closure)>(&mut self, idx: CacheIndex, f: F);
+    fn get_then<T, F: FnOnce(&Closure) -> T>(&self, idx: CacheIndex, f: F) -> T;
+    fn update(&mut self, clos: Closure, idx: Self::UpdateIndex);
+    fn new() -> Self;
+    fn reset_index_state(&self, idx: &mut Self::UpdateIndex);
+    fn map_at_index<F: FnMut(&Closure) -> Closure>(&mut self, idx: &CacheIndex, f: F)
+        -> CacheIndex;
+    // TODO: Needs a better name
+    fn build_cached(&mut self, idx: &mut CacheIndex, rec_env: &[(Ident, CacheIndex)]);
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CBNCache {}
+
+pub type CacheIndex = Thunk;
+
+impl Cache for CBNCache {
+    type UpdateIndex = ThunkUpdateFrame;
+
+    fn get(&self, idx: CacheIndex) -> Closure {
+        idx.get_owned()
+    }
+
+    fn get_update_index(
+        &mut self,
+        idx: &mut CacheIndex,
+    ) -> Result<Option<Self::UpdateIndex>, BlackholedError> {
+        if idx.state() != ThunkState::Evaluated {
+            if idx.should_update() {
+                idx.mk_update_frame().map(Some)
+            }
+            // If the thunk isn't to be updated, directly set the evaluated flag.
+            else {
+                idx.set_evaluated();
+                Ok(None)
+            }
+        } else {
+            Ok(None)
+        }
+    }
+
+    fn add(&mut self, clos: Closure, kind: IdentKind, bty: BindingType) -> CacheIndex {
+        match bty {
+            BindingType::Normal => Thunk::new(clos, kind),
+            BindingType::Revertible(deps) => Thunk::new_rev(clos, kind, deps),
+        }
+    }
+
+    fn patch<F: FnOnce(&mut Closure)>(&mut self, mut idx: CacheIndex, f: F) {
+        f(&mut idx.borrow_mut());
+    }
+
+    fn get_then<T, F: FnOnce(&Closure) -> T>(&self, idx: CacheIndex, f: F) -> T {
+        f(&idx.borrow())
+    }
+
+    fn update(&mut self, clos: Closure, uidx: Self::UpdateIndex) {
+        uidx.update(clos);
+    }
+
+    fn new() -> Self {
+        CBNCache {}
+    }
+
+    fn reset_index_state(&self, idx: &mut Self::UpdateIndex) {
+        idx.reset_state();
+    }
+
+    fn map_at_index<F: FnMut(&Closure) -> Closure>(
+        &mut self,
+        idx: &CacheIndex,
+        f: F,
+    ) -> CacheIndex {
+        idx.map(f)
+    }
+
+    fn build_cached(&mut self, idx: &mut CacheIndex, rec_env: &[(Ident, CacheIndex)]) {
+        idx.build_cached(rec_env)
+    }
+}

--- a/src/eval/fixpoint.rs
+++ b/src/eval/fixpoint.rs
@@ -5,18 +5,19 @@ use super::*;
 /// the corresponding thunk from the environment in the general case, or create a closure on the
 /// fly if the field is a constant. The resulting environment is to be passed to the
 /// [`patch_field`] function.
-pub fn rec_env<'a, I: Iterator<Item = (&'a Ident, &'a RichTerm)>>(
+pub fn rec_env<'a, I: Iterator<Item = (&'a Ident, &'a RichTerm)>, C: Cache>(
+    cache: &mut C,
     bindings: I,
     env: &Environment,
-) -> Result<Vec<(Ident, Thunk)>, EvalError> {
+) -> Result<Vec<(Ident, CacheIndex)>, EvalError> {
     bindings
         .map(|(id, rt)| match rt.as_ref() {
             Term::Var(ref var_id) => {
-                let thunk = env
+                let idx = env
                     .get(var_id)
                     .cloned()
                     .ok_or(EvalError::UnboundIdentifier(*var_id, rt.pos))?;
-                Ok((*id, thunk))
+                Ok((*id, idx))
             }
             _ => {
                 // If we are in this branch, `rt` must be a constant after the share normal form
@@ -26,7 +27,7 @@ pub fn rec_env<'a, I: Iterator<Item = (&'a Ident, &'a RichTerm)>>(
                     body: rt.clone(),
                     env: Environment::new(),
                 };
-                Ok((*id, Thunk::new(closure, IdentKind::Let)))
+                Ok((*id, cache.add(closure, IdentKind::Let, BindingType::Normal)))
             }
         })
         .collect()
@@ -37,21 +38,23 @@ pub fn rec_env<'a, I: Iterator<Item = (&'a Ident, &'a RichTerm)>>(
 /// step correspond to function application (see documentation of [crate::eval::lazy::ThunkData]).
 ///
 /// For each field, retrieve the set set of dependencies from the corresponding thunk in the
-/// environment, and only add those dependencies to the environment. This avoid retaining
+/// environment, and only add those dependencies to the environment. This avoids retaining
 /// reference-counted pointers to unused data. If no dependencies are available, conservatively add
 /// all the recursive environment. See [`crate::transform::free_vars`].
-pub fn patch_field(
+pub fn patch_field<C: Cache>(
+    cache: &mut C,
     rt: &RichTerm,
-    rec_env: &[(Ident, Thunk)],
+    rec_env: &[(Ident, CacheIndex)],
     env: &Environment,
 ) -> Result<(), EvalError> {
     if let Term::Var(var_id) = &*rt.term {
-        let mut thunk = env
+        // TODO: Shouldn't be mutable, [`CBNCache`] abstraction is leaking.
+        let mut idx = env
             .get(var_id)
             .cloned()
             .ok_or(EvalError::UnboundIdentifier(*var_id, rt.pos))?;
 
-        thunk.build_cached(rec_env);
+        cache.build_cached(&mut idx, rec_env);
     }
 
     // Thanks to the share normal form transformation, the content is either a constant or a

--- a/src/eval/lazy.rs
+++ b/src/eval/lazy.rs
@@ -1,5 +1,5 @@
 //! Thunks and associated devices used to implement lazy evaluation.
-use super::{Closure, Environment, IdentKind};
+use super::{cache::CacheIndex, Closure, Environment, IdentKind};
 use crate::{
     identifier::Ident,
     term::{FieldDeps, RichTerm, Term},
@@ -31,6 +31,8 @@ pub struct ThunkData {
     inner: InnerThunkData,
     state: ThunkState,
 }
+
+type CBNClosure = Closure;
 
 /// The part of [ThunkData] responsible for storing the closure itself. It can either be:
 /// - A standard thunk, that is destructively updated once and for all
@@ -104,7 +106,7 @@ pub struct ThunkData {
 /// variables of `orig`.
 #[derive(Clone, Debug, PartialEq)]
 pub enum InnerThunkData {
-    Standard(Closure),
+    Standard(CBNClosure),
     Revertible {
         orig: Rc<Closure>,
         cached: Option<Closure>,
@@ -117,7 +119,7 @@ const REVTHUNK_NO_CACHED_VALUE_MSG: &str =
 
 impl ThunkData {
     /// Create new standard thunk data.
-    pub fn new(closure: Closure) -> Self {
+    pub fn new(closure: CBNClosure) -> Self {
         ThunkData {
             inner: InnerThunkData::Standard(closure),
             state: ThunkState::Suspended,
@@ -224,7 +226,7 @@ impl ThunkData {
     }
 
     /// Return a reference to the closure currently cached.
-    pub fn closure(&self) -> &Closure {
+    pub fn closure(&self) -> &CBNClosure {
         match self.inner {
             InnerThunkData::Standard(ref closure) => closure,
             // Nothing should peek into a revertible thunk before the cached value has been
@@ -243,7 +245,7 @@ impl ThunkData {
     }
 
     /// Return a mutable reference to the closure currently cached.
-    pub fn closure_mut(&mut self) -> &mut Closure {
+    pub fn closure_mut(&mut self) -> &mut CBNClosure {
         match self.inner {
             InnerThunkData::Standard(ref mut closure) => closure,
             InnerThunkData::Revertible {
@@ -255,7 +257,7 @@ impl ThunkData {
     }
 
     /// Consume the data and return the cached closure.
-    pub fn into_closure(self) -> Closure {
+    pub fn into_closure(self) -> CBNClosure {
         match self.inner {
             InnerThunkData::Standard(closure) => closure,
             // Nothing should access the cached value of a revertible thunk before the cached
@@ -274,7 +276,7 @@ impl ThunkData {
     }
 
     /// Update the cached closure.
-    pub fn update(&mut self, new: Closure) {
+    pub fn update(&mut self, new: CBNClosure) {
         match self.inner {
             InnerThunkData::Standard(ref mut closure) => *closure = new,
             InnerThunkData::Revertible { ref mut cached, .. } => *cached = Some(new),
@@ -312,7 +314,7 @@ impl ThunkData {
     /// the cached expression.
     pub fn map<F>(&self, mut f: F) -> Self
     where
-        F: FnMut(&Closure) -> Closure,
+        F: FnMut(&CBNClosure) -> CBNClosure,
     {
         match self.inner {
             InnerThunkData::Standard(ref c) => ThunkData {
@@ -367,7 +369,7 @@ pub struct BlackholedError;
 
 impl Thunk {
     /// Create a new standard thunk.
-    pub fn new(closure: Closure, ident_kind: IdentKind) -> Self {
+    pub fn new(closure: CBNClosure, ident_kind: IdentKind) -> Self {
         Thunk {
             data: Rc::new(RefCell::new(ThunkData::new(closure))),
             ident_kind,
@@ -411,17 +413,17 @@ impl Thunk {
     }
 
     /// Immutably borrow the inner closure. Panic if there is another active mutable borrow.
-    pub fn borrow(&self) -> Ref<'_, Closure> {
+    pub fn borrow(&self) -> Ref<'_, CBNClosure> {
         Ref::map(self.data.borrow(), |data| data.closure())
     }
 
     /// Mutably borrow the inner closure. Panic if there is any other active borrow.
-    pub fn borrow_mut(&mut self) -> RefMut<'_, Closure> {
+    pub fn borrow_mut(&mut self) -> RefMut<'_, CBNClosure> {
         RefMut::map(self.data.borrow_mut(), |data| data.closure_mut())
     }
 
     /// Get an owned clone of the inner closure.
-    pub fn get_owned(&self) -> Closure {
+    pub fn get_owned(&self) -> CBNClosure {
         self.data.borrow().closure().clone()
     }
 
@@ -431,7 +433,7 @@ impl Thunk {
 
     /// Consume the thunk and return an owned closure. Avoid cloning if this thunk is the only
     /// reference to the inner closure.
-    pub fn into_closure(self) -> Closure {
+    pub fn into_closure(self) -> CBNClosure {
         match Rc::try_unwrap(self.data) {
             Ok(inner) => inner.into_inner().into_closure(),
             Err(rc) => rc.borrow().closure().clone(),
@@ -448,7 +450,7 @@ impl Thunk {
         }
     }
 
-    pub fn build_cached(&mut self, rec_env: &[(Ident, Thunk)]) {
+    pub fn build_cached(&mut self, rec_env: &[(Ident, CacheIndex)]) {
         self.data.borrow_mut().init_cached(rec_env)
     }
 
@@ -541,7 +543,7 @@ impl Thunk {
     /// cached expression.
     pub fn map<F>(&self, f: F) -> Self
     where
-        F: FnMut(&Closure) -> Closure,
+        F: FnMut(&CBNClosure) -> CBNClosure,
     {
         Thunk {
             data: Rc::new(RefCell::new(self.data.borrow().map(f))),
@@ -583,7 +585,7 @@ impl ThunkUpdateFrame {
     ///
     /// - `true` if the thunk was successfully updated
     /// - `false` if the corresponding closure has been dropped since
-    pub fn update(self, closure: Closure) -> bool {
+    pub fn update(self, closure: CBNClosure) -> bool {
         if let Some(data) = Weak::upgrade(&self.data) {
             data.borrow_mut().update(closure);
             true
@@ -594,7 +596,7 @@ impl ThunkUpdateFrame {
 
     /// Reset the state of the thunk to Suspended
     /// Mainly used to reset the state of the vm between REPL runs
-    pub fn reset_state(self) {
+    pub fn reset_state(&mut self) {
         if let Some(data) = Weak::upgrade(&self.data) {
             data.borrow_mut().state = ThunkState::Suspended;
         }

--- a/src/eval/operation.rs
+++ b/src/eval/operation.rs
@@ -1231,8 +1231,12 @@ impl<R: ImportResolver, C: Cache> VirtualMachine<R, C> {
                     })
                 }
             }
-            UnaryOp::RecDefault() => Ok(RecPriority::Bottom.propagate_in_term(&mut self.cache, t, env, pos)),
-            UnaryOp::RecForce() => Ok(RecPriority::Top.propagate_in_term(&mut self.cache, t, env, pos)),
+            UnaryOp::RecDefault() => {
+                Ok(RecPriority::Bottom.propagate_in_term(&mut self.cache, t, env, pos))
+            }
+            UnaryOp::RecForce() => {
+                Ok(RecPriority::Top.propagate_in_term(&mut self.cache, t, env, pos))
+            }
             UnaryOp::RecordEmptyWithTail() => match_sharedterm! { t,
                 with {
                     Term::Record(r) => {

--- a/src/label.rs
+++ b/src/label.rs
@@ -4,7 +4,7 @@
 //! information about the context of a contract failure.
 use std::rc::Rc;
 
-use crate::eval::lazy::Thunk;
+use crate::eval::cache::CacheIndex;
 use crate::position::{RawSpan, TermPos};
 use crate::types::{TypeF, Types};
 use codespan::Files;
@@ -246,8 +246,8 @@ pub struct Label {
     pub tag: String,
     /// The position of the original contract.
     pub span: RawSpan,
-    /// The thunk corresponding to the value being checked. Set at run-time by the interpreter.
-    pub arg_thunk: Option<Thunk>,
+    /// The index corresponding to the value being checked. Set at run-time by the interpreter.
+    pub arg_idx: Option<CacheIndex>,
     /// The original position of the value being checked. Set at run-time by the interpreter.
     pub arg_pos: TermPos,
     /// The polarity, used for higher-order contracts, that specifies if the current contract is
@@ -268,7 +268,7 @@ impl Label {
                 start: 0.into(),
                 end: 1.into(),
             },
-            arg_thunk: None,
+            arg_idx: None,
             arg_pos: TermPos::None,
             polarity: true,
             path: Vec::new(),
@@ -286,7 +286,7 @@ impl Default for Label {
                 start: 0.into(),
                 end: 1.into(),
             },
-            arg_thunk: None,
+            arg_idx: None,
             arg_pos: TermPos::None,
             polarity: true,
             path: Vec::new(),

--- a/src/parser/utils.rs
+++ b/src/parser/utils.rs
@@ -419,7 +419,7 @@ pub fn mk_label(types: Types, src_id: FileId, l: usize, r: usize) -> Label {
         types: Rc::new(types),
         tag: String::new(),
         span: mk_span(src_id, l, r),
-        arg_thunk: None,
+        arg_idx: None,
         arg_pos: TermPos::None,
         polarity: true,
         path: Vec::new(),

--- a/src/program.rs
+++ b/src/program.rs
@@ -22,6 +22,7 @@
 //! Each such value is added to the initial environment before the evaluation of the program.
 use crate::cache::*;
 use crate::error::{Error, ToDiagnostic};
+use crate::eval::cache::Cache as EvalCache;
 use crate::eval::VirtualMachine;
 use crate::identifier::Ident;
 use crate::parser::lexer::Lexer;
@@ -37,29 +38,29 @@ use std::result::Result;
 ///
 /// Manage a file database, which stores the original source code of the program and eventually the
 /// code of imported expressions, and a dictionary which stores corresponding parsed terms.
-pub struct Program {
+pub struct Program<EC: EvalCache> {
     /// The id of the program source in the file database.
     main_id: FileId,
     /// The state of the Nickel virtual machine.
-    vm: VirtualMachine<Cache>,
+    vm: VirtualMachine<Cache, EC>,
 }
 
-impl Program {
+impl<EC: EvalCache> Program<EC> {
     /// Create a program by reading it from the standard input.
-    pub fn new_from_stdin() -> std::io::Result<Program> {
+    pub fn new_from_stdin() -> std::io::Result<Self> {
         Program::new_from_source(io::stdin(), "<stdin>")
     }
 
-    pub fn new_from_file(path: impl Into<OsString>) -> std::io::Result<Program> {
+    pub fn new_from_file(path: impl Into<OsString>) -> std::io::Result<Self> {
         let mut cache = Cache::new(ErrorTolerance::Strict);
         let main_id = cache.add_file(path)?;
         let vm = VirtualMachine::new(cache);
 
-        Ok(Program { main_id, vm })
+        Ok(Self { main_id, vm })
     }
 
     /// Create a program by reading it from a generic source.
-    pub fn new_from_source<T, S>(source: T, source_name: S) -> std::io::Result<Program>
+    pub fn new_from_source<T, S>(source: T, source_name: S) -> std::io::Result<Self>
     where
         T: Read,
         S: Into<OsString> + Clone,
@@ -68,23 +69,13 @@ impl Program {
         let main_id = cache.add_source(source_name, source)?;
         let vm = VirtualMachine::new(cache);
 
-        Ok(Program { main_id, vm })
+        Ok(Self { main_id, vm })
     }
 
     /// Retrieve the parsed term and typecheck it, and generate a fresh initial environment. Return
     /// both.
     fn prepare_eval(&mut self) -> Result<(RichTerm, eval::Environment), Error> {
-        let Envs {
-            eval_env,
-            type_ctxt,
-        } = self.vm.import_resolver_mut().prepare_stdlib()?;
-        self.vm
-            .import_resolver_mut()
-            .prepare(self.main_id, &type_ctxt)?;
-        Ok((
-            self.vm.import_resolver().get(self.main_id).unwrap(),
-            eval_env,
-        ))
+        self.vm.prepare_eval(self.main_id)
     }
 
     /// Parse if necessary, typecheck and then evaluate the program.
@@ -110,7 +101,7 @@ impl Program {
 
     /// Wrapper for [`query`].
     pub fn query(&mut self, path: Option<String>) -> Result<Term, Error> {
-        let initial_env = self.vm.import_resolver_mut().prepare_stdlib()?;
+        let initial_env = self.vm.prepare_stdlib()?;
         query(&mut self.vm, self.main_id, &initial_env, path)
     }
 
@@ -191,8 +182,8 @@ impl Program {
 //would additionally report `type: Num` for example.
 //TODO: not sure where this should go. It seems to embed too much logic to be in `Cache`, but is
 //common to both `Program` and `Repl`. Leaving it here as a stand-alone function for now
-pub fn query(
-    vm: &mut VirtualMachine<Cache>,
+pub fn query<EC: EvalCache>(
+    vm: &mut VirtualMachine<Cache, EC>,
     file_id: FileId,
     initial_env: &Envs,
     path: Option<String>,
@@ -210,13 +201,15 @@ pub fn query(
 
         // Substituting `y` for `t`
         let mut env = eval::Environment::new();
+        let rt = vm.import_resolver().get_owned(file_id).unwrap();
         eval::env_add(
+            &mut vm.cache,
             &mut env,
             Ident::from("x"),
-            vm.import_resolver().get_owned(file_id).unwrap(),
+            rt,
             eval::Environment::new(),
         );
-        eval::subst(new_term, &eval::Environment::new(), &env)
+        eval::subst(&vm.cache, new_term, &eval::Environment::new(), &env)
     } else {
         vm.import_resolver().get_owned(file_id).unwrap()
     };
@@ -372,15 +365,18 @@ mod doc {
 mod tests {
     use super::*;
     use crate::error::EvalError;
+    use crate::eval::cache::CBNCache;
     use crate::position::TermPos;
     use crate::term::ArrayAttrs;
     use assert_matches::assert_matches;
     use std::io::Cursor;
 
+    type EC = CBNCache;
+
     fn eval_full(s: &str) -> Result<RichTerm, Error> {
         let src = Cursor::new(s);
 
-        let mut p = Program::new_from_source(src, "<test>").map_err(|io_err| {
+        let mut p: Program<EC> = Program::new_from_source(src, "<test>").map_err(|io_err| {
             Error::EvalError(EvalError::Other(
                 format!("IO error: {}", io_err),
                 TermPos::None,
@@ -392,7 +388,7 @@ mod tests {
     fn typecheck(s: &str) -> Result<(), Error> {
         let src = Cursor::new(s);
 
-        let mut p = Program::new_from_source(src, "<test>").map_err(|io_err| {
+        let mut p: Program<EC> = Program::new_from_source(src, "<test>").map_err(|io_err| {
             Error::EvalError(EvalError::Other(
                 format!("IO error: {}", io_err),
                 TermPos::None,

--- a/src/repl/mod.rs
+++ b/src/repl/mod.rs
@@ -8,6 +8,7 @@
 //! formatting), etc.
 use crate::cache::{Cache, Envs, ErrorTolerance};
 use crate::error::{Error, EvalError, IOError, ParseError, ParseErrors, ReplError};
+use crate::eval::cache::Cache as EvalCache;
 use crate::eval::VirtualMachine;
 use crate::identifier::Ident;
 use crate::parser::{grammar, lexer, ExtendedTerm};
@@ -67,7 +68,7 @@ pub trait Repl {
 }
 
 /// Standard implementation of the REPL backend.
-pub struct ReplImpl {
+pub struct ReplImpl<EC: EvalCache> {
     /// The parser, supporting toplevel let declaration.
     parser: grammar::ExtendedTermParser,
     /// The current environment (for evaluation and typing). Contain the initial environment with
@@ -77,10 +78,10 @@ pub struct ReplImpl {
     /// typecheck imports in a fresh environment.
     initial_type_ctxt: typecheck::Context,
     /// The state of the Nickel virtual machine, holding a cache of loaded files and parsed terms.
-    vm: VirtualMachine<Cache>,
+    vm: VirtualMachine<Cache, EC>,
 }
 
-impl ReplImpl {
+impl<EC: EvalCache> ReplImpl<EC> {
     /// Create a new empty REPL.
     pub fn new() -> Self {
         ReplImpl {
@@ -94,7 +95,7 @@ impl ReplImpl {
     /// Load and process the stdlib, and use it to populate the eval environment as well as the
     /// typing environment.
     pub fn load_stdlib(&mut self) -> Result<(), Error> {
-        self.env = self.vm.import_resolver_mut().prepare_stdlib()?;
+        self.env = self.vm.prepare_stdlib()?;
         self.initial_type_ctxt = self.env.type_ctxt.clone();
         Ok(())
     }
@@ -126,8 +127,8 @@ impl ReplImpl {
         // `id` must be set to `None` for normal lets and to `Some(id_)` for top-level lets. In the
         // latter case, we need to update the current type environment before doing program
         // transformations in the case of a top-level let.
-        fn prepare(
-            repl_impl: &mut ReplImpl,
+        fn prepare<EC: EvalCache>(
+            repl_impl: &mut ReplImpl<EC>,
             id: Option<Ident>,
             t: RichTerm,
         ) -> Result<RichTerm, Error> {
@@ -194,14 +195,14 @@ impl ReplImpl {
             ExtendedTerm::ToplevelLet(id, t) => {
                 let t = prepare(self, Some(id), t)?;
                 let local_env = self.env.eval_env.clone();
-                eval::env_add(&mut self.env.eval_env, id, t, local_env);
+                eval::env_add(&mut self.vm.cache, &mut self.env.eval_env, id, t, local_env);
                 Ok(EvalResult::Bound(id))
             }
         }
     }
 }
 
-impl Repl for ReplImpl {
+impl<EC: EvalCache> Repl for ReplImpl<EC> {
     fn eval(&mut self, exp: &str) -> Result<EvalResult, Error> {
         self.eval_(exp, false)
     }
@@ -249,7 +250,7 @@ impl Repl for ReplImpl {
             self.vm.import_resolver(),
         )
         .unwrap();
-        eval::env_add_term(&mut self.env.eval_env, term.clone()).unwrap();
+        eval::env_add_term(&mut self.vm.cache, &mut self.env.eval_env, term.clone()).unwrap();
 
         Ok(term)
     }

--- a/src/repl/rustyline_frontend.rs
+++ b/src/repl/rustyline_frontend.rs
@@ -21,7 +21,7 @@ pub fn config() -> Config {
 
 /// Main loop of the REPL.
 pub fn repl(histfile: PathBuf) -> Result<(), InitError> {
-    let mut repl = ReplImpl::new();
+    let mut repl = ReplImpl::<crate::eval::cache::CBNCache>::new();
 
     match repl.load_stdlib() {
         Ok(()) => (),

--- a/src/repl/simple_frontend.rs
+++ b/src/repl/simple_frontend.rs
@@ -29,7 +29,7 @@ impl From<Error> for InputError {
 }
 
 /// Return a new instance of an REPL with the standard library loaded.
-pub fn init() -> Result<ReplImpl, Error> {
+pub fn init<EC: EvalCache>() -> Result<ReplImpl<EC>, Error> {
     let mut repl = ReplImpl::new();
     repl.load_stdlib()?;
     Ok(repl)

--- a/src/repl/wasm_frontend.rs
+++ b/src/repl/wasm_frontend.rs
@@ -3,6 +3,7 @@ use super::simple_frontend::{input, serialize, InputError, InputResult};
 use super::{Repl, ReplImpl};
 use crate::cache::Cache;
 use crate::error::ToDiagnostic;
+use crate::eval::cache::CBNCache;
 use crate::serialize::ExportFormat;
 use codespan::{FileId, Files};
 use codespan_reporting::{
@@ -243,7 +244,7 @@ impl From<InputResult> for WasmInputResult {
 
 /// WASM-compatible wrapper around `ReplImpl`.
 #[wasm_bindgen]
-pub struct ReplState(ReplImpl);
+pub struct ReplState(ReplImpl<CBNCache>);
 
 /// WASM-compatible wrapper around `serialize::ExportFormat`.
 #[wasm_bindgen]

--- a/src/serialize.rs
+++ b/src/serialize.rs
@@ -1,7 +1,11 @@
 //! Serialization of an evaluated program to various data format.
 use crate::{
     error::SerializationError,
-    eval::{self, is_empty_optional},
+    eval::{
+        self,
+        cache::{CBNCache, Cache},
+        is_empty_optional,
+    },
     term::{array::Array, record::RecordData, ArrayAttrs, MetaValue, RichTerm, Term},
 };
 
@@ -105,7 +109,7 @@ where
         .iter()
         // Filtering out optional fields without a definition. All variable should have been
         // substituted at this point, so we pass an empty environment.
-        .filter(|(_, t)| !is_empty_optional(t, &eval::Environment::new()))
+        .filter(|(_, t)| !is_empty_optional(&CBNCache {}, t, &eval::Environment::new()))
         .collect();
     entries.sort_by_key(|(k, _)| *k);
 
@@ -174,6 +178,7 @@ impl<'de> Deserialize<'de> for RichTerm {
 
 /// Check that a term is serializable. Serializable terms are booleans, numbers, strings, enum,
 /// arrays of serializable terms or records of serializable terms.
+/// TODO: We should have a NoCache impl of Cache or adapt the signature of [is_empty_optional()]
 pub fn validate(format: ExportFormat, t: &RichTerm) -> Result<(), SerializationError> {
     use crate::term;
     use Term::*;
@@ -206,7 +211,8 @@ pub fn validate(format: ExportFormat, t: &RichTerm) -> Result<(), SerializationE
                 value: Some(ref t), ..
             }) => validate(format, t),
             // Optional field without definition are accepted and ignored during serialization.
-            _ if is_empty_optional(t, &eval::Environment::new()) => Ok(()),
+            // TODO: This shouldn't spin a new cache
+            _ if is_empty_optional(&CBNCache::new(), t, &eval::Environment::new()) => Ok(()),
             _ => Err(SerializationError::NonSerializable(t.clone())),
         }
     }
@@ -267,14 +273,16 @@ mod tests {
     use super::*;
     use crate::cache::resolvers::DummyResolver;
     use crate::error::{Error, EvalError};
-    use crate::eval::{Environment, VirtualMachine};
+    use crate::eval::{cache::CBNCache, Environment, VirtualMachine};
     use crate::position::TermPos;
     use crate::program::Program;
     use crate::term::{make as mk_term, BinaryOp};
     use serde_json::json;
     use std::io::Cursor;
 
-    fn mk_program(s: &str) -> Result<Program, Error> {
+    type EC = CBNCache;
+
+    fn mk_program(s: &str) -> Result<Program<EC>, Error> {
         let src = Cursor::new(s);
 
         Program::new_from_source(src, "<test>").map_err(|io_err| {
@@ -330,7 +338,7 @@ mod tests {
                     .unwrap();
 
             assert_eq!(
-                VirtualMachine::new(DummyResolver {})
+                VirtualMachine::<_, EC>::new(DummyResolver {})
                     .eval(
                         mk_term::op2(BinaryOp::Eq(), from_json, evaluated.clone()),
                         &Environment::new(),
@@ -339,7 +347,7 @@ mod tests {
                 Ok(Term::Bool(true))
             );
             assert_eq!(
-                VirtualMachine::new(DummyResolver {})
+                VirtualMachine::<_, EC>::new(DummyResolver {})
                     .eval(
                         mk_term::op2(BinaryOp::Eq(), from_yaml, evaluated.clone()),
                         &Environment::new(),
@@ -348,7 +356,7 @@ mod tests {
                 Ok(Term::Bool(true))
             );
             assert_eq!(
-                VirtualMachine::new(DummyResolver {})
+                VirtualMachine::<_, EC>::new(DummyResolver {})
                     .eval(
                         mk_term::op2(BinaryOp::Eq(), from_toml, evaluated),
                         &Environment::new(),

--- a/src/transform/mod.rs
+++ b/src/transform/mod.rs
@@ -1,9 +1,9 @@
 //! Various post transformations of nickel code.
 use crate::{
     cache::ImportResolver,
-    eval::{lazy::Thunk, Closure, Environment, IdentKind},
+    eval::{cache::Cache, Closure, Environment, IdentKind},
     identifier::Ident,
-    term::{Contract, RichTerm, Term, TraverseOrder},
+    term::{BindingType, Contract, RichTerm, Term, TraverseOrder},
     typecheck::Wildcards,
     types::{TypeF, Types, UnboundTypeVariableError},
 };
@@ -70,7 +70,12 @@ pub fn transform_no_free_vars(
 pub trait Closurizable {
     /// Pack a closurizable together with its environment `with_env` as a closure in the main
     /// environment `env`.
-    fn closurize(self, env: &mut Environment, with_env: Environment) -> Self;
+    fn closurize<C: Cache>(
+        self,
+        cache: &mut C,
+        env: &mut Environment,
+        with_env: Environment,
+    ) -> Self;
 }
 
 impl Closurizable for RichTerm {
@@ -78,7 +83,12 @@ impl Closurizable for RichTerm {
     ///
     /// Generate a fresh variable, bind it to the corresponding closure `(t,with_env)` in `env`,
     /// and return this variable as a fresh term.
-    fn closurize(self, env: &mut Environment, with_env: Environment) -> RichTerm {
+    fn closurize<C: Cache>(
+        self,
+        cache: &mut C,
+        env: &mut Environment,
+        with_env: Environment,
+    ) -> RichTerm {
         // If the term is already a variable, we don't have to create a useless intermediate
         // closure. We just transfer the original thunk to the new environment. This is not only an
         // optimization: this is relied upon by recursive record merging when computing the
@@ -125,7 +135,7 @@ impl Closurizable for RichTerm {
         let var = Ident::fresh();
         let pos = self.pos;
 
-        let thunk = match self.as_ref() {
+        let idx = match self.as_ref() {
             Term::Var(id) if id.is_generated() => with_env.get(id).cloned().unwrap_or_else(|| {
                 panic!(
                 "Internal error(closurize) : generated identifier {} not found in the environment",
@@ -133,15 +143,15 @@ impl Closurizable for RichTerm {
             )
             }),
             _ => {
-                let closure = Closure {
+                let closure: Closure = Closure {
                     body: self,
                     env: with_env,
                 };
-                Thunk::new(closure, IdentKind::Record)
+                cache.add(closure, IdentKind::Record, BindingType::Normal)
             }
         };
 
-        env.insert(var, thunk);
+        env.insert(var, idx);
         RichTerm::new(Term::Var(var), pos.into_inherited())
     }
 }
@@ -151,17 +161,27 @@ impl Closurizable for Types {
     ///
     /// Extract the underlying contract, closurize it and wrap it back as a flat type (an opaque
     /// type defined by a custom contract).
-    fn closurize(self, env: &mut Environment, with_env: Environment) -> Types {
+    fn closurize<C: Cache>(
+        self,
+        cache: &mut C,
+        env: &mut Environment,
+        with_env: Environment,
+    ) -> Types {
         Types(TypeF::Flat(
-            self.contract().unwrap().closurize(env, with_env),
+            self.contract().unwrap().closurize(cache, env, with_env),
         ))
     }
 }
 
 impl Closurizable for Contract {
-    fn closurize(self, env: &mut Environment, with_env: Environment) -> Contract {
+    fn closurize<C: Cache>(
+        self,
+        cache: &mut C,
+        env: &mut Environment,
+        with_env: Environment,
+    ) -> Contract {
         Contract {
-            types: self.types.closurize(env, with_env),
+            types: self.types.closurize(cache, env, with_env),
             label: self.label,
         }
     }

--- a/tests/integration/examples.rs
+++ b/tests/integration/examples.rs
@@ -1,13 +1,13 @@
 use assert_matches::assert_matches;
 use nickel_lang::error::{Error, EvalError};
-use nickel_lang::program::Program;
 use nickel_lang::term::RichTerm;
+use nickel_lang_utilities::TestProgram;
 use std::path::PathBuf;
 
 fn eval_file(file: &str) -> Result<RichTerm, Error> {
     let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     path.push(format!("examples/{}", file));
-    let mut p = Program::new_from_file(path).expect("could not load file as a program");
+    let mut p = TestProgram::new_from_file(path).expect("could not load file as a program");
     p.eval_deep()
 }
 

--- a/tests/integration/imports.rs
+++ b/tests/integration/imports.rs
@@ -1,7 +1,7 @@
 use assert_matches::assert_matches;
 use nickel_lang::error::{Error, EvalError, ImportError, TypecheckError};
-use nickel_lang::program::Program;
 use nickel_lang::term::Term;
+use nickel_lang_utilities::TestProgram;
 use std::io::BufReader;
 use std::path::PathBuf;
 
@@ -16,7 +16,7 @@ fn mk_import(file: &str) -> String {
 
 #[test]
 fn nested() {
-    let mut prog = Program::new_from_source(
+    let mut prog = TestProgram::new_from_source(
         BufReader::new(mk_import("nested.ncl").as_bytes()),
         "should_be = 3",
     )
@@ -26,7 +26,7 @@ fn nested() {
 
 #[test]
 fn root_path() {
-    let mut prog = Program::new_from_source(
+    let mut prog = TestProgram::new_from_source(
         BufReader::new(mk_import("root_path.ncl").as_bytes()),
         "should_be = 44",
     )
@@ -36,7 +36,7 @@ fn root_path() {
 
 #[test]
 fn multi_imports() {
-    let mut prog = Program::new_from_source(
+    let mut prog = TestProgram::new_from_source(
         BufReader::new(mk_import("multi_imports.ncl").as_bytes()),
         "should_be = 5",
     )
@@ -46,7 +46,7 @@ fn multi_imports() {
 
 #[test]
 fn contract_fail() {
-    let mut prog = Program::new_from_source(
+    let mut prog = TestProgram::new_from_source(
         BufReader::new(mk_import("contract-fail.ncl").as_bytes()),
         "should_fail",
     )
@@ -59,7 +59,7 @@ fn contract_fail() {
 
 #[test]
 fn typecheck_fail() {
-    let mut prog = Program::new_from_source(
+    let mut prog = TestProgram::new_from_source(
         BufReader::new(mk_import("typecheck-fail.ncl").as_bytes()),
         "should_fail",
     )
@@ -72,7 +72,7 @@ fn typecheck_fail() {
 
 #[test]
 fn static_typing_fail() {
-    let mut prog = Program::new_from_source(
+    let mut prog = TestProgram::new_from_source(
         BufReader::new(format!("(let x = {} in x) : Str", mk_import("two.ncl")).as_bytes()),
         "should_fail",
     )
@@ -86,7 +86,7 @@ fn static_typing_fail() {
 #[test]
 fn serialize() {
     use nickel_lang::term::Term;
-    let mut prog = Program::new_from_source(
+    let mut prog = TestProgram::new_from_source(
         BufReader::new(
             format!(
                 "(builtin.serialize `Json ({})) == (builtin.serialize `Json ({{foo = \"ab\"}}))",
@@ -102,7 +102,7 @@ fn serialize() {
 
 #[test]
 fn circular_imports_fail() {
-    let mut prog = Program::new_from_source(
+    let mut prog = TestProgram::new_from_source(
         BufReader::new(mk_import("cycle.ncl").as_bytes()),
         "should_fail",
     )
@@ -115,7 +115,7 @@ fn circular_imports_fail() {
 
 #[test]
 fn import_unexpected_token_fail() {
-    let mut prog = Program::new_from_source(
+    let mut prog = TestProgram::new_from_source(
         BufReader::new(mk_import("unexpected_token.ncl").as_bytes()),
         "should_fail",
     )
@@ -128,7 +128,7 @@ fn import_unexpected_token_fail() {
 
 #[test]
 fn import_unexpected_token_in_record_fail() {
-    let mut prog = Program::new_from_source(
+    let mut prog = TestProgram::new_from_source(
         BufReader::new(
             format!(
                 "let x = {} in \"Hello, \" ++ x.name",
@@ -147,7 +147,7 @@ fn import_unexpected_token_in_record_fail() {
 
 #[test]
 fn import_unexpected_token_buried_fail() {
-    let mut prog = Program::new_from_source(
+    let mut prog = TestProgram::new_from_source(
         BufReader::new(
             format!(
                 "let _ign = {} in 1",

--- a/tests/integration/merge_fail.rs
+++ b/tests/integration/merge_fail.rs
@@ -1,14 +1,14 @@
 use assert_matches::assert_matches;
 use nickel_lang::error::{Error, EvalError};
 use nickel_lang::position::TermPos;
-use nickel_lang::program::Program;
 use nickel_lang::term::RichTerm;
+use nickel_lang_utilities::TestProgram;
 use std::io::Cursor;
 
 fn eval_full(s: &str) -> Result<RichTerm, Error> {
     let src = Cursor::new(s);
 
-    let mut p = Program::new_from_source(src, "<test>").map_err(|io_err| {
+    let mut p = TestProgram::new_from_source(src, "<test>").map_err(|io_err| {
         Error::EvalError(EvalError::Other(
             format!("IO error: {}", io_err),
             TermPos::None,

--- a/tests/integration/pass.rs
+++ b/tests/integration/pass.rs
@@ -1,5 +1,5 @@
-use nickel_lang::program::Program;
 use nickel_lang::term::Term;
+use nickel_lang_utilities::TestProgram;
 use std::ffi::OsString;
 use std::path::PathBuf;
 use std::thread;
@@ -10,7 +10,7 @@ const STACK_SIZE: usize = 4 * 1024 * 1024;
 
 fn run(path: impl Into<OsString>) {
     let path = path.into();
-    let mut p = Program::new_from_file(path.clone()).expect("could not load file as a program");
+    let mut p = TestProgram::new_from_file(path.clone()).expect("could not load file as a program");
     assert_eq!(
         p.eval().map(Term::from),
         Ok(Term::Bool(true)),

--- a/tests/integration/query.rs
+++ b/tests/integration/query.rs
@@ -1,9 +1,9 @@
-use nickel_lang::program::Program;
 use nickel_lang::term::{MetaValue, SharedTerm, Term};
+use nickel_lang_utilities::TestProgram;
 
 #[test]
 pub fn test_query_metadata_basic() {
-    let mut program = Program::new_from_source(
+    let mut program = TestProgram::new_from_source(
         "{val | doc \"Test basic\" = (1 + 1)}".as_bytes(),
         "regr_tests",
     )
@@ -22,11 +22,11 @@ pub fn test_query_metadata_basic() {
 pub fn test_query_with_wildcard() {
     /// Checks whether `lhs` and `rhs` both evaluate to terms with the same static type
     fn assert_types_eq(lhs: &str, rhs: &str) {
-        let term1 = Program::new_from_source(lhs.as_bytes(), "regr_tests")
+        let term1 = TestProgram::new_from_source(lhs.as_bytes(), "regr_tests")
             .unwrap()
             .query(None)
             .unwrap();
-        let term2 = Program::new_from_source(rhs.as_bytes(), "regr_tests")
+        let term2 = TestProgram::new_from_source(rhs.as_bytes(), "regr_tests")
             .unwrap()
             .query(None)
             .unwrap();
@@ -52,7 +52,7 @@ pub fn test_query_with_wildcard() {
     }
 
     // Without wildcard, the result has no type annotation
-    let mut program = Program::new_from_source("10".as_bytes(), "regr_tests").unwrap();
+    let mut program = TestProgram::new_from_source("10".as_bytes(), "regr_tests").unwrap();
     let result = program.query(None).unwrap();
     assert!(!matches!(result, Term::MetaValue(_)));
 


### PR DESCRIPTION
This refactor adds a `Cache` trait that abstracts away (not yet 100%) from `Thunk`s.
This change will facilitate the adoption of a new incremental caching mechanism and further experiments on evaluation/caching strategies other than CBN.

`Thunk`s are still leaking from the abstraction, but I think that's the best we can afford given the current state of `CacheIndex`