### PR TITLE
Revertible thunks as function II: fix recursive overriding

### DIFF
--- a/src/eval/lazy.rs
+++ b/src/eval/lazy.rs
@@ -148,7 +148,7 @@ impl ThunkData {
     ///
     /// This function is similar in spirit to setting the cached value to be the explicit function
     /// application given as built by `saturate`, but applied to arguments taken
-    /// from `rec_env`. The major difference is that `init_cached` avoid the creation of the
+    /// from `rec_env`. The major difference is that `init_cached` avoids the creation of the
     /// intermediate redex `(fun id1 .. id n => orig) %1 .. %n` as well as the intermediate thunks
     /// and terms, because we can compute the result application right away, in-place.
     pub fn init_cached(&mut self, rec_env: &[(Ident, Thunk)]) {
@@ -163,7 +163,7 @@ impl ThunkData {
                 // an invariant that MUST be maintained by the interpreter.
                 //
                 // `cached` set to `None` solely exists because we need to first allocate all the
-                // revertible thunks corresponding to a recursive record, and only then we can
+                // revertible thunks corresponding to a recursive record, and only then can we
                 // patch them (build the cached value) in a second step, but they should be
                 // logically seen as one construction operation.
                 assert!(
@@ -354,7 +354,7 @@ impl ThunkData {
 /// revertible thunks. Most expressions don't need revertible thunks as their evaluation will
 /// always give the same result, but some others, such as the ones containing recursive references
 /// inside a record may be invalidated by merging, and thus need to store the unaltered original
-/// expression. Those aspects are mainly handled and discussed into more details in
+/// expression. Those aspects are handled and discussed in more detail in
 /// [InnerThunkData].
 #[derive(Clone, Debug, PartialEq)]
 pub struct Thunk {
@@ -487,7 +487,7 @@ impl Thunk {
     /// # Standard thunks (non-revertible)
     ///
     /// Non revertible thunks can be seen as a special case of revertible thunks with no
-    /// dependencies. Thus the abstraction and application are zero-ary, and the result is just the
+    /// dependencies. Thus the abstraction and application are nullary, and the result is just the
     /// current thunk closurized in `env` as a fresh variable.
     ///
     /// # Example

--- a/src/eval/lazy.rs
+++ b/src/eval/lazy.rs
@@ -1,5 +1,5 @@
 //! Thunks and associated devices used to implement lazy evaluation.
-use super::{Closure, IdentKind};
+use super::{Closure, Environment, IdentKind};
 use crate::{
     identifier::Ident,
     term::{FieldDeps, RichTerm, Term},
@@ -31,6 +31,13 @@ pub enum ThunkState {
 pub struct ThunkData {
     inner: InnerThunkData,
     state: ThunkState,
+}
+
+/// The two different kind of thunks.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ThunkType {
+    Standard,
+    Revertible,
 }
 
 /// The part of [ThunkData] responsible for storing the closure itself. It can either be:
@@ -124,11 +131,9 @@ impl ThunkData {
 
     /// Create new revertible thunk data.
     pub fn new_rev(orig: Closure, deps: FieldDeps) -> Self {
-        let rc = Rc::new(orig);
-
         ThunkData {
             inner: InnerThunkData::Revertible {
-                orig: rc.clone(),
+                orig: Rc::new(orig),
                 cached: None,
                 deps,
             },
@@ -136,22 +141,24 @@ impl ThunkData {
         }
     }
 
-    /// Build the cached value of a revertible thunk in a given recursive environment.
+    /// Initialize the cached value of a revertible thunk, given the recursive environment of the
+    /// corresponding record. This function is a no-op on a standard thunk.
     ///
     /// # Invariant
     ///
-    /// This function must be called **exactly once** on a revertible thunk, after the initial
+    /// **This function must be called exactly once** on a revertible thunk, after the initial
     /// construction. It's part of its initialization. Calling it on a revertible thunks a second
     /// time, with a `cached` value which is not set to `None`, will panic.
     ///
     /// Non-revertible thunks are not concerned: this function has no effect on them, even if
     /// called repeatedly.
     ///
-    /// This function is equivalent to calling TODO: FILL NAME, with generated variables pointing
-    /// to each thunk as arguments. The only difference is that `build_cached` avoid the creation
-    /// of an intermediate redex `(fun id1 .. id n => orig) %1 .. %n`, and perform the application
-    /// in one step.
-    pub fn build_cached(&mut self, rec_env: &[(Ident, Thunk)]) {
+    /// This function is similar in spirit to setting the cached value to be the explicit function
+    /// application given as built by `saturate`, but applied to arguments taken
+    /// from `rec_env`. The major difference is that `build_cached` avoid the creation of the
+    /// intermediate redex `(fun id1 .. id n => orig) %1 .. %n` as well as the intermediate thunks
+    /// and terms, because we can compute the result application right away, in-place.
+    pub fn init_cached(&mut self, rec_env: &[(Ident, Thunk)]) {
         match self.inner {
             InnerThunkData::Standard(_) => (),
             InnerThunkData::Revertible {
@@ -171,7 +178,7 @@ impl ThunkData {
                     "tried to build the cached value of a revertible thunk, but was already set"
                 );
 
-                let mut new_cached = Closure::clone(&*orig);
+                let mut new_cached = Closure::clone(orig);
 
                 match deps {
                     Some(deps) if deps.is_empty() => (),
@@ -186,65 +193,37 @@ impl ThunkData {
         }
     }
 
-    //build_cached ~ cached = build_cached_as_app(self, rec_env.iter())
-
-    // build_cached(rev_thunk, rec_env ~ arguments) ~> "app" (rev_thunk, rec_env)
-    // build_cached_as_app(..)
-    // (fun x y z ... => (original expr of rev_thunk) (rec_env filter by thunk deps)
-    //
-    pub fn build_cached_as_app<
-        'a,
-        I: DoubleEndedIterator<Item = (&'a Ident, &'a RichTerm)> + Clone,
-    >(
-        &mut self,
-        args: I,
-    ) {
+    /// Revert a thunk and abstract over the provided arguments to get back a function. The result
+    /// is returned in a new, non-revertible, thunk.
+    ///
+    /// Used by [Thunk::saturate]. See the corresponding documentation for more
+    /// details.
+    ///
+    /// # Example
+    ///
+    /// If `orig` is `foo + bar + a` and `args` correspond to `bar, foo`, this functions returns a
+    /// standard thunk containing `fun bar foo => foo + bar + a`.
+    fn revthunk_as_explicit_fun<'a, I>(self, args: I) -> Self
+    where
+        I: DoubleEndedIterator<Item = &'a Ident>,
+    {
         match self.inner {
-            InnerThunkData::Standard(_) => (),
-            InnerThunkData::Revertible {
-                ref mut cached,
-                ref orig,
-                ref deps,
-            } => {
-                // `build_cached_app` must be called exactly once on a revertible thunk. This is an
-                // invariant that MUST be maintained by the interpreter.
-                //
-                // `cached` set to `None` solely exists because we need to first allocate all the
-                // revertible thunks corresponding to a recursive record, and only then we can
-                // patch them (build the cached value) in a second step, but they should be
-                // logically seen as one construction operation.
-                assert!(
-                    cached.is_none(),
-                    "tried to build the applied version of cached value of a revertible thunk, but was already set"
-                );
-
-                let Closure { body, env } = Closure::clone(orig);
-
-                // Only keep arguments that actually appear free in the revertible thunk's body.
-                //
-                // It would be better to have the `match` outside of the filtering closure, because
-                // it is independent from the identifier, but Rust's closures make this hard to
-                // type (require dyn trait objects or boxing). Given the size of `deps`, and the
-                // overhead of dyn trait objects, it doesn't seem worth the trouble.
-                let filtered = args.filter(|(ident, _)| match deps {
-                    Some(deps) if deps.is_empty() => false,
-                    Some(deps) => deps.contains(ident),
-                    None => true,
-                });
+            InnerThunkData::Standard(_) => self,
+            InnerThunkData::Revertible { orig, .. } => {
+                let Closure { body, env } =
+                    Rc::try_unwrap(orig).unwrap_or_else(|rc| Closure::clone(&rc));
 
                 // Build a list of the arguments that the function will need in the same order as
                 // the original iterator. If the identifiers inside `args` are `a`, `b` and `c`, in
                 // that order, we want to build `fun a => (fun b (fun c => body))`. We thus need a
                 // reverse fold.
-                let as_function = filtered.clone().map(|(id, _)| id).rfold(body, |built, id| {
-                    RichTerm::from(Term::Fun(id.clone(), built))
-                });
-                // Apply the freshly built function to the corresponding arguments.
-                let applied = filtered.fold(as_function, |built, (_, rt)| {
-                    RichTerm::from(Term::App(built, rt.clone()))
-                });
+                let as_function =
+                    args.rfold(body, |built, id| RichTerm::from(Term::Fun(*id, built)));
 
-                *cached = Some(Closure { body: applied, env });
+                ThunkData::new(Closure {
+                    body: as_function,
+                    env,
+                })
             }
         }
     }
@@ -370,6 +349,13 @@ impl ThunkData {
                 .unwrap_or(ThunkDeps::Unknown),
         }
     }
+
+    pub fn typ(&self) -> ThunkType {
+        match self.inner {
+            InnerThunkData::Standard(_) => ThunkType::Standard,
+            InnerThunkData::Revertible { .. } => ThunkType::Revertible,
+        }
+    }
 }
 
 /// A thunk.
@@ -382,7 +368,8 @@ impl ThunkData {
 /// revertible thunks. Most expressions don't need revertible thunks as their evaluation will
 /// always give the same result, but some others, such as the ones containing recursive references
 /// inside a record may be invalidated by merging, and thus need to store the unaltered original
-/// expression. Those aspects are mainly handled in [InnerThunkData].
+/// expression. Those aspects are mainly handled and discussed into more details in
+/// [InnerThunkData].
 #[derive(Clone, Debug, PartialEq)]
 pub struct Thunk {
     data: Rc<RefCell<ThunkData>>,
@@ -473,7 +460,92 @@ impl Thunk {
     }
 
     pub fn build_cached(&mut self, rec_env: &[(Ident, Thunk)]) {
-        self.data.borrow_mut().build_cached(rec_env)
+        self.data.borrow_mut().init_cached(rec_env)
+    }
+
+    /// Revert a thunk, abstract over its dependencies to get back a function, and apply the
+    /// function to the given variables. The function part is allocated in a new fresh thunk,
+    /// stored as a generated variable, with the same environment as the original expression.
+    ///
+    /// Recall that revertible thunks are just a memoization mechanism) for function application.
+    /// The original expression (`orig`) and the dependencies (`deps`) are a representation of a
+    /// function. Most of the time, we don't have to go through an explicit function, and just
+    /// manipulate the body of the function directly (which is what is stored inside the `orig`
+    /// field).
+    ///
+    /// However, in the general case of merging two record fields which may be both recursive (i.e.
+    /// which may contain a revertible thunk), we have to use the explicit function representation
+    /// and apply it to variables, which correspond to the fields of the recursive record being
+    /// built by merging.
+    ///
+    /// `saturate`:
+    /// - abstract the original expression of the underlying revertible thunk, forming a function.
+    /// - store this function in a fresh standard thunk
+    /// - return the application of this function to the provided record field names (as variables)
+    ///
+    /// Field names are taken as an iterator over identifiers.
+    ///
+    /// # Parameters
+    ///
+    /// - `env`: the environment in which the explicit function expression is closurized. When
+    ///   performing recursive overriding, this is the local environment of the final merged field.
+    /// - `fields`: the fields of the resulting recursive record being built by merging. `fields` is used for two
+    ///   purposes:
+    ///     - to impose a fixed order on the arguments of the function. The particular order is not
+    ///       important but it must be the same used for forming the function and forming the
+    ///       application, to avoid a mismatch like `(fun foo bar => ...) bar foo`
+    ///     - to know what parameters to use for reverting a thunk whose dependencies are unknown.
+    ///       In that case, we must be conservative and abstract over all the fields of the
+    ///       recursive record, but we can't get this information from `self` alone
+    ///
+    /// # Standard thunks (non-revertible)
+    ///
+    /// Non revertible thunks can be seen as a special case of revertible thunks with no
+    /// dependencies. Thus the abstraction and application are zero-ary, and the result is just the
+    /// current thunk closurized in `env` as a fresh variable.
+    ///
+    /// # Example
+    ///
+    /// If `orig` is `foo + bar + a` where `foo` and `bar` are thunk dependencies (hence are free
+    /// variables) and `a` is bound in the environment. Say the iterator represents the fields
+    /// `bar, b, foo` in that order. Then `rev_thunk_as_explicit_app`:
+    ///
+    /// - stores `fun bar foo => foo + bar + a` in a fresh thunk with the same environment as
+    ///   `self` (in particular, `a` is bound)
+    /// - allocates a fresh variable, say `%1`, and binds it to the previous thunk in `env`
+    /// - returns the term `%1 foo bar`
+    pub fn saturate<'a, I: DoubleEndedIterator<Item = &'a Ident> + Clone>(
+        self,
+        env: &mut Environment,
+        fields: I,
+    ) -> RichTerm {
+        let deps = self.deps();
+        let inner = Rc::try_unwrap(self.data)
+            .map(RefCell::into_inner)
+            .unwrap_or_else(|rc| rc.borrow().clone());
+
+        let mut deps_filter: Box<dyn FnMut(&&Ident) -> bool> = match deps {
+            ThunkDeps::Empty => Box::new(|_: &&Ident| false),
+            ThunkDeps::Known(deps) => Box::new(move |id: &&Ident| deps.contains(id)),
+            ThunkDeps::Unknown => Box::new(|_: &&Ident| true),
+        };
+
+        let thunk_as_function = Thunk {
+            data: Rc::new(RefCell::new(
+                inner.revthunk_as_explicit_fun(fields.clone().filter(&mut deps_filter)),
+            )),
+            ident_kind: self.ident_kind,
+        };
+
+        let fresh_var = Ident::fresh();
+        env.insert(fresh_var, thunk_as_function);
+
+        let as_function = RichTerm::from(Term::Var(fresh_var));
+        let args = fields.filter_map(|id| deps_filter(&id).then(|| RichTerm::from(Term::Var(*id))));
+
+        args.fold(as_function, |partial_app, arg| {
+            RichTerm::from(Term::App(partial_app, arg))
+        })
     }
 
     /// Map a function over the content of the thunk to create a new, fresh independent thunk. If
@@ -502,6 +574,10 @@ impl Thunk {
     /// [`crate::transform::free_vars`].
     pub fn deps(&self) -> ThunkDeps {
         self.data.borrow().deps()
+    }
+
+    pub fn typ(&self) -> ThunkType {
+        self.data.borrow().typ()
     }
 }
 

--- a/src/eval/lazy.rs
+++ b/src/eval/lazy.rs
@@ -526,10 +526,10 @@ impl Thunk {
         let fresh_var = Ident::fresh();
         env.insert(fresh_var, thunk_as_function);
 
-        let as_function = RichTerm::from(Term::Var(fresh_var));
+        let as_function_closurized = RichTerm::from(Term::Var(fresh_var));
         let args = fields.filter_map(|id| deps_filter(&id).then(|| RichTerm::from(Term::Var(*id))));
 
-        args.fold(as_function, |partial_app, arg| {
+        args.fold(as_function_closurized, |partial_app, arg| {
             RichTerm::from(Term::App(partial_app, arg))
         })
     }

--- a/src/eval/lazy.rs
+++ b/src/eval/lazy.rs
@@ -113,6 +113,9 @@ pub enum InnerThunkData {
     },
 }
 
+const REVTHUNK_NO_CACHED_VALUE_MSG: &str =
+    "tried to get data from a revertible thunk without a cached value";
+
 impl ThunkData {
     /// Create new standard thunk data.
     pub fn new(closure: Closure) -> Self {
@@ -234,9 +237,9 @@ impl ThunkData {
             // them (build the cached value) in a second step. But calling to
             // [`ThunkData::new_rev`] followed by [`ThunkData::build_cached_value`] should be logically
             // seen as just one construction operation.
-            InnerThunkData::Revertible { ref cached, .. } => cached
-                .as_ref()
-                .expect("tried to get data from a revertible thunk without a cached value"),
+            InnerThunkData::Revertible { ref cached, .. } => {
+                cached.as_ref().expect(REVTHUNK_NO_CACHED_VALUE_MSG)
+            }
         }
     }
 
@@ -266,7 +269,7 @@ impl ThunkData {
             // [`ThunkData::new_rev`] followed by [`ThunkData::build_cached_value`] should be logically
             // seen as just one construction operation.
             InnerThunkData::Revertible { cached, .. } => {
-                cached.expect("tried to get data from a revertible thunk without a cached value")
+                cached.expect(REVTHUNK_NO_CACHED_VALUE_MSG)
             }
         }
     }

--- a/src/eval/lazy.rs
+++ b/src/eval/lazy.rs
@@ -263,7 +263,7 @@ impl ThunkData {
     pub fn into_closure(self) -> Closure {
         match self.inner {
             InnerThunkData::Standard(closure) => closure,
-            // Nothing should access the cached value of a revertible thunks before the cached
+            // Nothing should access the cached value of a revertible thunk before the cached
             // value has been constructed. This is an invariant that MUST be maintained by the
             // interpreter
             //
@@ -467,7 +467,7 @@ impl Thunk {
     /// function to the given variables. The function part is allocated in a new fresh thunk,
     /// stored as a generated variable, with the same environment as the original expression.
     ///
-    /// Recall that revertible thunks are just a memoization mechanism) for function application.
+    /// Recall that revertible thunks are just a memoization mechanism for function application.
     /// The original expression (`orig`) and the dependencies (`deps`) are a representation of a
     /// function. Most of the time, we don't have to go through an explicit function, and just
     /// manipulate the body of the function directly (which is what is stored inside the `orig`
@@ -479,9 +479,9 @@ impl Thunk {
     /// built by merging.
     ///
     /// `saturate`:
-    /// - abstract the original expression of the underlying revertible thunk, forming a function.
-    /// - store this function in a fresh standard thunk
-    /// - return the application of this function to the provided record field names (as variables)
+    /// - abstracts the original expression of the underlying revertible thunk, forming a function.
+    /// - stores this function in a fresh standard thunk
+    /// - returns the application of this function to the provided record field names (as variables)
     ///
     /// Field names are taken as an iterator over identifiers.
     ///
@@ -508,7 +508,7 @@ impl Thunk {
     ///
     /// If `orig` is `foo + bar + a` where `foo` and `bar` are thunk dependencies (hence are free
     /// variables) and `a` is bound in the environment. Say the iterator represents the fields
-    /// `bar, b, foo` in that order. Then `rev_thunk_as_explicit_app`:
+    /// `bar, b, foo` in that order. Then `saturate`:
     ///
     /// - stores `fun bar foo => foo + bar + a` in a fresh thunk with the same environment as
     ///   `self` (in particular, `a` is bound)

--- a/src/eval/lazy.rs
+++ b/src/eval/lazy.rs
@@ -33,13 +33,6 @@ pub struct ThunkData {
     state: ThunkState,
 }
 
-/// The two different kind of thunks.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum ThunkType {
-    Standard,
-    Revertible,
-}
-
 /// The part of [ThunkData] responsible for storing the closure itself. It can either be:
 /// - A standard thunk, that is destructively updated once and for all
 /// - A revertible thunk, that can be restored to its original expression. Used to implement
@@ -349,13 +342,6 @@ impl ThunkData {
                 .unwrap_or(ThunkDeps::Unknown),
         }
     }
-
-    pub fn typ(&self) -> ThunkType {
-        match self.inner {
-            InnerThunkData::Standard(_) => ThunkType::Standard,
-            InnerThunkData::Revertible { .. } => ThunkType::Revertible,
-        }
-    }
 }
 
 /// A thunk.
@@ -574,10 +560,6 @@ impl Thunk {
     /// [`crate::transform::free_vars`].
     pub fn deps(&self) -> ThunkDeps {
         self.data.borrow().deps()
-    }
-
-    pub fn typ(&self) -> ThunkType {
-        self.data.borrow().typ()
     }
 }
 

--- a/src/eval/lazy.rs
+++ b/src/eval/lazy.rs
@@ -215,7 +215,7 @@ impl ThunkData {
 
                 // Build a list of the arguments that the function will need in the same order as
                 // the original iterator. If the identifiers inside `args` are `a`, `b` and `c`, in
-                // that order, we want to build `fun a => (fun b (fun c => body))`. We thus need a
+                // that order, we want to build `fun a => (fun b => (fun c => body))`. We thus need a
                 // reverse fold.
                 let as_function =
                     args.rfold(body, |built, id| RichTerm::from(Term::Fun(*id, built)));

--- a/src/eval/lazy.rs
+++ b/src/eval/lazy.rs
@@ -225,7 +225,7 @@ impl ThunkData {
     pub fn closure(&self) -> &Closure {
         match self.inner {
             InnerThunkData::Standard(ref closure) => closure,
-            // Nothing should peek into a revertible thunks before the cached value has been
+            // Nothing should peek into a revertible thunk before the cached value has been
             // constructed by [`build_cached_value`]. This is an invariant that MUST be maintained
             // by the interpreter.
             //

--- a/src/eval/lazy.rs
+++ b/src/eval/lazy.rs
@@ -148,7 +148,7 @@ impl ThunkData {
     ///
     /// This function is similar in spirit to setting the cached value to be the explicit function
     /// application given as built by `saturate`, but applied to arguments taken
-    /// from `rec_env`. The major difference is that `build_cached` avoid the creation of the
+    /// from `rec_env`. The major difference is that `init_cached` avoid the creation of the
     /// intermediate redex `(fun id1 .. id n => orig) %1 .. %n` as well as the intermediate thunks
     /// and terms, because we can compute the result application right away, in-place.
     pub fn init_cached(&mut self, rec_env: &[(Ident, Thunk)]) {

--- a/src/eval/merge.rs
+++ b/src/eval/merge.rs
@@ -396,6 +396,10 @@ pub fn merge(
                 _ => (),
             };
 
+            // We use field_names for saturating revertible thunks. The iterator order is important
+            // and must stay the same within this function. Because hashset are randomized, cloning
+            // field_names, inserting new values, etc. will change iteration order. Please don't do
+            // that.
             let field_names: Vec<_> = left
                 .keys()
                 .chain(center.keys())

--- a/src/eval/merge.rs
+++ b/src/eval/merge.rs
@@ -393,7 +393,7 @@ pub fn merge(
             let mut m = HashMap::with_capacity(left.len() + center.len() + right.len());
             let mut env = Environment::new();
 
-            // Merging recursive record is the one operation that may override recursive fields. To
+            // Merging recursive records is the one operation that may override recursive fields. To
             // have the recursive fields depend on the updated values, we need to revert the
             // corresponding thunks to their original expression.
             //
@@ -540,10 +540,10 @@ fn field_deps(rt: &RichTerm, local_env: &Environment) -> Result<ThunkDeps, EvalE
 /// is the merge of the two fields, closurized in the provided final environment.
 ///
 /// The thunk allocated for the result is revertible if and only if at least one of the original
-/// thunk is (if one of the original value is overridable, then so is the merge of the two). In
+/// thunks is (if one of the original values is overridable, then so is the merge of the two). In
 /// this case, the field dependencies are the union of the dependencies of each field.
 ///
-/// The fields are saturaed (see [saturate]) to properly propagate recursive dependencies down to
+/// The fields are saturated (see [saturate]) to properly propagate recursive dependencies down to
 /// `t1` and `t2` in the final, merged record.
 fn fields_merge_closurize<'a, I: DoubleEndedIterator<Item = &'a Ident> + Clone>(
     env: &mut Environment,

--- a/src/eval/merge.rs
+++ b/src/eval/merge.rs
@@ -504,8 +504,8 @@ fn merge_doc(doc1: Option<String>, doc2: Option<String>) -> Option<String> {
 /// fields. See [crate::eval::lazy::Thunk::saturate].
 ///
 /// If the expression is not a variable referring to a thunk (this can happen e.g. for numeric
-/// constant), we just return the term as it is, which falls into the zero dependencies special
-/// case as well.
+/// constants), we just return the term as it is, which falls into the zero dependencies special
+/// case.
 fn saturate<'a, I: DoubleEndedIterator<Item = &'a Ident> + Clone>(
     rt: RichTerm,
     env: &mut Environment,
@@ -544,7 +544,7 @@ fn field_deps(rt: &RichTerm, local_env: &Environment) -> Result<ThunkDeps, EvalE
 /// this case, the field dependencies are the union of the dependencies of each field.
 ///
 /// The fields are saturaed (see [saturate]) to properly propagate recursive dependencies down to
-/// the `t1` and `t2` in the final, merged record.
+/// `t1` and `t2` in the final, merged record.
 fn fields_merge_closurize<'a, I: DoubleEndedIterator<Item = &'a Ident> + Clone>(
     env: &mut Environment,
     t1: RichTerm,

--- a/tests/integration/pass.rs
+++ b/tests/integration/pass.rs
@@ -132,3 +132,8 @@ fn quote_in_indentifier() {
 fn priorities() {
     check_file("priorities.ncl")
 }
+
+#[test]
+fn multiple_overrides() {
+    check_file("multiple-overrides.ncl")
+}

--- a/tests/integration/pass/multiple-overrides.ncl
+++ b/tests/integration/pass/multiple-overrides.ncl
@@ -1,0 +1,112 @@
+let {check, ..} = import "testlib.ncl" in
+
+[
+  # regression test for issue #908 (https://github.com/tweag/nickel/issues/908)
+  let override = { foo = "overridden" } in
+  let schema = {
+    config | {
+      output | {
+          value | Str,
+      }
+    },
+  } in
+  let data = {
+    foo | Str
+      | default = "original",
+
+    config.output.value = foo,
+  } in
+  (override & (schema & data))
+  == {
+
+    foo = "overridden",
+    config.output.value = "overridden",
+  },
+
+  # 2-stage override
+  let fst_override = { foo = "first override"} in
+  let snd_override = { foo | force = "second override"} in
+  let schema = {
+    config | {
+      output | {
+          value | Str,
+      }
+    },
+  } in
+  let data = {
+    foo | Str
+        | default = "original",
+
+    config.output.value = foo,
+  } in
+  (fst_override & (schema & data) & snd_override)
+  == {
+    foo = "second override",
+    config.output.value = "second override",
+  },
+
+  # 2-stage overriding, with a 3-way merging
+  let fst_override = { foo = "first override"} in
+  let snd_override = { foo | force = "second override"} in
+  let schema = {
+    config | {
+      output | {
+          value | Str,
+          ..
+      }
+    },
+  } in
+  let fst_data = {
+    foo | Str
+        | default = "original",
+
+    config.output.value = foo,
+  } in
+  let snd_data = {
+    foo,
+    config.output.snd_data = foo,
+  } in
+  (fst_override
+  & (schema & fst_data & snd_data)
+  & snd_override)
+  == {
+    foo = "second override",
+    config.output.value = "second override",
+    config.output.snd_data = "second override",
+  },
+
+  # merging recursive expressions with different dependencies
+  let fst_data = {
+    common.fst = snd_data ++ "_data",
+    snd_data | Str
+             | default = "",
+    fst_data = "fst",
+  } in
+  let snd_data = {
+    common.snd = fst_data ++ "_data",
+    fst_data | Str
+             | default = "",
+    snd_data = "snd",
+  } in
+  let final_override | _push_force = {
+    fst_data = "override",
+    snd_data = "override",
+    common.final = fst_data ++ "_" ++ snd_data,
+  } in
+  [
+    fst_data & snd_data == {
+      common.fst = "snd_data",
+      common.snd = "fst_data",
+      fst_data = "fst",
+      snd_data = "snd",
+    },
+    (fst_data & snd_data) & final_override == {
+      common.fst = "override_data",
+      common.snd = "override_data",
+      common.final = "override_override",
+      fst_data = "override",
+      snd_data = "override",
+    }
+  ] |> check,
+]
+|> check


### PR DESCRIPTION
# Revertible thunks are functions

Closes #908.

Follow-up of #924: bring the presentation of revertible thunks as just functions  memoization devices to its logical conclusion by providing helper to explicitly rebuild the represented function and apply it. This explicit application was required to fix recursive overriding in the general case, see #908. Now, the implementation faithfully expresses general merging of recursive fields as `common_field = fun self => (left_field self) & (right_field self)`, when recursive record fields are understood as functions of `self` (representing the ambient record).

## Revertible thunks representation

This PR also reworks the representation of revertible thunks. They used to store the cached data as an `Rc<Closure>`, initialized as soon as the revertible thunks was initialized. This doesn't model revertible thunks faithfully: the cached value should be owned (as it is for normal thunks), and as long as the revertible thunks hasn't be "patched" (or, when seen as a function, applied), the cached value is meaningless and may contain free variables, id est unbound identifiers.

The cached value should never be used before full initialization. This PR sets the cached value to be an `Option<Closure>`, and to panic if it used before initialization. It also ensures that initialization is done only once. The previous implementation wouldn't complain about such violation. Note that we have no choice to perform the construction of a revertible thunks in two steps, and thus observe a transitory state where the cached value is not initialized, because we are potentially building cyclic values. However, if the implementation is correct, the state where the cached value is set to `None` shouldn't really be observable.

