### PR TITLE
Raise an error when functions are compared with `==`

### DIFF
--- a/tests/integration/eq_fail.rs
+++ b/tests/integration/eq_fail.rs
@@ -1,0 +1,37 @@
+use assert_matches::assert_matches;
+use nickel_lang::error::{Error, EvalError};
+use nickel_lang_utilities::eval;
+
+#[test]
+fn functions_cannot_be_compared_for_equality() {
+    for (name, src) in [
+        (
+            "lhs is function",
+            r#"
+                let f = fun x => x in
+                f == 1
+            "#,
+        ),
+        (
+            "rhs is function",
+            r#"
+                let g = fun x => x + 1 in
+                "a" == g
+            "#,
+        ),
+        (
+            "both sides are functions",
+            r#"
+                let f = fun x => x in
+                f == f
+            "#,
+        ),
+    ] {
+        assert_matches!(
+            eval(src),
+            Err(Error::EvalError(EvalError::EqError { .. })),
+            "failed on test: {}",
+            name
+        )
+    }
+}

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -1,6 +1,7 @@
 mod basics_fail;
 mod contracts_fail;
 mod destructuring;
+mod eq_fail;
 mod examples;
 mod free_vars;
 mod imports;


### PR DESCRIPTION
This commit raises a new `EvalError::EqError` variant if either argument to an equality evaluates to a function term. This is true even if both arguments evaluate to the exact same function term. Previously this would just return `false`.

Merging this will close #921.