### PR TITLE
Fix mantis benchmark

### DIFF
--- a/benches/mantis/lib.ncl
+++ b/benches/mantis/lib.ncl
@@ -14,9 +14,9 @@
     Smaller = fun x => contract.from_predicate (fun y => y < x),
     SmallerEq = fun x => contract.from_predicate (fun y => y <= x),
     MatchRegexp = fun regex label value =>
-      let match = string.is_match regex in
+      let str_match = string.is_match regex in
       if builtin.is_str value then
-        if match value then
+        if str_match value then
           value
         else
           contract.blame_with "no match" label


### PR DESCRIPTION
Close #1076. That being said, there's something fishy about imports - again! - in that a parse error in one of the import is not correctly reported but lead to a panic. Once again, it's probably due to a parser that is configured in error recovery mode, while it shouldn't.