### PR TITLE
pyckel: diagnostics in exception

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1705,6 +1705,7 @@ dependencies = [
 name = "pyckel"
 version = "0.3.1"
 dependencies = [
+ "codespan-reporting",
  "nickel-lang",
  "pyo3",
 ]

--- a/pyckel/Cargo.toml
+++ b/pyckel/Cargo.toml
@@ -13,6 +13,7 @@ edition = "2018"
 [dependencies]
 nickel-lang = {default-features = false, path = "../", version = "0.3.1" }
 pyo3 = { version = "0.17.3", features = ["extension-module"] }
+codespan-reporting = "0.11"
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/pyckel/src/lib.rs
+++ b/pyckel/src/lib.rs
@@ -11,7 +11,7 @@ use pyo3::{create_exception, exceptions::PyException, prelude::*};
 
 create_exception!(pyckel, NickelException, PyException);
 
-/// Turn a Nickel (Rust) error into a NickelException (Python)
+/// Turn an internal Nickel error into a PyErr with a fancy diagnostic message
 fn error_to_exception<E: Into<Error>, EC: Cache>(error: E, program: &mut Program<EC>) -> PyErr {
     NickelException::new_err(program.report_as_str(error.into()))
 }

--- a/pyckel/src/lib.rs
+++ b/pyckel/src/lib.rs
@@ -1,49 +1,10 @@
 use std::io::Cursor;
 
-use nickel_lang::{
-    error::{Error, SerializationError},
-    eval::cache::CBNCache,
-    program::Program,
-    serialize,
-};
+use nickel_lang::{eval::cache::CBNCache, program::Program, serialize};
 
 use pyo3::{create_exception, exceptions::PyException, prelude::*};
 
 create_exception!(pyckel, NickelException, PyException);
-
-// see https://pyo3.rs/v0.17.3/function/error_handling.html#foreign-rust-error-types
-struct NickelError(Error);
-struct NickelSerializationError(SerializationError);
-
-impl From<Error> for NickelError {
-    fn from(value: Error) -> Self {
-        Self(value)
-    }
-}
-
-impl std::convert::From<NickelError> for PyErr {
-    fn from(err: NickelError) -> PyErr {
-        match err {
-            // TODO better exceptions
-            NickelError(error) => NickelException::new_err(format!("{error:?}")),
-        }
-    }
-}
-
-impl From<SerializationError> for NickelSerializationError {
-    fn from(value: SerializationError) -> Self {
-        Self(value)
-    }
-}
-
-impl std::convert::From<NickelSerializationError> for PyErr {
-    fn from(err: NickelSerializationError) -> PyErr {
-        match err {
-            // TODO better exceptions
-            NickelSerializationError(error) => NickelException::new_err(format!("{error:?}")),
-        }
-    }
-}
 
 /// Evaluate from a Python str of a Nickel expression to a Python str of the resulting JSON.
 #[pyfunction]
@@ -51,12 +12,15 @@ pub fn run(s: String) -> PyResult<String> {
     let mut program: Program<CBNCache> =
         Program::new_from_source(Cursor::new(s.to_string()), "python")?;
 
-    let term = program.eval_full().map_err(NickelError)?;
+    let term = program
+        .eval_full()
+        .map_err(|err| NickelException::new_err(program.report_as_str(err)))?;
 
-    serialize::validate(serialize::ExportFormat::Json, &term).map_err(NickelSerializationError)?;
+    serialize::validate(serialize::ExportFormat::Json, &term)
+        .map_err(|err| NickelException::new_err(program.report_as_str(err)))?;
 
     let json_string = serialize::to_string(serialize::ExportFormat::Json, &term)
-        .map_err(NickelSerializationError)?;
+        .map_err(|err| NickelException::new_err(program.report_as_str(err)))?;
 
     Ok(json_string)
 }

--- a/src/program.rs
+++ b/src/program.rs
@@ -29,9 +29,9 @@ use crate::parser::lexer::Lexer;
 use crate::term::{RichTerm, Term};
 use crate::{eval, parser};
 use codespan::FileId;
-use codespan_reporting::term::termcolor::{ColorChoice, StandardStream};
+use codespan_reporting::term::termcolor::{Ansi, ColorChoice, StandardStream};
 use std::ffi::OsString;
-use std::io::{self, Read};
+use std::io::{self, Cursor, Read};
 use std::result::Result;
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
@@ -161,6 +161,32 @@ impl<EC: EvalCache> Program<EC> {
         E: ToDiagnostic<FileId>,
     {
         report(self.vm.import_resolver_mut(), error, self.color_opt)
+    }
+
+    /// Wrapper for [`report`].
+    pub fn report_as_str<E>(&mut self, error: E) -> String
+    where
+        E: ToDiagnostic<FileId>,
+    {
+        let contracts_id = self.vm.import_resolver().id_of("<stdlib/contract.ncl>");
+        let diagnostics =
+            error.to_diagnostic(self.vm.import_resolver_mut().files_mut(), contracts_id);
+        let mut buffer = Ansi::new(Cursor::new(Vec::new()));
+        let config = codespan_reporting::term::Config::default();
+        // write to `buffer`
+        diagnostics
+            .iter()
+            .try_for_each(|d| {
+                codespan_reporting::term::emit(
+                    &mut buffer,
+                    &config,
+                    self.vm.import_resolver_mut().files_mut(),
+                    d,
+                )
+            })
+            // safe because writing to a cursor in memory
+            .unwrap();
+        String::from_utf8(buffer.into_inner().into_inner()).unwrap()
     }
 
     /// Create a markdown file with documentation for the specified program in `.nickel/doc/program_main_file_name.md`


### PR DESCRIPTION
Makes `pyckel` render beautiful diagnostics on evaluation error.

```shell
$ python -c 'import pyckel; print(pyckel.run("let x = 1 in { y = x / 0 }"))'
Traceback (most recent call last):
  File "<string>", line 1, in <module>
pyckel.NickelException: error: division by zero
  ┌─ python:1:20
  │
1 │ let x = 1 in { y = x / 0 }
  │                    ^^^^^ here
```