### PR TITLE
Remove trailing `m` from multiline strings

### DIFF
--- a/benches/mantis/deploy.ncl
+++ b/benches/mantis/deploy.ncl
@@ -51,7 +51,7 @@ fun vars =>
                     mantis.blockchains.testnet-internal-nomad.bootstrap-nodes = [
                       %{string.join ",\n" bootstrapNodes."%{vars.namespace}"})
                     ]
-                    "%m,
+                    "%,
     logLevel | default = "INFO",
     loggers = defaultLoggers,
     job = vars.job,

--- a/benches/mantis/tasks/telegraf.ncl
+++ b/benches/mantis/tasks/telegraf.ncl
@@ -42,7 +42,7 @@ let types = import "../schemas/nomad/types.ncl" in
       [outputs.influxdb]
       database = "telegraf"
       urls = [ "http://172.16.0.20:8428" ]
-    "%m
+    "%
   },
   ..
 }

--- a/benches/nixpkgs/lists.ncl
+++ b/benches/nixpkgs/lists.ncl
@@ -10,7 +10,7 @@
       Example:
         singleton "foo"
         >> [ "foo" ]
-    "%m
+    "%
     = fun x => [x],
 
   forEach: forall a b. (Array a) -> (a -> b) -> (Array b)
@@ -23,7 +23,7 @@
           toString x
         )
         >> [ "1" "2" ]
-    "%m
+    "%
   = fun xs f => array.map f xs,
 
   foldr: forall a b. (a -> b -> b) -> b -> (Array a) -> b
@@ -40,7 +40,7 @@
        strange = foldr (fun int str => toString (int + 1) @@ str) "a"
        strange [ 1 2 3 4 ]
        => "2345a"
-  "%m
+  "%
   = fun op nul list =>
     let len = array.length list in
     let rec fold_ = fun n =>
@@ -51,7 +51,7 @@
 
   fold: forall a b. (a -> b -> b) -> b -> (Array a) -> b
   | doc m%"
-      `fold` is an alias of `foldr` for historic reasons "%m
+      `fold` is an alias of `foldr` for historic reasons "%
   # FIXME(Profpatsch): deprecate?
   = foldr,
 
@@ -69,7 +69,7 @@
        lstrange = foldl (str: int: str + toString (int + 1)) "a"
        lstrange [ 1 2 3 4 ]
        => "a2345"
-  "%m
+  "%
   = fun op nul list =>
     let rec foldl_ = fun n =>
         if n == -1
@@ -84,7 +84,7 @@
      The difference is that evaluation is forced upon access. Usually used
      with small whole results (in contrast with lazily-generated list or large
      lists where only a part is consumed.)
-  "%m
+  "%
   = fun op nul list => array.foldl op nul list,
 
   imap0: forall a b. (Num -> a -> b) -> (Array a) -> (Array b)
@@ -94,7 +94,7 @@
      Example:
        imap0 (fun i v => "%{v}-%{%to_string% i}") ["a", "b"]
        >> [ "a-0", "b-1" ]
-  "%%m
+  "%%
   = fun f list => array.generate (fun n => f n (array.elem_at n list)) (array.length list),
 
   imap1: forall a b. (Num -> a -> b) -> (Array a) -> (Array b)
@@ -104,7 +104,7 @@
      Example:
        imap1 (fun i v => "%{v}-%{toString i}") ["a", "b"]
        >> [ "a-1", "b-2" ]
-  "%%m
+  "%%
   = fun f list => array.generate (fun n => f (n + 1) (array.elem_at n list)) (array.length list),
 
   concatMap: forall a b. (a -> (Array b)) -> (Array a) -> (Array b)
@@ -114,7 +114,7 @@
      Example:
        concatMap (fun x => [x] @ ["z"]) ["a", "b"]
        >> [ "a", "z", "b", "z" ]
-  "%m
+  "%
   = (fun f list => array.flatten (array.map f list)),
 
   flatten: Dyn -> Array Dyn
@@ -127,7 +127,7 @@
        >> [1, 2, 3, 4, 5]
        flatten 1
        >> [1]
-  "%m
+  "%
   = fun x =>
     if builtin.is_array x
     then concatMap (fun y => flatten y) (x | Array Dyn)
@@ -140,7 +140,7 @@
      Example:
        remove 3 [ 1, 3, 4, 3 ]
        >> [ 1, 4 ]
-  "%m
+  "%
   = # Element to remove from the list
     fun e => array.filter ((!=) e),
 
@@ -157,7 +157,7 @@
        >> 3
        findSingle (fun x => x == 3) "none" "multiple" [ 1, 9 ]
        >> "none"
-  "%m
+  "%
   = fun
     # Predicate
     pred
@@ -183,7 +183,7 @@
        >> 6
        findFirst (fun x => x > 9) 7 [ 1, 6, 4 ]
        >> 7
-  "%m
+  "%
   = fun
     # Predicate
     pred
@@ -204,7 +204,7 @@
        >> true
        any builtin.is_str [ 1, { } ]
        >> false
-  "%m
+  "%
   = fun pred => foldr (fun x y => if pred x then true else y) false,
 
   all: forall a. (a -> Bool) -> Array a -> Bool
@@ -217,7 +217,7 @@
        >> true
        all (fun x => x < 3) [ 1, 2, 3 ]
        >> false
-  "%m
+  "%
   = fun pred => foldr (fun x y => if pred x then y else false) true,
 
   count: forall a. (a -> Bool) -> Array a -> Num
@@ -228,7 +228,7 @@
      Example:
        count (fun x => x == 3) [ 3, 2, 3, 4, 6 ]
        >> 2
-  "%m
+  "%
   = fun
     # Predicate
     pred => foldl_ (fun c x => if pred x then c + 1 else c) 0,
@@ -244,7 +244,7 @@
        >> [ "foo" ]
        optional' false "foo"
        >> [ ]
-  "%m
+  "%
   = fun cond elem => if cond then [elem] else [],
 
   optionals: forall a. Bool -> Array a -> Array a
@@ -256,7 +256,7 @@
        >> [ 2, 3 ]
        optionals false [ 2, 3 ]
        >> [ ]
