### PR TITLE
Statically type `string.join`

### DIFF
--- a/stdlib/string.ncl
+++ b/stdlib/string.ncl
@@ -146,8 +146,7 @@
       else
         %blame% (%tag% "not a string" l),
 
-    # using a contract instead of type for now because of https://github.com/tweag/nickel/issues/226
-    join | Str -> Array Str -> Str
+    join : Str -> Array Str -> Str
     | doc m%"
       Joins a array of strings given a seperator.
 


### PR DESCRIPTION
This previously used a contract annotation rather than a type, due to issue #226, however the annotation wasn't updated after that issue was closed. This commit fixes that.