### PR TITLE
Add a %trace% primop

### DIFF
--- a/src/eval/operation.rs
+++ b/src/eval/operation.rs
@@ -1258,6 +1258,29 @@ impl<R: ImportResolver, C: Cache> VirtualMachine<R, C> {
                     ))
                 }
             },
+            UnaryOp::Trace() => {
+                if let Term::Str(s) = &*t {
+                    println!("builtin.trace: {s}");
+                    Ok(())
+                } else {
+                    Err(EvalError::TypeError(
+                        String::from("Str"),
+                        String::from("trace"),
+                        arg_pos,
+                        RichTerm { term: t, pos },
+                    ))
+                }?;
+
+                if self.stack.count_args() >= 1 {
+                    let (next, ..) = self
+                        .stack
+                        .pop_arg(&self.cache)
+                        .expect("Condition already checked.");
+                    Ok(next)
+                } else {
+                    Err(EvalError::NotEnoughArgs(2, String::from("trace"), pos_op))
+                }
+            }
         }
     }
 

--- a/src/eval/operation.rs
+++ b/src/eval/operation.rs
@@ -1254,7 +1254,7 @@ impl<R: ImportResolver, C: Cache> VirtualMachine<R, C> {
             },
             UnaryOp::Trace() => {
                 if let Term::Str(s) = &*t {
-                    println!("builtin.trace: {s}");
+                    eprintln!("builtin.trace: {s}");
                     Ok(())
                 } else {
                     Err(EvalError::TypeError(

--- a/src/eval/operation.rs
+++ b/src/eval/operation.rs
@@ -672,17 +672,11 @@ impl<R: ImportResolver, C: Cache> VirtualMachine<R, C> {
                     }
                 }
             }
-            UnaryOp::Seq() => {
-                if self.stack.count_args() >= 1 {
-                    let (next, ..) = self
-                        .stack
-                        .pop_arg(&self.cache)
-                        .expect("Condition already checked.");
-                    Ok(next)
-                } else {
-                    Err(EvalError::NotEnoughArgs(2, String::from("seq"), pos_op))
-                }
-            }
+            UnaryOp::Seq() => self
+                .stack
+                .pop_arg(&self.cache)
+                .map(|(next, ..)| next)
+                .ok_or_else(|| EvalError::NotEnoughArgs(2, String::from("seq"), pos_op)),
             UnaryOp::DeepSeq(_) => {
                 /// Build a RichTerm that forces a given list of terms, and at the end resumes the
                 /// evaluation of the argument on the top of the stack. The argument must iterate over
@@ -1271,15 +1265,10 @@ impl<R: ImportResolver, C: Cache> VirtualMachine<R, C> {
                     ))
                 }?;
 
-                if self.stack.count_args() >= 1 {
-                    let (next, ..) = self
-                        .stack
-                        .pop_arg(&self.cache)
-                        .expect("Condition already checked.");
-                    Ok(next)
-                } else {
-                    Err(EvalError::NotEnoughArgs(2, String::from("trace"), pos_op))
-                }
+                self.stack
+                    .pop_arg(&self.cache)
+                    .map(|(next, ..)| next)
+                    .ok_or_else(|| EvalError::NotEnoughArgs(2, String::from("trace"), pos_op))
             }
         }
     }