-  "%m
+  "%
   = fun
     # Condition
     cond
@@ -276,7 +276,7 @@
        >> [ 1, 2 ]
        toList "hi"
        >> [ "hi "]
-  "%m
+  "%
   = fun x => if builtin.is_array x then (x | Array Dyn) else [x],
 
   range: Num -> Num -> Array Num
@@ -288,7 +288,7 @@
        >> [ 2, 3, 4 ]
        range 3 2
        >> [ ]
-  "%m
+  "%
   = fun
     # First integer in the range
     first
@@ -307,7 +307,7 @@
      Example:
        partition (fun x => x > 2) [ 5, 1, 2, 3, 4 ]
        >> { right = [ 5, 3, 4 ], wrong = [ 1, 2 ] }
-  "%m
+  "%
   = fun pred =>
     foldr (fun h t =>
       if pred h
@@ -334,7 +334,7 @@
             mate  = [ { name = "mate",  script = "gnome-session &" } ],
             xfce  = [ { name = "xfce",  script = "xfce4-session &" } ],
           }
-  "%m
+  "%
   = fun pred => foldl_ (fun r e =>
        let key = pred e in
          { "%{key}" = (r."%{key}" @ [e]) } & (record.remove key r)
@@ -347,7 +347,7 @@
      Example:
        groupBy_ builtins.add 0 (fun x => boolToString (x > 2)) [ 5, 1, 2, 3, 4 ]
        >> { true = 12, false = 3 }
-  "%m
+  "%
   = fun op nul pred lst => record.map (fun name value => foldl op nul value) (groupBy pred lst),
 
   zipListsWith: forall a b c. (a -> b -> c) -> Array a -> Array b -> Array c
@@ -359,7 +359,7 @@
      Example:
        zipListsWith (fun a b => a @@ b) ["h", "l"] ["e", "o"]
        >> ["he", "lo"]
-  "%m
+  "%
   = fun
     # Function to zip elements of both lists
     f
@@ -377,7 +377,7 @@
      Example:
        zipLists [ 1, 2 ] [ "a", "b" ]
        >> [ { fst = 1, snd = "a" }, { fst = 2, snd = "b" } ]
-  "%m
+  "%
   = zipListsWith (fun fst snd => { fst = fst, snd = snd }),
 
   reverseList: forall a. Array a -> Array a
@@ -387,7 +387,7 @@
      Example:
        reverseList [ "b", "o", "j" ]
        >> [ "j", "o", "b" ]
-  "%m
+  "%
   = fun xs =>
     let l = array.length xs in
     array.generate (fun n => array.elem_at (l - n - 1) xs) l,
@@ -413,7 +413,7 @@
                 visited = [ "/" "/home/user" ], # elements leading to the cycle (in reverse order)
                 rest    = [ "/home" "other" ],  # everything else
 
-   "%m
+   "%
   = fun stopOnCycles before list =>
     let rec dfs_ = fun us visited_ rest_ =>
         let c = array.filter (fun x => before x us) visited_ in
@@ -452,7 +452,7 @@
            == { result = [ "other", "/", "/home", "/home/user" ], }
 
          toposort (a: b: a < b) [ 3, 2, 1 ] == { result = [ 1, 2, 3 ], }
-  "%m
+  "%
   = fun before list =>
     let dfsthis = listDfs true before list in
     let toporest = toposort before (dfsthis.visited @ dfsthis.rest) in
@@ -481,7 +481,7 @@
      Example:
        sort (a: b: a < b) [ 5, 3, 7 ]
        >> [ 3, 5, 7 ]
-  "%m
+  "%
   = fun strictLess list =>
     let len = array.length list in
     let first = array.head list in
@@ -511,7 +511,7 @@
        >> 1
        compareLists compare [ "a", "b" ] [ "a", "c" ]
        >> 1
-  "%m
+  "%
   = fun cmp a b =>
     if a == []
     then if b == []
@@ -536,7 +536,7 @@
 #      >> ["10.5.16.62" "10.46.133.149" "10.54.16.25"]
 #      naturalSort ["v0.2", "v0.15", "v0.0.9"]
 #      >> [ "v0.0.9", "v0.2", "v0.15" ]
-# "%m
+# "%
 # # TODO: broken. how to implement it in nickel?
 # = fun lst =>
 #   let vectorise = fun s => array.map (fun x => if builtin.is_array x then (array.head x) | Num else x | Num) (string.split "(0|[1-9][0-9]*)" s) | Array Dyn
@@ -555,7 +555,7 @@
        >> [ "a", "b" ]
        take 2 [ ]
        >> [ ]
-  "%m
+  "%
   = fun 
     # Number of elements to take
     count => sublist 0 count,
@@ -570,7 +570,7 @@
        >> [ "c", "d" ]
        drop 2 [ ]
        >> [ ]
-  "%m
+  "%
   = fun
     # Number of elements to drop
     count
@@ -588,7 +588,7 @@
        >> [ "b", "c", "d" ]
        sublist 1 3 [ ]
        >> [ ]
-  "%m
+  "%
   = fun
     # Index at which to start the sublist
     start
@@ -613,7 +613,7 @@
      Example:
        last [ 1, 2, 3 ]
        >> 3
-  "%m
+  "%
   = fun lst =>
     #assert lib.assertMsg (lst != []) "lists.last: list must not be empty!",
     array.elem_at (array.length lst - 1) lst,
@@ -627,7 +627,7 @@
      Example:
        init [ 1, 2, 3 ]
        >> [ 1, 2 ]
-  "%m
+  "%
   = fun lst =>
     #assert lib.assertMsg (lst != []) "lists.init: list must not be empty!",
     take (array.length lst - 1) lst,
@@ -639,7 +639,7 @@
      Example:
        unique [ 3, 2, 3, 4 ]
        >> [ 3, 2, 4 ]
-   "%m
+   "%
   = foldl_ (fun acc e => if array.elem e acc then acc else acc @ [ e ]) [],
 
   intersectLists: Array Dyn -> Array Dyn -> Array Dyn
@@ -649,7 +649,7 @@
      Example:
        intersectLists [ 1, 2, 3 ] [ 6, 3, 2 ]
        >> [ 3, 2 ]
-  "%m
+  "%
   = fun e => array.filter (fun x => array.elem x e),
 
   subtractLists: Array Dyn -> Array Dyn -> Array Dyn
@@ -659,14 +659,14 @@
      Example:
        subtractLists [ 3, 2 ] [ 1, 2, 3, 4, 5, 3 ]
        >> [ 1, 4, 5 ]
-  "%m
+  "%
   = fun e => array.filter (fun x => !(array.elem x e)),
 
   mutuallyExclusive: Array Dyn -> Array Dyn -> Bool
   | doc m%"
       Test if two lists have no common element.
      It should be slightly more efficient than (intersectLists a b == [])
-  "%m
+  "%
   = fun a b => array.length a == 0 || !(any (fun x => array.elem x a) b),
 
 }

