### PR TITLE
[Refactor] Renaming `tyw` to `uty`

### DIFF
--- a/lsp/nls/src/requests/completion.rs
+++ b/lsp/nls/src/requests/completion.rs
@@ -427,13 +427,13 @@ mod tests {
 
     #[test]
     fn test_extract_ident_with_path() {
-        use nickel_lang::{mk_tyw_record, mk_tyw_row, types::RecordRowsF};
+        use nickel_lang::{mk_uty_record, mk_uty_row, types::RecordRowsF};
         use std::convert::TryInto;
 
         // Representing the type: {a: {b : {c1 : Num, c2: Num}}}
-        let c_record_type = mk_tyw_record!(("c1", TypeF::Num), ("c2", TypeF::Num));
-        let b_record_type = mk_tyw_record!(("b", c_record_type));
-        let a_record_type = mk_tyw_row!(("a", b_record_type));
+        let c_record_type = mk_uty_record!(("c1", TypeF::Num), ("c2", TypeF::Num));
+        let b_record_type = mk_uty_record!(("b", c_record_type));
+        let a_record_type = mk_uty_row!(("a", b_record_type));
 
         let mut path = vec![Ident::from("b"), Ident::from("a")];
         // unwrap: the conversion must succeed because we built a type without unification variable

--- a/src/typecheck/eq.rs
+++ b/src/typecheck/eq.rs
@@ -419,31 +419,31 @@ fn type_eq_bounded<E: TermEnvironment>(
             | (TypeF::Bool, TypeF::Bool)
             | (TypeF::Sym, TypeF::Sym)
             | (TypeF::Str, TypeF::Str) => true,
-            (TypeF::Dict(tyw1), TypeF::Dict(tyw2)) | (TypeF::Array(tyw1), TypeF::Array(tyw2)) => {
-                type_eq_bounded(state, tyw1, env1, tyw2, env2)
+            (TypeF::Dict(uty1), TypeF::Dict(uty2)) | (TypeF::Array(uty1), TypeF::Array(uty2)) => {
+                type_eq_bounded(state, uty1, env1, uty2, env2)
             }
             (TypeF::Arrow(s1, t1), TypeF::Arrow(s2, t2)) => {
                 type_eq_bounded(state, s1, env1, s2, env2)
                     && type_eq_bounded(state, t1, env1, t2, env2)
             }
-            (TypeF::Enum(tyw1), TypeF::Enum(tyw2)) => {
-                let rows1 = rows_as_set(tyw1);
-                let rows2 = rows_as_set(tyw2);
+            (TypeF::Enum(uty1), TypeF::Enum(uty2)) => {
+                let rows1 = rows_as_set(uty1);
+                let rows2 = rows_as_set(uty2);
                 rows1.is_some() && rows2.is_some() && rows1 == rows2
             }
-            (TypeF::Record(tyw1), TypeF::Record(tyw2)) => {
+            (TypeF::Record(uty1), TypeF::Record(uty2)) => {
                 fn type_eq_bounded_wrapper<E: TermEnvironment>(
                     state: &mut State,
-                    tyw1: &&GenericUnifType<E>,
+                    uty1: &&GenericUnifType<E>,
                     env1: &E,
-                    tyw2: &&GenericUnifType<E>,
+                    uty2: &&GenericUnifType<E>,
                     env2: &E,
                 ) -> bool {
-                    type_eq_bounded(state, *tyw1, env1, *tyw2, env2)
+                    type_eq_bounded(state, *uty1, env1, *uty2, env2)
                 }
 
-                let map1 = rows_as_map(tyw1);
-                let map2 = rows_as_map(tyw2);
+                let map1 = rows_as_map(uty1);
+                let map2 = rows_as_map(uty2);
 
                 map1.zip(map2)
                     .map(|(m1, m2)| map_eq(type_eq_bounded_wrapper, state, &m1, env1, &m2, env2))

--- a/src/typecheck/mk_uniftype.rs
+++ b/src/typecheck/mk_uniftype.rs
@@ -3,7 +3,7 @@ use super::{TypeF, UnifType};
 
 /// Multi-ary arrow constructor for types implementing `Into<TypeWrapper>`.
 #[macro_export]
-macro_rules! mk_tyw_arrow {
+macro_rules! mk_uty_arrow {
     ($left:expr, $right:expr) => {
         $crate::typecheck::UnifType::Concrete(
             $crate::types::TypeF::Arrow(
@@ -13,14 +13,14 @@ macro_rules! mk_tyw_arrow {
         )
     };
     ( $fst:expr, $snd:expr , $( $types:expr ),+ ) => {
-        mk_tyw_arrow!($fst, mk_tyw_arrow!($snd, $( $types ),+))
+        mk_uty_arrow!($fst, mk_uty_arrow!($snd, $( $types ),+))
     };
 }
 
 /// Multi-ary enum row constructor for types implementing `Into<TypeWrapper>`.
-/// `mk_tyw_enum_row!(id1, .., idn; tail)` correspond to `<id1, .., idn | tail>.
+/// `mk_uty_enum_row!(id1, .., idn; tail)` correspond to `<id1, .., idn | tail>.
 #[macro_export]
-macro_rules! mk_tyw_enum_row {
+macro_rules! mk_uty_enum_row {
     () => {
         $crate::typecheck::UnifEnumRows::Concrete(EnumRowsF::Empty)
     };
@@ -31,17 +31,17 @@ macro_rules! mk_tyw_enum_row {
         $crate::typecheck::UnifEnumRows::Concrete(
             $crate::types::EnumRowsF::Extend {
                 row: Ident::from($id),
-                tail: Box::new(mk_tyw_enum_row!($( $ids ),* $(; $tail)?))
+                tail: Box::new(mk_uty_enum_row!($( $ids ),* $(; $tail)?))
             }
         )
     };
 }
 
 /// Multi-ary record row constructor for types implementing `Into<TypeWrapper>`.
-/// `mk_tyw_row!((id1, ty1), .., (idn, tyn); tail)` correspond to `{id1: ty1, .., idn: tyn |
+/// `mk_uty_row!((id1, ty1), .., (idn, tyn); tail)` correspond to `{id1: ty1, .., idn: tyn |
 /// tail}. The tail can be omitted, in which case the empty row is uses as a tail instead.
 #[macro_export]
-macro_rules! mk_tyw_row {
+macro_rules! mk_uty_row {
     () => {
         $crate::typecheck::UnifRecordRows::Concrete(RecordRowsF::Empty)
     };
@@ -55,31 +55,31 @@ macro_rules! mk_tyw_row {
                     id: Ident::from($id),
                     types: Box::new($ty.into()),
                 },
-                tail: Box::new(mk_tyw_row!($(($ids, $tys)),* $(; $tail)?)),
+                tail: Box::new(mk_uty_row!($(($ids, $tys)),* $(; $tail)?)),
             }
         )
     };
 }
 
-/// Wrapper around `mk_tyw_enum_row!` to build an enum type from an enum row.
+/// Wrapper around `mk_uty_enum_row!` to build an enum type from an enum row.
 #[macro_export]
-macro_rules! mk_tyw_enum {
+macro_rules! mk_uty_enum {
     ($( $ids:expr ),* $(; $tail:expr)?) => {
         $crate::typecheck::UnifType::Concrete(
             $crate::types::TypeF::Enum(
-                mk_tyw_enum_row!($( $ids ),* $(; $tail)?)
+                mk_uty_enum_row!($( $ids ),* $(; $tail)?)
             )
         )
     };
 }
 
-/// Wrapper around `mk_tyw_record!` to build a record type from a record row.
+/// Wrapper around `mk_uty_record!` to build a record type from a record row.
 #[macro_export]
-macro_rules! mk_tyw_record {
+macro_rules! mk_uty_record {
     ($(($ids:expr, $tys:expr)),* $(; $tail:expr)?) => {
         $crate::typecheck::UnifType::Concrete(
             $crate::types::TypeF::Record(
-                mk_tyw_row!($(($ids, $tys)),* $(; $tail)?)
+                mk_uty_row!($(($ids, $tys)),* $(; $tail)?)
             )
         )
     };


### PR DESCRIPTION
Gets rid of the last references to the old name of `UnifType` (previously `TypeWrapper`) in function, macro or variable names after #875.