--- a/src/parser/grammar.lalrpop
+++ b/src/parser/grammar.lalrpop
@@ -596,6 +596,7 @@ UOp: UnaryOp = {
     "rec_force_op" => UnaryOp::RecForce(),
     "rec_default_op" => UnaryOp::RecDefault(),
     "record_empty_with_tail" => UnaryOp::RecordEmptyWithTail(),
+    "trace" => UnaryOp::Trace(),
 };
 
 MatchCase: MatchCase = {
@@ -937,6 +938,7 @@ extern {
         "pow" => Token::Normal(NormalToken::Pow),
         "rec_force_op" => Token::Normal(NormalToken::RecForceOp),
         "rec_default_op" => Token::Normal(NormalToken::RecDefaultOp),
+        "trace" => Token::Normal(NormalToken::Trace),
 
         "has_field" => Token::Normal(NormalToken::HasField),
         "map" => Token::Normal(NormalToken::Map),

--- a/src/parser/lexer.rs
+++ b/src/parser/lexer.rs
@@ -223,6 +223,8 @@ pub enum NormalToken<'input> {
     ValuesOf,
     #[token("%pow%")]
     Pow,
+    #[token("%trace%")]
+    Trace,
 
     #[token("%has_field%")]
     HasField,

--- a/src/term/mod.rs
+++ b/src/term/mod.rs
@@ -1048,7 +1048,8 @@ pub enum UnaryOp {
     /// tail of its argument.
     RecordEmptyWithTail(),
 
-    /// Print a message when encountered during evaluation. Operationally the same as the identity
+    /// Print a message when encountered during evaluation and proceed with the evaluation of the argument
+    /// on the top of the stack. Operationally the same as the identity
     /// function
     Trace(),
 }

--- a/src/term/mod.rs
+++ b/src/term/mod.rs
@@ -1047,6 +1047,10 @@ pub enum UnaryOp {
     /// define a `field_diff` function that preserves the sealed polymorphic
     /// tail of its argument.
     RecordEmptyWithTail(),
+
+    /// Print a message when encountered during evaluation. Operationally the same as the identity
+    /// function
+    Trace(),
 }
 
 // See: https://github.com/rust-lang/regex/issues/178

--- a/src/typecheck/operation.rs
+++ b/src/typecheck/operation.rs
@@ -211,6 +211,12 @@ pub fn get_uop_type(
             (ty.clone(), ty)
         }
         UnaryOp::RecordEmptyWithTail() => (mk_uniftype::dynamic(), mk_uniftype::dynamic()),
+
+        // forall a. Str -> a -> a
+        UnaryOp::Trace() => {
+            let ty = UnifType::UnifVar(state.table.fresh_type_var_id());
+            (mk_uniftype::str(), mk_uty_arrow!(ty.clone(), ty))
+        }
     })
 }
 

--- a/stdlib/builtin.ncl
+++ b/stdlib/builtin.ncl
@@ -213,7 +213,8 @@
 
     trace : forall a. Str -> a -> a
     | doc m%"
-      `builtin.trace msg x` prints `msg` to standard output when encountered by the evaluator.
+      `builtin.trace msg x` prints `msg` to standard output when encountered by the evaluator,
+      and proceed with the evaluation of `x`.
 
       For example:
       ```nickel

--- a/stdlib/builtin.ncl
+++ b/stdlib/builtin.ncl
@@ -207,11 +207,21 @@
         "Foo"
       from null =>
         "null"
+      ```
       "%
     = fun x => %to_str% x,
 
     trace : forall a. Str -> a -> a
-    | doc "TODO"
+    | doc m%"
+      `builtin.trace msg x` prints `msg` to standard output when encountered by the evaluator.
+
+      For example:
+      ```nickel
+      builtin.trace "Hello, world!" true =>
+        builtin.trace: Hello, world!
+        true
+      ```
+      "%
     = fun msg x => %trace% msg x,
   },
 }

--- a/stdlib/builtin.ncl
+++ b/stdlib/builtin.ncl
@@ -210,5 +210,8 @@
       "%
     = fun x => %to_str% x,
 
+    trace : forall a. Str -> a -> a
+    | doc "TODO"
+    = fun msg x => %trace% msg x,
   },
 }

--- a/tests/snapshot/inputs/export/trace.ncl
+++ b/tests/snapshot/inputs/export/trace.ncl
@@ -1,0 +1,1 @@
+builtin.trace "Hello, world!" true

--- a/tests/snapshot/snapshots/snapshot__export_trace.ncl.snap
+++ b/tests/snapshot/snapshots/snapshot__export_trace.ncl.snap
@@ -1,0 +1,6 @@
+---
+source: tests/snapshot/main.rs
+expression: snapshot
+---
+builtin.trace: Hello, world!
+true

--- a/tests/snapshot/snapshots/snapshot__export_trace.ncl.snap
+++ b/tests/snapshot/snapshots/snapshot__export_trace.ncl.snap
@@ -2,5 +2,4 @@
 source: tests/snapshot/main.rs
 expression: snapshot
 ---
-builtin.trace: Hello, world!
 true


### PR DESCRIPTION
Add a `%trace%` builtin which prints a message to standard output when encountered by the evaluator, together with a standard libary function `builtin.trace`.