--- a/benches/strings/interpolation.ncl
+++ b/benches/strings/interpolation.ncl
@@ -104,5 +104,5 @@
         Ue3d9Jd3nZeSetAzBBqk
         DvN7NvTzdt4EyvUCq4Se
         a9TLAq2eVr0exurkvJZN
-      "%m
+      "%
 }

--- a/doc/manual/syntax.md
+++ b/doc/manual/syntax.md
@@ -93,7 +93,7 @@ false
 ### Strings
 
 Nickel can work with sequences of characters, or strings. Strings are enclosed
-by `" ... "` for a single line string or by `m%" ... "%m` for a multiline
+by `" ... "` for a single line string or by `m%" ... "%` for a multiline
 string. They can be concatenated with the operator `++`. Strings must be UTF-8
 valid.
 
@@ -107,7 +107,7 @@ Examples:
 "Hello, World!"
 
 > m%"Well, if this isn't a multiline string?
-Yes it is, indeed it is"%m
+Yes it is, indeed it is"%
 "Well, if this isn't a string?
 Yes it is, indeed it is"
 
@@ -136,7 +136,7 @@ This line has no indentation.
   This line is indented.
     This line is even more indented.
 This line has no more indentation.
-"%m
+"%
 "This line has no indentation.
   This line is indented.
     This line is even more indented.
@@ -148,10 +148,10 @@ The only special sequence in a multiline string is the string interpolation.
 Examples:
 
 ```text
-> m%"Multiline\nString?"%m
+> m%"Multiline\nString?"%
 "Multiline\nString?"
 
-> m%"Multiline%{"\n"}String"%m
+> m%"Multiline%{"\n"}String"%
 "Multiline
 String"
 ```
@@ -163,16 +163,16 @@ the same amount of `%` as in the delimiters.
 Examples:
 
 ```text
-> m%%"Hello World"%%m
+> m%%"Hello World"%%
 "Hello World"
 
-> m%%%%%"Hello World"%%%%%m
+> m%%%%%"Hello World"%%%%%
 "Hello World"
 
-> let w = "World" in m%%"Hello %{w}"%%m
+> let w = "World" in m%%"Hello %{w}"%%
 "Hello %{w}"
 
-> let w = "World" in m%%"Hello %%{w}"%%m
+> let w = "World" in m%%"Hello %%{w}"%%
 "Hello World"
 ```
 
@@ -183,14 +183,14 @@ indented string interpolation and the indentation would behave as expected:
 > let log = m%"
 if log:
   print("log:", s)
-"%m in m%"
+"% in m%"
 def concat(str_array, log=false):
   res = []
   for s in str_array:
     %{log}
     res.append(s)
   return res
-"%m
+"%
 "def concat(str_array, log=false):
   res = []
   for s in str_array:
@@ -528,7 +528,7 @@ Adding documentation can be done with `| doc < string >`. Examples:
     it is based on facts rather than being invented or imagined,
     and is accurate and reliable.
     (Collins dictionary)
-    "%m
+    "%
 true
 ```
 

--- a/examples/config-gcc/config-gcc.ncl
+++ b/examples/config-gcc/config-gcc.ncl
@@ -25,7 +25,7 @@ let GccFlag =
     contract.blame_with "expected record or string" label in
 
 let Path =
-  let pattern = m%"^(.+)/([^/]+)$"%m in
+  let pattern = m%"^(.+)/([^/]+)$"% in
   fun label value =>
     if builtin.is_str value then
       if string.is_match pattern value then
@@ -37,7 +37,7 @@ let Path =
 
 let SharedObjectFile = fun label value =>
   if builtin.is_str value then
-    if string.is_match m%"\.so$"%m value then
+    if string.is_match m%"\.so$"% value then
       value
     else
       contract.blame_with "not an .so file" label

--- a/rfcs/004-typechecking.md
+++ b/rfcs/004-typechecking.md
@@ -220,14 +220,14 @@ subtractLists: forall a. Array a -> Array a -> Array a
      Example:
        subtractLists [ 3, 2 ] [ 1, 2, 3, 4, 5, 3 ]
        >> [ 1, 4, 5 ]
-  "%m
+  "%
   = fun e => array.filter (fun x => !(array.elem (x | Dyn) (e | Array Dyn))),
 
 mutuallyExclusive: forall a. Array a -> Array a -> Bool
   | doc m%"
       Test if two lists have no common element.
      It should be slightly more efficient than (intersectLists a b == [])
-  "%m
+  "%
   = fun a b =>
     array.length a == 0
     || !(any (fun x => array.elem (x | Dyn) (a | Array Dyn)) b),
@@ -253,7 +253,7 @@ flatten: Dyn -> Array Dyn
        >> [1, 2, 3, 4, 5]
        flatten 1
        >> [1]
-  "%m
+  "%
   = fun x =>
      if builtin.is_array x then
        concatMap (fun y => flatten y) (x | Array Dyn)

--- a/rfcs/005-metadata-rework.md
+++ b/rfcs/005-metadata-rework.md
@@ -171,7 +171,7 @@ let Package = { name | Str, drv | Drv, .. } in
   },
   build = m%"
     %{build_inputs.foo.drv.out_path}/bin/foo $out
-  "%m,
+  "%,
 } & {
   build_inputs = {
     foo = { name = "foo", drv.out_path = "/fake/path" },

--- a/src/parser/grammar.lalrpop
+++ b/src/parser/grammar.lalrpop
@@ -511,7 +511,7 @@ StringStart : StringKind = {
 
 StringEnd : StringKind = {
     "\"" => StringKind::Standard,
-    "\"%m" => StringKind::Multiline,
+    "\"%" => StringKind::Multiline,
 };
 
 ChunkLiteral : String =
@@ -884,7 +884,7 @@ extern {
         "=>" => Token::Normal(NormalToken::DoubleArrow),
         "_" => Token::Normal(NormalToken::Underscore),
         "\"" => Token::Normal(NormalToken::DoubleQuote),
-        "\"%m" => Token::MultiStr(MultiStringToken::End),
+        "\"%" => Token::MultiStr(MultiStringToken::End),
         "m%\"" => Token::Normal(NormalToken::MultiStringStart(<usize>)),
 
         "Num" => Token::Normal(NormalToken::Num),

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -197,7 +197,7 @@ fn enum_terms() {
         ("whitespace between backtick & identifier", "`     test"),
         ("invalid identifier", "`$s"),
         ("empty raw identifier", "`"),
