### PR TITLE
Symbolic strings

### DIFF
--- a/src/parser/grammar.lalrpop
+++ b/src/parser/grammar.lalrpop
@@ -474,7 +474,9 @@ Bool: bool = {
     "false" => false,
 };
 
-// Strings that support interpolation.
+// String-like syntax which supports interpolation.
+// Depending on the opening brace, these either parse as strings, or as "symbolic strings",
+// which get desugared here to an array of terms.
 StrChunks: RichTerm = {
   <start: StringStart> <fst: ChunkLiteral?> <chunks: (ChunkExpr+ChunkLiteral)*> <lasts:ChunkExpr*> <end: StringEnd> => {
         debug_assert!(
@@ -493,20 +495,30 @@ StrChunks: RichTerm = {
             .chain(lasts.into_iter())
             .collect();
 
-        let mut chunks = if start.needs_strip_indent() {
+        let chunks = if start.needs_strip_indent() {
             strip_indent(chunks)
         } else {
             chunks
         };
-        chunks.reverse();
 
-        RichTerm::from(Term::StrChunks(chunks))
+        if start == StringStartDelimiter::Symbolic {
+            let terms = chunks.into_iter().map(|chunk| match chunk {
+                StrChunk::Literal(l) => Term::Str(l).into(),
+                StrChunk::Expr(e, _) => e,
+            }).collect();
+            RichTerm::from(Term::Array(terms, Default::default()))
+        } else {
+            let mut chunks = chunks;
+            chunks.reverse();
+            RichTerm::from(Term::StrChunks(chunks))
+        }
     },
 };
 
 StringStart : StringStartDelimiter = {
     "\"" => StringStartDelimiter::Standard,
     "m%\"" => StringStartDelimiter::Multiline,
+    "s%\"" => StringStartDelimiter::Symbolic,
 };
 
 StringEnd : StringEndDelimiter = {
@@ -886,6 +898,7 @@ extern {
         "\"" => Token::Normal(NormalToken::DoubleQuote),
         "\"%" => Token::MultiStr(MultiStringToken::End),
         "m%\"" => Token::Normal(NormalToken::MultiStringStart(<usize>)),
+        "s%\"" => Token::Normal(NormalToken::SymbolicStringStart(<usize>)),
 
         "Num" => Token::Normal(NormalToken::Num),
         "Dyn" => Token::Normal(NormalToken::Dyn),

--- a/src/parser/grammar.lalrpop
+++ b/src/parser/grammar.lalrpop
@@ -523,7 +523,7 @@ StringStart : StringStartDelimiter = {
 
 StringEnd : StringEndDelimiter = {
     "\"" => StringEndDelimiter::Standard,
-    "\"%" => StringEndDelimiter::Multiline,
+    "\"%" => StringEndDelimiter::Special,
 };
 
 ChunkLiteral : String =

--- a/src/parser/grammar.lalrpop
+++ b/src/parser/grammar.lalrpop
@@ -477,7 +477,10 @@ Bool: bool = {
 // Strings that support interpolation.
 StrChunks: RichTerm = {
   <start: StringStart> <fst: ChunkLiteral?> <chunks: (ChunkExpr+ChunkLiteral)*> <lasts:ChunkExpr*> <end: StringEnd> => {
-        debug_assert_eq!(start, end);
+        debug_assert!(
+            start.is_closed_by(&end),
+            "Fatal parser error: a string starting with {start:?} should never be closed by {end:?}"
+        );
 
         let chunks: Vec<StrChunk<RichTerm>> = fst.into_iter()
             .map(StrChunk::Literal)
@@ -490,10 +493,9 @@ StrChunks: RichTerm = {
             .chain(lasts.into_iter())
             .collect();
 
-        let mut chunks = if start == StringKind::Multiline {
+        let mut chunks = if start.needs_strip_indent() {
             strip_indent(chunks)
-        }
-        else {
+        } else {
             chunks
         };
         chunks.reverse();
@@ -502,14 +504,14 @@ StrChunks: RichTerm = {
     },
 };
 
-StringStart : StringKind = {
-    "\"" => StringKind::Standard,
-    "m%\"" => StringKind::Multiline,
+StringStart : StringStartDelimiter = {
+    "\"" => StringStartDelimiter::Standard,
+    "m%\"" => StringStartDelimiter::Multiline,
 };
 
-StringEnd : StringKind = {
-    "\"" => StringKind::Standard,
-    "\"%" => StringKind::Multiline,
+StringEnd : StringEndDelimiter = {
+    "\"" => StringEndDelimiter::Standard,
+    "\"%" => StringEndDelimiter::Multiline,
 };
 
 ChunkLiteral : String =

--- a/src/parser/lexer.rs
+++ b/src/parser/lexer.rs
@@ -160,6 +160,8 @@ pub enum NormalToken<'input> {
     Underscore,
     #[regex("m(%+)\"", |lex| lex.slice().len())]
     MultiStringStart(usize),
+    #[regex("s(%+)\"", |lex| lex.slice().len())]
+    SymbolicStringStart(usize),
 
     #[token("%tag%")]
     Tag,
@@ -605,7 +607,10 @@ impl<'input> Iterator for Lexer<'input> {
             Some(Normal(NormalToken::DoubleQuote | NormalToken::StrEnumTagBegin)) => {
                 self.enter_str()
             }
-            Some(Normal(NormalToken::MultiStringStart(delim_size))) => {
+            Some(Normal(
+                NormalToken::MultiStringStart(delim_size)
+                | NormalToken::SymbolicStringStart(delim_size),
+            )) => {
                 // for interpolation & closing delimeters we only care about
                 // the number of `%`s (plus the opening `"` or `{`) so we
                 // drop the "kind marker" size here (i.e. the `m` character).

--- a/src/parser/utils.rs
+++ b/src/parser/utils.rs
@@ -23,10 +23,38 @@ use crate::{
     types::{TypeF, Types},
 };
 
-/// Distinguish between the standard string separators `"`/`"` and the multi-line string separators
-/// `m%"`/`"%` in the parser.
+/// Distinguish between the standard string opening delimiter `"` and the multi-line string
+/// opening delimter `m%"`
 #[derive(Copy, Clone, Eq, PartialEq, Debug)]
-pub enum StringKind {
+pub enum StringStartDelimiter {
+    Standard,
+    Multiline,
+}
+
+impl StringStartDelimiter {
+    pub fn is_closed_by(&self, close: &StringEndDelimiter) -> bool {
+        matches!(
+            (self, close),
+            (StringStartDelimiter::Standard, StringEndDelimiter::Standard)
+                | (
+                    StringStartDelimiter::Multiline,
+                    StringEndDelimiter::Multiline
+                )
+        )
+    }
+
+    pub fn needs_strip_indent(&self) -> bool {
+        match self {
+            StringStartDelimiter::Standard => false,
+            StringStartDelimiter::Multiline => true,
+        }
+    }
+}
+
+/// Distinguish between the standard string closing delimter `"` and the multi-line string
+/// closing delimeter `"%`.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum StringEndDelimiter {
     Standard,
     Multiline,
 }

--- a/src/parser/utils.rs
+++ b/src/parser/utils.rs
@@ -23,12 +23,13 @@ use crate::{
     types::{TypeF, Types},
 };
 
-/// Distinguish between the standard string opening delimiter `"` and the multi-line string
-/// opening delimter `m%"`
+/// Distinguish between the standard string opening delimiter `"`, the multi-line string
+/// opening delimter `m%"`, and the symbolic string opening delimiter `s%"`.
 #[derive(Copy, Clone, Eq, PartialEq, Debug)]
 pub enum StringStartDelimiter {
     Standard,
     Multiline,
+    Symbolic,
 }
 
 impl StringStartDelimiter {
@@ -40,13 +41,17 @@ impl StringStartDelimiter {
                     StringStartDelimiter::Multiline,
                     StringEndDelimiter::Multiline
                 )
+                | (
+                    StringStartDelimiter::Symbolic,
+                    StringEndDelimiter::Multiline
+                )
         )
     }
 
     pub fn needs_strip_indent(&self) -> bool {
         match self {
             StringStartDelimiter::Standard => false,
-            StringStartDelimiter::Multiline => true,
+            StringStartDelimiter::Multiline | StringStartDelimiter::Symbolic => true,
         }
     }
 }

--- a/src/parser/utils.rs
+++ b/src/parser/utils.rs
@@ -37,14 +37,8 @@ impl StringStartDelimiter {
         matches!(
             (self, close),
             (StringStartDelimiter::Standard, StringEndDelimiter::Standard)
-                | (
-                    StringStartDelimiter::Multiline,
-                    StringEndDelimiter::Multiline
-                )
-                | (
-                    StringStartDelimiter::Symbolic,
-                    StringEndDelimiter::Multiline
-                )
+                | (StringStartDelimiter::Multiline, StringEndDelimiter::Special)
+                | (StringStartDelimiter::Symbolic, StringEndDelimiter::Special)
         )
     }
 
@@ -56,12 +50,12 @@ impl StringStartDelimiter {
     }
 }
 
-/// Distinguish between the standard string closing delimter `"` and the multi-line string
+/// Distinguish between the standard string closing delimter `"` and the "special" string
 /// closing delimeter `"%`.
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum StringEndDelimiter {
     Standard,
-    Multiline,
+    Special,
 }
 
 /// Distinguish between a normal case `id => exp` and a default case `_ => exp`.

--- a/tests/integration/pass/symbolic-strings.ncl
+++ b/tests/integration/pass/symbolic-strings.ncl
@@ -1,0 +1,44 @@
+let {check, ..} = import "lib/assert.ncl" in
+
+[
+  # Static symbolic string
+  s%"hello, world"% == ["hello, world"],
+  # Interpolating a string
+  let s = "test" in
+  s%"This is a %{s}"% == ["This is a ", "test"],
+  # Interpolating an interpolated string
+  let f = "f" in
+  s%"abc %{"de%{f}"}"% == ["abc ", "def"],
+  # Interpolating a number
+  s%"num: %{100}"% == ["num: ", 100],
+  # Interpolating a bool
+  s%"bool: %{true}"% == ["bool: ", true],
+  # Interpolating an array
+  s%"array: %{[true, 1, "yes"]}"% == ["array: ", [true, 1, "yes"]],
+  # Interpolating a record
+  let r = { a = 1, b = false } in
+  s%"record: %{r}"% == ["record: ", r],
+  # Interpolating multiple values
+  let str = "some string" in
+  let num = 999.999 in
+  let bool = false in
+  let array = ["an", "array", 100] in
+  let record = { a = 1, simple = "yes", record = true } in
+  let actual = s%"
+     1. %{str}
+     2. %{num}
+     3. %{bool}
+     4. %{array}
+     5. %{record}"%
+  in
+  let expected = [
+    "1. ", str,
+    "\n2. ", num,
+    "\n3. ", bool,
+    "\n4. ", array,
+    "\n5. ", record
+  ]
+  in
+  actual == expected,
+]
+|> check


### PR DESCRIPTION
This PR introduces a simple form of "symbolic strings" (#948), whereby the syntax `s%"..."%` is just de-sugared to an array.