### PR TITLE
Support completion for field names inside recursive records.

### DIFF
--- a/lsp/nls/src/requests/completion.rs
+++ b/lsp/nls/src/requests/completion.rs
@@ -561,7 +561,8 @@ fn get_completion_identifiers(
                     .get_in_scope(item, &server.lin_cache)
                     .iter()
                     .filter_map(|i| match i.kind {
-                        TermKind::Declaration(ident, _, _) => Some(IdentWithType {
+                        TermKind::Declaration(ident, _, _)
+                        | TermKind::RecordField { ident, .. } => Some(IdentWithType {
                             ident,
                             item: Some(item.clone()),
                             ty: ty.clone(),


### PR DESCRIPTION
Implements item 4 in #877 

As a consequence of this change, we get completion on stdlib names (such as `string`, `array`, `contracts`, etc), because they are record field names which are in scope.