### PR TITLE
Nix/rnix update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -232,15 +232,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cbitset"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29b6ad25ae296159fb0da12b970b2fe179b234584d7cd294c891e2bbb284466b"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
 name = "cc"
 version = "1.0.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -345,9 +336,9 @@ dependencies = [
 
 [[package]]
 name = "countme"
-version = "2.0.4"
+version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "328b822bdcba4d4e402be8d9adb6eebf269f969f8eadef977a553ff3c4fbcb58"
+checksum = "7704b5fdd17b18ae31c4c1da5a2e0305a2bf17b5249300a9ee9ed7b72114c636"
 
 [[package]]
 name = "cpp_demangle"
@@ -842,15 +833,15 @@ checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
 
 [[package]]
 name = "hashbrown"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
-
-[[package]]
-name = "hashbrown"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+
+[[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "heck"
@@ -1222,6 +1213,7 @@ dependencies = [
  "pretty_assertions",
  "regex",
  "rnix",
+ "rowan",
  "rustyline",
  "rustyline-derive",
  "serde",
@@ -1808,23 +1800,21 @@ dependencies = [
 
 [[package]]
 name = "rnix"
-version = "0.10.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "065c5eac8e8f7e7b0e7227bdc46e2d8dd7d69fff7a9a2734e21f686bbcb9b2c9"
+checksum = "bb35cedbeb70e0ccabef2a31bcff0aebd114f19566086300b8f42c725fc2cb5f"
 dependencies = [
- "cbitset",
  "rowan",
- "smol_str",
 ]
 
 [[package]]
 name = "rowan"
-version = "0.12.6"
+version = "0.15.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1b36e449f3702f3b0c821411db1cbdf30fb451726a9456dce5dabcd44420043"
+checksum = "5811547e7ba31e903fe48c8ceab10d40d70a101f3d15523c847cce91aa71f332"
 dependencies = [
  "countme",
- "hashbrown 0.9.1",
+ "hashbrown 0.12.3",
  "memoffset",
  "rustc-hash",
  "text-size",
@@ -2106,15 +2096,6 @@ name = "smallvec"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2dd574626839106c320a323308629dcb1acfc96e32a8cba364ddc61ac23ee83"
-
-[[package]]
-name = "smol_str"
-version = "0.1.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7475118a28b7e3a2e157ce0131ba8c5526ea96e90ee601d9f6bb2e286a35ab44"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "stable_deref_trait"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,8 @@ pretty = "0.11.3"
 comrak = { version = "0.12.1", optional = true, features = [] }
 once_cell = "1.14.0"
 typed-arena = "2.0.1"
-rnix = "0.10.1"
+rnix = "0.11"
+rowan = "0.15.10"
 
 [dev-dependencies]
 pretty_assertions = "1.2.1"

--- a/flake.nix
+++ b/flake.nix
@@ -175,6 +175,7 @@
               mkFilter = regexp: path: _type: builtins.match regexp path != null;
               lalrpopFilter = mkFilter ".*lalrpop$";
               nclFilter = mkFilter ".*ncl$";
+              nixFilter = mkFilter ".*/tests/nix/.+\\.nix$";
               txtFilter = mkFilter ".*txt$";
             in
             pkgs.lib.cleanSourceWith {
@@ -186,6 +187,7 @@
                 builtins.any (filter: filter path type) [
                   lalrpopFilter
                   nclFilter
+                  nixFilter
                   txtFilter
                   craneLib.filterCargoSources
                 ];


### PR DESCRIPTION
To try to fix some strange bugs and because the API is a lot cleaner, this branch update `rnix` from 0.10 to 0.11. with a lot of breakage in the API but with a good improvement.