### PR TITLE
Move comparison table to main README; add JSON, YAML and TOML

### DIFF
--- a/RATIONALE.md
+++ b/RATIONALE.md
@@ -347,16 +347,20 @@ The main difference between Jsonnet and Nickel are types. Jsonnet does not
 feature static types, contracts or enriched values, and thus can't type library
 code and has no principled approach to data validation.
 
-### Summary
+### Comparison with other configuration languages
+<!-- Intentionally duplicated in `README.md`, please update the other one for any change done here -->
 
-| Language | Typing                        | Recursion  | Evaluation | Side-effects                                      |
-|----------|-------------------------------|------------|------------|---------------------------------------------------|
-| Nickel   | Gradual (dynamic + static)    | Yes        | Lazy       | Yes (constrained)                                 |
-| Starlark | Dynamic                       | No         | Strict     | No                                                |
-| Nix      | Dynamic                       | Yes        | Lazy       | Predefined and specialized to package management  |
-| Dhall    | Static (requires annotations) | Restricted | Lazy       | No                                                |
-| CUE      | Static (everything is a type) | No         | Lazy       | No, but allowed in the separated scripting layer  |
-| Jsonnet  | Dynamic                       | Yes        | Lazy       | No                                                |
+| Language | Typing                        | Recursion  | Evaluation | Side-effects                                     |
+|----------|-------------------------------|------------|------------|--------------------------------------------------|
+| Nickel   | Gradual (dynamic + static)    | Yes        | Lazy       | Yes (constrained, planned)                       |
+| Starlark | Dynamic                       | No         | Strict     | No                                               |
+| Nix      | Dynamic                       | Yes        | Lazy       | Predefined and specialized to package management |
+| Dhall    | Static (requires annotations) | Restricted | Lazy       | No                                               |
+| CUE      | Static (everything is a type) | No         | Lazy       | No, but allowed in the separated scripting layer |
+| Jsonnet  | Dynamic                       | Yes        | Lazy       | No                                               |
+| JSON     | None                          | No         | Strict     | No                                               |
+| YAML     | None                          | No         | N/A        | No                                               |
+| TOML     | None                          | No         | N/A        | No                                               |
 
 ## Conclusion
 

--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ comparison with these languages.
 
 | Language | Typing                        | Recursion  | Evaluation | Side-effects                                     |
 |----------|-------------------------------|------------|------------|--------------------------------------------------|
-| Nickel   | Gradual (dynamic + static)    | Yes        | Lazy       | Yes (constrained)                                |
+| Nickel   | Gradual (dynamic + static)    | Yes        | Lazy       | Yes (constrained, planned)                       |
 | Starlark | Dynamic                       | No         | Strict     | No                                               |
 | Nix      | Dynamic                       | Yes        | Lazy       | Predefined and specialized to package management |
 | Dhall    | Static (requires annotations) | Restricted | Lazy       | No                                               |

--- a/README.md
+++ b/README.md
@@ -247,11 +247,14 @@ comparison with these languages.
 ### Comparison with other configuration languages
 <!-- Intentionally duplicated in `RATIONALE.md`, please update the other one for any change done here -->
 
-| Language | Typing                        | Recursion  | Evaluation | Side-effects                                      |
-|----------|-------------------------------|------------|------------|---------------------------------------------------|
-| Nickel   | Gradual (dynamic + static)    | Yes        | Lazy       | Yes (constrained)                                 |
-| Starlark | Dynamic                       | No         | Strict     | No                                                |
-| Nix      | Dynamic                       | Yes        | Lazy       | Predefined and specialized to package management  |
-| Dhall    | Static (requires annotations) | Restricted | Lazy       | No                                                |
-| CUE      | Static (everything is a type) | No         | Lazy       | No, but allowed in the separated scripting layer  |
-| Jsonnet  | Dynamic                       | Yes        | Lazy       | No                                                |
+| Language | Typing                        | Recursion  | Evaluation | Side-effects                                     |
+|----------|-------------------------------|------------|------------|--------------------------------------------------|
+| Nickel   | Gradual (dynamic + static)    | Yes        | Lazy       | Yes (constrained)                                |
+| Starlark | Dynamic                       | No         | Strict     | No                                               |
+| Nix      | Dynamic                       | Yes        | Lazy       | Predefined and specialized to package management |
+| Dhall    | Static (requires annotations) | Restricted | Lazy       | No                                               |
+| CUE      | Static (everything is a type) | No         | Lazy       | No, but allowed in the separated scripting layer |
+| Jsonnet  | Dynamic                       | Yes        | Lazy       | No                                               |
+| JSON     | None                          | No         | Strict     | No                                               |
+| YAML     | None                          | No         | N/A        | No                                               |
+| TOML     | None                          | No         | N/A        | No                                               |

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ The motivating use cases are in particular:
     a specification of the dependency graph.
 
 Most aforementioned projects have their own bespoke configuration language. See
-[Related projects and inspirations](#related-projects-and-inspirations). In
+[Comparison](#comparison). In
 general, application-specific languages might suffer from feature creep, lack of
 abstractions or just feel ad hoc. Nickel buys you more for less.
 
@@ -208,7 +208,7 @@ to be used in production. The next steps we plan to work on are:
   [overriding proposal](https://github.com/tweag/nickel/blob/9fd6e436c0db8f101d4eb26cf97c4993357a7c38/rfcs/001-overriding.md))
 - Performance improvements
 
-## Related projects and inspirations
+## Comparison
 
 - [CUE](https://cuelang.org/) is a configuration language with a focus on data
     validation. It introduces a new constraint system backed by a solid theory
@@ -242,4 +242,16 @@ to be used in production. The next steps we plan to work on are:
     forbidden, making it not Turing-complete.
 
 See [RATIONALE.md](./RATIONALE.md) for the design rationale and a more detailed
-comparison with a selection of these languages.
+comparison with these languages.
+
+### Comparison with other configuration languages
+<!-- Intentionally duplicated in `RATIONALE.md`, please update the other one for any change done here -->
+
+| Language | Typing                        | Recursion  | Evaluation | Side-effects                                      |
+|----------|-------------------------------|------------|------------|---------------------------------------------------|
+| Nickel   | Gradual (dynamic + static)    | Yes        | Lazy       | Yes (constrained)                                 |
+| Starlark | Dynamic                       | No         | Strict     | No                                                |
+| Nix      | Dynamic                       | Yes        | Lazy       | Predefined and specialized to package management  |
+| Dhall    | Static (requires annotations) | Restricted | Lazy       | No                                                |
+| CUE      | Static (everything is a type) | No         | Lazy       | No, but allowed in the separated scripting layer  |
+| Jsonnet  | Dynamic                       | Yes        | Lazy       | No                                                |


### PR DESCRIPTION
I don't know how this PR will be received but I think it's worth having this conversation :smile: 

This PR contains 2 commits but we can remove one of them (I coupled them in the same PR to avoid conflicts).

* Move the comparison table with other languages to the main README
   I have always felt this was needed. When users evaluate a new tech, they want to quickly compare to familiar things, to understand what they would get and lose at first glance. This table should thus be promoted to the main README, and the section renamed
* Add JSON, YAML and TOML in the comparison list
   As silly as it may seem, I think this is legitimate to add those in the comparison. 