### PR TITLE
Add support for LSP completion using the surrounding context

### DIFF
--- a/lsp/nls/src/linearization/completed.rs
+++ b/lsp/nls/src/linearization/completed.rs
@@ -25,6 +25,24 @@ impl Completed {
         }
     }
 
+    /// Returns the closest item to the left (if any) and to the right (if any) of
+    /// a specified item. The "closeness" metric in this context is just the source
+    /// position.
+    pub fn get_items_adjacent(
+        &self,
+        id: ItemId,
+    ) -> (
+        Option<&LinearizationItem<Resolved>>,
+        Option<&LinearizationItem<Resolved>>,
+    ) {
+        // this unwrap might not be safe, we can't make assumptions about the caller
+        let index = self.id_to_index.get(&id).copied().unwrap();
+        let (left_index, right_index) = (index - 1, index + 1);
+        let left = self.linearization.get(left_index);
+        let right = self.linearization.get(right_index);
+        (left, right)
+    }
+
     pub fn get_item<'a>(
         &'a self,
         id: ItemId,

--- a/lsp/nls/src/linearization/completed.rs
+++ b/lsp/nls/src/linearization/completed.rs
@@ -35,8 +35,9 @@ impl Completed {
         Option<&LinearizationItem<Resolved>>,
         Option<&LinearizationItem<Resolved>>,
     ) {
-        // this unwrap might not be safe, we can't make assumptions about the caller
-        let index = self.id_to_index.get(&id).copied().unwrap();
+        let Some(index) = self.id_to_index.get(&id).copied() else {
+            return (None, None)
+        };
         let (left_index, right_index) = (index - 1, index + 1);
         let left = self.linearization.get(left_index);
         let right = self.linearization.get(right_index);

--- a/lsp/nls/src/requests/completion.rs
+++ b/lsp/nls/src/requests/completion.rs
@@ -111,7 +111,8 @@ impl IdentWithType {
     }
 }
 
-pub struct LinInfo<'a> {
+/// General data structures required by most completion functions.
+pub struct ComplInfo<'a> {
     linearization: &'a Completed,
     lin_cache: &'a HashMap<FileId, Completed>,
 }
@@ -121,10 +122,10 @@ pub struct LinInfo<'a> {
 fn find_fields_from_term_kind<'a>(
     id: ItemId,
     path: &'a mut Vec<Ident>,
