### PR TITLE
Assign the correct position to the value of nested record fields

### DIFF
--- a/src/parser/utils.rs
+++ b/src/parser/utils.rs
@@ -282,14 +282,17 @@ pub fn elaborate_field_path(
         // unwrap is safe here becuase the initial content has a position,
         // and we make sure we assign a position for the next field.
         let acc_span = acc.pos.unwrap();
+        let pos = match path_elem {
+            FieldPathElem::Ident(id) => id.pos,
+            FieldPathElem::Expr(ref expr) => expr.pos,
+        };
+        // unwrap is safe here because every id should have a non-`TermPos::None` position
+        let id_span = pos.unwrap();
+        // `RawSpan::fuse` only returns `None` when the two spans are in different files.
+        // A record field and its value *must* be in the same file, so this is safe.
+        let pos = TermPos::Original(RawSpan::fuse(id_span, acc_span).unwrap());
         match path_elem {
             FieldPathElem::Ident(id) => {
-                // unwrap is safe here because every id should have a non-`TermPos::None` position
-                let id_span = id.pos.unwrap();
-                // `RawSpan::fuse` only returns `None` when the two spans are in different files.
-                // A record field and its value *must* be in the same file, so this is safe.
-                let pos = TermPos::Original(RawSpan::fuse(id_span, acc_span).unwrap());
-
                 let mut fields = HashMap::new();
                 fields.insert(id, acc);
 
@@ -310,10 +313,6 @@ pub fn elaborate_field_path(
                     }
                     _ => None,
                 };
-
-                let id_span = exp.pos.unwrap();
-                let pos = TermPos::Original(RawSpan::fuse(id_span, acc_span).unwrap());
-
                 if let Some(static_access) = static_access {
                     let id = Ident::new_with_pos(static_access, exp.pos);
                     let mut fields = HashMap::new();

--- a/src/parser/utils.rs
+++ b/src/parser/utils.rs
@@ -292,7 +292,7 @@ pub fn elaborate_field_path(
             let mut fields = HashMap::new();
             fields.insert(id, acc);
 
-            RichTerm::with_pos(Term::Record(RecordData::with_fields(fields)).into(), pos)
+            RichTerm::new(Term::Record(RecordData::with_fields(fields)), pos)
         }
         FieldPathElem::Expr(exp) => {
             let static_access = match exp.term.as_ref() {
@@ -318,14 +318,10 @@ pub fn elaborate_field_path(
                 let id = Ident::new_with_pos(static_access, exp.pos);
                 let mut fields = HashMap::new();
                 fields.insert(id, acc);
-
-                RichTerm::with_pos(Term::Record(RecordData::with_fields(fields)).into(), pos)
+                RichTerm::new(Term::Record(RecordData::with_fields(fields)), pos)
             } else {
                 let empty = Term::Record(RecordData::empty());
-                RichTerm::with_pos(
-                    mk_app!(mk_term::op2(BinaryOp::DynExtend(), exp, empty), acc),
-                    pos,
-                )
+                mk_app!(mk_term::op2(BinaryOp::DynExtend(), exp, empty), acc).with_pos(pos)
             }
         }
     });

--- a/src/parser/utils.rs
+++ b/src/parser/utils.rs
@@ -286,7 +286,7 @@ pub fn elaborate_field_path(
             // and we make sure we assign a position for the next field.
             let acc_span = acc.pos.unwrap();
             // `RawSpan::fuse` only returns `None` when the two spans are in different files.
-            // A record field and its value *must* to be in the same file, so this is safe.
+            // A record field and its value *must* be in the same file, so this is safe.
             let pos = TermPos::Original(RawSpan::fuse(id_span, acc_span).unwrap());
 
             let mut fields = HashMap::new();

--- a/src/parser/utils.rs
+++ b/src/parser/utils.rs
@@ -310,14 +310,22 @@ pub fn elaborate_field_path(
                 _ => None,
             };
 
+            let id_span = exp.pos.unwrap();
+            let acc_span = acc.pos.unwrap();
+            let pos = TermPos::Original(RawSpan::fuse(id_span, acc_span).unwrap());
+
             if let Some(static_access) = static_access {
                 let id = Ident::new_with_pos(static_access, exp.pos);
                 let mut fields = HashMap::new();
                 fields.insert(id, acc);
-                Term::Record(RecordData::with_fields(fields)).into()
+
+                RichTerm::with_pos(Term::Record(RecordData::with_fields(fields)).into(), pos)
             } else {
                 let empty = Term::Record(RecordData::empty());
-                mk_app!(mk_term::op2(BinaryOp::DynExtend(), exp, empty), acc)
+                RichTerm::with_pos(
+                    mk_app!(mk_term::op2(BinaryOp::DynExtend(), exp, empty), acc),
+                    pos,
+                )
             }
         }
     });


### PR DESCRIPTION
Currently, when we have a nested record, defined like this: 
```
{ foo.bar.baz.boo = 5 }
```
Nickel desugars it to: 
```
{ foo = {bar = {baz = {boo = 5}}}}
```
But the position of the value of `foo`, `bar`, and `baz` are set to `TermPos::None`

This pull request changes this by setting the position of a nested record field's value (that is defined inline), to span from the identifier of the field up until the value (represented by an expression)

For example:  
```
{ foo = <foos value> }
```
`<foos value>` would have a position which spans  `foo.bar.baz.boo = 5`

and 

```
{  ... bar = <bars value> }
```
<bars value> would have a position which spans `baz.boo = 5`


