### PR TITLE
Improve the "goto definition" feature of the LSP by making it work across multiple files

### DIFF
--- a/lsp/nls/src/linearization/building.rs
+++ b/lsp/nls/src/linearization/building.rs
@@ -32,6 +32,14 @@ impl<'b> Building<'b> {
         self.linearization.push(item)
     }
 
+    fn get_item(&self, id: ItemId) -> Option<&LinearizationItem<Unresolved>> {
+        self.linearization.get(id.index)
+    }
+
+    fn get_item_mut(&mut self, id: ItemId) -> Option<&mut LinearizationItem<Unresolved>> {
+        self.linearization.get_mut(id.index)
+    }
+
     fn get_item_kind_with_id(
         &self,
         current_file: FileId,
@@ -39,7 +47,7 @@ impl<'b> Building<'b> {
     ) -> Option<(&ItemId, &TermKind)> {
         if current_file == id.file_id {
             // This usage references an item in the file we're currently linearizing
-            let item = self.linearization.get(id.index)?;
+            let item = self.get_item(id)?;
             Some((&item.id, &item.kind))
         } else {
             // This usage references an item in another file (that has already been linearized)
@@ -59,7 +67,7 @@ impl<'b> Building<'b> {
     fn get_item_kind_mut(&mut self, current_file: FileId, id: ItemId) -> Option<&mut TermKind> {
         if current_file == id.file_id {
             // This usage references an item in the file we're currently linearizing
-            let item = self.linearization.get_mut(id.index)?;
+            let item = self.get_item_mut(id)?;
             Some(&mut item.kind)
         } else {
             // This usage references an item in another file (that has already been linearized)

--- a/lsp/nls/src/linearization/building.rs
+++ b/lsp/nls/src/linearization/building.rs
@@ -174,6 +174,8 @@ impl<'b> Building<'b> {
         }
     }
 
+    /// [`resolve_record_references`] tries to resolve the references passed to it, and
+    /// returns the ids of the items it couldn't resolve.
     pub(super) fn resolve_record_references(
         &mut self,
         current_file: FileId,
@@ -271,7 +273,6 @@ impl<'b> Building<'b> {
         }
 
         if defers.is_empty() && !unresolved.is_empty() {
-            debug!("unresolved references: {:?}", unresolved);
             defers = mem::take(&mut unresolved);
             defers
         } else {

--- a/lsp/nls/src/linearization/building.rs
+++ b/lsp/nls/src/linearization/building.rs
@@ -190,7 +190,7 @@ impl<'b> Building<'b> {
 
             // load the parent referenced declaration (i.e.: a declaration or record field term)
             let parent_declaration = parent_referenced
-                .and_then(|parent_usage_value| self.resolve_reference(file, &parent_usage_value));
+                .and_then(|parent_usage_value| self.resolve_reference(file, parent_usage_value));
 
             if let Some(TermKind::Usage(UsageState::Deferred { .. })) = parent_declaration {
                 debug!("parent references deferred usage");

--- a/lsp/nls/src/linearization/mod.rs
+++ b/lsp/nls/src/linearization/mod.rs
@@ -330,10 +330,6 @@ impl<'a> Linearizer for AnalysisHost<'a> {
                             index: id_gen.get_and_advance(),
                         };
 
-                        // if ident.label() == "string" {
-                        //     panic!("{:?}", accessor.label());
-                        // }
-
                         lin.push(LinearizationItem {
                             env: self.env.clone(),
                             id,
@@ -475,7 +471,7 @@ impl<'a> Linearizer for AnalysisHost<'a> {
         debug!("linearizing");
 
         // TODO: Storing defers while linearizing?
-        let defers: Vec<(ItemId, ItemId, Ident)> = lin
+        let mut defers: Vec<(ItemId, ItemId, Ident)> = lin
             .linearization
             .iter()
             .filter_map(|item| match &item.kind {
@@ -486,7 +482,8 @@ impl<'a> Linearizer for AnalysisHost<'a> {
             })
             .collect();
 
-        lin.resolve_record_references(self.file, defers.into_iter().rev().collect());
+        defers.reverse();
+        lin.resolve_record_references(self.file, defers);
 
         let Building {
             mut linearization, ..

--- a/lsp/nls/src/linearization/mod.rs
+++ b/lsp/nls/src/linearization/mod.rs
@@ -357,7 +357,7 @@ impl<'a> Linearizer for AnalysisHost<'a> {
                     meta: self.meta.take(),
                 });
 
-                lin.register_fields(&record.fields, id, &mut self.env, self.file);
+                lin.register_fields(self.file, &record.fields, id, &mut self.env);
                 let mut field_names = record.fields.keys().cloned().collect::<Vec<_>>();
                 field_names.sort_unstable();
 

--- a/lsp/nls/src/linearization/mod.rs
+++ b/lsp/nls/src/linearization/mod.rs
@@ -329,6 +329,11 @@ impl<'a> Linearizer for AnalysisHost<'a> {
                             file_id: self.file,
                             index: id_gen.get_and_advance(),
                         };
+
+                        // if ident.label() == "string" {
+                        //     panic!("{:?}", accessor.label());
+                        // }
+
                         lin.push(LinearizationItem {
                             env: self.env.clone(),
                             id,

--- a/lsp/nls/src/linearization/mod.rs
+++ b/lsp/nls/src/linearization/mod.rs
@@ -486,7 +486,7 @@ impl<'a> Linearizer for AnalysisHost<'a> {
             })
             .collect();
 
-        lin.resolve_record_references(self.file, defers);
+        lin.resolve_record_references(self.file, defers.into_iter().rev().collect());
 
         let Building {
             mut linearization, ..

--- a/lsp/nls/src/linearization/mod.rs
+++ b/lsp/nls/src/linearization/mod.rs
@@ -483,7 +483,8 @@ impl<'a> Linearizer for AnalysisHost<'a> {
             .collect();
 
         defers.reverse();
-        lin.resolve_record_references(self.file, defers);
+        let unresolved = lin.resolve_record_references(self.file, defers);
+        debug!("unresolved references: {:?}", unresolved);
 
         let Building {
             mut linearization, ..

--- a/lsp/nls/src/requests/goto.rs
+++ b/lsp/nls/src/requests/goto.rs
@@ -44,16 +44,14 @@ pub fn handle_to_definition(
 
     Trace::enrich(&id, linearization);
 
-    let item = linearization.item_at(&locator);
-
-    if item.is_none() {
+    let Some(item) = linearization.item_at(&locator) else {
         server.reply(Response::new_ok(id, Value::Null));
-        return Ok(());
-    }
-
-    let item = item.unwrap();
+        return Ok(())
+    };
 
     debug!("found referencing item: {:?}", item);
+
+    // panic!("{:?}", item);
 
     let location = match item.kind {
         TermKind::Usage(UsageState::Resolved(usage_id)) => {

--- a/lsp/nls/src/requests/goto.rs
+++ b/lsp/nls/src/requests/goto.rs
@@ -51,8 +51,6 @@ pub fn handle_to_definition(
 
     debug!("found referencing item: {:?}", item);
 
-    // panic!("{:?}", item);
-
     let location = match item.kind {
         TermKind::Usage(UsageState::Resolved(usage_id)) => {
             let definition = linearization.get_item(usage_id, &server.lin_cache).unwrap();
@@ -91,7 +89,14 @@ pub fn handle_to_usages(
 ) -> Result<(), ResponseError> {
     let file_id = server
         .cache
-        .id_of(params.text_document_position.text_document.uri.as_str())
+        .id_of(
+            params
+                .text_document_position
+                .text_document
+                .uri
+                .to_file_path()
+                .unwrap(),
+        )
         .unwrap();
 
     let start = position_to_byte_index(
@@ -126,7 +131,7 @@ pub fn handle_to_usages(
                         .pos
                         .as_opt_ref()
                         .map(|RawSpan { start, end, src_id }| Location {
-                            uri: Url::parse(&server.cache.name(*src_id).to_string_lossy()).unwrap(),
+                            uri: Url::from_file_path(server.cache.name(*src_id)).unwrap(),
                             range: Range::from_codespan(
                                 src_id,
                                 &((*start).into()..(*end).into()),

--- a/lsp/nls/src/requests/goto.rs
+++ b/lsp/nls/src/requests/goto.rs
@@ -54,6 +54,12 @@ pub fn handle_to_definition(
     let location = match item.kind {
         TermKind::Usage(UsageState::Resolved(usage_id)) => {
             let definition = linearization.get_item(usage_id, &server.lin_cache).unwrap();
+            if server.cache.is_stdlib_module(definition.id.file_id) {
+                // The standard library files are embeded in the executable,
+                // so we can't possibly go their definition on disk.
+                server.reply(Response::new_ok(id, Value::Null));
+                return Ok(());
+            }
             let RawSpan {
                 start: ByteIndex(start),
                 end: ByteIndex(end),

--- a/lsp/nls/src/requests/goto.rs
+++ b/lsp/nls/src/requests/goto.rs
@@ -56,7 +56,7 @@ pub fn handle_to_definition(
             let definition = linearization.get_item(usage_id, &server.lin_cache).unwrap();
             if server.cache.is_stdlib_module(definition.id.file_id) {
                 // The standard library files are embeded in the executable,
-                // so we can't possibly go their definition on disk.
+                // so we can't possibly go to their definition on disk.
                 server.reply(Response::new_ok(id, Value::Null));
                 return Ok(());
             }

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -850,6 +850,14 @@ impl Cache {
         self.terms.get(&file_id).map(|CachedTerm { term, .. }| term)
     }
 
+    /// Returns true if a particular file id represents a Nickel standard library file, false otherwise.
+    pub fn is_stdlib_module(&self, file: FileId) -> bool {
+        let Some(table) = &self.stdlib_ids else {
+            return false
+        };
+        table.values().any(|stdlib_file| *stdlib_file == file)
+    }
+
     /// Retrieve the FileId for a given standard libray module.
     pub fn get_submodule_file_id(&self, module: StdlibModule) -> Option<FileId> {
         let file = self.stdlib_ids.as_ref()?.get(&module).copied()?;


### PR DESCRIPTION
Closes #932 

This change adds support for cross file navigation using the "goto reference" feature of the LSP.