### PR TITLE
tutorial: use a different code fence to allow nesting in an example

### DIFF
--- a/doc/manual/tutorial.md
+++ b/doc/manual/tutorial.md
@@ -233,10 +233,8 @@ the command: `nickel -f users-contract.ncl doc -o /dev/stdout`
 
 You should obtain the following output in your terminal:
 
-<!-- markdownlint-disable MD031 -->
-<!-- markdownlint-disable MD040 -->
-
-```nickel
+<!-- markdownlint-disable MD048 MD031 MD040 -->
+~~~nickel
 # `UserSchema`
 
 ## `extra-groups`
@@ -260,10 +258,9 @@ Name of the user
 ## `ssh-keys`
 
 List of ssh-keys in OpenSSH-specific format
-```
+~~~
 
-<!-- markdownlint-enable MD031 -->
-<!-- markdownlint-enable MD040 -->
+<!-- markdownlint-enable MD048 MD031 MD040 -->
 
 Please note that we used `-o /dev/stdout` in the example above to display
 the result in the terminal. Otherwise, `nickel -f users-contract.ncl doc`


### PR DESCRIPTION
the current rendering on gatsby is wrong, we need to use different code fences to not mix them.