### PR TITLE
Fix unresolved references in documentation

### DIFF
--- a/src/cache.rs
+++ b/src/cache.rs
@@ -268,8 +268,8 @@ impl Cache {
         self.add_file_(normalized, timestamp)
     }
 
-    /// Same as [get_or_add_file], but assume that the path is already normalized, and take the
-    /// timestamp as a parameter.
+    /// Same as [Self::add_file], but assume that the path is already normalized, and take the timestamp
+    /// as a parameter.
     fn get_or_add_file_(
         &mut self,
         path: impl Into<OsString>,

--- a/src/error.rs
+++ b/src/error.rs
@@ -1193,8 +1193,9 @@ mod blame_error {
         }
     }
 
-    /// Generate a codespan label that describes the [type path][crate::label::TyPath] of a (Nickel)
-    /// label, and notes to hint at the situation that may have caused the corresponding error.
+    /// Generate a codespan label that describes the [type path][crate::label::ty_path::Path] of a
+    /// (Nickel) label, and notes to hint at the situation that may have caused the corresponding
+    /// error.
     pub fn report_ty_path(
         l: &label::Label,
         files: &mut Files<String>,

--- a/src/eval/mod.rs
+++ b/src/eval/mod.rs
@@ -195,7 +195,7 @@ impl<R: ImportResolver, C: Cache> VirtualMachine<R, C> {
         &mut self.import_resolver
     }
 
-    /// Evaluate a Nickel term. Wrapper around [eval_closure] that starts from an empty local
+    /// Evaluate a Nickel term. Wrapper around [VirtualMachine::eval_closure] that starts from an empty local
     /// environment and drops the final environment.
     pub fn eval(&mut self, t0: RichTerm, initial_env: &Environment) -> Result<RichTerm, EvalError> {
         self.eval_closure(Closure::atomic_closure(t0), initial_env)

--- a/src/eval/operation.rs
+++ b/src/eval/operation.rs
@@ -2,7 +2,7 @@
 //!
 //! Define functions which perform the evaluation of primitive operators. The machinery required
 //! for the strict evaluation of the operands is mainly handled by [crate::eval], and marginally in
-//! [`continuate_operation`].
+//! [`VirtualMachine::continuate_operation`].
 //!
 //! On the other hand, the functions `process_unary_operation` and `process_binary_operation`
 //! receive evaluated operands and implement the actual semantics of operators.

--- a/src/parser/uniterm.rs
+++ b/src/parser/uniterm.rs
@@ -35,7 +35,7 @@ use std::{cell::RefCell, convert::TryFrom};
 /// As soon as this variable is used in a compound expression, the top-level rule tells us how to
 /// translate it. For example, if we see an arrow `a -> Num`, then we will convert it to a type
 /// variable, and return `UniTermNode::Types(TypeF::Arrow(..))` (there is actually a subtlety:
-/// see [`fix_type_vars`], but let's ignore it here). If, on the other hand, we enter the rule for
+/// see [`FixTypeVars::fix_type_vars`], but let's ignore it here). If, on the other hand, we enter the rule for
 /// an infix operator as in `a + 1`, `a` will be converted to a `Term::Var` and the resulting
 /// uniterm will be `UniTermNode::Term(Term::Op2(..))`.
 pub enum UniTermNode {
@@ -261,7 +261,7 @@ impl TryFrom<UniRecord> for RichTerm {
     /// field paths `foo.bar = value` to the expanded form `{foo = {bar = value}}`.
     ///
     /// We also fix the type variables of the type appearing inside annotations (see
-    /// [`fix_type_vars`]).
+    /// [`FixTypeVars::fix_type_vars`]).
     fn try_from(ur: UniRecord) -> Result<Self, ParseError> {
         let pos = ur.pos;
 
@@ -588,7 +588,7 @@ impl FixTypeVars for EnumRows {
 }
 
 /// Fix the type variables of types appearing as annotations of record fields. See
-/// [`fix_type_vars`].
+/// [`Types::fix_type_vars`].
 pub fn fix_field_types(rt: &mut RichTerm) -> Result<(), ParseError> {
     if let Term::MetaValue(ref mut m) = SharedTerm::make_mut(&mut rt.term) {
         if let Some(Contract { ref mut types, .. }) = m.types {

--- a/src/repl/query_print.rs
+++ b/src/repl/query_print.rs
@@ -158,7 +158,7 @@ impl Default for Attributes {
 }
 
 /// Print the result of a metadata query, which is a "weakly" evaluated term (see
-/// [`crate::eval::eval_meta`] and [`crate::program::query`]).
+/// [`crate::eval::VirtualMachine::eval_meta`] and [`crate::program::query`]).
 ///
 /// Wrapper around `write_query_result_` that selects an adapated query printer at compile time.
 pub fn write_query_result(
@@ -176,7 +176,7 @@ pub fn write_query_result(
 }
 
 /// Print the result of a metadata query, which is a "weakly" evaluated term (see
-/// [`crate::eval::eval_meta`] and [`crate::program::query`]).
+/// [`crate::eval::VirtualMachine::eval_meta`] and [`crate::program::query`]).
 fn write_query_result_<R: QueryPrinter>(
     out: &mut impl Write,
     term: &Term,

--- a/src/term.rs
+++ b/src/term.rs
@@ -425,8 +425,8 @@ pub mod record {
 
     /// The base structure of a Nickel record.
     ///
-    /// Used to group together fields common to both the [Record](Term::Record) and
-    /// [RecRecord](Term::RecRecord) terms.
+    /// Used to group together fields common to both the [super::Term::Record] and
+    /// [super::Term::RecRecord] terms.
     #[derive(Clone, Debug, Default, PartialEq)]
     pub struct RecordData {
         /// Fields whose names are known statically.
@@ -486,9 +486,8 @@ pub mod record {
 
     /// The sealed tail of a Nickel record under a polymorphic contract.
     ///
-    /// Note that access to the enclosed [term] must only be allowed when a
-    /// matching [sealing_key] is provided. If this is not enforced it will
-    /// lead to parametricity violations.
+    /// Note that access to the enclosed term must only be allowed when a matching sealing key is
+    /// provided. If this is not enforced it will lead to parametricity violations.
     #[derive(Clone, Debug, PartialEq)]
     pub struct SealedTail {
         /// The key with which the tail is sealed.
@@ -1481,7 +1480,7 @@ pub enum BinaryOp {
     Assume(),
     /// Unseal a sealed term.
     ///
-    /// See [`UnaryOp::Seal`].
+    /// See [`BinaryOp::Seal`].
     Unseal(),
     /// Go to a specific field in the type path of a label.
     ///
@@ -1573,7 +1572,7 @@ pub enum NAryOp {
     ///
     /// Takes three arguments:
     ///   - the [sealing key](Term::SealingKey), which was used to seal the tail,
-    ///   - a [label](Term::Label) which will be used to assign blame correctly if
+    ///   - a [label](Term::Lbl) which will be used to assign blame correctly if
     ///     something goes wrong while unsealing,
     ///   - the [record](Term::Record) whose tail we wish to unseal.
     RecordUnsealTail(),
@@ -2055,7 +2054,7 @@ pub mod make {
 
     /// Array for types implementing `Into<RichTerm>` (for elements).
     /// The array's attributes are a trailing (optional) `ArrayAttrs`, separated by a `;`.
-    /// `mk_array!(Term::Num(42)) corresponds to `[42]`. Here the attributes are `ArrayAttrs::default()`, though the evaluated array may have different attributes.
+    /// `mk_array!(Term::Num(42))` corresponds to `\[42\]`. Here the attributes are `ArrayAttrs::default()`, though the evaluated array may have different attributes.
     #[macro_export]
     macro_rules! mk_array {
         ( $( $terms:expr ),* ; $attrs:expr ) => {

--- a/src/typecheck/eq.rs
+++ b/src/typecheck/eq.rs
@@ -56,7 +56,7 @@ pub const MAX_GAS: u8 = 8;
 /// Abstract over the term environment, which is represented differently in the typechecker and
 /// during evaluation.
 ///
-/// The evaluation environment holds [`crate::eval::lazy::Thunks`], which are `Rc<RefCell<_>>`
+/// The evaluation environment holds [crate::eval::lazy::Thunk]s, which are `Rc<RefCell<_>>`
 /// under the hood, while the term environment used during typechecking is just maps identifiers to
 /// a pair `(RichTerm, Environment)`. To have an interface that works with both,
 /// `TermEnvironment::get_then` has to take a closure representing the continuation of the task to

--- a/src/typecheck/mod.rs
+++ b/src/typecheck/mod.rs
@@ -410,7 +410,7 @@ impl UnifEnumRows {
 }
 
 impl UnifType {
-    /// Create a [`UnifType`] from an [`ApparentType`]. As for [`from_type`], this function requires
+    /// Create a [`UnifType`] from an [`ApparentType`]. As for [`GenericUnifType::from_type`], this function requires
     /// the current term environment.
     pub fn from_apparent_type(at: ApparentType, env: &SimpleTermEnvironment) -> Self {
         match at {
@@ -476,7 +476,7 @@ impl From<EnumRowsF<Box<UnifEnumRows>>> for UnifEnumRows {
     }
 }
 
-/// Iterator items produced by [`GenericUnifRecordRowsIterator`].
+/// Iterator items produced by [RecordRowsIterator] on [GenericUnifRecordRows].
 pub enum GenericUnifRecordRowsIteratorItem<'a, E: TermEnvironment> {
     TailDyn,
     TailVar(&'a Ident),
@@ -1437,7 +1437,7 @@ fn type_check_<L: Linearizer>(
 /// that may be stored in a typing environment at some point.
 ///
 /// Call [`apparent_type`] to see if the binding is annotated. If it is, return this type as a
-/// [`TypeWrapper`]. Otherwise:
+/// [`UnifType`]. Otherwise:
 ///     * in non strict mode, we won't (and possibly can't) infer the type of `bound_exp`: just
 ///       return `Dyn`.
 ///     * in strict mode, we will typecheck `bound_exp`: return a new unification variable to be
@@ -2259,7 +2259,7 @@ impl UnifTable {
     /// different from all the currently live variables. This is currently simply the max of the
     /// length of the various unification tables.
     ///
-    /// Used inside [super::eq] to generate temporary rigid type variables that are guaranteed to
+    /// Used inside [self::eq] to generate temporary rigid type variables that are guaranteed to
     /// not conflict with existing variables.
     pub fn max_uvars_count(&self) -> VarId {
         use std::cmp::max;

--- a/src/typecheck/reporting.rs
+++ b/src/typecheck/reporting.rs
@@ -25,8 +25,8 @@ impl NameReg {
 
 /// Create a fresh name candidate for a type variable or a type constant.
 ///
-/// Used by [`to_type_report`] and subfunctions `var_to_type` and `cst_to_type` when converting a
-/// type wrapper to a human-readable representation.
+/// Used by [`to_type`] and subfunctions [`var_name`] and [`cst_name`] when converting a type
+/// wrapper to a human-readable representation.
 ///
 /// To select a candidate, first check in `names` if the variable or the constant corresponds to a
 /// type variable written by the user. If it is, return the name of the variable. Otherwise, use


### PR DESCRIPTION
Another cherry-pick from 0.3.0: fix warnings of `cargo doc` about unresolved references.