### PR TITLE
Update flake lock + fix markdown lint

### DIFF
--- a/RATIONALE.md
+++ b/RATIONALE.md
@@ -348,7 +348,8 @@ feature static types, contracts or enriched values, and thus can't type library
 code and has no principled approach to data validation.
 
 ### Comparison with other configuration languages
-<!-- Intentionally duplicated in `README.md`, please update the other one for any change done here -->
+<!-- Intentionally duplicated in `README.md`, please update the other one for
+any change done here -->
 
 | Language | Typing                        | Recursion  | Evaluation | Side-effects                                     |
 |----------|-------------------------------|------------|------------|--------------------------------------------------|

--- a/README.md
+++ b/README.md
@@ -249,7 +249,8 @@ See [RATIONALE.md](./RATIONALE.md) for the design rationale and a more detailed
 comparison with these languages.
 
 ### Comparison with other configuration languages
-<!-- Intentionally duplicated in `RATIONALE.md`, please update the other one for any change done here -->
+<!-- Intentionally duplicated in `RATIONALE.md`, please update the other one for
+any change done here -->
 
 | Language | Typing                        | Recursion  | Evaluation | Side-effects                                     |
 |----------|-------------------------------|------------|------------|--------------------------------------------------|

--- a/doc/manual/cookbook.md
+++ b/doc/manual/cookbook.md
@@ -44,13 +44,3 @@ record level. It makes code more navigable and `query`-friendly, but at the
 expense of repetition and duplicated contract checks. It is also currently
 required for polymorphic functions because of [the following
 bug](https://github.com/tweag/nickel/issues/360).
-
-<!-- # Note: we already have type wildcard, but they don't "export" the inferred type. -->
-<!-- A better solution will probably be implemented in the future: type wildcard (TODO: -->
-<!--  -->
-<!-- ```nickel -->
-<!-- { -->
-<!--   foo : Num -> Num = fun x => x + 1, -->
-<!--   bar : Num -> Num = foo, -->
-<!-- } : _ -->
-<!-- ``` -->

--- a/doc/manual/typing.md
+++ b/doc/manual/typing.md
@@ -165,7 +165,7 @@ Let us now have a quick tour of the type system. The basic types are:
 - `Num`: the only number type. Currently implemented as a 64bits float.
 - `Str`: a string, which must always be valid UTF8.
 - `Bool`: a boolean, that is either `true` or `false`.
-<!-- - `Lbl`: a contract label. You usually don't need to use it or worry about it, -->
+<!-- - `Lbl`: a contract label. You usually don't need to use it or worry about it,-->
 <!--     it is more of an internal thing.  -->
 
 The following type constructors are available:
@@ -398,21 +398,21 @@ could still write `addTotal {total = 1, foo = 1} {total = 2, foo = 2}` but not
 What comes before the tail may include several fields, is in e.g. `forall a.
 {total: Num, subtotal: Num ; a} -> Num`.
 
-<!-- Note that row polymorphism also works with enums, with the same intuition of a -->
-<!-- tail that can be substituted for something else. For example: -->
-<!--  -->
-<!-- ```nickel -->
-<!-- let portOf : forall a. <http, ftp | a> -> Num = fun protocol => -->
-<!-- switch { -->
-<!--   `http -> 80, -->
-<!--   `ftp -> 21, -->
-<!--   _ -> 8000, -->
-<!-- } protocol -->
-<!-- ``` -->
-<!--  -->
-<!-- Because the `switch` statement has a catch-all case `_`, this function is indeed -->
-<!-- able to handle other tags than `http` and `ftp`, as expressed by its polymorphic -->
-<!-- type. -->
+Note that row polymorphism also works with enums, with the same intuition of a
+tail that can be substituted for something else. For example:
+
+```nickel
+let port_of : forall a. [| `http, `ftp; a |] -> Num =
+  match {
+    `http => 80,
+    `ftp => 21,
+    _ => 8000,
+  }
+```
+
+Because the `match` statement has a catch-all case `_`, this function is indeed
+able to handle other tags than `http` and `ftp`, as expressed by its polymorphic
+type.
 
 ### Take-away
 

--- a/flake.lock
+++ b/flake.lock
@@ -42,11 +42,11 @@
     "flake-compat_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1668681692,
-        "narHash": "sha256-Ht91NGdewz8IQLtWZ9LCeNXMSXHUss+9COoqu6JLmXU=",
+        "lastModified": 1673956053,
+        "narHash": "sha256-4gtG9iQuiKITOjNQQeQIpoIB6b16fm+504Ch3sNKLd8=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "009399224d5e398d03b22badca40a37ac85412a1",
+        "rev": "35bb57c0c8d8b62bbfd284272c928ceb64ddbde9",
         "type": "github"
       },
       "original": {
@@ -108,11 +108,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1673540789,
-        "narHash": "sha256-xqnxBOK3qctIeUVxecydrEDbEXjsvHCPGPbvsl63M/U=",
+        "lastModified": 1674211260,
+        "narHash": "sha256-xU6Rv9sgnwaWK7tgCPadV6HhI2Y/fl4lKxJoG2+m9qs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0f213d0fee84280d8c3a97f7469b988d6fe5fcdf",
+        "rev": "5ed481943351e9fd354aeb557679624224de38d5",
         "type": "github"
       },
       "original": {
@@ -123,16 +123,16 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1671271954,
-        "narHash": "sha256-cSvu+bnvN08sOlTBWbBrKaBHQZq8mvk8bgpt0ZJ2Snc=",
+        "lastModified": 1673800717,
+        "narHash": "sha256-SFHraUqLSu5cC6IxTprex/nTsI81ZQAtDvlBvGDWfnA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d513b448cc2a6da2c8803e3c197c9fc7e67b19e3",
+        "rev": "2f9fd351ec37f5d479556cd48be4ca340da59b8f",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-22.05",
+        "ref": "nixos-22.11",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -150,11 +150,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1673627351,
-        "narHash": "sha256-oppRxEg/7ICcG67ErBvu1UlXt3su6zMcNoQmKaHPs5I=",
+        "lastModified": 1674122161,
+        "narHash": "sha256-9QM4rvgUSEwO8DWtJN9sR/afEqrH1s3b6ACsZT5wiAM=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "496e4505c2ddf5f205242eae8064d7d89cd976c0",
+        "rev": "53e766957b73298fa68b47478c48cbcc005cc18a",
         "type": "github"
       },
       "original": {
@@ -207,11 +207,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1673662873,
-        "narHash": "sha256-/YOtiDKPUXKKpIhsAds11llfC42ScGW27bbHnNZebco=",
+        "lastModified": 1674267882,
+        "narHash": "sha256-53sIczqxA5BbrhgO6l54DSisDqHvQ3UUwbSqBryA/k0=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "90163bbbadce526f8b248a5fe545b06c59597108",
+        "rev": "1fd6d280c132f4facad8cd023543fb10121e6487",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Same as #1061, but with the CI fixed for markdown documentation. Commented out documentation lines were too wide, and one section actually needed to be restored now that enum types are back.