### PR TITLE
Remove double build of nickel-repl

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -215,7 +215,6 @@
         rec {
           nickel = buildPackage "nickel-lang";
           lsp-nls = buildPackage "nickel-lang-lsp";
-          nickel-wasm-repl = buildPackage "nickel-repl";
 
           rustfmt = craneLib.cargoFmt {
             # Notice that unlike other Crane derivations, we do not pass `cargoArtifacts` to `cargoFmt`, because it does not need access to dependencies to format the code.
@@ -405,7 +404,6 @@
         inherit (mkCraneArtifacts { })
           nickel
           lsp-nls
-          nickel-wasm-repl
           clippy
           rustfmt;
         # An optimizing release build is long: eschew optimizations in checks by


### PR DESCRIPTION
In #1036, the different crates build by Nickel were separated each in their own derivation. Doing so, we included `nickel-repl`, e.g. in the flake checks, but the WASM repl is already build independently by `nickelWasm`. So we most probably rebuild a wrapper of `nickel-lang` (and not in WASM) for nothing.