### PR TITLE
Simplify the structure of field/thunk dependencies

### DIFF
--- a/src/eval/lazy.rs
+++ b/src/eval/lazy.rs
@@ -88,7 +88,7 @@ pub struct ThunkData {
 /// it reveals more static information about the record (such as the list of fields) without having
 /// to provide any argument first. Then, splitting `self` and removing the function altogether when
 /// the field doesn't depend on other fields is more precise with respect to dependency tracking
-/// (this has an important positive memory impact, see [ThunkDeps]).
+/// (this has an important positive memory impact, see [crate::term::FieldDeps]).
 ///
 /// In practice, Nickel uses the last representation. Fields that don't have any free variable
 /// intersecting with the name of the other fields are allocated as normal thunks that will only be
@@ -374,8 +374,8 @@ impl Thunk {
         }
     }
 
-    /// Create a new revertible thunk. If the dependencies are empty [`ThunkDeps::Empty`], this
-    /// function acts as [Thunk::new] and create a standard (non-revertible) thunk.
+    /// Create a new revertible thunk. If the dependencies are empty, this function acts as
+    /// [Thunk::new] and create a standard (non-revertible) thunk.
     pub fn new_rev(closure: Closure, ident_kind: IdentKind, deps: FieldDeps) -> Self {
         match deps {
             FieldDeps::Known(deps) if deps.is_empty() => Self::new(closure, ident_kind),

--- a/src/eval/merge.rs
+++ b/src/eval/merge.rs
@@ -570,7 +570,7 @@ fn fields_merge_closurize<'a, I: DoubleEndedIterator<Item = &'a Ident> + Clone>(
     };
     let fresh_var = Ident::fresh();
 
-    // new_rev takes care of not creating a revertible thunks if the dependencies are empty.
+    // new_rev takes care of not creating a revertible thunk if the dependencies are empty.
     env.insert(
         fresh_var,
         Thunk::new_rev(closure, IdentKind::Record, combined_deps),

--- a/src/eval/merge.rs
+++ b/src/eval/merge.rs
@@ -57,7 +57,8 @@ use crate::label::Label;
 use crate::position::TermPos;
 use crate::term::record::RecordData;
 use crate::term::{
-    make as mk_term, BinaryOp, Contract, MetaValue, RecordAttrs, RichTerm, SharedTerm, Term,
+    make as mk_term, BinaryOp, Contract, FieldDeps, MetaValue, RecordAttrs, RichTerm, SharedTerm,
+    Term,
 };
 use crate::transform::Closurizable;
 use std::collections::HashMap;
@@ -525,14 +526,14 @@ fn saturate<'a, I: DoubleEndedIterator<Item = &'a Ident> + Clone>(
 }
 
 /// Return the dependencies of a field when represented as a `RichTerm`.
-fn field_deps(rt: &RichTerm, local_env: &Environment) -> Result<ThunkDeps, EvalError> {
+fn field_deps(rt: &RichTerm, local_env: &Environment) -> Result<FieldDeps, EvalError> {
     if let Term::Var(var_id) = &*rt.term {
         local_env
             .get(var_id)
             .map(Thunk::deps)
             .ok_or(EvalError::UnboundIdentifier(*var_id, rt.pos))
     } else {
-        Ok(ThunkDeps::Empty)
+        Ok(FieldDeps::empty())
     }
 }
 
@@ -569,16 +570,11 @@ fn fields_merge_closurize<'a, I: DoubleEndedIterator<Item = &'a Ident> + Clone>(
     };
     let fresh_var = Ident::fresh();
 
-    match combined_deps {
-        ThunkDeps::Empty => env.insert(fresh_var, Thunk::new(closure, IdentKind::Record)),
-        ThunkDeps::Known(deps) => env.insert(
-            fresh_var,
-            Thunk::new_rev(closure, IdentKind::Record, Some(deps)),
-        ),
-        ThunkDeps::Unknown => {
-            env.insert(fresh_var, Thunk::new_rev(closure, IdentKind::Record, None))
-        }
-    };
+    // new_rev takes care of not creating a revertible thunks if the dependencies are empty.
+    env.insert(
+        fresh_var,
+        Thunk::new_rev(closure, IdentKind::Record, combined_deps),
+    );
 
     Ok(RichTerm::from(Term::Var(fresh_var)))
 }

--- a/src/term.rs
+++ b/src/term.rs
@@ -505,8 +505,8 @@ pub enum FieldDeps {
 }
 
 impl FieldDeps {
-    /// Compute the union of two thunk dependencies. [`ThunkDeps::Unknown`] can be see as the top
-    /// element, meaning that if one of the two set of dependencies is [`ThunkDeps::Unknown`], so
+    /// Compute the union of two thunk dependencies. [`FieldDeps::Unknown`] can be see as the top
+    /// element, meaning that if one of the two set of dependencies is [`FieldDeps::Unknown`], so
     /// is the result.
     pub fn union(self, other: Self) -> Self {
         match (self, other) {

--- a/src/transform/free_vars.rs
+++ b/src/transform/free_vars.rs
@@ -6,7 +6,7 @@
 use crate::{
     destruct::{Destruct, Match},
     identifier::Ident,
-    term::{RecordDeps, RichTerm, SharedTerm, StrChunk, Term},
+    term::{FieldDeps, RecordDeps, RichTerm, SharedTerm, StrChunk, Term},
     types::{RecordRowF, RecordRows, RecordRowsF, TypeF, Types},
 };
 
@@ -122,7 +122,9 @@ impl CollectFreeVars for RichTerm {
                     fresh.clear();
 
                     t.collect_free_vars(&mut fresh);
-                    new_deps.stat_fields.insert(*id, &fresh & &rec_fields);
+                    new_deps
+                        .stat_fields
+                        .insert(*id, FieldDeps::from(&fresh & &rec_fields));
 
                     free_vars.extend(&fresh - &rec_fields);
                 }
@@ -135,7 +137,9 @@ impl CollectFreeVars for RichTerm {
                     // recursive dependencies.
                     t1.collect_free_vars(free_vars);
                     t2.collect_free_vars(&mut fresh);
-                    new_deps.dyn_fields.push(&fresh & &rec_fields);
+                    new_deps
+                        .dyn_fields
+                        .push(FieldDeps::from(&fresh & &rec_fields));
 
                     free_vars.extend(&fresh - &rec_fields);
                 }


### PR DESCRIPTION
Follow-up of https://github.com/tweag/nickel/pull/940#discussion_r1034525151. 

The dependencies of a recursive fields were represented with several different types: `Option<HashSet<Ident>>`, `ThunkDeps` and `FieldDeps`, corresponding to different stages of the pipeline. ThunkDeps also had redundant states (`ThunkDeps::Empty` and `ThunkDeps::Know(deps)` if `deps.is_empty()`).

This commit simplifies the situation by committing to one type, and removing multiple states representing the same thing.