### PR TITLE
Fix nix run

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -350,6 +350,13 @@
         inherit stdlibDoc;
       };
 
+      apps = {
+        default = {
+          type = "app";
+          program = "${packages.nickel}/bin/nickel";
+        };
+      };
+
       devShells = (forEachRustChannel (channel: {
         name = channel;
         value = makeDevShell { rust = mkRust { inherit channel; rustProfile = "default"; }; };


### PR DESCRIPTION
With the current flake, `nix run` commands aren't working. The command found on the homepage isn't working either:

```
> nix run --experimental-features "flakes nix-command" github:tweag/nickel -- repl
error: unable to execute '/nix/store/hggp49h0q7kw77i4mrj4ccz3dyxmg815-nickel-lang-0.3.1/bin/nickel-lang': No such file or directory
```

This PR instructs the flake that the default app is `bin/nickel` for package nickel. You may want to backport it to stable branch to fix the homepage example (I need to make a PR to change the command to use the stable branch there)