### PR TITLE
Introduce `%record_diff_fields%` primitive

### DIFF
--- a/src/eval/operation.rs
+++ b/src/eval/operation.rs
@@ -1955,6 +1955,42 @@ impl<R: ImportResolver> VirtualMachine<R> {
                     ))
                 }
             },
+            BinaryOp::DiffRecordFields() => match_sharedterm! {t1,
+                with {
+                    Term::Record(r1) => match_sharedterm! {t2,
+                        with {
+                            Term::Record(r2) => {
+                                let mut r1 = r1;
+                                r1.fields.retain(|k, _| !r2.fields.contains_key(k));
+                                Ok(Closure {
+                                    body: RichTerm::new(Term::Record(r1), fst_pos),
+                                    env: env1
+                                })
+                            }
+                        } else {
+                            Err(EvalError::TypeError(
+                                String::from("Record"),
+                                String::from("%record_diff_fields%, 2nd argument"),
+                                snd_pos,
+                                RichTerm {
+                                    term: t2,
+                                    pos: pos2
+                                }
+                            ))
+                        }
+                    }
+                } else {
+                    Err(EvalError::TypeError(
+                        String::from("Record"),
+                        String::from("%record_diff_fields%, 1st argument"),
+                        fst_pos,
+                        RichTerm {
+                            term: t1,
+                            pos: pos1,
+                        }
+                    ))
+                }
+            },
             BinaryOp::HasField() => match_sharedterm! {t1, with {
                     Term::Str(id) => {
                         if let Term::Record(record) = &*t2 {

--- a/src/parser/grammar.lalrpop
+++ b/src/parser/grammar.lalrpop
@@ -736,6 +736,7 @@ BOpPre: BinaryOp = {
     "str_contains" => BinaryOp::StrContains(),
     "record_insert" => BinaryOp::DynExtend(),
     "record_remove" => BinaryOp::DynRemove(),
+    "record_diff_fields" => BinaryOp::DiffRecordFields(),
 }
 
 NOpPre<ArgRule>: UniTerm = {
@@ -878,6 +879,7 @@ extern {
         "record_map" => Token::Normal(NormalToken::RecordMap),
         "record_insert" => Token::Normal(NormalToken::RecordInsert),
         "record_remove" => Token::Normal(NormalToken::RecordRemove),
+        "record_diff_fields" => Token::Normal(NormalToken::RecordDiffFields),
         "seq" => Token::Normal(NormalToken::Seq),
         "deep_seq" => Token::Normal(NormalToken::DeepSeq),
         "head" => Token::Normal(NormalToken::Head),

--- a/src/parser/lexer.rs
+++ b/src/parser/lexer.rs
@@ -197,6 +197,8 @@ pub enum NormalToken<'input> {
     RecordInsert,
     #[token("%record_remove%")]
     RecordRemove,
+    #[token("%record_diff_fields%")]
+    RecordDiffFields,
     #[token("%seq%")]
     Seq,
     #[token("%deep_seq%")]

--- a/src/term.rs
+++ b/src/term.rs
@@ -1370,6 +1370,11 @@ pub enum BinaryOp {
     DynRemove(),
     /// Access the field of record. The field name is given as an arbitrary Nickel expression.
     DynAccess(),
+    /// Return a new record containing all the fields of the first argument which are
+    /// not featured in the second argument.
+    ///
+    /// Preserves the polymorphic tail of the first argument, if one is set.
+    DiffRecordFields(),
     /// Test if a record has a specific field.
     HasField(),
     /// Concatenate two arrays.

--- a/src/typecheck/operation.rs
+++ b/src/typecheck/operation.rs
@@ -304,6 +304,12 @@ pub fn get_bop_type(
                 mk_typewrapper::dyn_record(res),
             )
         }
+        // Dyn -> Dyn -> Dyn
+        BinaryOp::DiffRecordFields() => (
+            mk_typewrapper::dynamic(),
+            mk_typewrapper::dynamic(),
+            mk_typewrapper::dynamic(),
+        ),
         // forall a. Str -> {_: a} -> Bool
         BinaryOp::HasField() => {
             let ty_elt = UnifType::UnifVar(state.table.fresh_type_var_id());

--- a/stdlib/internals.ncl
+++ b/stdlib/internals.ncl
@@ -47,23 +47,11 @@
 
   "$record" = fun field_contracts tail_contract l t =>
     if %typeof% t == `Record then
-      # Returns the sub-record of `l` containing only those
-      # fields which are not present in `r`.
-      let field_diff = fun l r => array.foldl
-        (fun acc f =>
-          if %has_field% f r then
-            acc
-          else
-            %record_insert% f acc (l."%{f}"))
-        {}
-        (%fields% l)
-      in
-
-      let contracts_not_in_t = field_diff field_contracts t in
+      let contracts_not_in_t = %record_diff_fields% field_contracts t in
       let missing_fields = %fields% contracts_not_in_t in
 
       if %length% missing_fields == 0 then
-        let tail_fields = field_diff t field_contracts in
+        let tail_fields = %record_diff_fields% t field_contracts in
         let fields_with_contracts = array.foldl
           (fun acc f =>
             if %has_field% f field_contracts then


### PR DESCRIPTION
Previously we used a regular Nickel function to diff the fields of the records inside the `$record` contract. However, as we are moving to an "internal" representation of sealed polymorphic record tails, a regular function will no longer work. This is because there's no way on the Nickel side to build a new record which is guaranteed to have the sealed tail of another.

This commit introduces a new primitive, `%record_diff_fields%`, which returns only the (visible) fields of the first argument which are not also present in the second argument, while preserving whatever tail the first argument had.