### PR TITLE
add the `or <default>` form for a field access in Nix

### DIFF
--- a/tests/nix/records.nix
+++ b/tests/nix/records.nix
@@ -9,4 +9,11 @@
   ({ a.foo = 1; } ? "a.foo" == false)
   ({ a.foo = 1; } ? "a".foo == true)
   ({ a.foo = 1; } ? a == true)
+
+  # field access or default
+  ({ a = "a"; }.a or "x" == "a")
+  ({ a = "a"; }.b or "x" == "x")
+  ({ a.b = "ab"; }.a or "x" == { b = "ab"; })
+  ({ a.b = "ab"; }.a.b or "x" == "ab")
+  ({ a.b = "ab"; }.a.c or "x" == "x")
 ]


### PR DESCRIPTION
Add the syntax for the or default of Nix:

```
builtins.fold or localfold
```
which will return `builtins.fold` if `builtins` effectively contains a field named `fold`. If not, it will return the term on the RHS of `or`, in this case ``localfold`.

We transform it to Nickel with the composition of an other feature "has_field_path" from the compat library and a simple if then else.