### PR TITLE
Bump to 0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1174,7 +1174,7 @@ dependencies = [
 
 [[package]]
 name = "nickel-lang"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "ansi_term",
  "assert_matches",
@@ -1215,7 +1215,7 @@ dependencies = [
 
 [[package]]
 name = "nickel-lang-lsp"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -1241,7 +1241,7 @@ dependencies = [
 
 [[package]]
 name = "nickel-lang-utilities"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "codespan",
  "criterion",
@@ -1250,7 +1250,7 @@ dependencies = [
 
 [[package]]
 name = "nickel-repl"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "nickel-lang",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nickel-lang"
-version = "0.2.1"
+version = "0.3.0"
 authors = ["Nickel team"]
 license = "MIT"
 readme = "README.md"
@@ -68,7 +68,7 @@ pretty_assertions = "1.2.1"
 assert_matches = "1.5.0"
 criterion = "0.3"
 pprof = { version = "0.9.1", features = ["criterion", "flamegraph"] }
-nickel-lang-utilities = {path = "utilities", version = "0.2.1"}
+nickel-lang-utilities = {path = "utilities", version = "0.3.0"}
 similar = "2.1.0"
 
 [workspace]

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,3 +1,47 @@
+Version 0.3  (2022-12-07)
+=========================
+
+Fixes
+-----
+
+- Fix polymorphic contracts unduly changing semantics by @ebresafegaga in https://github.com/tweag/nickel/pull/802
+- Fix typechecking and unification in presence of flat types (aka opaque types, aka contracts) by @yannham in https://github.com/tweag/nickel/pull/766
+- Fix polarity for polymorphic contract failure by @ebresafegaga in https://github.com/tweag/nickel/pull/831
+- Fix panic when a row mismatch occurs while unifying row tails by @matthew-healy in https://github.com/tweag/nickel/pull/847
+- Fix type to term conversion causing unbound type variables errors by @francois-caddet in https://github.com/tweag/nickel/pull/854
+- Fix bad lexing of enum tags by @matthew-healy in https://github.com/tweag/nickel/pull/874
+- Fix multiple recursive overriding by @yannham in https://github.com/tweag/nickel/pull/940
+
+Language features
+-----------------
+
+- Optional fields by @yannham in https://github.com/tweag/nickel/pull/815
+- Numeral merge priorities by @yannham in https://github.com/tweag/nickel/pull/829
+- Recursive merge priorities (or push-priorities, or leafy priorities) by @yannham in https://github.com/tweag/nickel/pull/845
+- Change `switch` to `match` and make it a proper function by @yannham in https://github.com/tweag/nickel/pull/970
+
+Stdlib
+------
+
+- Statically type `string.join` by @matthew-healy in https://github.com/tweag/nickel/pull/946
+
+Tooling
+-------
+
+- Add record completion in the LSP by @ebresafegaga in
+  - https://github.com/tweag/nickel/pull/867
+  - https://github.com/tweag/nickel/pull/909
+  - https://github.com/tweag/nickel/pull/913
+  - https://github.com/tweag/nickel/pull/914
+- Add completion for Nickel's stdlib in the LSP by @ebresafegaga in https://github.com/tweag/nickel/pull/918
+
+Performances
+------------
+
+- Lazy array contracts by @fuzzypixelz in https://github.com/tweag/nickel/pull/809
+- Array slices by @fuzzypixelz in https://github.com/tweag/nickel/pull/776
+- String interning for identifiers by @Acaccia in https://github.com/tweag/nickel/pull/835
+
 Version 0.2  (2022-07-29)
 =========================
 

--- a/lsp/nls/Cargo.toml
+++ b/lsp/nls/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nickel-lang-lsp"
-version = "0.2.1"
+version = "0.3.0"
 authors = ["Nickel team"]
 license = "MIT"
 readme = "README.md"
@@ -31,7 +31,7 @@ lsp-types = "0.88"
 log = "0.4"
 env_logger = "0.9"
 anyhow = "1.0"
-nickel-lang = {path = "../../", version = "0.2.1"}
+nickel-lang = {path = "../../", version = "0.3.0"}
 derive_more = "0.99"
 lazy_static = "1"
 csv = "1"

--- a/nickel-wasm-repl/Cargo.toml
+++ b/nickel-wasm-repl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nickel-repl"
-version = "0.2.1"
+version = "0.3.0"
 authors = ["Nickel team"]
 license = "MIT"
 readme = "README.md"
@@ -11,7 +11,7 @@ keywords = ["configuration", "language", "nix", "nickel"]
 edition = "2018"
 
 [dependencies]
-nickel-lang = {default-features = false, path = "../", version = "0.2.1", features=["repl-wasm"]}
+nickel-lang = {default-features = false, path = "../", version = "0.3.0", features=["repl-wasm"]}
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/utilities/Cargo.toml
+++ b/utilities/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nickel-lang-utilities"
-version = "0.2.1"
+version = "0.3.0"
 authors = ["The Nickel Team <nickel-lang@protonmail.com>"]
 description = "Common helper functions for the tests and benchmarks of the nickel-lang crate."
 edition = "2018"
@@ -10,6 +10,6 @@ bench = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-nickel-lang = {path = "../", version = "0.2.1"}
+nickel-lang = {path = "../", version = "0.3.0"}
 criterion = "0.3"
 codespan = "0.11"


### PR DESCRIPTION
Cherry-pick the version bump as well as the update of RELEASES.md from the new `stable` branch.