### PR TITLE
Improve the performance of array.foldl and array.fold

### DIFF
--- a/stdlib/array.ncl
+++ b/stdlib/array.ncl
@@ -108,12 +108,17 @@
             6
         ```
         "%
-      = fun f acc l =>
-        if %length% l == 0 then
-          acc
+    = fun f acc l =>
+        let length = %length% l in
+        if length == 0 then acc
         else
-          let newAcc = f acc (%head% l) in
-          %seq% newAcc (foldl f newAcc (%tail% l)),
+          let rec loop = fun acc n => 
+            if n == length then acc
+            else 
+              let next_acc = %elem_at% l n |> f acc in
+              %seq% next_acc (loop next_acc (n+1))
+          in
+          loop acc 0,
 
     fold : forall a b. (a -> b -> b) -> b -> Array a -> b
       | doc m%"
@@ -128,10 +133,12 @@
         ```
         "%
       = fun f fst l =>
-        if %length% l == 0 then
-          fst
-        else
-          f (%head% l) (fold f fst (%tail% l)),
+        let rec go = fun n =>
+          if n == %length% l then
+            fst 
+          else
+            go (n+1) |> f (%elem_at% l n)
+        in go 0,
 
     cons : forall a. a -> Array a -> Array a
       | doc m%"

--- a/stdlib/array.ncl
+++ b/stdlib/array.ncl
@@ -133,8 +133,9 @@
         ```
         "%
       = fun f fst l =>
+        let length = %length% l in
         let rec go = fun n =>
-          if n == %length% l then
+          if n == length then
             fst 
           else
             go (n+1) |> f (%elem_at% l n)

--- a/stdlib/array.ncl
+++ b/stdlib/array.ncl
@@ -112,13 +112,13 @@
         let length = %length% l in
         if length == 0 then acc
         else
-          let rec loop = fun acc n => 
+          let rec go = fun acc n => 
             if n == length then acc
             else 
               let next_acc = %elem_at% l n |> f acc in
-              %seq% next_acc (loop next_acc (n+1))
+              %seq% next_acc (go next_acc (n+1))
           in
-          loop acc 0,
+          go acc 0,
 
     fold : forall a b. (a -> b -> b) -> b -> Array a -> b
       | doc m%"
@@ -138,7 +138,8 @@
           if n == length then
             fst 
           else
-            go (n+1) |> f (%elem_at% l n)
+            go (n+1)
+            |> f (%elem_at% l n)
         in go 0,
 
     cons : forall a. a -> Array a -> Array a


### PR DESCRIPTION
This change improves the performance of the standard library fold functions from "Eats all my RAM before finishing" to
```
❯ time nickel <<<'array.generate function.id 16384 |> array.foldl (+) 0'
134209536
nickel <<< 'array.generate function.id 16384 |> array.foldl (+) 0'  0.49s user 0.02s system 99% cpu 0.512 total
```

There are still performance problems with using the standard library array functions, for example
```
❯ time nickel <<<'array.generate (function.const []) 16384 |> array.flatten'
[  ]
nickel <<< 'array.generate (function.const []) 16384 |> array.flatten'  6.66s user 0.04s system 99% cpu 6.694 total
```
while inlining `array.flatten` without a contract annotation runs in about 0.4s. But this change already improves the situation from not terminating in a reasonable timeframe to just being slow.