### PR TITLE
[Fix] Do not panic on type path mismatch

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -1216,7 +1216,7 @@ mod blame_error {
         } = ty_path::span(l.path.iter().peekable(), &l.types);
 
         let (msg, notes) = match (last, last_arrow_elem) {
-            // The type path contract doesn't contain any arrow, and the failing subcontract is the
+            // The type path doesn't contain any arrow, and the failing subcontract is the
             // contract for the elements of an array
             (Some(ty_path::Elem::Array), None) => (String::from("expected array element type"), Vec::new()),
             // The type path doesn't contain any arrow, and the failing subcontract is the contract

--- a/src/error.rs
+++ b/src/error.rs
@@ -1231,8 +1231,8 @@ mod blame_error {
                     vec![
                         String::from(
                             "This error may happen in the following situation:
-    1. A fun    ction `f` is bound by a contract: e.g. `Bool -> Num`.
-    2. `f` r    eturns a value of the wrong type: e.g. `f = fun c => \"string\"` while `Num` is expected.",
+    1. A function `f` is bound by a contract: e.g. `Bool -> Num`.
+    2. `f` returns a value of the wrong type: e.g. `f = fun c => \"string\"` while `Num` is expected.",
                         ),
                         String::from(
                             "Either change the contract accordingly, or change the return value of `f`",

--- a/src/label.rs
+++ b/src/label.rs
@@ -63,18 +63,10 @@ pub mod ty_path {
         !p.iter().any(|elt| matches!(*elt, Elem::Domain))
     }
 
-    /// Return the last element of the path which is either `Domain` or `Codomain`.
-    pub fn last_arrow_elem(p: &Path) -> Option<Elem> {
-        p.iter().fold(None, |current_last, elt| {
-            matches!(*elt, Elem::Domain | Elem::Codomain)
-                .then_some(*elt)
-                .or(current_last)
-        })
-    }
-
     /// Determine if the path is not higher order, that is, if it doesn't contain any arrow.
     pub fn has_no_arrow(p: &Path) -> bool {
-        last_arrow_elem(p).is_none()
+        !p.iter()
+            .any(|elt| matches!(*elt, Elem::Domain | Elem::Codomain))
     }
 
     #[derive(Clone, Copy, Debug)]

--- a/src/label.rs
+++ b/src/label.rs
@@ -63,7 +63,7 @@ pub mod ty_path {
         !p.iter().any(|elt| matches!(*elt, Elem::Domain))
     }
 
-    /// Return the last element of the past which is either `Domain` or `Codomain`.
+    /// Return the last element of the path which is either `Domain` or `Codomain`.
     pub fn last_arrow_elem(p: &Path) -> Option<Elem> {
         p.iter().fold(None, |current_last, elt| {
             matches!(*elt, Elem::Domain | Elem::Codomain)
@@ -86,7 +86,7 @@ pub mod ty_path {
     /// is an arrow element (`Domain` or `Codomain`).
     ///
     /// In the general case, this should be respectively the last element of the path and the last
-    /// element of the path filtered by keeping only `Domain` and `Codmain`. But sometimes the
+    /// element of the path filtered by keeping only `Domain` and `Codomain`. But sometimes the
     /// `span` function couldn't make further progress:
     ///
     /// ```nickel

--- a/src/typecheck/mod.rs
+++ b/src/typecheck/mod.rs
@@ -898,8 +898,8 @@ fn walk<L: Linearizer>(
         }
         Term::Record(record) => {
             record.fields
-                .iter()
-                .try_for_each(|(_, t)| -> Result<(), TypecheckError> {
+                .values()
+                .try_for_each(|t| -> Result<(), TypecheckError> {
                     walk(state, ctxt.clone(), lin, linearizer.scope(), t)
                 })
         }
@@ -1257,8 +1257,8 @@ fn type_check_<L: Linearizer>(
             // `Let` case in `walk`.
             record
                 .fields
-                .iter()
-                .try_for_each(|(_, t)| -> Result<(), TypecheckError> {
+                .values()
+                .try_for_each(|t| -> Result<(), TypecheckError> {
                     type_check_(
                         state,
                         ctxt.clone(),
@@ -1290,8 +1290,8 @@ fn type_check_<L: Linearizer>(
                 // Checking for a dictionary
                 record
                     .fields
-                    .iter()
-                    .try_for_each(|(_, t)| -> Result<(), TypecheckError> {
+                    .values()
+                    .try_for_each(|t| -> Result<(), TypecheckError> {
                         type_check_(
                             state,
                             ctxt.clone(),

--- a/utilities/src/lib.rs
+++ b/utilities/src/lib.rs
@@ -19,9 +19,13 @@ use std::{io::Cursor, path::PathBuf};
 pub type EC = CBNCache;
 pub type TestProgram = Program<EC>;
 
+/// Create a program from a Nickel expression provided as a string.
+pub fn program_from_expr(s: impl std::string::ToString) -> Program<EC> {
+    Program::<EC>::new_from_source(Cursor::new(s.to_string()), "test").unwrap()
+}
+
 pub fn eval(s: impl std::string::ToString) -> Result<Term, Error> {
-    let mut p = Program::<EC>::new_from_source(Cursor::new(s.to_string()), "test").unwrap();
-    p.eval().map(Term::from)
+    program_from_expr(s).eval().map(Term::from)
 }
 
 pub fn eval_file(f: &str) -> Result<Term, Error> {


### PR DESCRIPTION
Closes #1021 

Before, the type path information encoded in a label and the original type/contract annotation had to match, by virtue of the Nickel implementation. We panicked if not the case.

Typically, if the implementation of builtin contracts called to `%go_dom%`, `%go_codom%` and `%go_array%` in this order, giving a type path `[Dom, Codom, Array]`, we expected that the original contract annotation must have the shape `(_ -> Array _) -> _`. 

Since the addition of `contract.apply` and the possibility of mixing types and terms, this is not true anymore. 
For example, if we set `let Alias = Num -> Array Num -> Num` and use `Alias` in place of the original type: the type path will be unchanged, but the original annotation is now just `Alias`.

This PR relaxes the invariant expected by the error reporting code to avoid panicking in valid cases, and adapt the error reporting messages accordingly.

## TODO

The error reporting may be slightly off now when using aliases:

```nickel
nickel> let Foo = Array Num in ["a"] | Foo
error: contract broken by a value
  ┌─ :1:1
  │
1 │ Foo
  │ --- expected type
  │
  ┌─ repl-input-0:1:25
  │
1 │ let Foo = Array Num in ["a"] | Foo
  │                         ^^^ applied to this expression
  │
  ┌─ <unknown> (generated by evaluation):1:1
  │
1 │ "a"
  │ --- evaluated to this value

note: 
  ┌─ repl-input-0:1:32
  │
1 │ let Foo = Array Num in ["a"] | Foo
  │                                ^^^ bound here
```

The error reporting points at `Foo`, but points to the specific value inside the array which is failing the contracts. The latter is more precise, and probably what we want, but the overall error might be deceiving. We're saying that there is a problem with a `Foo = Array Num` contract and points to a string value, which can be interpreted as we're using a string in place of an array, while we're really using a string in place of a number.

Compare with the version without alias:

```nickel
["a"] | Array Num
error: contract broken by a value
  ┌─ :1:7
  │
1 │ Array Num
  │       --- expected array element type
  │
  ┌─ repl-input-1:1:2
  │
1 │ ["a"] | Array Num
  │  ^^^ applied to this expression
  │
  ┌─ <unknown> (generated by evaluation):1:1
  │
1 │ "a"
  │ --- evaluated to this value

note: 
  ┌─ repl-input-1:1:9
  │
1 │ ["a"] | Array Num
  │         ^^^^^^^^^ bound here
```

I don't have a great solution right now. In the meantime, this PR still strictly improves on the previous situation (it just handles more cases instead of panicking, and the cases already supported on the current master should be identical).