### PR TITLE
Return the shape string.find expects from %str_find%

### DIFF
--- a/src/eval/operation.rs
+++ b/src/eval/operation.rs
@@ -1131,7 +1131,7 @@ impl<R: ImportResolver, C: Cache> VirtualMachine<R, C> {
                             .collect();
 
                         mk_record!(
-                            ("match", Term::Str(String::from(first_match.as_str()))),
+                            ("matched", Term::Str(String::from(first_match.as_str()))),
                             ("index", Term::Num(first_match.start() as f64)),
                             (
                                 "groups",
@@ -1141,7 +1141,7 @@ impl<R: ImportResolver, C: Cache> VirtualMachine<R, C> {
                     } else {
                         //FIXME: what should we return when there's no match?
                         mk_record!(
-                            ("match", Term::Str(String::new())),
+                            ("matched", Term::Str(String::new())),
                             ("index", Term::Num(-1.)),
                             (
                                 "groups",

--- a/src/typecheck/operation.rs
+++ b/src/typecheck/operation.rs
@@ -184,7 +184,7 @@ pub fn get_uop_type(
         UnaryOp::StrFindCompiled(_) => (
             mk_uniftype::str(),
             mk_uty_record!(
-                ("match", TypeF::Str),
+                ("matched", TypeF::Str),
                 ("index", TypeF::Num),
                 ("groups", mk_uniftype::array(TypeF::Str))
             ),

--- a/tests/integration/pass/strings.ncl
+++ b/tests/integration/pass/strings.ncl
@@ -24,5 +24,6 @@ let {check, ..} = import "testlib.ncl" in
   # regression test for issue #659 (https://github.com/tweag/nickel/issues/659)
   let b = "x" in m%"a%%{b}c"% == "a%xc",
   m%"%Hel%%{"1"}lo%%%{"2"}"% == "%Hel%1lo%%2",
+  let res = string.find "a" "bac" in res.matched == "a" && res.index == 1,
 ]
 |> check


### PR DESCRIPTION
The included integration test fails without the change.

Fixes #987 

Based on "match" becoming a keyword, I think it's intentional that the rename happens on the `%str_find%` side rather than reverting the `string.find` contract change to still be `match`, so I took that approach for this PR.