-    info @ LinInfo {
+    info @ ComplInfo {
         linearization,
         lin_cache,
-    }: &'a LinInfo<'a>,
+    }: &'a ComplInfo<'a>,
 ) -> Vec<IdentWithType> {
     let Some(item) = linearization.get_item(id, lin_cache) else {
         return Vec::new()
@@ -157,7 +158,7 @@ fn find_fields_from_term_kind<'a>(
                 find_fields_from_term_kind(
                     *new_id,
                     path,
-                    &LinInfo {
+                    &ComplInfo {
                         linearization,
                         lin_cache,
                     },
@@ -186,10 +187,10 @@ fn find_fields_from_term_kind<'a>(
 fn find_fields_from_contract<'a>(
     id: ItemId,
     path: &'a mut Vec<Ident>,
-    info @ LinInfo {
+    info @ ComplInfo {
         linearization,
         lin_cache,
-    }: &'a LinInfo<'a>,
+    }: &'a ComplInfo<'a>,
 ) -> Vec<IdentWithType> {
     let Some(item) = linearization.get_item(id, lin_cache) else {
         return Vec::new()
@@ -211,7 +212,7 @@ fn find_fields_from_contract<'a>(
 fn find_fields_from_meta_value<'a>(
     meta_value: &'a MetaValue,
     path: &'a mut Vec<Ident>,
-    info @ LinInfo { lin_cache, .. }: &'a LinInfo<'a>,
+    info @ ComplInfo { lin_cache, .. }: &'a ComplInfo<'a>,
 ) -> Vec<IdentWithType> {
     meta_value
         .contracts
@@ -252,7 +253,7 @@ fn find_fields_from_meta_value<'a>(
 fn find_fields_from_type<'a>(
     rrows: &'a RecordRows,
     path: &'a mut Vec<Ident>,
-    info @ LinInfo { .. }: &'a LinInfo<'a>,
+    info @ ComplInfo { .. }: &'a ComplInfo<'a>,
 ) -> Vec<IdentWithType> {
     if let Some(current) = path.pop() {
         let type_of_current = rrows.iter().find_map(|item| match item {
@@ -287,7 +288,7 @@ fn find_fields_from_type<'a>(
 fn find_fields_from_term<'a>(
     term: &'a RichTerm,
     path: &'a mut Vec<Ident>,
-    info @ LinInfo { .. }: &'a LinInfo<'a>,
+    info @ ComplInfo { .. }: &'a ComplInfo<'a>,
 ) -> Vec<IdentWithType> {
     let current = path.pop();
     match (term.as_ref(), current) {
@@ -399,7 +400,7 @@ fn collect_record_info(
     path: &mut Vec<Ident>,
     lin_cache: &HashMap<FileId, Completed>,
 ) -> Vec<IdentWithType> {
-    let info = LinInfo {
+    let info = ComplInfo {
         linearization,
         lin_cache,
     };
@@ -484,10 +485,10 @@ fn get_completion_identifiers(
                     /// accumulate all the record metadata and corresponding path.
                     fn accumulate_record_meta_data<'a>(
                         record: ItemId,
-                        info @ LinInfo {
+                        info @ ComplInfo {
                             linearization,
                             lin_cache,
-                        }: &'a LinInfo<'a>,
+                        }: &'a ComplInfo<'a>,
                         mut path: Vec<Ident>,
                         mut result: Vec<(&'a LinearizationItem<Types>, Vec<Ident>)>,
                     ) -> Vec<(&'a LinearizationItem<Types>, Vec<Ident>)> {
@@ -517,7 +518,7 @@ fn get_completion_identifiers(
                         }
                     }
 
-                    let info = LinInfo {
+                    let info = ComplInfo {
                         linearization,
                         lin_cache: &server.lin_cache,
                     };
@@ -735,7 +736,7 @@ mod tests {
         let mut path = vec![Ident::from("b"), Ident::from("a")];
         // unwrap: the conversion must succeed because we built a type without unification variable
         // nor type constants
-        let info = LinInfo {
+        let info = ComplInfo {
             linearization: &Default::default(),
             lin_cache: &HashMap::new(),
         };
@@ -822,7 +823,7 @@ mod tests {
             expected.sort();
             let completed = make_completed(linearization);
             for id in ids {
-                let info = LinInfo {
+                let info = ComplInfo {
                     linearization: &completed,
                     lin_cache: &HashMap::new(),
                 };

--- a/lsp/nls/src/requests/completion.rs
+++ b/lsp/nls/src/requests/completion.rs
@@ -478,7 +478,9 @@ fn get_completion_identifiers(
                 let name = path.pop().unwrap();
                 complete(item, name, server, &mut path).unwrap_or_default()
             } else {
-                if let TermKind::RecordField { record, .. } = item.kind {
+                if let ((TermKind::RecordField { record, .. }, _) | TermKind::Record(..), record) =
+                    (item.kind, item.id)
+                {
                     // Context completion
 
                     /// As we traverse a nested record all the way to the topmost record,

--- a/lsp/nls/src/requests/completion.rs
+++ b/lsp/nls/src/requests/completion.rs
@@ -433,8 +433,8 @@ fn accumulate_record_meta_data<'a>(
         lin_cache,
     }: &'a ComplCtx<'a>,
     mut path: Vec<Ident>,
-    mut result: Vec<(&'a LinearizationItem<Types>, Vec<Ident>)>,
-) -> Vec<(&'a LinearizationItem<Types>, Vec<Ident>)> {
+    result: &mut Vec<(&'a LinearizationItem<Types>, Vec<Ident>)>,
+) {
     // This unwrap is safe: we know a `RecordField` must have a containing `Record`.
     let parent = linearization.get_item(record, lin_cache).unwrap();
 
@@ -453,7 +453,7 @@ fn accumulate_record_meta_data<'a>(
 
     result.push((parent, path.clone()));
     match next {
-        None => result,
+        None => {}
         Some((name, record)) => {
             path.push(name);
             accumulate_record_meta_data(record, info, path, result)
@@ -491,7 +491,10 @@ fn get_completion_identifiers(
         if let (&TermKind::RecordField { record, .. }, _) | (TermKind::Record(..), record) =
             (&item.kind, item.id)
         {
-            accumulate_record_meta_data(record, info, path, Vec::new())
+            let mut result = Vec::new();
+            accumulate_record_meta_data(record, info, path, &mut result);
+
+            result
                 .into_iter()
                 .flat_map(|(parent, mut path)| {
                     let Some(meta) = parent.meta.as_ref() else {

--- a/lsp/nls/src/requests/completion.rs
+++ b/lsp/nls/src/requests/completion.rs
@@ -119,13 +119,13 @@ pub struct ComplInfo<'a> {
 
 /// Find the record field associated with a particular ID in the linearization
 /// using lexical scoping rules.
-fn find_fields_from_term_kind<'a>(
+fn find_fields_from_term_kind(
     id: ItemId,
-    path: &'a mut Vec<Ident>,
+    path: &mut Vec<Ident>,
     info @ ComplInfo {
         linearization,
         lin_cache,
-    }: &'a ComplInfo<'a>,
+    }: &'_ ComplInfo<'_>,
 ) -> Vec<IdentWithType> {
     let Some(item) = linearization.get_item(id, lin_cache) else {
         return Vec::new()
@@ -184,13 +184,13 @@ fn find_fields_from_term_kind<'a>(
 
 /// Find the record fields associated with an ID in the linearization using
 /// its contract information.
-fn find_fields_from_contract<'a>(
+fn find_fields_from_contract(
     id: ItemId,
-    path: &'a mut Vec<Ident>,
+    path: &mut Vec<Ident>,
     info @ ComplInfo {
         linearization,
         lin_cache,
-    }: &'a ComplInfo<'a>,
+    }: &'_ ComplInfo<'_>,
 ) -> Vec<IdentWithType> {
     let Some(item) = linearization.get_item(id, lin_cache) else {
         return Vec::new()
@@ -209,10 +209,10 @@ fn find_fields_from_contract<'a>(
 
 /// Find record field associated associated with a MetaValue.
 /// This can be gotten from the type or the contracts.
-fn find_fields_from_meta_value<'a>(
-    meta_value: &'a MetaValue,
-    path: &'a mut Vec<Ident>,
-    info @ ComplInfo { lin_cache, .. }: &'a ComplInfo<'a>,
+fn find_fields_from_meta_value(
+    meta_value: &MetaValue,
+    path: &mut Vec<Ident>,
+    info @ ComplInfo { .. }: &'_ ComplInfo<'_>,
 ) -> Vec<IdentWithType> {
     meta_value
         .contracts
@@ -234,10 +234,10 @@ fn find_fields_from_meta_value<'a>(
 }
 
 /// Extract the fields from a given record type.
-fn find_fields_from_type<'a>(
-    rrows: &'a RecordRows,
-    path: &'a mut Vec<Ident>,
-    info @ ComplInfo { .. }: &'a ComplInfo<'a>,
+fn find_fields_from_type(
+    rrows: &RecordRows,
+    path: &mut Vec<Ident>,
+    info @ ComplInfo { .. }: &'_ ComplInfo<'_>,
 ) -> Vec<IdentWithType> {
     if let Some(current) = path.pop() {
         let type_of_current = rrows.iter().find_map(|item| match item {
@@ -484,7 +484,7 @@ fn get_completion_identifiers(
     }
 
     fn context_complete(
-        item: &'_ LinearizationItem<Types>,
+        item: &LinearizationItem<Types>,
         info: &'_ ComplInfo<'_>,
         path: Vec<Ident>,
     ) -> Vec<IdentWithType> {

--- a/lsp/nls/src/requests/completion.rs
+++ b/lsp/nls/src/requests/completion.rs
@@ -497,7 +497,7 @@ fn get_completion_identifiers(
                     }
                     let (parent, mut path) =
                         find_topmost_record(linearization, server, record, Vec::new());
-                    let Some(meta) = parent.meta.as_ref().map(|meta| &meta.contracts) else {
+                    let Some(meta) = parent.meta.as_ref() else {
                         // I'm not *entirely* sure we want to do this here.
                         // Alternative: if we cannot find a meta on any record,
                         //              we just switch to "Global name completion"
@@ -507,21 +507,7 @@ fn get_completion_identifiers(
                         linearization,
                         lin_cache: &server.lin_cache,
                     };
-                    let contract = meta.first().unwrap();
-                    let result = match &contract.types {
-                        Types(TypeF::Flat(RichTerm { pos, .. })) => {
-                            let span = pos.unwrap();
-                            let locator = (span.src_id, span.start);
-                            let item = linearization.item_at(&locator).unwrap();
-
-                            find_fields_from_term_kind(item.id, &mut path, &info)
-                        }
-                        Types(TypeF::Record(rrows)) => {
-                            find_fields_from_type(rrows, &mut path, &info)
-                        }
-                        _ => Vec::new(),
-                    };
-                    result
+                    find_fields_from_meta_value(meta, &mut path, &info)
                 } else {
                     // Global name completion
                     let (ty, _) = linearization.resolve_item_type_meta(item, &server.lin_cache);

--- a/lsp/nls/src/requests/completion.rs
+++ b/lsp/nls/src/requests/completion.rs
@@ -478,8 +478,8 @@ fn get_completion_identifiers(
                 let name = path.pop().unwrap();
                 complete(item, name, server, &mut path).unwrap_or_default()
             } else {
-                if let ((TermKind::RecordField { record, .. }, _) | TermKind::Record(..), record) =
-                    (item.kind, item.id)
+                if let (&TermKind::RecordField { record, .. }, _) | (TermKind::Record(..), record) =
+                    (&item.kind, item.id)
                 {
                     // Context completion
 

--- a/src/identifier.rs
+++ b/src/identifier.rs
@@ -1,7 +1,7 @@
 //! Define the type of an identifier.
 use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
-use std::fmt;
+use std::fmt::{self, Debug};
 use std::hash::Hash;
 
 use crate::position::TermPos;
@@ -9,12 +9,20 @@ use crate::position::TermPos;
 simple_counter::generate_counter!(GeneratedCounter, usize);
 static INTERNER: Lazy<interner::Interner> = Lazy::new(interner::Interner::new);
 
-#[derive(Debug, Clone, Copy, Deserialize, Serialize)]
+#[derive(Clone, Copy, Deserialize, Serialize)]
 #[serde(into = "String", from = "String")]
 pub struct Ident {
     symbol: interner::Symbol,
     pub pos: TermPos,
     generated: bool,
+}
+
+impl Debug for Ident {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Ident")
+            .field("label", &self.label())
+            .finish()
+    }
 }
 
 impl Ident {

--- a/src/parser/grammar.lalrpop
+++ b/src/parser/grammar.lalrpop
@@ -396,7 +396,19 @@ RecordField: (FieldPath, RichTerm) = {
         };
 
         (path, term)
-    }
+    },
+     <l: @L> <t: !> <r: @R> => {
+        let pos = mk_pos(src_id, l, r);
+        errors.push(t.clone());
+
+        let expr = RichTerm::new(Term::ParseError(
+            crate::error::ParseError::from_lalrpop(t.error, src_id)), pos);
+
+        let elem = FieldPathElem::Expr(expr);
+        let path = vec![elem];
+        let term = RichTerm::new(Term::MetaValue(MetaValue::new()), pos);
+        (path, term)
+    },
 };
 
 RecordLastField: RecordLastField = {

--- a/src/parser/grammar.lalrpop
+++ b/src/parser/grammar.lalrpop
@@ -311,7 +311,7 @@ RecordOperand: UniTerm = {
 
 // A record operation chain, such as `{foo = data}.bar.baz`.
 RecordOperationChain: RichTerm = {
-    <t: AsTerm<RecordOperand>> "." <id: Ident> => mk_term::op1_with_pos(UnaryOp::StaticAccess(id), t, id.pos),
+    <t: AsTerm<RecordOperand>> "." <id: Ident> => mk_term::op1(UnaryOp::StaticAccess(id), t).with_pos(id.pos),
     <t: AsTerm<RecordOperand>> "." <t_id: WithPos<StrChunks>> => mk_access(t_id, t),
 };
 

--- a/src/parser/grammar.lalrpop
+++ b/src/parser/grammar.lalrpop
@@ -311,7 +311,7 @@ RecordOperand: UniTerm = {
 
 // A record operation chain, such as `{foo = data}.bar.baz`.
 RecordOperationChain: RichTerm = {
-    <t: AsTerm<RecordOperand>> "." <id: Ident> => mk_term::op1(UnaryOp::StaticAccess(id), t),
+    <t: AsTerm<RecordOperand>> "." <id: Ident> => mk_term::op1_with_pos(UnaryOp::StaticAccess(id), t, id.pos),
     <t: AsTerm<RecordOperand>> "." <t_id: WithPos<StrChunks>> => mk_access(t_id, t),
 };
 

--- a/src/parser/grammar.lalrpop
+++ b/src/parser/grammar.lalrpop
@@ -238,13 +238,8 @@ UniTerm: UniTerm = {
     },
     "if" <cond: Term> "then" <t1: Term> "else" <t2: Term> =>
         UniTerm::from(mk_app!(Term::Op1(UnaryOp::Ite(), cond), t1, t2)),
-    <l: @L> <t: !> <r: @R> => {
-        let pos = mk_pos(src_id, l, r);
-        errors.push(t.clone());
-
-        UniTerm::from(RichTerm::new(Term::ParseError(
-            crate::error::ParseError::from_lalrpop(t.error, src_id)
-        ), pos))
+    <err: Error> => {
+        UniTerm::from(err)
     },
 };
 
@@ -397,18 +392,21 @@ RecordField: (FieldPath, RichTerm) = {
 
         (path, term)
     },
-     <l: @L> <t: !> <r: @R> => {
-        let pos = mk_pos(src_id, l, r);
-        errors.push(t.clone());
-
-        let expr = RichTerm::new(Term::ParseError(
-            crate::error::ParseError::from_lalrpop(t.error, src_id)), pos);
-
-        let elem = FieldPathElem::Expr(expr);
-        let path = vec![elem];
+    <err: Error> => {
+        let pos = err.pos;
+        let path = vec![FieldPathElem::Expr(err)];
         let term = RichTerm::new(Term::MetaValue(MetaValue::new()), pos);
         (path, term)
     },
+};
+
+// An error recovery handler.
+Error : RichTerm =  <l: @L> <t: !> <r: @R> => {
+        let pos = mk_pos(src_id, l, r);
+        errors.push(t.clone());
+
+        RichTerm::new(Term::ParseError(
+            crate::error::ParseError::from_lalrpop(t.error, src_id)), pos)
 };
 
 RecordLastField: RecordLastField = {

--- a/src/term/mod.rs
+++ b/src/term/mod.rs
@@ -1792,6 +1792,13 @@ pub mod make {
         Term::Op1(op, t.into()).into()
     }
 
+    pub fn op1_with_pos<T>(op: UnaryOp, t: T, pos: TermPos) -> RichTerm
+    where
+        T: Into<RichTerm>,
+    {
+        RichTerm::new(Term::Op1(op, t.into()), pos)
+    }
+
     pub fn op2<T1, T2>(op: BinaryOp, t1: T1, t2: T2) -> RichTerm
     where
         T1: Into<RichTerm>,

--- a/src/term/mod.rs
+++ b/src/term/mod.rs
@@ -1792,13 +1792,6 @@ pub mod make {
         Term::Op1(op, t.into()).into()
     }
 
-    pub fn op1_with_pos<T>(op: UnaryOp, t: T, pos: TermPos) -> RichTerm
-    where
-        T: Into<RichTerm>,
-    {
-        RichTerm::new(Term::Op1(op, t.into()), pos)
-    }
-
     pub fn op2<T1, T2>(op: BinaryOp, t1: T1, t2: T2) -> RichTerm
     where
         T1: Into<RichTerm>,


### PR DESCRIPTION
This pull request adds support for auto-completion based on the context (from a record, type, or contract.)

### Case 1
Say we have the following: 
```
{
[.]
} | SchemaFromNix
```
With this change, if the contract `SchemaFromNix`, represents a record or dictionary contract, we will get completion corresponding to its fields. 

### Case 2
This will for work not only for basic records, but also for nested records: 
```
let Tf = import "./contract.ncl" in
{
  config = {
    data.dhall.my_dhall_resource = {
      [.]
    }
  }
} | Tf.Config
```
Here, we would get a completion based on the fields of  `Tf.Config.config.data.dhall.my_dhall_resource`, if it is a record dictionary contract.

### Case 3
This also includes support for nested record completion based on the context contract.
```
let Tf = import "./contract.ncl" in
{
  config[.]
} | Tf.Config
```
In this case, we would get completion based on the fields of `Tf.Config.config`, if it is a record or dictionary contract.

### Additional improvements 
#### 1. Adds error recovery if parsing record fields fails
#### 2. Adds support for completion when we have a dictionary contract: say we have the following:
  ``` 
let foo | {_: {a: Str, b: Str}} = <record definition> in 
 foo[.] 
```
This doesn't get a completion, becuase the dictionary has dynamic fields, but when we do this: 
```
foo.random_dynamic_field[.]
```
We will get a completion
#### 3. Adds support for contracts represented by variables or static record access (See #998)


<hr />
Closes #995, Closes #998