-        ("multiline string", "`m%\"words\"%m"),
+        ("multiline string", "`m%\"words\"%"),
         ("interpolation", "`\"%{x}\""),
     ];
 
@@ -337,9 +337,9 @@ fn string_lexing() {
     );
 
     assert_eq!(
-        lex_without_pos(r##"m%""%"%m"##),
+        lex_without_pos(r#"m%%""%"%%"#),
         Ok(vec![
-            Token::Normal(NormalToken::MultiStringStart(3)),
+            Token::Normal(NormalToken::MultiStringStart(4)),
             Token::MultiStr(MultiStringToken::Literal("\"%")),
             Token::MultiStr(MultiStringToken::End),
         ])
@@ -398,19 +398,19 @@ fn ascii_escape() {
     assert_eq!(parse_without_pos("\"\\x08\""), mk_single_chunk("\x08"));
     assert_eq!(parse_without_pos("\"\\x7F\""), mk_single_chunk("\x7F"));
 
-    assert_eq!(parse_without_pos("m%\"\\x[f\"%m"), mk_single_chunk("\\x[f"));
-    assert_eq!(parse_without_pos("m%\"\\x0\"%m"), mk_single_chunk("\\x0"));
-    assert_eq!(parse_without_pos("m%\"\\x0z\"%m"), mk_single_chunk("\\x0z"));
-    assert_eq!(parse_without_pos("m%\"\\x00\"%m"), mk_single_chunk("\\x00"));
-    assert_eq!(parse_without_pos("m%\"\\x08\"%m"), mk_single_chunk("\\x08"));
-    assert_eq!(parse_without_pos("m%\"\\x7F\"%m"), mk_single_chunk("\\x7F"));
+    assert_eq!(parse_without_pos("m%\"\\x[f\"%"), mk_single_chunk("\\x[f"));
+    assert_eq!(parse_without_pos("m%\"\\x0\"%"), mk_single_chunk("\\x0"));
+    assert_eq!(parse_without_pos("m%\"\\x0z\"%"), mk_single_chunk("\\x0z"));
+    assert_eq!(parse_without_pos("m%\"\\x00\"%"), mk_single_chunk("\\x00"));
+    assert_eq!(parse_without_pos("m%\"\\x08\"%"), mk_single_chunk("\\x08"));
+    assert_eq!(parse_without_pos("m%\"\\x7F\"%"), mk_single_chunk("\\x7F"));
 }
 
 /// Regression test for [#230](https://github.com/tweag/nickel/issues/230).
 #[test]
 fn multiline_str_escape() {
     assert_eq!(
-        parse_without_pos(r##"m%"%Hel%%lo%%%"%m"##),
+        parse_without_pos(r##"m%"%Hel%%lo%%%"%"##),
         mk_single_chunk("%Hel%%lo%%%"),
     );
 }

--- a/src/parser/utils.rs
+++ b/src/parser/utils.rs
@@ -24,7 +24,7 @@ use crate::{
 };
 
 /// Distinguish between the standard string separators `"`/`"` and the multi-line string separators
-/// `m%"`/`"%m` in the parser.
+/// `m%"`/`"%` in the parser.
 #[derive(Copy, Clone, Eq, PartialEq, Debug)]
 pub enum StringKind {
     Standard,
@@ -527,7 +527,7 @@ pub fn min_indent(chunks: &[StrChunk<RichTerm>]) -> usize {
 ///   baseline
 ///     ${x}
 ///   end
-/// "%m
+/// "%
 /// ```
 ///
 /// gives
@@ -548,7 +548,7 @@ pub fn min_indent(chunks: &[StrChunk<RichTerm>]) -> usize {
 ///   baseline
 ///     ${x} sth
 ///   end
-/// "%m
+/// "%
 /// ```
 ///
 /// gives
@@ -578,7 +578,7 @@ pub fn strip_indent(mut chunks: Vec<StrChunk<RichTerm>>) -> Vec<StrChunk<RichTer
     //    ${x} ${y}
     //    ${x}
     //  string
-    // "%m
+    // "%
     // ```
     //
     // We don't know at the time we process the expression `${x}` if it wil have to be re-indented,

--- a/src/pretty.rs
+++ b/src/pretty.rs
@@ -12,15 +12,14 @@ fn min_interpolate_sign(text: &str) -> usize {
     reg.find_iter(text)
         .map(|m| {
             let d = m.end() - m.start();
-            // We iterate over all sequences `%+{` and `"%+m`, which could clash with the interpolation
+            // We iterate over all sequences `%+{` and `"%+`, which could clash with the interpolation
             // syntax, and return the maximum number of `%` insead each sequence.
             //
-            // For the case of a closing delimiter `"%m`, we could actually be slightly smarter as we
+            // For the case of a closing delimiter `"%`, we could actually be slightly smarter as we
             // don't necessarily need more `%`, but just a different number of `%`. For example, if the
-            // string contains only one `"%%m`, then single `%` delimiters like `m%"` and `"%m` would
-            // be fine. But picking the maximum
-            //
-            // TODO: Improve the `"%*m` case if necessary.
+            // string contains only one `"%%`, then single `%` delimiters like `m%"` and `"%` would
+            // be fine. But picking the maximum results in a simpler algorithm for now, which we can
+            // update later if necessary.
             if m.as_str().ends_with('{') {
                 d
             } else {
@@ -314,11 +313,7 @@ where
                         } else {
                             "".to_string()
                         },
-                        if multiline {
-                            format!("{}m", interp)
-                        } else {
-                            "".to_string()
-                        },
+                        if multiline { interp } else { "".to_string() },
                     )
             }
             Fun(id, rt) => {

--- a/stdlib/array.ncl
+++ b/stdlib/array.ncl
@@ -11,7 +11,7 @@
           ([ 1 ] | NonEmpty) =>
             [ 1 ]
         ```
-        "%m
+        "%
       = fun label value =>
        if %typeof% value == `Array then
          if %length% value != 0 then
@@ -30,7 +30,7 @@
           head [ "this is the head", "this is not" ] =>
             "this is the head"
         ```
-        "%m
+        "%
       = fun l => %head% l,
 
     tail : forall a. Array a -> Array a
@@ -42,7 +42,7 @@
           tail [ 1, 2, 3 ] =>
             [ 2, 3 ]
         ```
-        "%m
+        "%
       = fun l => %tail% l,
 
     length : forall a. Array a -> Num
@@ -54,7 +54,7 @@
           length [ "Hello,", " World!" ] =>
             2
         ```
-        "%m
+        "%
       = fun l => %length% l,
 
     map : forall a b. (a -> b) -> Array a -> Array b
@@ -67,7 +67,7 @@
           map (fun x => x + 1) [ 1, 2, 3 ] =>
             [ 2, 3, 4 ]
         ```
-        "%m
+        "%
       = fun f l => %map% l f,
 
     elem_at : forall a. Num -> Array a -> a
@@ -79,7 +79,7 @@
           elem_at 3 [ "zero" "one" "two" "three" "four" ] =>
             "three"
         ```
-        "%m
+        "%
       = fun n l => %elem_at% l n,
 
     concat : forall a. Array a -> Array a -> Array a
@@ -91,7 +91,7 @@
           concat [ 1, 2, 3 ] [ 4, 5, 6 ] =>
             [ 1, 2, 3, 4, 5, 6 ]
         ```
-        "%m
+        "%
       = fun l1 l2 => l1 @ l2,
 
     foldl : forall a b. (a -> b -> a) -> a -> Array b -> a
@@ -107,7 +107,7 @@
             (((0 + 1) + 2) 3) =>
             6
         ```
-        "%m
+        "%
       = fun f acc l =>
         if %length% l == 0 then
           acc
@@ -126,7 +126,7 @@
             ((([] @ [3]) @ [2]) @ [1]) =>
             [ 3, 2, 1 ]
         ```
-        "%m
+        "%
       = fun f fst l =>
         if %length% l == 0 then
           fst
@@ -142,7 +142,7 @@
           cons 1 [ 2, 3 ] =>
             [ 1, 2, 3 ]
         ```
-        "%m
+        "%
       = fun x l => [x] @ l,
 
     reverse : forall a. Array a -> Array a
@@ -154,7 +154,7 @@
           reverse [ 1, 2, 3 ] =>
             [ 3, 2, 1 ]
         ```
-        "%m
+        "%
       = fun l => foldl (fun acc e => [e] @ acc) [] l,
 
     filter : forall a. (a -> Bool) -> Array a -> Array a
@@ -166,7 +166,7 @@
           filter (fun x => x <= 3) [ 4, 3, 2, 5, 1 ] =>
             [ 3, 2, 1 ]
         ```
-        "%m
+        "%
       = fun pred l => foldl (fun acc x => if pred x then acc @ [x] else acc) [] l,
 
     flatten : forall a. Array (Array a) -> Array a
@@ -178,7 +178,7 @@
           flatten [[1, 2], [3, 4]] =>
             [1, 2, 3, 4]
         ```
-        "%m
+        "%
       = fun l => fold (fun l acc => l @ acc) [] l,
 
     all : forall a. (a -> Bool) -> Array a -> Bool
@@ -192,7 +192,7 @@
           all (fun x => x < 3) [ 1, 2 3 ] =>
             false
         ```
-        "%m
+        "%
       = fun pred l => fold (fun x acc => if pred x then acc else false) true l,
 
     any : forall a. (a -> Bool) -> Array a -> Bool
@@ -206,7 +206,7 @@
           any (fun x => x < 3) [ 5, 6, 7, 8 ] =>
             false
         ```
-        "%m
+        "%
       = fun pred l => fold (fun x acc => if pred x then true else acc) false l,
 
     elem : Dyn -> Array Dyn -> Bool
@@ -218,7 +218,7 @@
           elem 3 [ 1, 2, 3, 4, 5 ] =>
             true
         ```
-        "%m
+        "%
       = fun elt => any (fun x => x == elt),
 
     partition : forall a. (a -> Bool) -> Array a -> {right: Array a, wrong: Array a}
@@ -231,7 +231,7 @@
           partition (fun x => x < 5) [ 2, 4, 5, 3, 7, 8, 6 ] =>
             { right = [ 3, 4, 2 ], wrong = [ 6, 8, 7, 5 ] }
         ```
-        "%m
+        "%
       = fun pred l =>
         let aux = fun acc x =>
           if (pred x) then
@@ -251,7 +251,7 @@
           generate function.id 4 =>
             [ 0, 1, 2, 3 ]
         ```
-        "%m
+        "%
       = fun f n => %generate% n f,
 
     sort | forall a. (a -> a -> [| `Lesser, `Equal, `Greater |]) -> Array a -> Array a
@@ -263,7 +263,7 @@
           sort (fun x y => if x < y then `Lesser else if (x == y) then `Equal else `Greater) [ 4, 5, 1, 2 ] =>
             [ 1, 2, 4, 5 ]
         ```
-        "%m
+        "%
       = fun cmp l =>
         let first = %head% l in
         let parts = partition (fun x => (cmp x first == `Lesser)) (%tail% l) in

--- a/stdlib/builtin.ncl
+++ b/stdlib/builtin.ncl
@@ -11,7 +11,7 @@
         is_num "Hello, World!" =>
           false
       ```
-      "%m
+      "%
     = fun x => %typeof% x == `Num,
 
     is_bool : Dyn -> Bool
@@ -25,7 +25,7 @@
         is_bool 42 =>
           false
       ```
-      "%m
+      "%
     = fun x => %typeof% x == `Bool,
 
     is_str : Dyn -> Bool
@@ -39,7 +39,7 @@
         is_str "Hello, World!" =>
           true
       ```
-      "%m
+      "%
     = fun x => %typeof% x == `Str,
 
     is_enum : Dyn -> Bool
@@ -53,7 +53,7 @@
         is_enum `false =>
           true
       ```
-      "%m
+      "%
 
     = fun x => %typeof% x == `Enum,
 
@@ -68,7 +68,7 @@
         is_fun 42 =>
           false
       ```
-      "%m
+      "%
     = fun x => %typeof% x == `Fun,
 
     is_array : Dyn -> Bool
@@ -82,7 +82,7 @@
         is_array 42 =>
           false
       ```
-      "%m
+      "%
     = fun x => %typeof% x == `Array,
 
     is_record : Dyn -> Bool
@@ -96,7 +96,7 @@
         is_record { hello = "Hello", world = "World" } =>
           true
       ```
-      "%m
+      "%
     = fun x => %typeof% x == `Record,
 
     typeof : Dyn -> [|
@@ -120,7 +120,7 @@
         typeof (fun x => x) =>
           `Fun
       ```
-      "%m
+      "%
     = fun x => %typeof% x,
 
     seq : forall a. Dyn -> a -> a
@@ -136,7 +136,7 @@
         seq { tooFar = 42 / 0 } 37 =>
           37
       ```
-      "%m
+      "%
     = fun x y => %seq% x y,
 
     deep_seq : forall a. Dyn -> a -> a
@@ -152,7 +152,7 @@
         deep_seq { tooFar = 42 / 0 } 37 =>
           error
       ```
-      "%m
+      "%
     = fun x y => %deep_seq% x y,
 
     hash : [| `Md5, `Sha1, `Sha256, `Sha512 |] -> Str -> Str
@@ -164,7 +164,7 @@
         hash `Md5 "hunter2" =>
           "2ab96390c7dbe3439de74d0c9b0b1767"
       ```
-      "%m
+      "%
     = fun type s => %hash% type s,
 
     serialize : [| `Json, `Toml, `Yaml |] -> Dyn -> Str
@@ -179,7 +179,7 @@
             "world": "World"
           }"
       ```
-      "%m
+      "%
     = fun format x => %serialize% format (%force% x),
 
     deserialize : [| `Json, `Toml, `Yaml |] -> Str -> Dyn
@@ -191,7 +191,7 @@
         deserialize `Json "{ \"hello\": \"Hello\", \"world\": \"World\" }"
           { hello = "Hello", world = "World" }
       ```
-      "%m
+      "%
     = fun format x => %deserialize% format x,
 
     to_str | string.Stringable -> Str
@@ -207,7 +207,7 @@
         "Foo"
       from null =>
         "null"
-      "%m
+      "%
     = fun x => %to_str% x,
 
   },

--- a/stdlib/contract.ncl
+++ b/stdlib/contract.ncl
@@ -17,7 +17,7 @@
           if value == 0 then value
           else contract.blame label
         ```
-        "%m
+        "%
       = fun l => %blame% l,
 
     blame_with
@@ -38,7 +38,7 @@
           else contract.blame_with "Not zero" label in
         0 | IsZero
         ```
-        "%m
+        "%
       = fun msg l => %blame% (%tag% msg l),
 
     from_predicate
@@ -53,7 +53,7 @@
         let IsZero = contract.from_predicate (fun x => x == 0) in
         0 | IsZero
         ```
-        "%m
+        "%
       = fun pred l v => if pred v then v else %blame% l,
 
     tag
@@ -76,7 +76,7 @@
             value in
         5 | Contract
         ```
-        "%m
+        "%
       = fun msg l => %tag% msg l,
 
     apply
@@ -101,7 +101,7 @@
         let Contract = Nullable {foo | Num} in
         ({foo = 1} | Contract)
         ```
-        "%m
+        "%
       = fun contract label value => %assume% contract label value,
   },
 }

--- a/stdlib/num.ncl
+++ b/stdlib/num.ncl
@@ -11,7 +11,7 @@
         (42 | Int) =>
           42
       ```
-      "%m
+      "%
     = fun label value =>
       if %typeof% value == `Num then
         if value % 1 == 0 then
@@ -34,7 +34,7 @@
         (-4 | Nat) =>
           error
       ```
-      "%m
+      "%
     = fun label value =>
       if %typeof% value == `Num then
         if value % 1 == 0 && value >= 0 then
@@ -57,7 +57,7 @@
         (-4 | PosNat) =>
           error
       ```
-      "%m
+      "%
     = fun label value =>
       if %typeof% value == `Num then
         if value % 1 == 0 && value > 0 then
@@ -78,7 +78,7 @@
         (0.0 | NonZero) =>
           error
       ```
-      "%m
+      "%
     = fun label value =>
       if %typeof% value == `Num then
         if value != 0 then
@@ -99,7 +99,7 @@
         is_int 1.5 =>
           false
       ```
-      "%m
+      "%
     = fun x => x % 1 == 0,
 
     min : Num -> Num -> Num
@@ -111,7 +111,7 @@
         min (-1337) 42 =>
           -1337
       ```
-      "%m
+      "%
     = fun x y => if x <= y then x else y,
 
     max : Num -> Num -> Num
@@ -123,7 +123,7 @@
         max (-1337) 42 =>
           42
       ```
-      "%m
+      "%
     = fun x y => if x >= y then x else y,
 
     floor : Num -> Num
@@ -135,7 +135,7 @@
         floor 42.5 =>
           42
       ```
-      "%m
+      "%
     = fun x =>
       if x >= 0
       then x - (x % 1)
@@ -152,7 +152,7 @@
         abs 42 =>
           42
       ```
-      "%m
+      "%
     = fun x => if x < 0 then -x else x,
 
     fract : Num -> Num
@@ -166,7 +166,7 @@
         fract 42 =>
           0
       ```
-      "%m
+      "%
     = fun x => x % 1,
 
     trunc : Num -> Num
@@ -180,7 +180,7 @@
         trunc 42.5 =>
           42
       ```
-      "%m
+      "%
     = fun x => x - (x % 1),
 
     pow : Num -> Num -> Num
@@ -192,7 +192,7 @@
         pow 2 8 =>
           256
       ```
-      "%m
+      "%
     = fun x n => %pow% x n,
   }
 }

--- a/stdlib/record.ncl
+++ b/stdlib/record.ncl
@@ -12,7 +12,7 @@
         map (fun s x => x + 1) { hello = 1, world = 2 } =>
           { hello = 2, world = 3 }
       ```
-      "%m
+      "%
     = fun f r => %record_map% r f,
 
     fields | { ; Dyn} -> Array Str
@@ -23,7 +23,7 @@
         fields { one = 1, two = 2 } =>
           [ "one", "two" ]
       ```
-      "%m
+      "%
     = fun r => %fields% r,
 
     values | { ; Dyn} -> Array Dyn
@@ -34,7 +34,7 @@
         values { one = 1, world = "world" }
           [ 1, "world" ]
       ```
-      "%m
+      "%
     = fun r => %values% r,
 
     has_field : forall a. Str -> {_ : a} -> Bool
@@ -47,7 +47,7 @@
         has_field "one" { one = 1, two = 2 } =>
           true
       ```
-      "%m
+      "%
     = fun field r => %has_field% field r,
 
     insert : forall a. Str -> a -> {_: a} -> {_: a}
@@ -64,7 +64,7 @@
         |> insert "length" 10*1000 =>
           {"file.txt" = "data/text", "length" = 10000}
         ```
-      "%%m
+      "%%
       = fun field content r => %record_insert% field r content,
 
     remove : forall a. Str -> {_: a} -> {_: a}
@@ -76,7 +76,7 @@
         remove "foo" foo { foo = "foo", bar = "bar" } =>
           { bar = "bar }
         ```
-      "%m
+      "%
       = fun field r => %record_remove% field r,
 
     update | forall a. Str -> a -> {_: a} -> {_: a}
@@ -100,7 +100,7 @@
         update "bar" 1 {foo = bar + 1, bar | default = 0 } =>
           { foo = 1, bar = 1 }
         ```
-      "%m
+      "%
       = fun field content r =>
         let r = if %has_field% field r then
           %record_remove% field r

--- a/stdlib/string.ncl
+++ b/stdlib/string.ncl
@@ -14,7 +14,7 @@
         (true | BoolLiteral) =>
           error
       ```
-      "%m
+      "%
     = fun l s =>
       if %typeof% s == `Str then
         if s == "true" || s == "True" then
@@ -39,8 +39,8 @@
         (42 | NumLiteral) =>
           error
       ```
-      "%m
-    = let pattern = m%"^[+-]?(\d+(\.\d*)?(e[+-]?\d+)?|\.\d+(e[+-]?\d+)?)$"%m in
+      "%
+    = let pattern = m%"^[+-]?(\d+(\.\d*)?(e[+-]?\d+)?|\.\d+(e[+-]?\d+)?)$"% in
       let is_num_literal = %str_is_match% pattern in
       fun l s =>
         if %typeof% s == `Str then
@@ -66,7 +66,7 @@
         (1 | CharLiteral) =>
           error
       ```
-      "%m
+      "%
     = fun l s =>
       if %typeof% s == `Str then
         if length s == 1 then
@@ -89,7 +89,7 @@
         ("tag" | EnumTag) =>
           error
       ```
-      "%m
+      "%
     = contract.from_predicate builtin.is_enum,
 
     Stringable
@@ -114,7 +114,7 @@
         ({foo = "baz"} | Stringable) =>
           error
       ```
-      "%m
+      "%
     = contract.from_predicate (fun value =>
       let type = builtin.typeof value in
       value == null
@@ -136,7 +136,7 @@
         (42 | NonEmpty) =>
           error
       ```
-      "%m
+      "%
     = fun l s =>
       if %typeof% s == `Str then
         if %str_length% s > 0 then
@@ -155,7 +155,7 @@
         join ", " [ "Hello", "World!" ] =>
           "Hello, World!"
       ```
-      "%m
+      "%
     = fun sep l =>
       if %length% l == 0 then
         ""
@@ -173,7 +173,7 @@
       split "." "1,2,3" =>
         [ "1,2,3" ]
       ```
-      "%m
+      "%
     = fun sep s => %str_split% s sep,
 
     trim : Str -> Str
@@ -187,7 +187,7 @@
       trim "1   2   3   " =>
         "1   2   3"
       ```
-      "%m
+      "%
     = fun s => %str_trim% s,
 
     chars : Str -> Array Str
@@ -199,11 +199,11 @@
         chars "Hello" =>
           [ "H", "e", "l", "l", "o" ]
       ```
-      "%m
+      "%
     = fun s => %str_chars% s,
 
     code | CharLiteral -> Num
-    | doc m%"
+    | doc m%%"
       Results in the ascii code of the given character.
 
       For example:
@@ -215,11 +215,11 @@
         code "å" =>
           error
       ```
-      "%m
+      "%%
     = fun s => %char_code% s,
 
     from_code | Num -> CharLiteral
-    | doc m%"
+    | doc m%%"
       Results in the character for a given ascii code. Any number outside the ascii range results in an error.
 
       For example:
@@ -231,7 +231,7 @@
         from_code 128 =>
           error
       ```
-      "%m
+      "%%
     = fun s => %char_from_code% s,
 
     uppercase : Str -> Str
@@ -248,7 +248,7 @@
         uppercase "." =>
           "."
       ```
-      "%m
+      "%
     = fun s => %str_uppercase% s,
 
     lowercase : Str -> Str
@@ -265,7 +265,7 @@
         lowercase "." =>
           "."
       ```
-      "%m
+      "%
     = fun s => %str_lowercase% s,
 
     contains: Str -> Str -> Bool
@@ -281,7 +281,7 @@
         contains "ghj" "abcdef" =>
           false
       ```
-      "%m
+      "%
     = fun subs s => %str_contains% s subs,
 
     replace: Str -> Str -> Str -> Str
@@ -295,7 +295,7 @@
         replace "" "A" "abcdef" =>
           "AaAbAcAdAeAfA"
       ```
-      "%m
+      "%
     = fun pattern replace s =>
        %str_replace% s pattern replace,
 
@@ -310,7 +310,7 @@
         replace_regex "\\d+" "\"a\" is not" "This 37 is a number." =>
           "This \"a\" is not a number."
       ```
-      "%m
+      "%
     = fun pattern replace s =>
        %str_replace_regex% s pattern replace,
 
@@ -346,7 +346,7 @@
       ["0", "42", "0.5"] |> array.all is_number' =>
         true
       ```
-      "%m
+      "%
     = fun regex => %str_is_match% regex,
 
     match : Str -> Str -> {match: Str, index: Num, groups: Array Str}
@@ -365,7 +365,7 @@
       Note that this function may perform better by sharing its partial application between multiple calls,
       because in this case the underlying regular expression will only be compiled once (See the documentation
       of `string.is_match` for more details).
-      "%m
+      "%
     = fun regex => %str_match% regex,
 
     length : Str -> Num
@@ -379,7 +379,7 @@
         length "hi" =>
           2
       ```
-      "%m
+      "%
     = fun s => %str_length% s,
 
     substring: Num -> Num -> Str -> Str
@@ -395,7 +395,7 @@
         substring (-3) 4 "abcdef" =>
           error
       ```
-      "%m
+      "%
     = fun start end s => %str_substr% s start end,
 
     from | Stringable -> Str
@@ -411,7 +411,7 @@
         "Foo"
       from null =>
         "null"
-      "%m
+      "%
     = fun x => %to_str% x,
 
     from_num | Num -> Str
@@ -423,7 +423,7 @@
       from_num 42 =>
         "42"
       ```
-      "%m
+      "%
     = from,
 
     # from_enum | < | Dyn> -> Str = fun tag => %to_str% tag,
@@ -436,7 +436,7 @@
       from_enum `MyEnum =>
         "MyEnum"
       ```
-      "%m
+      "%
     = from,
 
     from_bool | Bool -> Str
@@ -448,7 +448,7 @@
         from_bool true =>
           "true"
       ```
-      "%m
+      "%
     = from,
 
     to_num | NumLiteral -> Num
@@ -460,7 +460,7 @@
         to_num "123" =>
           123
       ```
-      "%m
+      "%
     = fun s => %num_from_str% s,
 
     to_bool | BoolLiteral -> Bool
@@ -476,7 +476,7 @@
         to_bool "false" =>
           false
       ```
-      "%m
+      "%
     = fun s => s == "true",
 
     # to_enum | Str -> < | Dyn> = fun s => %enum_from_str% s,
@@ -489,7 +489,7 @@
         to_enum "Hello" =>
           `Hello
       ```
-      "%m
+      "%
     = fun s => %enum_from_str% s,
   }
 }

--- a/tests/integration/pass/strings.ncl
+++ b/tests/integration/pass/strings.ncl
@@ -12,17 +12,17 @@ let {check, ..} = import "testlib.ncl" in
     == "Hello, world! Welcome in the world-universe",
 
   # regression test for issue #361 (https://github.com/tweag/nickel/issues/361)
-  m%""%{"foo"}""%m == "\"foo\"",
-  m%"""%m == "\"",
-  m%""%"%"%"%m == "\"%\"%\"%",
+  m%""%{"foo"}""% == "\"foo\"",
+  m%"""% == "\"",
 
   # regression test for issue #596 (https://github.com/tweag/nickel/issues/596)
-  let s = "Hello" in m%%""%%{s}" World"%%m == "\"Hello\" World",
-  let s = "Hello" in m%%""%%%{s}" World"%%m == "\"%Hello\" World",
-  m%%""%%s"%%m == "\"%%s",
+  let s = "Hello" in m%%""%%{s}" World"%% == "\"Hello\" World",
+  let s = "Hello" in m%%""%%%{s}" World"%% == "\"%Hello\" World",
+  m%"%s"% == "%s",
+  m%%"%%s"%% == "%%s",
 
   # regression test for issue #659 (https://github.com/tweag/nickel/issues/659)
-  let b = "x" in m%"a%%{b}c"%m == "a%xc",
-  m%"%Hel%%{"1"}lo%%%{"2"}"%m == "%Hel%1lo%%2",
+  let b = "x" in m%"a%%{b}c"% == "a%xc",
+  m%"%Hel%%{"1"}lo%%%{"2"}"% == "%Hel%1lo%%2",
 ]
 |> check

--- a/tests/integration/pass/testlib.ncl
+++ b/tests/integration/pass/testlib.ncl
@@ -7,7 +7,7 @@
     However, we apply this contract to each test instead because it provides
     fine-grained error reporting, pinpointoing the exact expression that failed
     in an array of tests, as opposed to the pure boolean solution.
-    "%m
+    "%
     = fun l x => x || %blame% l,
   # We can't use a static type because x | Assert is not of type bool.
   # We could use additional contracts to make it work but it's not worth the
@@ -25,6 +25,6 @@
     ```
 
     But will give more precise error reporting when one test fails.
-    "%m
+    "%
     = array.foldl (fun acc test => (test | Assert) && acc) true,
 }


### PR DESCRIPTION
This commit simplifies the syntax for multiline strings by removing the trailing `m`.

Merging this will close #961.