### PR TITLE
Add multiline doc logic to the pretty printer

### DIFF
--- a/src/pretty.rs
+++ b/src/pretty.rs
@@ -61,13 +61,9 @@ where
     }
 
     fn multiline_string(&'a self, s: &str) -> DocBuilder<'a, Self, A> {
-        let percent_count = s.split(|c| c != '%').map(|v| v.len()).max().unwrap();
-        let delimiter = "%".repeat(percent_count + 1);
+        let delimiter = "%".repeat(min_interpolate_sign(s));
         self.hardline()
-            .append(self.intersperse(
-                s.lines().map(|d| self.text(d.to_owned())),
-                self.hardline().clone(),
-            ))
+            .append(self.intersperse(s.lines().map(|d| self.text(d.to_owned())), self.hardline()))
             .enclose(format!("m{delimiter}\""), format!("\"{delimiter}"))
     }
 

--- a/src/pretty.rs
+++ b/src/pretty.rs
@@ -60,6 +60,17 @@ where
         self.text(s)
     }
 
+    fn multiline_string(&'a self, s: &str) -> DocBuilder<'a, Self, A> {
+        let percent_count = s.split(|c| c != '%').map(|v| v.len()).max().unwrap();
+        let delimiter = "%".repeat(percent_count + 1);
+        self.hardline()
+            .append(self.intersperse(
+                s.lines().map(|d| self.text(d.to_owned())),
+                self.hardline().clone(),
+            ))
+            .enclose(format!("m{delimiter}\""), format!("\"{delimiter}"))
+    }
+
     fn metadata(&'a self, mv: &MetaValue, with_doc: bool) -> DocBuilder<'a, Self, A> {
         if let Some(types) = &mv.types {
             self.text(":")
@@ -71,20 +82,19 @@ where
         }
         .append(if with_doc {
             mv.doc
-                .clone()
+                .as_ref()
                 .map(|doc| {
                     self.text("|")
                         .append(self.space())
                         .append(self.text("doc"))
-                        .append(self.space())
-                        .append(
-                            self.hardline()
-                                .append(self.intersperse(
-                                    doc.lines().map(|d| self.escaped_string(d)),
-                                    self.hardline().clone(),
-                                ))
-                                .double_quotes(),
-                        )
+                        .append(self.hardline())
+                        .append({
+                            if doc.contains('\n') {
+                                self.multiline_string(doc)
+                            } else {
+                                self.escaped_string(doc).double_quotes()
+                            }
+                        })
                         .append(self.line())
                 })
                 .unwrap_or_else(|| self.nil())

--- a/tests/snapshot/inputs/pretty/multiline_doc.ncl
+++ b/tests/snapshot/inputs/pretty/multiline_doc.ncl
@@ -1,0 +1,18 @@
+{
+  field
+    | doc m%%"
+      Contract to enforce the value is a string that represents a boolean literal. Additionally casts "True" to "true"
+      and "False" to "false". This shouldn't interpolate: %{null}
+
+      For example:
+      ```nickel
+        ("True" | BoolLiteral) =>
+          "true"
+        ("hello" | BoolLiteral) =>
+          error
+        (true | BoolLiteral) =>
+          error
+      ```
+      "%%
+    = 1
+}

--- a/tests/snapshot/inputs/pretty/multiline_doc.ncl
+++ b/tests/snapshot/inputs/pretty/multiline_doc.ncl
@@ -1,18 +1,17 @@
 {
-  field
-    | doc m%%"
-      Contract to enforce the value is a string that represents a boolean literal. Additionally casts "True" to "true"
-      and "False" to "false". This shouldn't interpolate: %{null}
+  field | doc m%%"
+    Contract to enforce the value is a string that represents a boolean literal. Additionally casts "True" to "true"
+    and "False" to "false". This shouldn't interpolate: %{null}
 
-      For example:
-      ```nickel
-        ("True" | BoolLiteral) =>
-          "true"
-        ("hello" | BoolLiteral) =>
-          error
-        (true | BoolLiteral) =>
-          error
-      ```
-      "%%
+    For example:
+    ```nickel
+      ("True" | BoolLiteral) =>
+        "true"
+      ("hello" | BoolLiteral) =>
+        error
+      (true | BoolLiteral) =>
+        error
+    ```
+    "%%
     = 1
 }

--- a/tests/snapshot/snapshots/snapshot__pretty_multiline_doc.ncl.snap
+++ b/tests/snapshot/snapshots/snapshot__pretty_multiline_doc.ncl.snap
@@ -1,0 +1,21 @@
+---
+source: tests/snapshot/main.rs
+expression: snapshot
+---
+{
+  field | doc
+    m%%"
+    Contract to enforce the value is a string that represents a boolean literal. Additionally casts "True" to "true"
+    and "False" to "false". This shouldn't interpolate: %{null}
+    
+    For example:
+    ```nickel
+      ("True" | BoolLiteral) =>
+        "true"
+      ("hello" | BoolLiteral) =>
+        error
+      (true | BoolLiteral) =>
+        error
+    ```"%%
+     = 1,
+}


### PR DESCRIPTION
This PR makes the pretty printer emit multiline strings if it encounters documentation metadata containing newlines. Previously, as I complained about in #1044, the pretty printer would unconditionally insert a hard newline after the opening double quote. Additionally, it would indent the documentation string and thereby change the semantics of the code.

With this PR, multiline strings are used when necessary and single line strings are used whenever the docstring does not contain newlines. Additionally, there's a regression test using the new snapshot testing infrastructure.

Closes #1044 