### PR TITLE
Assign the correct position to a linearized function term 

### DIFF
--- a/lsp/nls/src/linearization/mod.rs
+++ b/lsp/nls/src/linearization/mod.rs
@@ -210,11 +210,16 @@ impl<'a> Linearizer for AnalysisHost<'a> {
                         index: id_gen.get_and_advance(),
                     };
                     self.env.insert(ident.to_owned(), id);
+                    let pos = match term {
+                        Term::LetPattern(..) => ident.pos,
+                        Term::FunPattern(..) => pos,
+                        _ => unreachable!(),
+                    };
                     lin.push(LinearizationItem {
                         env: self.env.clone(),
                         id,
                         ty,
-                        pos: ident.pos,
+                        pos,
                         kind: TermKind::Declaration(ident.to_owned(), Vec::new(), value_ptr),
                         meta: None,
                     });
@@ -283,6 +288,11 @@ impl<'a> Linearizer for AnalysisHost<'a> {
                         index: id_gen.get(),
                     },
                 );
+                let pos = match term {
+                    Term::Let(..) => ident.pos,
+                    Term::Fun(..) => pos,
+                    _ => unreachable!(),
+                };
                 lin.push(LinearizationItem {
                     env: self.env.clone(),
                     id: ItemId {
@@ -290,7 +300,7 @@ impl<'a> Linearizer for AnalysisHost<'a> {
                         index: id_gen.get(),
                     },
                     ty,
-                    pos: ident.pos,
+                    pos,
                     kind: TermKind::Declaration(ident.to_owned(), Vec::new(), value_ptr),
                     meta: self.meta.take(),
                 });
@@ -423,6 +433,7 @@ impl<'a> Linearizer for AnalysisHost<'a> {
                 let locator = (*file, start);
 
                 let Some(term_id) = linearization.item_at(&locator) else {
+                    panic!("hey");
                     return
                 };
                 let term_id = term_id.id;

--- a/lsp/nls/src/linearization/mod.rs
+++ b/lsp/nls/src/linearization/mod.rs
@@ -210,9 +210,19 @@ impl<'a> Linearizer for AnalysisHost<'a> {
                         index: id_gen.get_and_advance(),
                     };
                     self.env.insert(ident.to_owned(), id);
-                    let pos = match term {
-                        Term::LetPattern(..) => ident.pos,
-                        Term::FunPattern(..) => pos,
+                    let (pos, kind) = match term {
+                        Term::LetPattern(..) => (
+                            ident.pos,
+                            TermKind::Declaration(ident.to_owned(), Vec::new(), value_ptr),
+                        ),
+                        Term::FunPattern(..) => (
+                            pos,
+                            TermKind::Declaration(
+                                ident.to_owned(),
+                                Vec::new(),
+                                ValueState::Unknown,
+                            ),
+                        ),
                         _ => unreachable!(),
                     };
                     lin.push(LinearizationItem {
@@ -220,7 +230,7 @@ impl<'a> Linearizer for AnalysisHost<'a> {
                         id,
                         ty,
                         pos,
-                        kind: TermKind::Declaration(ident.to_owned(), Vec::new(), value_ptr),
+                        kind,
                         meta: None,
                     });
                 }
@@ -288,9 +298,15 @@ impl<'a> Linearizer for AnalysisHost<'a> {
                         index: id_gen.get(),
                     },
                 );
-                let pos = match term {
-                    Term::Let(..) => ident.pos,
-                    Term::Fun(..) => pos,
+                let (pos, kind) = match term {
+                    Term::Let(..) => (
+                        ident.pos,
+                        TermKind::Declaration(ident.to_owned(), Vec::new(), value_ptr),
+                    ),
+                    Term::Fun(..) => (
+                        pos,
+                        TermKind::Declaration(ident.to_owned(), Vec::new(), ValueState::Unknown),
+                    ),
                     _ => unreachable!(),
                 };
                 lin.push(LinearizationItem {
@@ -301,7 +317,7 @@ impl<'a> Linearizer for AnalysisHost<'a> {
                     },
                     ty,
                     pos,
-                    kind: TermKind::Declaration(ident.to_owned(), Vec::new(), value_ptr),
+                    kind,
                     meta: self.meta.take(),
                 });
             }

--- a/lsp/nls/src/linearization/mod.rs
+++ b/lsp/nls/src/linearization/mod.rs
@@ -183,7 +183,7 @@ impl<'a> Linearizer for AnalysisHost<'a> {
                             ValueState::Unknown
                         }
                         Term::FunPattern(..) => {
-                            // stub object
+                            // stub object, representing the whole function
                             lin.push(LinearizationItem {
                                 env: self.env.clone(),
                                 id: ItemId {
@@ -192,7 +192,7 @@ impl<'a> Linearizer for AnalysisHost<'a> {
                                 },
 
                                 ty: ty.clone(),
-                                pos: ident.pos,
+                                pos,
                                 kind: TermKind::Structure,
                                 meta: self.meta.take(),
                             });
@@ -210,26 +210,20 @@ impl<'a> Linearizer for AnalysisHost<'a> {
                         index: id_gen.get_and_advance(),
                     };
                     self.env.insert(ident.to_owned(), id);
-                    let (pos, kind) = match term {
-                        Term::LetPattern(..) => (
-                            ident.pos,
-                            TermKind::Declaration(ident.to_owned(), Vec::new(), value_ptr),
-                        ),
-                        Term::FunPattern(..) => (
-                            pos,
-                            TermKind::Declaration(
-                                ident.to_owned(),
-                                Vec::new(),
-                                ValueState::Unknown,
-                            ),
-                        ),
+                    let kind = match term {
+                        Term::LetPattern(..) => {
+                            TermKind::Declaration(ident.to_owned(), Vec::new(), value_ptr)
+                        }
+                        Term::FunPattern(..) => {
+                            TermKind::Declaration(ident.to_owned(), Vec::new(), ValueState::Unknown)
+                        }
                         _ => unreachable!(),
                     };
                     lin.push(LinearizationItem {
                         env: self.env.clone(),
                         id,
                         ty,
-                        pos,
+                        pos: ident.pos,
                         kind,
                         meta: None,
                     });
@@ -270,7 +264,7 @@ impl<'a> Linearizer for AnalysisHost<'a> {
                         ValueState::Unknown
                     }
                     Term::Fun(..) => {
-                        // stub object
+                        // stub object, representing the whole function
                         lin.push(LinearizationItem {
                             env: self.env.clone(),
                             id: ItemId {
@@ -279,7 +273,7 @@ impl<'a> Linearizer for AnalysisHost<'a> {
                             },
 
                             ty: ty.clone(),
-                            pos: ident.pos,
+                            pos,
                             kind: TermKind::Structure,
                             meta: self.meta.take(),
                         });
@@ -298,15 +292,11 @@ impl<'a> Linearizer for AnalysisHost<'a> {
                         index: id_gen.get(),
                     },
                 );
-                let (pos, kind) = match term {
-                    Term::Let(..) => (
-                        ident.pos,
-                        TermKind::Declaration(ident.to_owned(), Vec::new(), value_ptr),
-                    ),
-                    Term::Fun(..) => (
-                        pos,
-                        TermKind::Declaration(ident.to_owned(), Vec::new(), ValueState::Unknown),
-                    ),
+                let kind = match term {
+                    Term::Let(..) => TermKind::Declaration(ident.to_owned(), Vec::new(), value_ptr),
+                    Term::Fun(..) => {
+                        TermKind::Declaration(ident.to_owned(), Vec::new(), ValueState::Unknown)
+                    }
                     _ => unreachable!(),
                 };
                 lin.push(LinearizationItem {
@@ -316,7 +306,7 @@ impl<'a> Linearizer for AnalysisHost<'a> {
                         index: id_gen.get(),
                     },
                     ty,
-                    pos,
+                    pos: ident.pos,
                     kind,
                     meta: self.meta.take(),
                 });

--- a/lsp/nls/src/linearization/mod.rs
+++ b/lsp/nls/src/linearization/mod.rs
@@ -433,7 +433,6 @@ impl<'a> Linearizer for AnalysisHost<'a> {
                 let locator = (*file, start);
 
                 let Some(term_id) = linearization.item_at(&locator) else {
-                    panic!("hey");
                     return
                 };
                 let term_id = term_id.id;


### PR DESCRIPTION
Currently, the linearization algorithm assumes that the position of a function is the position of the its argument. For example, if we have the term `fun x => x`, the algorithm assigns the position of this function to be the position of the argument `x`  in the linearization data structure.

This is *obviously* not right: the position of a function should span the whole range of the function, not just its arguments. 

This causes problems (e.g LSP server crash because of wrong assumptions or wrong results to the LSP client)  with some of the LSP features (e.g hover, cross-file auto-completion, etc)

This change fixes this issue. 