### PR TITLE
Automate adding tests for examples

### DIFF
--- a/examples/arrays/arrays.ncl
+++ b/examples/arrays/arrays.ncl
@@ -1,3 +1,5 @@
+# test: pass
+
 # Example array functions. This code is illustrative: prefer using the array 
 # stdlib functions `array.map` and `array.fold` instead.
 let my_array_lib = {

--- a/examples/config-gcc/config-gcc.ncl
+++ b/examples/config-gcc/config-gcc.ncl
@@ -1,3 +1,5 @@
+# test: pass
+
 # Validate and normalize gcc flags. They can be either a string `-Wextra` or
 # a structured value `{flag = "W", arg = "extra"}`. Arguments are not checked.
 let GccFlag =

--- a/examples/fibonacci/fibonacci.ncl
+++ b/examples/fibonacci/fibonacci.ncl
@@ -1,3 +1,5 @@
+# test: pass
+
 # This is the naive, exponential version of fibonacci: don't call it on a big
 # value!
 let rec fibonacci = fun n =>

--- a/examples/merge-priorities/main.ncl
+++ b/examples/merge-priorities/main.ncl
@@ -1,3 +1,5 @@
+# test: pass
+
 # Merge several blocks into one final configuration. In a real world case, one
 # would also want contracts to validate the shape of the data.
 let server = import "server.ncl" in

--- a/examples/merge-priorities/security.ncl
+++ b/examples/merge-priorities/security.ncl
@@ -1,3 +1,5 @@
+# test: ignore
+
 {
   server.host.options | priority 10 = "TLS",
 

--- a/examples/merge-priorities/server.ncl
+++ b/examples/merge-priorities/server.ncl
@@ -1,3 +1,5 @@
+# test: ignore
+
 {
   server.host.ip | default = "182.168.1.1",
   server.host.port | default = 80,

--- a/examples/merge/main.ncl
+++ b/examples/merge/main.ncl
@@ -1,3 +1,5 @@
+# test: pass
+
 # Merge several blocks into one final configuration. In a real world case, one
 # would also want contracts to validate the shape of the data.
 let server = import "server.ncl" in

--- a/examples/merge/security.ncl
+++ b/examples/merge/security.ncl
@@ -1,3 +1,5 @@
+# test: ignore
+
 {
   server.host.options = "TLS",
 

--- a/examples/merge/server.ncl
+++ b/examples/merge/server.ncl
@@ -1,3 +1,5 @@
+# test: ignore
+
 {
   server.host.ip = "182.168.1.1",
   server.host.port = 80,

--- a/examples/polymorphism/polymorphism.ncl
+++ b/examples/polymorphism/polymorphism.ncl
@@ -1,3 +1,5 @@
+# test: pass
+
 # First projection, statically typed
 let fst : forall a b. a -> b -> a = fun x y => x in
 # Evaluation function, statically typed

--- a/examples/record-contract/record-contract.ncl
+++ b/examples/record-contract/record-contract.ncl
@@ -1,3 +1,5 @@
+# test: pass
+
 # An illustrative (thus incomplete and maybe incorrect) contract example for a
 # Kubernetes configuration.
 # Schema and example derived from https://github.com/kubernetes/examples/blob/master/guestbook-go/guestbook-controller.json.

--- a/examples/simple-contracts/simple-contract-bool.ncl
+++ b/examples/simple-contracts/simple-contract-bool.ncl
@@ -1,3 +1,5 @@
+# test: pass
+
 # Example of simple custom contract, parametrized by a first argument.
 # In practice, for this kind of simple predicate, one should rather use
 # `contract.from_predicate`

--- a/examples/simple-contracts/simple-contract-div.ncl
+++ b/examples/simple-contracts/simple-contract-div.ncl
@@ -1,5 +1,4 @@
-# /!\ THIS EXAMPLE IS EXPECTED TO FAIL
-# Illustrate a basic contract violation.
+# test: blame
 
 let Even = fun label value =>
   if builtin.is_num value && value % 2 == 0 then
@@ -11,6 +10,6 @@ let DivBy3 = fun label value =>
     value
   else
     contract.blame label in
-# Will cause an error! 4 is no divided by 3.
+# Will cause an error! 4 is not divisible by 3.
 (4 | Even
    | DivBy3)


### PR DESCRIPTION
This PR updates the  `examples.rs` test file to use the `test-generator` crate to automatically generate tests from programs in the `examples/` directory. 

Since not every example file is (1) actually tested or (2) expected to pass, this PR also introduces a limited form of annotation in these files. This is a testing approach I first noticed in the Swift project (see, e.g., [here](https://github.com/apple/swift/blob/main/test/expr/expressions.swift#L50)), where source files are annotated with expectations about their behaviour in comments, which are then parsed during testing. 

Currently the annotations here aren't particularly complex - they just expect a file to pass, fail with a blame error, or ignore the file entirely. This is something which could - & should! - be expanded in future (which would mean we no longer need to write Nickel code inside Rust strings when we want to test failure cases).