### PR TITLE
Remove redundant check for "indirect" nested record usage.

### DIFF
--- a/lsp/nls/src/linearization/building.rs
+++ b/lsp/nls/src/linearization/building.rs
@@ -233,36 +233,6 @@ impl<'b> Building<'b> {
                     _ => None,
                 });
 
-            let referenced_declaration =
-                referenced_declaration.and_then(|(id, referenced)| match &referenced {
-                    TermKind::Usage(UsageState::Resolved(pointed)) => {
-                        self.get_item_kind_with_id(current_file, *pointed)
-                    }
-                    TermKind::RecordField { value, .. } => value
-                        // retrieve record
-                        .as_option()
-                        .and_then(|value_index| self.get_item_kind(current_file, value_index))
-                        // retrieve field
-                        .and_then(|record| match &record {
-                            TermKind::Record(fields) => {
-                                debug!(
-                                    "parent referenced a nested record indirectly`: {:?}",
-                                    fields
-                                );
-                                fields.get(child_ident).and_then(|accessor_id| {
-                                    self.get_item_kind_with_id(current_file, *accessor_id)
-                                })
-                            }
-                            TermKind::Usage(UsageState::Resolved(pointed)) => {
-                                self.get_item_kind_with_id(current_file, *pointed)
-                            }
-                            _ => None,
-                        })
-                        .or(Some((id, referenced))),
-
-                    _ => Some((id, referenced)),
-                });
-
             let referenced_id = referenced_declaration.map(|(id, _)| *id);
 
             debug!(


### PR DESCRIPTION
This fixes an issue where the LSP crashes if you try to reference a field which has a value of `Import(..)`, and the import refers to a record.  

i.e, if you have this: 
```nickel
let foo = {
  S3Backend = import "./aws-s3-backend.ncl",
}
foo.S3Backend
```
And `import "./aws-s3-backend.ncl"`, has a record term as its value.  What causes the crash exactly is  resolving the  `foo.S3Backend` field reference.

See [here](https://github.com/tweag/tf-ncl-examples/blob/lsp-crash/aws/main.tf.ncl) for the example that caused this crash.