### PR TITLE
[refactor] Re-implement polymorphic record contracts

### DIFF
--- a/src/destruct.rs
+++ b/src/destruct.rs
@@ -67,6 +67,7 @@ impl Destruct {
                             .map(|m| m.as_meta_field())
                             .collect(),
                         RecordAttrs { open },
+                        None,
                     ))
                     .into(),
                 )),

--- a/src/eval/merge.rs
+++ b/src/eval/merge.rs
@@ -55,7 +55,7 @@ use super::*;
 use crate::error::EvalError;
 use crate::label::Label;
 use crate::position::TermPos;
-use crate::term::record::RecordData;
+use crate::term::record::{self, RecordData};
 use crate::term::{
     make as mk_term, BinaryOp, Contract, FieldDeps, MetaValue, RecordAttrs, RichTerm, SharedTerm,
     Term,
@@ -93,7 +93,7 @@ pub fn merge(
     env2: Environment,
     pos_op: TermPos,
     mode: MergeMode,
-    call_stack: &CallStack,
+    call_stack: &mut CallStack,
 ) -> Result<Closure, EvalError> {
     // Merging a simple value and a metavalue is equivalent to first wrapping the simple value in a
     // new metavalue (with no attribute set excepted the value), and then merging the two
@@ -368,6 +368,15 @@ pub fn merge(
         // Merge put together the fields of records, and recursively merge
         // fields that are present in both terms
         (Term::Record(r1), Term::Record(r2)) => {
+            // While it wouldn't be impossible to merge records with sealed tails,
+            // working out how to do so in a "sane" way that preserves parametricity
+            // is non-trivial. It's also not entirely clear that this is something
+            // users will generally have reason to do, so in the meantime we've
+            // decided to just prevent this entirely
+            if let Some(record::SealedTail { label, .. }) = r1.sealed_tail.or(r2.sealed_tail) {
+                return Err(EvalError::BlameError(label, std::mem::take(call_stack)));
+            }
+
             let hashmap::SplitResult {
                 left,
                 center,

--- a/src/eval/merge.rs
+++ b/src/eval/merge.rs
@@ -52,7 +52,7 @@
 //! - *Contract check*: merging a `Contract` or a `ContractDefault` with a simple value `t`
 //! evaluates to a contract check, that is an `Assume(..., t)`
 use super::*;
-use crate::error::EvalError;
+use crate::error::{EvalError, IllegalPolymorphicTailAction};
 use crate::label::Label;
 use crate::position::TermPos;
 use crate::term::record::{self, RecordData};
@@ -374,7 +374,11 @@ pub fn merge(
             // users will generally have reason to do, so in the meantime we've
             // decided to just prevent this entirely
             if let Some(record::SealedTail { label, .. }) = r1.sealed_tail.or(r2.sealed_tail) {
-                return Err(EvalError::BlameError(label, std::mem::take(call_stack)));
+                return Err(EvalError::IllegalPolymorphicTailAccess {
+                    action: IllegalPolymorphicTailAction::Merge,
+                    label,
+                    call_stack: std::mem::take(call_stack),
+                });
             }
 
             let hashmap::SplitResult {

--- a/src/eval/merge.rs
+++ b/src/eval/merge.rs
@@ -433,7 +433,7 @@ pub fn merge(
                     // about them anymore, and dependencies are stored at the level of revertible
                     // thunks directly.
                     Term::RecRecord(
-                        RecordData::new(m, RecordAttrs::merge(r1.attrs, r2.attrs)),
+                        RecordData::new(m, RecordAttrs::merge(r1.attrs, r2.attrs), None),
                         Vec::new(),
                         None,
                     ),

--- a/src/eval/operation.rs
+++ b/src/eval/operation.rs
@@ -1201,6 +1201,25 @@ impl<R: ImportResolver> VirtualMachine<R> {
             }
             UnaryOp::PushDefault() => Ok(PushPriority::Bottom.push_into(t, env, pos)),
             UnaryOp::PushForce() => Ok(PushPriority::Top.push_into(t, env, pos)),
+            UnaryOp::RecordEmptyWithTail() => match_sharedterm! { t,
+                with {
+                    Term::Record(r) => {
+                        let mut empty = RecordData::empty();
+                        empty.sealed_tail = r.sealed_tail;
+                        Ok(Closure {
+                            body: RichTerm::new(Term::Record(empty), pos_op.into_inherited()),
+                            env
+                        })
+                    },
+                } else {
+                    Err(EvalError::TypeError(
+                        String::from("Record"),
+                        String::from("%record_empty_with_tail%, 1st arg"),
+                        arg_pos,
+                        RichTerm { term: t, pos }
+                    ))
+                }
+            },
         }
     }
 

--- a/src/eval/operation.rs
+++ b/src/eval/operation.rs
@@ -615,6 +615,19 @@ impl<R: ImportResolver> VirtualMachine<R> {
 
                 match_sharedterm! {t, with {
                         Term::Record(record) => {
+                            // While it's certainly possible to allow mapping over
+                            // a record with a sealed tail, it's not entirely obvious
+                            // how that should behave. It's also not clear that this
+                            // is something users will actually need to do, so we've
+                            // decided to prevent this until we have a clearer idea
+                            // of potential use-cases.
+                            if let Some(record::SealedTail { label, .. }) = record.sealed_tail {
+                                return Err(EvalError::BlameError(
+                                    label,
+                                    std::mem::take(&mut self.call_stack),
+                                ))
+                            }
+
                             let mut shared_env = Environment::new();
                             let f_as_var = f.body.closurize(&mut env, f.env);
 

--- a/src/eval/operation.rs
+++ b/src/eval/operation.rs
@@ -1876,7 +1876,7 @@ impl<R: ImportResolver> VirtualMachine<R> {
                                 match fields.insert(Ident::from(id), as_var) {
                                     Some(t) if !is_empty_optional(&t, &env2) => Err(EvalError::Other(format!("$[ .. ]: tried to extend record with the field {}, but it already exists", id), pos_op)),
                                     _ => Ok(Closure {
-                                        body: Term::Record(RecordData::new(fields, record.attrs)).into(),
+                                        body: Term::Record(RecordData::new(fields, record.attrs, record.sealed_tail)).into(),
                                         env: env2,
                                     }),
                                 }
@@ -1916,7 +1916,7 @@ impl<R: ImportResolver> VirtualMachine<R> {
                                         id,
                                         String::from("(-$)"),
                                         RichTerm::new(
-                                            Term::Record(RecordData::new(fields, record.attrs)),
+                                            Term::Record(RecordData::new(fields, record.attrs, record.sealed_tail)),
                                             pos2,
                                         ),
                                         pos_op,
@@ -1925,7 +1925,7 @@ impl<R: ImportResolver> VirtualMachine<R> {
                                 else {
                                     Ok(Closure {
                                         body: RichTerm::new(
-                                            Term::Record(RecordData::new(fields, record.attrs)), pos_op_inh
+                                            Term::Record(RecordData::new(fields, record.attrs, record.sealed_tail)), pos_op_inh
                                         ),
                                         env: env2,
                                     })

--- a/src/eval/operation.rs
+++ b/src/eval/operation.rs
@@ -2144,7 +2144,7 @@ impl<R: ImportResolver> VirtualMachine<R> {
                 env2,
                 pos_op,
                 MergeMode::Standard,
-                &self.call_stack,
+                &mut self.call_stack,
             ),
 
             BinaryOp::Hash() => {
@@ -2586,7 +2586,7 @@ impl<R: ImportResolver> VirtualMachine<R> {
                                 env3,
                                 pos_op,
                                 MergeMode::Contract(lbl),
-                                &self.call_stack
+                                &mut self.call_stack
                             )
                         }
                     } else {

--- a/src/eval/operation.rs
+++ b/src/eval/operation.rs
@@ -1912,7 +1912,7 @@ impl<R: ImportResolver> VirtualMachine<R> {
                                 match fields.insert(Ident::from(id), as_var) {
                                     Some(t) if !is_empty_optional(&t, &env2) => Err(EvalError::Other(format!("$[ .. ]: tried to extend record with the field {}, but it already exists", id), pos_op)),
                                     _ => Ok(Closure {
-                                        body: Term::Record(RecordData::new(fields, record.attrs, record.sealed_tail)).into(),
+                                        body: Term::Record(RecordData { fields, ..record }).into(),
                                         env: env2,
                                     }),
                                 }
@@ -1952,7 +1952,7 @@ impl<R: ImportResolver> VirtualMachine<R> {
                                         id,
                                         String::from("(-$)"),
                                         RichTerm::new(
-                                            Term::Record(RecordData::new(fields, record.attrs, record.sealed_tail)),
+                                            Term::Record(RecordData { fields, ..record }),
                                             pos2,
                                         ),
                                         pos_op,
@@ -1961,7 +1961,7 @@ impl<R: ImportResolver> VirtualMachine<R> {
                                 else {
                                     Ok(Closure {
                                         body: RichTerm::new(
-                                            Term::Record(RecordData::new(fields, record.attrs, record.sealed_tail)), pos_op_inh
+                                            Term::Record(RecordData { fields, ..record }), pos_op_inh
                                         ),
                                         env: env2,
                                     })

--- a/src/eval/operation.rs
+++ b/src/eval/operation.rs
@@ -11,8 +11,11 @@ use super::{
     merge::{merge, MergeMode},
     subst, Closure, Environment, ImportResolver, VirtualMachine,
 };
-use crate::term::{record, MetaValue};
 use crate::term::{record::RecordData, MergePriority};
+use crate::{
+    error::IllegalPolymorphicTailAction,
+    term::{record, MetaValue},
+};
 
 use crate::{
     error::EvalError,
@@ -622,10 +625,11 @@ impl<R: ImportResolver> VirtualMachine<R> {
                             // decided to prevent this until we have a clearer idea
                             // of potential use-cases.
                             if let Some(record::SealedTail { label, .. }) = record.sealed_tail {
-                                return Err(EvalError::BlameError(
+                                return Err(EvalError::IllegalPolymorphicTailAccess {
+                                    action: IllegalPolymorphicTailAction::Map,
                                     label,
-                                    std::mem::take(&mut self.call_stack),
-                                ))
+                                    call_stack: std::mem::take(&mut self.call_stack),
+                                })
                             }
 
                             let mut shared_env = Environment::new();

--- a/src/parser/grammar.lalrpop
+++ b/src/parser/grammar.lalrpop
@@ -776,6 +776,8 @@ NOpPre<ArgRule>: UniTerm = {
         UniTerm::from(mk_opn!(NAryOp::StrSubstr(), t1, t2, t3)),
     "record_seal_tail" <t1: ArgRule> <t2: ArgRule> <t3: ArgRule> <t4: ArgRule> =>
         UniTerm::from(mk_opn!(NAryOp::RecordSealTail(), t1, t2, t3, t4)),
+    "record_unseal_tail" <t1: ArgRule> <t2: ArgRule> <t3: ArgRule> =>
+        UniTerm::from(mk_opn!(NAryOp::RecordUnsealTail(), t1, t2, t3)),
 }
 
 TypeBuiltin: Types = {
@@ -911,6 +913,7 @@ extern {
         "record_insert" => Token::Normal(NormalToken::RecordInsert),
         "record_remove" => Token::Normal(NormalToken::RecordRemove),
         "record_seal_tail" => Token::Normal(NormalToken::RecordSealTail),
+        "record_unseal_tail" => Token::Normal(NormalToken::RecordUnsealTail),
         "seq" => Token::Normal(NormalToken::Seq),
         "deep_seq" => Token::Normal(NormalToken::DeepSeq),
         "head" => Token::Normal(NormalToken::Head),

--- a/src/parser/grammar.lalrpop
+++ b/src/parser/grammar.lalrpop
@@ -583,6 +583,7 @@ UOp: UnaryOp = {
     "str_match" => UnaryOp::StrMatch(),
     "push_force_op" => UnaryOp::PushForce(),
     "push_default_op" => UnaryOp::PushDefault(),
+    "record_empty_with_tail" => UnaryOp::RecordEmptyWithTail(),
 };
 
 SwitchCase: SwitchCase = {
@@ -904,6 +905,7 @@ extern {
         "unseal" => Token::Normal(NormalToken::Unseal),
         "embed" => Token::Normal(NormalToken::Embed),
         "record_map" => Token::Normal(NormalToken::RecordMap),
+        "record_empty_with_tail" => Token::Normal(NormalToken::RecordEmptyWithTail),
         "record_insert" => Token::Normal(NormalToken::RecordInsert),
         "record_remove" => Token::Normal(NormalToken::RecordRemove),
         "seq" => Token::Normal(NormalToken::Seq),

--- a/src/parser/grammar.lalrpop
+++ b/src/parser/grammar.lalrpop
@@ -774,6 +774,8 @@ NOpPre<ArgRule>: UniTerm = {
         UniTerm::from(mk_opn!(NAryOp::StrReplaceRegex(), t1, t2, t3)),
     "str_substr" <t1: ArgRule> <t2: ArgRule> <t3: ArgRule> =>
         UniTerm::from(mk_opn!(NAryOp::StrSubstr(), t1, t2, t3)),
+    "record_seal_tail" <t1: ArgRule> <t2: ArgRule> <t3: ArgRule> <t4: ArgRule> =>
+        UniTerm::from(mk_opn!(NAryOp::RecordSealTail(), t1, t2, t3, t4)),
 }
 
 TypeBuiltin: Types = {
@@ -908,6 +910,7 @@ extern {
         "record_empty_with_tail" => Token::Normal(NormalToken::RecordEmptyWithTail),
         "record_insert" => Token::Normal(NormalToken::RecordInsert),
         "record_remove" => Token::Normal(NormalToken::RecordRemove),
+        "record_seal_tail" => Token::Normal(NormalToken::RecordSealTail),
         "seq" => Token::Normal(NormalToken::Seq),
         "deep_seq" => Token::Normal(NormalToken::DeepSeq),
         "head" => Token::Normal(NormalToken::Head),

--- a/src/parser/lexer.rs
+++ b/src/parser/lexer.rs
@@ -199,6 +199,8 @@ pub enum NormalToken<'input> {
     RecordRemove,
     #[token("%record_empty_with_tail%")]
     RecordEmptyWithTail,
+    #[token("%record_seal_tail%")]
+    RecordSealTail,
     #[token("%seq%")]
     Seq,
     #[token("%deep_seq%")]

--- a/src/parser/lexer.rs
+++ b/src/parser/lexer.rs
@@ -201,6 +201,8 @@ pub enum NormalToken<'input> {
     RecordEmptyWithTail,
     #[token("%record_seal_tail%")]
     RecordSealTail,
+    #[token("%record_unseal_tail%")]
+    RecordUnsealTail,
     #[token("%seq%")]
     Seq,
     #[token("%deep_seq%")]

--- a/src/parser/lexer.rs
+++ b/src/parser/lexer.rs
@@ -197,6 +197,8 @@ pub enum NormalToken<'input> {
     RecordInsert,
     #[token("%record_remove%")]
     RecordRemove,
+    #[token("%record_empty_with_tail%")]
+    RecordEmptyWithTail,
     #[token("%seq%")]
     Seq,
     #[token("%deep_seq%")]

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -212,15 +212,14 @@ fn record_terms() {
     assert_eq!(
         parse_without_pos("{ a = 1, b = 2, c = 3}"),
         RecRecord(
-            record::RecordData::new(
+            record::RecordData::with_fields(
                 vec![
                     (Ident::from("a"), Num(1.).into()),
                     (Ident::from("b"), Num(2.).into()),
                     (Ident::from("c"), Num(3.).into()),
                 ]
                 .into_iter()
-                .collect(),
-                Default::default(),
+                .collect()
             ),
             Vec::new(),
             None,
@@ -231,14 +230,13 @@ fn record_terms() {
     assert_eq!(
         parse_without_pos("{ a = 1, \"%{123}\" = (if 4 then 5 else 6), d = 42}"),
         RecRecord(
-            record::RecordData::new(
+            record::RecordData::with_fields(
                 vec![
                     (Ident::from("a"), Num(1.).into()),
                     (Ident::from("d"), Num(42.).into()),
                 ]
                 .into_iter()
-                .collect(),
-                Default::default(),
+                .collect()
             ),
             vec![(
                 StrChunks(vec![StrChunk::expr(RichTerm::from(Num(123.)))]).into(),
@@ -252,14 +250,13 @@ fn record_terms() {
     assert_eq!(
         parse_without_pos("{ a = 1, \"\\\"%}%\" = 2}"),
         RecRecord(
-            record::RecordData::new(
+            record::RecordData::with_fields(
                 vec![
                     (Ident::from("a"), Num(1.).into()),
                     (Ident::from("\"%}%"), Num(2.).into()),
                 ]
                 .into_iter()
-                .collect(),
-                Default::default(),
+                .collect()
             ),
             Vec::new(),
             None,

--- a/src/parser/utils.rs
+++ b/src/parser/utils.rs
@@ -358,7 +358,11 @@ where
         }
     });
 
-    Term::RecRecord(RecordData::new(static_fields, attrs), dynamic_fields, None)
+    Term::RecRecord(
+        RecordData::new(static_fields, attrs, None),
+        dynamic_fields,
+        None,
+    )
 }
 
 /// Merge two fields by performing the merge of both their value and MetaValue if any.

--- a/src/parser/utils.rs
+++ b/src/parser/utils.rs
@@ -279,10 +279,7 @@ pub fn elaborate_field_path(
                 fields.insert(id, acc);
                 Term::Record(RecordData::with_fields(fields)).into()
             } else {
-                let empty = Term::Record(RecordData {
-                    fields: HashMap::new(),
-                    attrs: Default::default(),
-                });
+                let empty = Term::Record(RecordData::empty());
                 mk_app!(mk_term::op2(BinaryOp::DynExtend(), exp, empty), acc)
             }
         }

--- a/src/term.rs
+++ b/src/term.rs
@@ -1352,6 +1352,14 @@ pub enum UnaryOp {
     PushDefault(),
     /// doc: TODO
     PushForce(),
+
+    /// Creates an "empty" record with the sealed tail of its [`Term::Record`]
+    /// argument.
+    ///
+    /// Used in the `$record` contract implementation to ensure that we can
+    /// define a `field_diff` function that preserves the sealed polymorphic
+    /// tail of its argument.
+    RecordEmptyWithTail(),
 }
 
 // See: https://github.com/rust-lang/regex/issues/178

--- a/src/term.rs
+++ b/src/term.rs
@@ -1530,6 +1530,15 @@ pub enum NAryOp {
     /// The merge operator in contract mode (see [crate::eval::merge]). The arguments are in order
     /// the contract's label, the value to check, and the contract as a record.
     MergeContract(),
+    /// Seals one record into the tail of another. Used to ensure that functions
+    /// using polymorphic record contracts do not violate parametricity.
+    ///
+    /// Takes four arguments:
+    ///   - a [sealing key](Term::SealingKey), which must be provided later to unseal the tail,
+    ///   - a [label](Term::Lbl), which will be used to assign blame correctly tail access is attempted,
+    ///   - a [record](Term::Record), which is the record we wish to seal the tail into,
+    ///   - the [term](Term) that we wish to seal.
+    RecordSealTail(),
 }
 
 impl NAryOp {
@@ -1539,6 +1548,7 @@ impl NAryOp {
             | NAryOp::StrReplaceRegex()
             | NAryOp::StrSubstr()
             | NAryOp::MergeContract() => 3,
+            NAryOp::RecordSealTail() => 4,
         }
     }
 
@@ -1554,6 +1564,7 @@ impl fmt::Display for NAryOp {
             NAryOp::StrReplaceRegex() => write!(f, "strReplaceRegex"),
             NAryOp::StrSubstr() => write!(f, "substring"),
             NAryOp::MergeContract() => write!(f, "mergeContract"),
+            NAryOp::RecordSealTail() => write!(f, "%record_seal_tail%"),
         }
     }
 }

--- a/src/term.rs
+++ b/src/term.rs
@@ -1537,7 +1537,7 @@ pub enum NAryOp {
     ///   - a [sealing key](Term::SealingKey), which must be provided later to unseal the tail,
     ///   - a [label](Term::Lbl), which will be used to assign blame correctly tail access is attempted,
     ///   - a [record](Term::Record), which is the record we wish to seal the tail into,
-    ///   - the [term](Term) that we wish to seal.
+    ///   - the [record](Term::Record) that we wish to seal.
     RecordSealTail(),
     /// Unseals a term from the tail of a record and returns it.
     ///

--- a/src/term.rs
+++ b/src/term.rs
@@ -1915,7 +1915,7 @@ pub mod make {
                 $(
                     fields.insert($id.into(), $body.into());
                 )*
-                $crate::term::RichTerm::from($crate::term::Term::Record($crate::term::record::RecordData::new(fields, Default::default())))
+                $crate::term::RichTerm::from($crate::term::Term::Record($crate::term::record::RecordData::with_fields(fields)))
             }
         };
     }

--- a/src/term.rs
+++ b/src/term.rs
@@ -1539,6 +1539,14 @@ pub enum NAryOp {
     ///   - a [record](Term::Record), which is the record we wish to seal the tail into,
     ///   - the [term](Term) that we wish to seal.
     RecordSealTail(),
+    /// Unseals a term from the tail of a record and returns it.
+    ///
+    /// Takes three arguments:
+    ///   - the [sealing key](Term::SealingKey), which was used to seal the tail,
+    ///   - a [label](Term::Label) which will be used to assign blame correctly if
+    ///     something goes wrong while unsealing,
+    ///   - the [record](Term::Record) whose tail we wish to unseal.
+    RecordUnsealTail(),
 }
 
 impl NAryOp {
@@ -1547,7 +1555,8 @@ impl NAryOp {
             NAryOp::StrReplace()
             | NAryOp::StrReplaceRegex()
             | NAryOp::StrSubstr()
-            | NAryOp::MergeContract() => 3,
+            | NAryOp::MergeContract()
+            | NAryOp::RecordUnsealTail() => 3,
             NAryOp::RecordSealTail() => 4,
         }
     }
@@ -1565,6 +1574,7 @@ impl fmt::Display for NAryOp {
             NAryOp::StrSubstr() => write!(f, "substring"),
             NAryOp::MergeContract() => write!(f, "mergeContract"),
             NAryOp::RecordSealTail() => write!(f, "%record_seal_tail%"),
+            NAryOp::RecordUnsealTail() => write!(f, "%record_unseal_tail%"),
         }
     }
 }

--- a/src/typecheck/operation.rs
+++ b/src/typecheck/operation.rs
@@ -389,6 +389,15 @@ pub fn get_nop_type(
             ],
             mk_uniftype::dynamic(),
         ),
+        // Dyn -> Dyn -> Dyn -> Dyn
+        NAryOp::RecordUnsealTail() => (
+            vec![
+                mk_uniftype::dynamic(),
+                mk_uniftype::dynamic(),
+                mk_uniftype::dynamic(),
+            ],
+            mk_uniftype::dynamic(),
+        ),
         // This should not happen, as Switch() is only produced during evaluation.
         NAryOp::MergeContract() => panic!("cannot typecheck MergeContract()"),
     })

--- a/src/typecheck/operation.rs
+++ b/src/typecheck/operation.rs
@@ -379,6 +379,16 @@ pub fn get_nop_type(
             vec![mk_uniftype::str(), mk_uniftype::num(), mk_uniftype::num()],
             mk_uniftype::str(),
         ),
+        // Dyn -> Dyn -> Dyn -> Dyn -> Dyn
+        NAryOp::RecordSealTail() => (
+            vec![
+                mk_uniftype::dynamic(),
+                mk_uniftype::dynamic(),
+                mk_uniftype::dynamic(),
+                mk_uniftype::dynamic(),
+            ],
+            mk_uniftype::dynamic(),
+        ),
         // This should not happen, as Switch() is only produced during evaluation.
         NAryOp::MergeContract() => panic!("cannot typecheck MergeContract()"),
     })

--- a/src/typecheck/operation.rs
+++ b/src/typecheck/operation.rs
@@ -384,8 +384,8 @@ pub fn get_nop_type(
             vec![
                 mk_uniftype::dynamic(),
                 mk_uniftype::dynamic(),
-                mk_uniftype::dynamic(),
-                mk_uniftype::dynamic(),
+                mk_uniftype::dyn_record(mk_uniftype::dynamic()),
+                mk_uniftype::dyn_record(mk_uniftype::dynamic()),
             ],
             mk_uniftype::dynamic(),
         ),
@@ -394,7 +394,7 @@ pub fn get_nop_type(
             vec![
                 mk_uniftype::dynamic(),
                 mk_uniftype::dynamic(),
-                mk_uniftype::dynamic(),
+                mk_uniftype::dyn_record(mk_uniftype::dynamic()),
             ],
             mk_uniftype::dynamic(),
         ),

--- a/src/typecheck/operation.rs
+++ b/src/typecheck/operation.rs
@@ -201,6 +201,7 @@ pub fn get_uop_type(
             let ty = state.table.fresh_type_uvar();
             (ty.clone(), ty)
         }
+        UnaryOp::RecordEmptyWithTail() => (mk_uniftype::dynamic(), mk_uniftype::dynamic()),
     })
 }
 

--- a/stdlib/internals.ncl
+++ b/stdlib/internals.ncl
@@ -47,15 +47,16 @@
 
   "$record" = fun field_contracts tail_contract l t =>
     if %typeof% t == `Record then
-      # Returns the sub-record of `l` containing only those
-      # fields which are not present in `r`.
+      # Returns the sub-record of `l` containing only those fields which are not
+      # present in `r`. If `l` has a sealed polymorphic tail then it will be
+      # preserved.
       let field_diff = fun l r => array.foldl
         (fun acc f =>
           if %has_field% f r then
             acc
           else
             %record_insert% f acc (l."%{f}"))
-        {}
+        (%record_empty_with_tail% l)
         (%fields% l)
       in
 

--- a/stdlib/internals.ncl
+++ b/stdlib/internals.ncl
@@ -90,20 +90,20 @@
           %blame% (%tag% "not a record" l),
 
   "$forall_tail" = fun sy pol acc l t =>
-      let magic_fld = "_%sealed" in
       if pol == (%polarity% l) then
-          if %has_field% magic_fld t then
-              let rest = %record_remove% magic_fld t in
-              if rest == {} then
-                  let fail = %blame% (%tag% "polymorphic tail mismatch" l) in
-                  let inner = %unseal% sy (t."%{magic_fld}") fail in
-                  acc & inner
-              else
-                  %blame% (%tag% "extra field `%{%head% (%fields% rest)}`" l)
+          if t == {} then
+            let tagged_l = %tag% "polymorphic tail mismatch" l in
+            let tail = %record_unseal_tail% sy tagged_l t in
+            acc & tail
           else
-              %blame% (%tag% "missing polymorphic part" l)
+            %blame% (%tag% "extra field `%{%head% (%fields% t)}`" l)
       else
-          %record_insert% magic_fld acc (%seal% sy l t),
+          # Note: in order to correctly attribute blame, the polarity of `l`
+          # must match the polarity of the `forall` which introduced the
+          # polymorphic contract (i.e. `pol`). Since we know in this branch
+          # that `pol` and `%polarity% l` differ, we swap `l`'s polarity before
+          # we continue.
+          %record_seal_tail% sy (%chng_pol% l) acc t,
 
   "$dyn_tail" = fun acc l t => acc & t,
 

--- a/tests/integration/contracts_fail.rs
+++ b/tests/integration/contracts_fail.rs
@@ -11,6 +11,13 @@ macro_rules! assert_raise_blame {
             Err(Error::EvalError(EvalError::BlameError(..)))
         )
     }};
+    ($term:expr, $($arg:tt)+) => {{
+        assert_matches!(
+            eval($term),
+            Err(Error::EvalError(EvalError::BlameError(..))),
+            $($arg)+
+        )
+    }}
 }
 
 #[test]
@@ -94,41 +101,108 @@ fn records_contracts_simple() {
 
 #[test]
 fn records_contracts_poly() {
-    // TODO: this test should ultimately pass (i.e., the program should be rejected)
-    // but this is not yet the case.
-    // eval_string(&format!("{} {{foo = 2}}", extd)).unwrap_err();
+    for (name, input) in [
+        (
+            "record argument missing all required fields",
+            r#"
+            let f | forall a. { foo: Num; a } -> Num = fun r => r.foo in
+            f { }
+            "#,
+        ),
+        (
+            "record argument missing one required field",
+            r#"
+            let f | forall r. { x: Num, y: Num; r } -> { x: Num, y: Num; r } =
+                fun r => r
+            in
+            f { x = 1 }
+            "#,
+        ),
+        (
+            "function arg which does not satisfy higher-order contract",
+            r#"
+            let f | (forall r. { x: Num; r } -> { ; r }) -> { x: Num, y: Num } -> { y : Num } =
+                fun g r => g r
+            in
+            f (fun r => r) { x = 1, y = 2 }
+            "#,
+        ),
+        (
+            "invalid record argument to function arg",
+            r#"
+            let f | (forall r. { x: Num; r } -> { x: Num ; r }) -> { x: Str, y: Num } -> { x: Num, y: Num } =
+                fun g r => g r
+            in
+            # We need to evaluate x here to cause the error.
+            (f (fun r => r) { x = "", y = 1 }).x
+            "#,
+        ),
+        (
+            "return value without tail",
+            r#"
+            let f | forall r. { foo: Num; r } -> { foo: Num; r } =
+                fun r => { foo = 1 }
+            in
+            f { foo = 1, other = 2 }
+            "#,
+        ),
+        (
+            "return value with wrong tail",
+            r#"
+            let f | forall r r'. { a: Num; r } -> { a: Num; r' } -> { a: Num; r } =
+                fun r r' => r'
+            in
+            f { a = 1, b = "yes" } { a = 1, b = "no" }
+            "#,
+        ),
+        (
+            "mapping over a record violates parametricity",
+            r#"
+            let f | forall r. { a: Num; r } -> { a: Str; r } =
+                fun r => %record_map% r (fun x => %to_str% x)
+            in
+            f { a = 1, b = 2 }
+            "#,
+        ),
+        (
+            "merging a record violates parametricity, lhs arg",
+            r#"
+            let f | forall r. { a : Num; r } -> { a: Num; r } =
+                fun r => { a | force = 0 } & r
+            in
+            f { a | default = 100, b = 1 }
+            "#,
+        ),
+        (
+            "merging a record violates parametricity, rhs arg",
+            r#"
+            let f | forall r. { a : Num; r } -> { a: Num; r } =
+                fun r => r & { a | force = 0 }
+            in
+            f { a | default = 100, b = 1 }
+            "#,
+        ),
+    ] {
+        assert_raise_blame!(input, "failed on case: {}", name);
+    }
 
-    let remv =
-        "let f | forall a. {foo: Num ; a} -> { ; a} = fun x => %record_remove% \"foo\" x in f";
-    assert_raise_blame!(&format!("{} {{}}", remv));
-
-    let bad_cst = "let f | forall a. { ; a} -> { ; a} = fun x => {a=1} in f";
+    // These are currently FieldMissing errors rather than BlameErrors as we
+    // don't yet inspect the sealed tail to see if the requested field is inside.
+    // Once we do, these tests will start failing, and if you're currently here
+    // for that reason, you can just move the examples into the array above.
     let bad_acc = "let f | forall a. { ; a} -> { ; a} = fun x => %seq% x.a x in f";
-    let bad_extd =
-        "let f | forall a. { ; a} -> {foo: Num ; a} = fun x => %record_remove% \"foo\" x in f";
-    let bad_rmv =
-        "let f | forall a. {foo: Num ; a} -> { ; a} = fun x => %record_insert% \"foo\" x 1 in f";
-
-    assert_raise_blame!(&format!("{} {{}}", bad_cst));
-    // The polymorphic part is protected by hiding it. Thus, trying to access the protected field
-    // gives a field missing error, instead of a blame error.
     assert_matches!(
         eval(&format!("{} {{a=1}}", bad_acc)),
         Err(Error::EvalError(EvalError::FieldMissing(..)))
     );
+
+    let remove_sealed_field = r#"
+        let remove_x | forall r. { ; r } -> { ; r } = fun r => %record_remove% "x" r in
+        remove_x { x = 1 }
+    "#;
     assert_matches!(
-        eval(&format!("{} {{foo=1}}", bad_extd)),
+        eval(&format!("{}", remove_sealed_field)),
         Err(Error::EvalError(EvalError::FieldMissing(..)))
-    );
-    assert_raise_blame!(&format!("{} {{}}", bad_rmv));
-    assert_raise_blame!(
-        "let f |
-            forall a.
-                (forall b. {a: Num, b: Num ; b} -> { a: Num ; b})
-                -> {a: Num ; a}
-                -> { ; a}
-            = fun f r => %record_remove% \"b\" (%record_remove% \"a\" (f r)) in
-        f (fun x => x) {a = 1, b = true, c = 3}"
     );
 }
 

--- a/tests/integration/pass/contracts.ncl
+++ b/tests/integration/pass/contracts.ncl
@@ -68,9 +68,12 @@ let {check, Assert, ..} = import "testlib.ncl" in
 
   # polymorphism
   (let id | forall a. { ; a} -> { ; a} = fun x => x in
-    let extend | forall a. { ; a} -> {foo: Num ; a} = fun x =>
-      x & {foo = 1} in
-    let remove | forall a. {foo: Num ; a} -> { ; a} = record.remove "foo" in
+    # Note that we have to use `%record_insert%` and `%record_remove%` here, as
+    # `record.insert` and `record.remove` enforce the `$dyn_record` contract on
+    # their record arguments. `$dyn_record` uses `%record_map%` internally, and
+    # mapping over a sealed record is currently forbidden.
+    let extend | forall a. { ; a} -> {foo: Num ; a} = fun x => %record_insert% "foo" x 1 in
+    let remove | forall a. {foo: Num ; a} -> { ; a} = fun x => %record_remove% "foo" x in
 
     (id {} == {} | Assert) &&
     (id {a = 1, b = false} == {a = 1, b = false} | Assert) &&


### PR DESCRIPTION
This PR re-implements polymorphic record contracts to use a pair of seal/unseal primitive operations. This has the benefit of preventing the sealed tail from ever being accessed from user code (whereas in the previous implementation functions like `record.fields` would leak the existence of this sealed field). 

Merging this will close #201.

This change will also make it possible to later implement improved error messaging. For example: correctly assigning blame if a function with a polymorphic record type attempts to access a sealed field (#952), or knowing at the point a function is called which fields a polymorphic record argument _cannot_ contain in the head (#950).

### How to review

Each commit is atomic and passes the whole test suite. Most commits also have a message which explains their contents in a little more detail. As such I would recommend reviewing this commit-by-commit.

### Notes

The error messages for mapping over or merging a record with a sealed tail aren't great right now. One simple way to improve them would be to explicitly set the `tag` of the label before raising the error (see [this comment](https://github.com/tweag/nickel/pull/949/files#r1033797621)), but I couldn't find anywhere else where we did that. 