### PR TITLE
Make export snapshot tests capture stderr

### DIFF
--- a/tests/snapshot/README.md
+++ b/tests/snapshot/README.md
@@ -18,6 +18,11 @@ nix dev shell, `cargo-insta` is already on your path. Most of this guide will
 assume you have `cargo-insta` installed. If you'd prefer not to install it,
 please read [this section](#without-cargo-insta).
 
+The snapshot tests for `nickel export` capture both `stdout` and `stderr`. For
+easier reviewability in `cargo insta review` this is done with two separate
+assertions. As an unfortunate side effect, adding a new test input requires
+running `cargo insta review` twice, once for `stdout` and once for `stderr`.
+
 ## What to do if a snapshot test fails
 
 1. Run `cargo insta review`.
@@ -33,7 +38,9 @@ please read [this section](#without-cargo-insta).
 3. You'll see a failure message, noting that the test was a new snapshot.
 4. Run `cargo insta review`.
 5. If you're happy with the output, accept it.
-6. Commit the input file and the generated snapshot. You're done!
+6. Run the snapshot tests again with `cargo test --test snapshot`. If anything
+   still fails, go to step 4.
+7. Commit the input file and the generated snapshot. You're done!
 
 ## Without `cargo-insta`
 

--- a/tests/snapshot/README.md
+++ b/tests/snapshot/README.md
@@ -18,11 +18,6 @@ nix dev shell, `cargo-insta` is already on your path. Most of this guide will
 assume you have `cargo-insta` installed. If you'd prefer not to install it,
 please read [this section](#without-cargo-insta).
 
-The snapshot tests for `nickel export` capture both `stdout` and `stderr`. For
-easier reviewability in `cargo insta review` this is done with two separate
-assertions. As an unfortunate side effect, adding a new test input requires
-running `cargo insta review` twice, once for `stdout` and once for `stderr`.
-
 ## What to do if a snapshot test fails
 
 1. Run `cargo insta review`.
@@ -38,9 +33,7 @@ running `cargo insta review` twice, once for `stdout` and once for `stderr`.
 3. You'll see a failure message, noting that the test was a new snapshot.
 4. Run `cargo insta review`.
 5. If you're happy with the output, accept it.
-6. Run the snapshot tests again with `cargo test --test snapshot`. If anything
-   still fails, go to step 4.
-7. Commit the input file and the generated snapshot. You're done!
+6. Commit the input file and the generated snapshot. You're done!
 
 ## Without `cargo-insta`
 

--- a/tests/snapshot/inputs/errors/trace_not_saturated.ncl
+++ b/tests/snapshot/inputs/errors/trace_not_saturated.ncl
@@ -1,0 +1,1 @@
+%trace% "too few arguments"

--- a/tests/snapshot/main.rs
+++ b/tests/snapshot/main.rs
@@ -18,16 +18,27 @@ fn check_pretty_print_snapshots(file: &str) {
 }
 
 #[test_resources("tests/snapshot/inputs/export/*.ncl")]
-fn check_export_snapshots(file: &str) {
+fn check_export_stdout_snapshots(file: &str) {
     let file = TestFile::from_project_path(file);
 
     let snapshot = NickelInvocation::new()
         .subcommand("export")
         .file(&file)
-        .snapshot_output();
+        .snapshot_stdout();
 
-    insta::assert_snapshot!(file.prefixed_test_name("export_stdout"), snapshot.stdout);
-    insta::assert_snapshot!(file.prefixed_test_name("export_stderr"), snapshot.stderr);
+    insta::assert_snapshot!(file.prefixed_test_name("export_stdout"), snapshot);
+}
+
+#[test_resources("tests/snapshot/inputs/export/*.ncl")]
+fn check_export_stderr_snapshots(file: &str) {
+    let file = TestFile::from_project_path(file);
+
+    let snapshot = NickelInvocation::new()
+        .subcommand("export")
+        .file(&file)
+        .snapshot_stderr();
+
+    insta::assert_snapshot!(file.prefixed_test_name("export_stderr"), snapshot);
 }
 
 #[test_resources("tests/snapshot/inputs/errors/*.ncl")]
@@ -79,11 +90,6 @@ struct NickelInvocation {
     cmd: Command,
 }
 
-struct NickelOutput {
-    stdout: String,
-    stderr: String,
-}
-
 impl NickelInvocation {
     fn new() -> Self {
         let nickel_loc = env!("CARGO_BIN_EXE_nickel");
@@ -112,13 +118,5 @@ impl NickelInvocation {
 
     fn snapshot_stdout(&mut self) -> String {
         String::from_utf8(self.run().stdout).expect("Output should be utf8")
-    }
-
-    fn snapshot_output(&mut self) -> NickelOutput {
-        let o = self.run();
-        NickelOutput {
-            stdout: String::from_utf8(o.stdout).expect("Output should be utf8"),
-            stderr: String::from_utf8(o.stderr).expect("Output should be utf8"),
-        }
     }
 }

--- a/tests/snapshot/main.rs
+++ b/tests/snapshot/main.rs
@@ -24,9 +24,10 @@ fn check_export_snapshots(file: &str) {
     let snapshot = NickelInvocation::new()
         .subcommand("export")
         .file(&file)
-        .snapshot_stdout();
+        .snapshot_output();
 
-    insta::assert_snapshot!(file.prefixed_test_name("export"), snapshot)
+    insta::assert_snapshot!(file.prefixed_test_name("export_stdout"), snapshot.stdout);
+    insta::assert_snapshot!(file.prefixed_test_name("export_stderr"), snapshot.stderr);
 }
 
 #[test_resources("tests/snapshot/inputs/errors/*.ncl")]
@@ -78,6 +79,11 @@ struct NickelInvocation {
     cmd: Command,
 }
 
+struct NickelOutput {
+    stdout: String,
+    stderr: String,
+}
+
 impl NickelInvocation {
     fn new() -> Self {
         let nickel_loc = env!("CARGO_BIN_EXE_nickel");
@@ -106,5 +112,13 @@ impl NickelInvocation {
 
     fn snapshot_stdout(&mut self) -> String {
         String::from_utf8(self.run().stdout).expect("Output should be utf8")
+    }
+
+    fn snapshot_output(&mut self) -> NickelOutput {
+        let o = self.run();
+        NickelOutput {
+            stdout: String::from_utf8(o.stdout).expect("Output should be utf8"),
+            stderr: String::from_utf8(o.stderr).expect("Output should be utf8"),
+        }
     }
 }

--- a/tests/snapshot/snapshots/snapshot__error_trace_not_saturated.ncl.snap
+++ b/tests/snapshot/snapshots/snapshot__error_trace_not_saturated.ncl.snap
@@ -1,0 +1,12 @@
+---
+source: tests/snapshot/main.rs
+expression: snapshot
+---
+builtin.trace: too few arguments
+error: not enough arguments
+  ┌─ [INPUTS_PATH]/errors/trace_not_saturated.ncl:1:1
+  │
+1 │ %trace% "too few arguments"
+  │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^ trace expects 2 arguments, but not enough were provided
+
+

--- a/tests/snapshot/snapshots/snapshot__export_stderr_nested_record.ncl.snap
+++ b/tests/snapshot/snapshots/snapshot__export_stderr_nested_record.ncl.snap
@@ -1,5 +1,5 @@
 ---
 source: tests/snapshot/main.rs
-expression: snapshot
+expression: snapshot.stderr
 ---
-true
+

--- a/tests/snapshot/snapshots/snapshot__export_stderr_trace.ncl.snap
+++ b/tests/snapshot/snapshots/snapshot__export_stderr_trace.ncl.snap
@@ -1,0 +1,6 @@
+---
+source: tests/snapshot/main.rs
+expression: snapshot.stderr
+---
+builtin.trace: Hello, world!
+

--- a/tests/snapshot/snapshots/snapshot__export_stdout_nested_record.ncl.snap
+++ b/tests/snapshot/snapshots/snapshot__export_stdout_nested_record.ncl.snap
@@ -1,6 +1,6 @@
 ---
 source: tests/snapshot/main.rs
-expression: snapshot
+expression: snapshot.stdout
 ---
 {
   "a_num": 1,

--- a/tests/snapshot/snapshots/snapshot__export_stdout_trace.ncl.snap
+++ b/tests/snapshot/snapshots/snapshot__export_stdout_trace.ncl.snap
@@ -1,0 +1,5 @@
+---
+source: tests/snapshot/main.rs
+expression: snapshot.stdout
+---
+true


### PR DESCRIPTION
Add standard error capture in the snapshot tests for `nickel export`. This is done by calling `assert_snapshot!` twice, once for `stdout` and once for `stderr`, so that the snapshots are reasonably reviewable in `cargo insta review`.

Combining both into one call would be feasible, but only at the cost of presenting the output as raw string literals during snapshot review, I think. If someone knows of a better way, I'd love to see it!

Depends on #1055 