### PR TITLE
Treat variables bound by record deconstruction like record static indexing

### DIFF
--- a/lsp/nls/src/linearization/building.rs
+++ b/lsp/nls/src/linearization/building.rs
@@ -198,7 +198,7 @@ impl<'b> Building<'b> {
                         _ => break,
                     }
                 }
-                // return the `prev_item` becuase that was the record field we want to 
+                // return the `prev_item` becuase that was the record field we want to
                 // resolve, and `curr_item` points to the record field's value.
                 Some(prev_item)
             }

--- a/lsp/nls/src/linearization/building.rs
+++ b/lsp/nls/src/linearization/building.rs
@@ -162,7 +162,7 @@ impl<'b> Building<'b> {
                     .as_option()
                     .and_then(|value_index| self.get_item_kind(current_file, value_index))
             }
-            TermKind::Declaration(ident, _, ValueState::Known(value), true) => {
+            TermKind::Declaration(_, _, ValueState::Known(value), Some(ident)) => {
                 let item = self.get_item_kind(current_file, *value)?;
                 let item = self.resolve_reference(current_file, item)?;
                 match item {

--- a/lsp/nls/src/linearization/building.rs
+++ b/lsp/nls/src/linearization/building.rs
@@ -175,9 +175,9 @@ impl<'b> Building<'b> {
 
                 let mut ids = idents.clone();
                 // (previous value, current value)
-                let mut result = (item, item);
+                let (mut prev_item, mut curr_item) = (item, item);
                 while let Some(id) = ids.pop() {
-                    match result.1 {
+                    match curr_item {
                         TermKind::Record(ref fields) => {
                             let item = fields.get(&id)?;
                             let item = self.get_item_kind(current_file, *item)?;
@@ -186,9 +186,9 @@ impl<'b> Building<'b> {
                                     value: ValueState::Known(next_item),
                                     ..
                                 } => {
-                                    result.0 = item;
+                                    prev_item = item;
                                     let item = self.get_item_kind(current_file, *next_item)?;
-                                    result.1 = item;
+                                    curr_item = item;
                                     continue;
                                 }
                                 // the value from a record is always a record field
@@ -198,9 +198,9 @@ impl<'b> Building<'b> {
                         _ => break,
                     }
                 }
-                // return the previous value becuase that was the record field we were
-                // looking for
-                Some(result.0)
+                // return the `prev_item` becuase that was the record field we want to 
+                // resolve, and `curr_item` points to the record field's value.
+                Some(prev_item)
             }
             // if declaration is a let binding resolve its value
             TermKind::Declaration {

--- a/lsp/nls/src/linearization/building.rs
+++ b/lsp/nls/src/linearization/building.rs
@@ -162,6 +162,18 @@ impl<'b> Building<'b> {
                     .as_option()
                     .and_then(|value_index| self.get_item_kind(current_file, value_index))
             }
+            TermKind::Declaration(ident, _, ValueState::Known(value), true) => {
+                let item = self.get_item_kind(current_file, *value)?;
+                let item = self.resolve_reference(current_file, item)?;
+                match item {
+                    TermKind::Record(fields) => {
+                        let item = fields.get(ident)?;
+                        let item = self.get_item_kind(current_file, *item)?;
+                        Some(item)
+                    }
+                    _ => None,
+                }
+            }
             // if declaration is a let binding resolve its value
             TermKind::Declaration(_, _, ValueState::Known(value), _) => {
                 self.get_item_kind(current_file, *value)

--- a/lsp/nls/src/linearization/building.rs
+++ b/lsp/nls/src/linearization/building.rs
@@ -190,6 +190,10 @@ impl<'b> Building<'b> {
                                     curr_item = item_kind;
                                     continue;
                                 }
+                                TermKind::RecordField {
+                                    value: ValueState::Unknown,
+                                    ..
+                                } => break,
                                 // the value from a record is always a record field
                                 _ => unreachable!(),
                             }

--- a/lsp/nls/src/linearization/building.rs
+++ b/lsp/nls/src/linearization/building.rs
@@ -167,7 +167,7 @@ impl<'b> Building<'b> {
             }
             TermKind::Declaration {
                 value: ValueState::Known(value),
-                pattern_bindings: Some(idents),
+                path: Some(idents),
                 ..
             } => {
                 let item = self.get_item_kind(current_file, *value)?;

--- a/lsp/nls/src/linearization/building.rs
+++ b/lsp/nls/src/linearization/building.rs
@@ -179,15 +179,15 @@ impl<'b> Building<'b> {
                     match curr_item {
                         TermKind::Record(ref fields) => {
                             let item = fields.get(&id)?;
-                            let item = self.get_item_kind(current_file, *item)?;
-                            match item {
+                            let item_kind = self.get_item_kind(current_file, *item)?;
+                            match item_kind {
                                 TermKind::RecordField {
                                     value: ValueState::Known(next_item),
                                     ..
                                 } => {
-                                    prev_item = item;
-                                    let item = self.get_item_kind(current_file, *next_item)?;
-                                    curr_item = item;
+                                    prev_item = item_kind;
+                                    let item_kind = self.get_item_kind(current_file, *next_item)?;
+                                    curr_item = item_kind;
                                     continue;
                                 }
                                 // the value from a record is always a record field

--- a/lsp/nls/src/linearization/building.rs
+++ b/lsp/nls/src/linearization/building.rs
@@ -165,6 +165,8 @@ impl<'b> Building<'b> {
             TermKind::Declaration(_, _, ValueState::Known(value), Some(ident)) => {
                 let item = self.get_item_kind(current_file, *value)?;
                 let item = self.resolve_reference(current_file, item)?;
+                // TODO: fix this
+                let ident = ident.last().unwrap();
                 match item {
                     TermKind::Record(fields) => {
                         let item = fields.get(ident)?;

--- a/lsp/nls/src/linearization/building.rs
+++ b/lsp/nls/src/linearization/building.rs
@@ -197,7 +197,7 @@ impl<'b> Building<'b> {
                         _ => break,
                     }
                 }
-                // return the `prev_item` becuase that was the record field we want to
+                // return the `prev_item` because that was the record field we wanted to
                 // resolve, and `curr_item` points to the record field's value.
                 Some(prev_item)
             }

--- a/lsp/nls/src/linearization/building.rs
+++ b/lsp/nls/src/linearization/building.rs
@@ -82,7 +82,7 @@ impl<'b> Building<'b> {
             .expect("Could not find parent")
         {
             TermKind::Record(_) | TermKind::Structure | TermKind::Usage(_) => unreachable!(),
-            TermKind::Declaration(_, ref mut usages, _)
+            TermKind::Declaration(_, ref mut usages, _, _)
             | TermKind::RecordField { ref mut usages, .. } => usages.push(usage),
         };
     }
@@ -94,7 +94,7 @@ impl<'b> Building<'b> {
         value: ItemId,
     ) {
         let kind = self.get_item_kind_mut(current_file, declaration);
-        if let Some(TermKind::Declaration(_, _, value_state)) = kind {
+        if let Some(TermKind::Declaration(_, _, value_state, _)) = kind {
             *value_state = ValueState::Known(value)
         }
     }
@@ -163,7 +163,7 @@ impl<'b> Building<'b> {
                     .and_then(|value_index| self.get_item_kind(current_file, value_index))
             }
             // if declaration is a let binding resolve its value
-            TermKind::Declaration(_, _, ValueState::Known(value)) => {
+            TermKind::Declaration(_, _, ValueState::Known(value), _) => {
                 self.get_item_kind(current_file, *value)
             }
 

--- a/lsp/nls/src/linearization/building.rs
+++ b/lsp/nls/src/linearization/building.rs
@@ -201,7 +201,7 @@ impl<'b> Building<'b> {
                 // resolve, and `curr_item` points to the record field's value.
                 Some(prev_item)
             }
-            // if declaration is a let binding resolve its value
+            // if declaration is a let binding, resolve its value
             TermKind::Declaration {
                 value: ValueState::Known(value),
                 ..

--- a/lsp/nls/src/linearization/building.rs
+++ b/lsp/nls/src/linearization/building.rs
@@ -174,7 +174,6 @@ impl<'b> Building<'b> {
                 let item = self.resolve_reference(current_file, item)?;
 
                 let mut ids = idents.clone();
-                // (previous value, current value)
                 let (mut prev_item, mut curr_item) = (item, item);
                 while let Some(id) = ids.pop() {
                     match curr_item {

--- a/lsp/nls/src/linearization/completed.rs
+++ b/lsp/nls/src/linearization/completed.rs
@@ -143,7 +143,10 @@ impl Completed {
             TermKind::Usage(UsageState::Resolved(declaration)) => self
                 .get_item(declaration, lin_cache)
                 .and_then(|decl| match decl.kind {
-                    TermKind::Declaration(_, _, ValueState::Known(value), _)
+                    TermKind::Declaration {
+                        value: ValueState::Known(value),
+                        ..
+                    }
                     | TermKind::RecordField {
                         value: ValueState::Known(value),
                         ..
@@ -151,9 +154,10 @@ impl Completed {
                     _ => None,
                 })
                 .unwrap_or(item),
-            TermKind::Declaration(_, _, ValueState::Known(value), _) => {
-                self.get_item(value, lin_cache).unwrap_or(item)
-            }
+            TermKind::Declaration {
+                value: ValueState::Known(value),
+                ..
+            } => self.get_item(value, lin_cache).unwrap_or(item),
             _ => item,
         };
 

--- a/lsp/nls/src/linearization/completed.rs
+++ b/lsp/nls/src/linearization/completed.rs
@@ -143,7 +143,7 @@ impl Completed {
             TermKind::Usage(UsageState::Resolved(declaration)) => self
                 .get_item(declaration, lin_cache)
                 .and_then(|decl| match decl.kind {
-                    TermKind::Declaration(_, _, ValueState::Known(value))
+                    TermKind::Declaration(_, _, ValueState::Known(value), _)
                     | TermKind::RecordField {
                         value: ValueState::Known(value),
                         ..
@@ -151,7 +151,7 @@ impl Completed {
                     _ => None,
                 })
                 .unwrap_or(item),
-            TermKind::Declaration(_, _, ValueState::Known(value)) => {
+            TermKind::Declaration(_, _, ValueState::Known(value), _) => {
                 self.get_item(value, lin_cache).unwrap_or(item)
             }
             _ => item,

--- a/lsp/nls/src/linearization/interface.rs
+++ b/lsp/nls/src/linearization/interface.rs
@@ -28,7 +28,13 @@ pub enum TermKind {
         id: Ident,
         usages: Vec<ItemId>,
         value: ValueState,
-        pattern_bindings: Option<Vec<Ident>>,
+        // This is the path to a bound variable. If we have
+        // `let { a = {b = {c, ..}, ..}, ..} = ...`,  the `path` will
+        // be `Some([a, b, c])`, and `ident` will be `c`.
+        // If we have `let { a = {b = {c = somevar, ..}, ..}, ..} = ...`
+        // instead, the `path` remains the same, but the ident will be `somevar`
+        // If there is no pattern variable bound, the `path` is `None`
+        path: Option<Vec<Ident>>,
     },
     Usage(UsageState),
     Record(HashMap<Ident, ItemId>),

--- a/lsp/nls/src/linearization/interface.rs
+++ b/lsp/nls/src/linearization/interface.rs
@@ -24,12 +24,12 @@ impl ResolutionState for Resolved {}
 /// Can be extended later to represent Contracts, Records, etc.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum TermKind {
-    Declaration(
-        Ident,
-        Vec<ItemId>,
-        ValueState,
-        /* pattern binding? */ Option<Vec<Ident>>,
-    ),
+    Declaration {
+        id: Ident,
+        usages: Vec<ItemId>,
+        value: ValueState,
+        pattern_bindings: Option<Vec<Ident>>,
+    },
     Usage(UsageState),
     Record(HashMap<Ident, ItemId>),
     RecordField {

--- a/lsp/nls/src/linearization/interface.rs
+++ b/lsp/nls/src/linearization/interface.rs
@@ -24,7 +24,12 @@ impl ResolutionState for Resolved {}
 /// Can be extended later to represent Contracts, Records, etc.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum TermKind {
-    Declaration(Ident, Vec<ItemId>, ValueState),
+    Declaration(
+        Ident,
+        Vec<ItemId>,
+        ValueState,
+        /* pattern binding? */ bool,
+    ),
     Usage(UsageState),
     Record(HashMap<Ident, ItemId>),
     RecordField {

--- a/lsp/nls/src/linearization/interface.rs
+++ b/lsp/nls/src/linearization/interface.rs
@@ -28,7 +28,7 @@ pub enum TermKind {
         Ident,
         Vec<ItemId>,
         ValueState,
-        /* pattern binding? */ Option<Ident>,
+        /* pattern binding? */ Option<Vec<Ident>>,
     ),
     Usage(UsageState),
     Record(HashMap<Ident, ItemId>),

--- a/lsp/nls/src/linearization/interface.rs
+++ b/lsp/nls/src/linearization/interface.rs
@@ -28,7 +28,7 @@ pub enum TermKind {
         Ident,
         Vec<ItemId>,
         ValueState,
-        /* pattern binding? */ bool,
+        /* pattern binding? */ Option<Ident>,
     ),
     Usage(UsageState),
     Record(HashMap<Ident, ItemId>),

--- a/lsp/nls/src/linearization/mod.rs
+++ b/lsp/nls/src/linearization/mod.rs
@@ -246,6 +246,8 @@ impl<'a> Linearizer for AnalysisHost<'a> {
                         metadata: None,
                     });
                 }
+
+                let mut let_pattern_bindings = Vec::new();
                 for matched in destruct.to_owned().inner() {
                     let (ident, field) = matched.as_binding();
 
@@ -253,6 +255,8 @@ impl<'a> Linearizer for AnalysisHost<'a> {
                         file_id: self.file,
                         index: id_gen.get_and_advance(),
                     };
+
+                    let_pattern_bindings.push(id);
                     self.env.insert(ident, id);
                     lin.push(LinearizationItem {
                         env: self.env.clone(),
@@ -263,12 +267,13 @@ impl<'a> Linearizer for AnalysisHost<'a> {
                         kind: TermKind::Declaration(
                             ident.to_owned(),
                             Vec::new(),
-                            ValueState::Known(id),
+                            ValueState::Unknown,
                             true,
                         ),
                         metadata: Some(field.metadata),
                     });
                 }
+                self.let_pattern_binding = Some(let_pattern_bindings);
             }
             Term::Let(ident, ..) | Term::Fun(ident, ..) => {
                 let value_ptr = match term {

--- a/lsp/nls/src/linearization/mod.rs
+++ b/lsp/nls/src/linearization/mod.rs
@@ -226,15 +226,18 @@ impl<'a> Linearizer for AnalysisHost<'a> {
                     };
                     self.env.insert(ident.to_owned(), id);
                     let kind = match term {
-                        Term::LetPattern(..) => {
-                            TermKind::Declaration(ident.to_owned(), Vec::new(), value_ptr, None)
-                        }
-                        Term::FunPattern(..) => TermKind::Declaration(
-                            ident.to_owned(),
-                            Vec::new(),
-                            ValueState::Unknown,
-                            None,
-                        ),
+                        Term::LetPattern(..) => TermKind::Declaration {
+                            id: ident.to_owned(),
+                            usages: Vec::new(),
+                            value: value_ptr,
+                            pattern_bindings: None,
+                        },
+                        Term::FunPattern(..) => TermKind::Declaration {
+                            id: ident.to_owned(),
+                            usages: Vec::new(),
+                            value: ValueState::Unknown,
+                            pattern_bindings: None,
+                        },
                         _ => unreachable!(),
                     };
                     lin.push(LinearizationItem {
@@ -270,12 +273,12 @@ impl<'a> Linearizer for AnalysisHost<'a> {
                         // TODO: get type from pattern
                         ty: UnifType::Concrete(TypeF::Dyn),
                         pos: new_ident.pos,
-                        kind: TermKind::Declaration(
-                            new_ident.to_owned(),
-                            Vec::new(),
-                            ValueState::Unknown,
-                            Some(path),
-                        ),
+                        kind: TermKind::Declaration {
+                            id: new_ident.to_owned(),
+                            usages: Vec::new(),
+                            value: ValueState::Unknown,
+                            pattern_bindings: Some(path),
+                        },
                         metadata: Some(field.metadata),
                     });
                 }
@@ -317,15 +320,18 @@ impl<'a> Linearizer for AnalysisHost<'a> {
                     },
                 );
                 let kind = match term {
-                    Term::Let(..) => {
-                        TermKind::Declaration(ident.to_owned(), Vec::new(), value_ptr, None)
-                    }
-                    Term::Fun(..) => TermKind::Declaration(
-                        ident.to_owned(),
-                        Vec::new(),
-                        ValueState::Unknown,
-                        None,
-                    ),
+                    Term::Let(..) => TermKind::Declaration {
+                        id: ident.to_owned(),
+                        usages: Vec::new(),
+                        value: value_ptr,
+                        pattern_bindings: None,
+                    },
+                    Term::Fun(..) => TermKind::Declaration{
+                        id:ident.to_owned(),
+                        usages:Vec::new(),
+                        value:ValueState::Unknown,
+                        pattern_bindings:None,
+                    },
                     _ => unreachable!(),
                 };
                 lin.push(LinearizationItem {

--- a/lsp/nls/src/linearization/mod.rs
+++ b/lsp/nls/src/linearization/mod.rs
@@ -246,7 +246,7 @@ impl<'a> Linearizer for AnalysisHost<'a> {
                     .to_owned()
                     .inner()
                     .into_iter()
-                    .flat_map(|matched| matched.clone().as_pattern_info())
+                    .flat_map(|matched| matched.clone().as_flattened_bindings())
                 {
                     // We cannot have an empty vector because a bound variable inside
                     // a record pattern must have at least one item in it's path,

--- a/lsp/nls/src/linearization/mod.rs
+++ b/lsp/nls/src/linearization/mod.rs
@@ -264,7 +264,7 @@ impl<'a> Linearizer for AnalysisHost<'a> {
                         id,
                         // TODO: get type from pattern
                         ty: UnifType::Concrete(TypeF::Dyn),
-                        pos: ident.pos,
+                        pos: new_ident.pos,
                         kind: TermKind::Declaration(
                             new_ident.to_owned(),
                             Vec::new(),

--- a/lsp/nls/src/linearization/mod.rs
+++ b/lsp/nls/src/linearization/mod.rs
@@ -326,11 +326,11 @@ impl<'a> Linearizer for AnalysisHost<'a> {
                         value: value_ptr,
                         pattern_bindings: None,
                     },
-                    Term::Fun(..) => TermKind::Declaration{
-                        id:ident.to_owned(),
-                        usages:Vec::new(),
-                        value:ValueState::Unknown,
-                        pattern_bindings:None,
+                    Term::Fun(..) => TermKind::Declaration {
+                        id: ident.to_owned(),
+                        usages: Vec::new(),
+                        value: ValueState::Unknown,
+                        pattern_bindings: None,
                     },
                     _ => unreachable!(),
                 };

--- a/lsp/nls/src/linearization/mod.rs
+++ b/lsp/nls/src/linearization/mod.rs
@@ -211,11 +211,14 @@ impl<'a> Linearizer for AnalysisHost<'a> {
                     self.env.insert(ident.to_owned(), id);
                     let kind = match term {
                         Term::LetPattern(..) => {
-                            TermKind::Declaration(ident.to_owned(), Vec::new(), value_ptr)
+                            TermKind::Declaration(ident.to_owned(), Vec::new(), value_ptr, true)
                         }
-                        Term::FunPattern(..) => {
-                            TermKind::Declaration(ident.to_owned(), Vec::new(), ValueState::Unknown)
-                        }
+                        Term::FunPattern(..) => TermKind::Declaration(
+                            ident.to_owned(),
+                            Vec::new(),
+                            ValueState::Unknown,
+                            true,
+                        ),
                         _ => unreachable!(),
                     };
                     lin.push(LinearizationItem {
@@ -245,6 +248,7 @@ impl<'a> Linearizer for AnalysisHost<'a> {
                             ident.to_owned(),
                             Vec::new(),
                             ValueState::Known(id),
+                            true,
                         ),
                         metadata: Some(field.metadata),
                     });
@@ -286,10 +290,15 @@ impl<'a> Linearizer for AnalysisHost<'a> {
                     },
                 );
                 let kind = match term {
-                    Term::Let(..) => TermKind::Declaration(ident.to_owned(), Vec::new(), value_ptr),
-                    Term::Fun(..) => {
-                        TermKind::Declaration(ident.to_owned(), Vec::new(), ValueState::Unknown)
+                    Term::Let(..) => {
+                        TermKind::Declaration(ident.to_owned(), Vec::new(), value_ptr, false)
                     }
+                    Term::Fun(..) => TermKind::Declaration(
+                        ident.to_owned(),
+                        Vec::new(),
+                        ValueState::Unknown,
+                        false,
+                    ),
                     _ => unreachable!(),
                 };
                 lin.push(LinearizationItem {

--- a/lsp/nls/src/linearization/mod.rs
+++ b/lsp/nls/src/linearization/mod.rs
@@ -248,7 +248,11 @@ impl<'a> Linearizer for AnalysisHost<'a> {
                     .into_iter()
                     .flat_map(|matched| matched.clone().as_pattern_info())
                 {
-                    // We cannot have an empty vec, so this is safe
+                    // We cannot have an empty vector because a bound variable inside
+                    // a record pattern must have at least one item in it's path,
+                    // namely, the record field. i.e if we have: `let {a = value, ..} = ... in ...`
+                    // the path will be `vec![a]`, and this is the smallest possible case for a
+                    // record pattern which binds variables.
                     let ident = path.first().unwrap();
                     let id = ItemId {
                         file_id: self.file,

--- a/lsp/nls/src/linearization/mod.rs
+++ b/lsp/nls/src/linearization/mod.rs
@@ -69,6 +69,7 @@ pub struct AnalysisHost<'a> {
     /// useable to construct a vale declaration.
     record_fields: Option<(ItemId, Vec<(ItemId, Ident)>)>,
     let_binding: Option<ItemId>,
+    let_pattern_binding: Option<Vec<ItemId>>,
     /// Accesses to nested records are recorded recursively.
     /// ```
     /// outer.middle.inner -> inner(middle(outer))
@@ -88,6 +89,7 @@ impl<'a> AnalysisHost<'a> {
             meta: Default::default(),
             record_fields: Default::default(),
             let_binding: Default::default(),
+            let_pattern_binding: Default::default(),
             access: Default::default(),
         }
     }
@@ -577,6 +579,7 @@ impl<'a> Linearizer for AnalysisHost<'a> {
                 Some(*record).zip(fields.pop().map(|field| vec![field]))
             }),
             let_binding: self.let_binding.take(),
+            let_pattern_binding: self.let_pattern_binding.take(),
             access: self.access.clone(),
         }
     }
@@ -594,6 +597,7 @@ impl<'a> Linearizer for AnalysisHost<'a> {
             meta: None,
             record_fields: None,
             let_binding: None,
+            let_pattern_binding: None,
             access: None,
         }
     }

--- a/lsp/nls/src/linearization/mod.rs
+++ b/lsp/nls/src/linearization/mod.rs
@@ -165,6 +165,20 @@ impl<'a> Linearizer for AnalysisHost<'a> {
                     },
                 );
             }
+
+            if let Some(decls) = self.let_pattern_binding.take() {
+                let offset = self.access.as_ref().map(|v| v.len()).unwrap_or(0);
+                for decl in decls {
+                    lin.inform_declaration(
+                        self.file,
+                        decl,
+                        ItemId {
+                            file_id: self.file,
+                            index: id_gen.get() + offset,
+                        },
+                    );
+                }
+            }
         }
 
         if pos == TermPos::None {

--- a/lsp/nls/src/linearization/mod.rs
+++ b/lsp/nls/src/linearization/mod.rs
@@ -227,13 +227,13 @@ impl<'a> Linearizer for AnalysisHost<'a> {
                     self.env.insert(ident.to_owned(), id);
                     let kind = match term {
                         Term::LetPattern(..) => {
-                            TermKind::Declaration(ident.to_owned(), Vec::new(), value_ptr, false)
+                            TermKind::Declaration(ident.to_owned(), Vec::new(), value_ptr, None)
                         }
                         Term::FunPattern(..) => TermKind::Declaration(
                             ident.to_owned(),
                             Vec::new(),
                             ValueState::Unknown,
-                            false,
+                            None,
                         ),
                         _ => unreachable!(),
                     };
@@ -257,8 +257,8 @@ impl<'a> Linearizer for AnalysisHost<'a> {
                     };
 
                     let_pattern_bindings.push(id);
-                    let ident = bind_ident.unwrap_or(ident);
-                    self.env.insert(ident, id);
+                    let new_ident = bind_ident.unwrap_or(ident);
+                    self.env.insert(new_ident, id);
                     lin.push(LinearizationItem {
                         env: self.env.clone(),
                         id,
@@ -266,10 +266,10 @@ impl<'a> Linearizer for AnalysisHost<'a> {
                         ty: UnifType::Concrete(TypeF::Dyn),
                         pos: ident.pos,
                         kind: TermKind::Declaration(
-                            ident.to_owned(),
+                            new_ident.to_owned(),
                             Vec::new(),
                             ValueState::Unknown,
-                            true,
+                            Some(ident),
                         ),
                         metadata: Some(field.metadata),
                     });
@@ -313,13 +313,13 @@ impl<'a> Linearizer for AnalysisHost<'a> {
                 );
                 let kind = match term {
                     Term::Let(..) => {
-                        TermKind::Declaration(ident.to_owned(), Vec::new(), value_ptr, false)
+                        TermKind::Declaration(ident.to_owned(), Vec::new(), value_ptr, None)
                     }
                     Term::Fun(..) => TermKind::Declaration(
                         ident.to_owned(),
                         Vec::new(),
                         ValueState::Unknown,
-                        false,
+                        None,
                     ),
                     _ => unreachable!(),
                 };

--- a/lsp/nls/src/linearization/mod.rs
+++ b/lsp/nls/src/linearization/mod.rs
@@ -217,13 +217,13 @@ impl<'a> Linearizer for AnalysisHost<'a> {
                             id: ident.to_owned(),
                             usages: Vec::new(),
                             value: value_ptr,
-                            pattern_bindings: None,
+                            path: None,
                         },
                         Term::FunPattern(..) => TermKind::Declaration {
                             id: ident.to_owned(),
                             usages: Vec::new(),
                             value: ValueState::Unknown,
-                            pattern_bindings: None,
+                            path: None,
                         },
                         _ => unreachable!(),
                     };
@@ -272,7 +272,7 @@ impl<'a> Linearizer for AnalysisHost<'a> {
                             id: new_ident.to_owned(),
                             usages: Vec::new(),
                             value: ValueState::Unknown,
-                            pattern_bindings: Some(path),
+                            path: Some(path),
                         },
                         metadata: Some(field.metadata),
                     });
@@ -319,13 +319,13 @@ impl<'a> Linearizer for AnalysisHost<'a> {
                         id: ident.to_owned(),
                         usages: Vec::new(),
                         value: value_ptr,
-                        pattern_bindings: None,
+                        path: None,
                     },
                     Term::Fun(..) => TermKind::Declaration {
                         id: ident.to_owned(),
                         usages: Vec::new(),
                         value: ValueState::Unknown,
-                        pattern_bindings: None,
+                        path: None,
                     },
                     _ => unreachable!(),
                 };

--- a/lsp/nls/src/linearization/mod.rs
+++ b/lsp/nls/src/linearization/mod.rs
@@ -227,13 +227,13 @@ impl<'a> Linearizer for AnalysisHost<'a> {
                     self.env.insert(ident.to_owned(), id);
                     let kind = match term {
                         Term::LetPattern(..) => {
-                            TermKind::Declaration(ident.to_owned(), Vec::new(), value_ptr, true)
+                            TermKind::Declaration(ident.to_owned(), Vec::new(), value_ptr, false)
                         }
                         Term::FunPattern(..) => TermKind::Declaration(
                             ident.to_owned(),
                             Vec::new(),
                             ValueState::Unknown,
-                            true,
+                            false,
                         ),
                         _ => unreachable!(),
                     };

--- a/lsp/nls/src/requests/completion.rs
+++ b/lsp/nls/src/requests/completion.rs
@@ -166,7 +166,7 @@ fn find_fields_from_term_kind(
                 }
             }
         }
-        TermKind::Declaration(ident, _, ValueState::Known(body_id), true) => {
+        TermKind::Declaration(_, _, ValueState::Known(body_id), Some(ident)) => {
             path.push(ident.clone());
             find_fields_from_term_kind(body_id, path, &info)
         }
@@ -443,7 +443,7 @@ fn collect_record_info(
             match (&item.kind, ty) {
                 // Get record fields from static type info
                 (_, Types(TypeF::Record(rrows))) => find_fields_from_rrows(&rrows, path, &info),
-                (TermKind::Declaration(ident, _, ValueState::Known(body_id), true), _) => {
+                (TermKind::Declaration(_, _, ValueState::Known(body_id), Some(ident)), _) => {
                     path.push(ident.clone());
                     find_fields_from_term_kind(*body_id, path, &info)
                 }
@@ -915,7 +915,7 @@ mod tests {
                 Ident::from("a"),
                 vec![ItemId { file_id, index: 3 }],
                 ValueState::Known(ItemId { file_id, index: 1 }),
-                false,
+                None,
             ),
             None,
         );
@@ -935,7 +935,7 @@ mod tests {
                 Ident::from("d"),
                 Vec::new(),
                 ValueState::Known(ItemId { file_id, index: 4 }),
-                false,
+                None,
             ),
             None,
         );
@@ -962,7 +962,7 @@ mod tests {
                 Ident::from("a"),
                 Vec::new(),
                 ValueState::Known(ItemId { file_id, index: 1 }),
-                false,
+                None,
             ),
             None,
         );
@@ -983,7 +983,7 @@ mod tests {
                 Ident::from("d"),
                 Vec::new(),
                 ValueState::Known(ItemId { file_id, index: 13 }),
-                false,
+                None,
             ),
             None,
         );
@@ -993,7 +993,7 @@ mod tests {
                 Ident::from("e"),
                 Vec::new(),
                 ValueState::Known(ItemId { file_id, index: 14 }),
-                false,
+                None,
             ),
             None,
         );
@@ -1003,7 +1003,7 @@ mod tests {
                 Ident::from("f"),
                 Vec::new(),
                 ValueState::Known(ItemId { file_id, index: 15 }),
-                false,
+                None,
             ),
             None,
         );
@@ -1052,7 +1052,7 @@ mod tests {
                 Ident::from("a"),
                 Vec::new(),
                 ValueState::Known(ItemId { file_id, index: 1 }),
-                false,
+                None,
             ),
             None,
         );

--- a/lsp/nls/src/requests/completion.rs
+++ b/lsp/nls/src/requests/completion.rs
@@ -166,8 +166,10 @@ fn find_fields_from_term_kind(
                 }
             }
         }
-        TermKind::Declaration(_, _, ValueState::Known(body_id), Some(ident)) => {
-            path.push(ident.clone());
+        TermKind::Declaration(_, _, ValueState::Known(body_id), Some(ref idents)) => {
+            for ident in idents {
+                path.push(ident.clone())
+            }
             find_fields_from_term_kind(body_id, path, &info)
         }
         TermKind::RecordField {
@@ -443,8 +445,10 @@ fn collect_record_info(
             match (&item.kind, ty) {
                 // Get record fields from static type info
                 (_, Types(TypeF::Record(rrows))) => find_fields_from_rrows(&rrows, path, &info),
-                (TermKind::Declaration(_, _, ValueState::Known(body_id), Some(ident)), _) => {
-                    path.push(ident.clone());
+                (TermKind::Declaration(_, _, ValueState::Known(body_id), Some(idents)), _) => {
+                    for ident in idents {
+                        path.push(ident.clone())
+                    }
                     find_fields_from_term_kind(*body_id, path, &info)
                 }
                 (

--- a/lsp/nls/src/requests/completion.rs
+++ b/lsp/nls/src/requests/completion.rs
@@ -168,7 +168,7 @@ fn find_fields_from_term_kind(
         }
         TermKind::Declaration {
             value: ValueState::Known(body_id),
-            pattern_bindings: Some(ref idents),
+            path: Some(ref idents),
             ..
         } => {
             for ident in idents {
@@ -456,7 +456,7 @@ fn collect_record_info(
                 (
                     TermKind::Declaration {
                         value: ValueState::Known(body_id),
-                        pattern_bindings: Some(idents),
+                        path: Some(idents),
                         ..
                     },
                     _,
@@ -937,7 +937,7 @@ mod tests {
                 id: Ident::from("a"),
                 usages: vec![ItemId { file_id, index: 3 }],
                 value: ValueState::Known(ItemId { file_id, index: 1 }),
-                pattern_bindings: None,
+                path: None,
             },
             None,
         );
@@ -957,7 +957,7 @@ mod tests {
                 id: Ident::from("d"),
                 usages: Vec::new(),
                 value: ValueState::Known(ItemId { file_id, index: 4 }),
-                pattern_bindings: None,
+                path: None,
             },
             None,
         );
@@ -984,7 +984,7 @@ mod tests {
                 id: Ident::from("a"),
                 usages: Vec::new(),
                 value: ValueState::Known(ItemId { file_id, index: 1 }),
-                pattern_bindings: None,
+                path: None,
             },
             None,
         );
@@ -1005,7 +1005,7 @@ mod tests {
                 id: Ident::from("d"),
                 usages: Vec::new(),
                 value: ValueState::Known(ItemId { file_id, index: 13 }),
-                pattern_bindings: None,
+                path: None,
             },
             None,
         );
@@ -1015,7 +1015,7 @@ mod tests {
                 id: Ident::from("e"),
                 usages: Vec::new(),
                 value: ValueState::Known(ItemId { file_id, index: 14 }),
-                pattern_bindings: None,
+                path: None,
             },
             None,
         );
@@ -1025,7 +1025,7 @@ mod tests {
                 id: Ident::from("f"),
                 usages: Vec::new(),
                 value: ValueState::Known(ItemId { file_id, index: 15 }),
-                pattern_bindings: None,
+                path: None,
             },
             None,
         );
@@ -1074,7 +1074,7 @@ mod tests {
                 id: Ident::from("a"),
                 usages: Vec::new(),
                 value: ValueState::Known(ItemId { file_id, index: 1 }),
-                pattern_bindings: None,
+                path: None,
             },
             None,
         );

--- a/lsp/nls/src/requests/completion.rs
+++ b/lsp/nls/src/requests/completion.rs
@@ -170,7 +170,7 @@ fn find_fields_from_term_kind(
             value: ValueState::Known(new_id),
             ..
         }
-        | TermKind::Declaration(_, _, ValueState::Known(new_id)) => {
+        | TermKind::Declaration(_, _, ValueState::Known(new_id), _) => {
             find_fields_from_term_kind(new_id, path, info)
         }
         TermKind::Usage(UsageState::Resolved(new_id)) => {
@@ -197,7 +197,7 @@ fn find_fields_from_contract(
     match &item.metadata {
         Some(metadata) => find_fields_from_contracts(&metadata.annotation, path, info),
         None => match item.kind {
-            TermKind::Declaration(_, _, ValueState::Known(new_id))
+            TermKind::Declaration(_, _, ValueState::Known(new_id), _)
             | TermKind::RecordField {
                 value: ValueState::Known(new_id),
                 ..
@@ -440,7 +440,7 @@ fn collect_record_info(
                 // Get record fields from static type info
                 (_, Types(TypeF::Record(rrows))) => find_fields_from_rrows(&rrows, path, &info),
                 (
-                    TermKind::Declaration(_, _, ValueState::Known(body_id))
+                    TermKind::Declaration(_, _, ValueState::Known(body_id), _)
                     | TermKind::RecordField {
                         value: ValueState::Known(body_id),
                         ..
@@ -599,7 +599,7 @@ fn get_completion_identifiers(
                     .get_in_scope(item, &server.lin_cache)
                     .iter()
                     .filter_map(|i| match i.kind {
-                        TermKind::Declaration(ident, _, _)
+                        TermKind::Declaration(ident, _, _, _)
                         | TermKind::RecordField { ident, .. } => Some(IdentWithType {
                             ident,
                             meta: item.metadata.clone(),
@@ -907,6 +907,7 @@ mod tests {
                 Ident::from("a"),
                 vec![ItemId { file_id, index: 3 }],
                 ValueState::Known(ItemId { file_id, index: 1 }),
+                false,
             ),
             None,
         );
@@ -926,6 +927,7 @@ mod tests {
                 Ident::from("d"),
                 Vec::new(),
                 ValueState::Known(ItemId { file_id, index: 4 }),
+                false,
             ),
             None,
         );
@@ -952,6 +954,7 @@ mod tests {
                 Ident::from("a"),
                 Vec::new(),
                 ValueState::Known(ItemId { file_id, index: 1 }),
+                false,
             ),
             None,
         );
@@ -972,6 +975,7 @@ mod tests {
                 Ident::from("d"),
                 Vec::new(),
                 ValueState::Known(ItemId { file_id, index: 13 }),
+                false,
             ),
             None,
         );
@@ -981,6 +985,7 @@ mod tests {
                 Ident::from("e"),
                 Vec::new(),
                 ValueState::Known(ItemId { file_id, index: 14 }),
+                false,
             ),
             None,
         );
@@ -990,6 +995,7 @@ mod tests {
                 Ident::from("f"),
                 Vec::new(),
                 ValueState::Known(ItemId { file_id, index: 15 }),
+                false,
             ),
             None,
         );
@@ -1038,6 +1044,7 @@ mod tests {
                 Ident::from("a"),
                 Vec::new(),
                 ValueState::Known(ItemId { file_id, index: 1 }),
+                false,
             ),
             None,
         );

--- a/lsp/nls/src/requests/completion.rs
+++ b/lsp/nls/src/requests/completion.rs
@@ -166,6 +166,10 @@ fn find_fields_from_term_kind(
                 }
             }
         }
+        TermKind::Declaration(ident, _, ValueState::Known(body_id), true) => {
+            path.push(ident.clone());
+            find_fields_from_term_kind(body_id, path, &info)
+        }
         TermKind::RecordField {
             value: ValueState::Known(new_id),
             ..
@@ -439,6 +443,10 @@ fn collect_record_info(
             match (&item.kind, ty) {
                 // Get record fields from static type info
                 (_, Types(TypeF::Record(rrows))) => find_fields_from_rrows(&rrows, path, &info),
+                (TermKind::Declaration(ident, _, ValueState::Known(body_id), true), _) => {
+                    path.push(ident.clone());
+                    find_fields_from_term_kind(*body_id, path, &info)
+                }
                 (
                     TermKind::Declaration(_, _, ValueState::Known(body_id), _)
                     | TermKind::RecordField {

--- a/lsp/nls/src/requests/goto.rs
+++ b/lsp/nls/src/requests/goto.rs
@@ -123,7 +123,7 @@ pub fn handle_to_usages(
     debug!("found referencing item: {:?}", item);
 
     let locations: Option<Vec<Location>> = match &item.kind {
-        TermKind::Declaration(_, usages, _, _) | TermKind::RecordField { usages, .. } => Some(
+        TermKind::Declaration { usages, .. } | TermKind::RecordField { usages, .. } => Some(
             usages
                 .iter()
                 .filter_map(|reference_id| {

--- a/lsp/nls/src/requests/goto.rs
+++ b/lsp/nls/src/requests/goto.rs
@@ -123,7 +123,7 @@ pub fn handle_to_usages(
     debug!("found referencing item: {:?}", item);
 
     let locations: Option<Vec<Location>> = match &item.kind {
-        TermKind::Declaration(_, usages, _) | TermKind::RecordField { usages, .. } => Some(
+        TermKind::Declaration(_, usages, _, _) | TermKind::RecordField { usages, .. } => Some(
             usages
                 .iter()
                 .filter_map(|reference_id| {

--- a/lsp/nls/src/requests/symbols.rs
+++ b/lsp/nls/src/requests/symbols.rs
@@ -25,7 +25,7 @@ pub fn handle_document_symbols(
             .linearization
             .iter()
             .filter_map(|item| match &item.kind {
-                TermKind::Declaration(name, _, _, _) => {
+                TermKind::Declaration { id: name, .. } => {
                     // TODO: can `unwrap` fail here?
                     let (file_id, span) = item.pos.unwrap().to_range();
 

--- a/lsp/nls/src/requests/symbols.rs
+++ b/lsp/nls/src/requests/symbols.rs
@@ -25,7 +25,7 @@ pub fn handle_document_symbols(
             .linearization
             .iter()
             .filter_map(|item| match &item.kind {
-                TermKind::Declaration(name, _, _) => {
+                TermKind::Declaration(name, _, _, _) => {
                     // TODO: can `unwrap` fail here?
                     let (file_id, span) = item.pos.unwrap().to_range();
 

--- a/src/destruct.rs
+++ b/src/destruct.rs
@@ -172,7 +172,6 @@ impl Match {
 
                 inner.chain(outer).collect()
             }
-            Match::Assign(_id, _m, (_, _d @ Destruct::Array { .. })) => unimplemented!(),
         }
     }
 }

--- a/src/destruct.rs
+++ b/src/destruct.rs
@@ -134,7 +134,7 @@ impl Match {
     /// Returns info about each variable bound in a particular pattern.
     /// It also tells the "path" to the bound variable; this is just the
     /// record field names traversed to get to a pattern.
-    pub fn as_pattern_info(self) -> Vec<(Vec<Ident>, Option<Ident>, Field)> {
+    pub fn as_flattened_bindings(self) -> Vec<(Vec<Ident>, Option<Ident>, Field)> {
         match self {
             Match::Simple(id, field) => vec![(vec![id], None, field)],
             Match::Assign(id, field, (bind_id, Destruct::Empty)) => {
@@ -156,7 +156,7 @@ impl Match {
 
                 let inner = matches
                     .iter()
-                    .flat_map(|m| m.clone().as_pattern_info())
+                    .flat_map(|m| m.clone().as_flattened_bindings())
                     .map(|(mut path, bind, field)| {
                         path.push(id);
                         (path, bind, field)


### PR DESCRIPTION
Currently, we can't get completion on variables bound by pattern matching, e.g:
```nickel
let {a, ..} = {a.b = 10 } in 
a[.]
```

With this change, we support completion for all variables (apart from variables bound by "rest" patterns) bound by a pattern deconstruction. This will work for both "context completion" and record completion. e.g:
```nickel 
let {Config, ..} = import "lib.ncl" in 
{
   data | Config = {
      [.]
   }
} 
```

Closes #1011