### PR TITLE
add `--all-features` to clippy

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -232,7 +232,7 @@
               cargoArtifacts;
 
             cargoExtraArgs = cargoBuildExtraArgs;
-            cargoClippyExtraArgs = "--all-targets -- --deny warnings --allow clippy::new-without-default --allow clippy::match_like_matches_macro";
+            cargoClippyExtraArgs = "--all-features --all-targets -- --deny warnings --allow clippy::new-without-default --allow clippy::match_like_matches_macro";
           };
         };
 


### PR DESCRIPTION
To check every parts of the source.
Without this flag, clippy ignore the code disabled by `#[cfg(feature=<some_feature>)]` wher `<some_feature>` can be repl or an other optional feature like thisone.