### PR TITLE
Return grapheme cluster count from `%str_length%` primitive

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1216,6 +1216,7 @@ dependencies = [
  "test-generator",
  "toml",
  "typed-arena 2.0.1",
+ "unicode-segmentation",
  "void",
  "wasm-bindgen",
 ]
@@ -2388,9 +2389,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e8820f5d777f6224dc4be3632222971ac30164d4a258d595640799554ebfd99"
+checksum = "0fdbf052a0783de01e944a6ce7a8cb939e295b1e7be835a1112c3b9a7f047a5a"
 
 [[package]]
 name = "unicode-width"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ sha-1 = "0.10.0"
 sha2 = "0.10.2"
 md-5 = "0.10.1"
 directories = "4.0.1"
+unicode-segmentation = "1.10.0"
 
 termimad = { version = "0.20.1", optional = true }
 ansi_term = { version = "0.12", optional = true }

--- a/src/eval/operation.rs
+++ b/src/eval/operation.rs
@@ -36,6 +36,7 @@ use crate::{
 use md5::digest::Digest;
 
 use simple_counter::*;
+use unicode_segmentation::UnicodeSegmentation;
 
 use std::{iter::Extend, rc::Rc};
 
@@ -984,8 +985,9 @@ impl<R: ImportResolver, C: Cache> VirtualMachine<R, C> {
             }
             UnaryOp::StrLength() => {
                 if let Term::Str(s) = &*t {
+                    let length = s.graphemes(true).count();
                     Ok(Closure::atomic_closure(RichTerm::new(
-                        Term::Num(s.len() as f64),
+                        Term::Num(length as f64),
                         pos_op_inh,
                     )))
                 } else {

--- a/stdlib/string.ncl
+++ b/stdlib/string.ncl
@@ -370,7 +370,10 @@
 
     length : Str -> Num
     | doc m%"
-      Results in the length of the given string.
+      Returns the length of the string, as measured by the number of UTF-8
+      [extended grapheme clusters](https://unicode.org/glossary/#extended_grapheme_cluster).
+
+      Generally speaking, this gives the number of "visible" glyphs in the string.
 
       For example:
       ```nickel
@@ -378,6 +381,10 @@
           0
         length "hi" =>
           2
+        length "四字熟語" =>
+          4
+        length "👨🏾‍❤️‍💋‍👨🏻" =>
+          1
       ```
       "%
     = fun s => %str_length% s,

--- a/tests/integration/pass/strings.ncl
+++ b/tests/integration/pass/strings.ncl
@@ -25,5 +25,16 @@ let {check, ..} = import "lib/assert.ncl" in
   let b = "x" in m%"a%%{b}c"% == "a%xc",
   m%"%Hel%%{"1"}lo%%%{"2"}"% == "%Hel%1lo%%2",
   let res = string.find "a" "bac" in res.matched == "a" && res.index == 1,
+
+  # length
+  string.length "" == 0,
+  string.length "nickel" == 6,
+  # Hungarian `ő` character.
+  string.length "unicőde" == 7,
+  # Vietnamese `ế ` character.
+  string.length "nickếl" == 6,
+  string.length "四字熟語" == 4,
+  string.length "👩🏿‍❤️‍💋‍👩🏼" == 1,
+  string.length "👨‍❤️‍💋‍👨" == 1,
 ]
 |> check


### PR DESCRIPTION
Previously `%str_length%` was returning the number of bytes in the Rust `String`, which lead to unexpected results.

This commit uses the `unicode-segmentation` crate to instead count the number of extended grapheme clusters in the string. This means that even complex emoji comprised of multiple characters, but visually rendering as one, get counted as just one character.

One potential downside to this is that this isn't consistent with how other standard library functions (such as splitting a string) currently work, however it also wasn't consistent before, and this change at least moves things in the right direction.

Merging this will close #1003. (cc @euank)