### PR TITLE
Fix completion on terms annotated with more than one contract

### DIFF
--- a/lsp/nls/src/requests/completion.rs
+++ b/lsp/nls/src/requests/completion.rs
@@ -131,7 +131,9 @@ fn find_fields_from_term_kind(
     let Some(item) = linearization.get_item(id, lin_cache) else {
         return Vec::new()
     };
-    match item.kind {
+    let mut path_clone = path.clone();
+    let contract_result = find_fields_from_contract(item.id, &mut path_clone, info);
+    let result = match item.kind {
         TermKind::Record(ref fields) => {
             if path.is_empty() {
                 fields
@@ -176,11 +178,9 @@ fn find_fields_from_term_kind(
         TermKind::Usage(UsageState::Resolved(new_id)) => {
             find_fields_from_term_kind(new_id, path, info)
         }
-        _ if item.metadata.is_some() => {
-            find_fields_from_contracts(&item.metadata.as_ref().unwrap().annotation, path, info)
-        }
         _ => Vec::new(),
-    }
+    };
+    result.into_iter().chain(contract_result).collect()
 }
 
 /// Find the record fields associated with an ID in the linearization using

--- a/lsp/nls/src/requests/completion.rs
+++ b/lsp/nls/src/requests/completion.rs
@@ -441,11 +441,11 @@ fn collect_record_info(
                 ) => {
                     // The path is mutable, so the first case would consume the path
                     // so we have to clone it so that it can be correctly used for the second case.
-                    let mut p = path.clone();
-                    let mut fst = find_fields_from_contract(*body_id, path, &info);
-                    let snd = find_fields_from_term_kind(*body_id, &mut p, &info);
-                    fst.extend(snd);
-                    fst
+                    let mut path_copy = path.clone();
+                    find_fields_from_contract(*body_id, path, &info)
+                        .into_iter()
+                        .chain(find_fields_from_term_kind(*body_id, &mut path_copy, &info))
+                        .collect()
                 }
                 _ => Vec::new(),
             }

--- a/lsp/nls/src/requests/completion.rs
+++ b/lsp/nls/src/requests/completion.rs
@@ -221,13 +221,15 @@ fn find_fields_from_contracts(
             let mut path_copy = path.clone();
             match &contract.types {
                 Types(TypeF::Record(row)) => find_fields_from_type(row, &mut path_copy, info),
-                Types(TypeF::Dict(ty)) => {
-                    if let (Types(TypeF::Flat(term)), Some(_)) = (&**ty, path_copy.pop()) {
+                Types(TypeF::Dict(ty)) => match (&**ty, path_copy.pop()) {
+                    (Types(TypeF::Flat(term)), Some(_)) => {
                         find_fields_from_term(term, &mut path_copy, info)
-                    } else {
-                        Vec::new()
                     }
-                }
+                    (Types(TypeF::Record(rrows)), Some(_)) => {
+                        find_fields_from_type(rrows, &mut path_copy, info)
+                    }
+                    _ => Vec::new(),
+                },
                 Types(TypeF::Flat(term)) => find_fields_from_term(term, &mut path_copy, info),
                 _ => Vec::new(),
             }

--- a/lsp/nls/src/requests/completion.rs
+++ b/lsp/nls/src/requests/completion.rs
@@ -217,17 +217,20 @@ fn find_fields_from_contracts(
 ) -> Vec<IdentWithType> {
     annot
         .iter()
-        .flat_map(|contract| match &contract.types {
-            Types(TypeF::Record(row)) => find_fields_from_type(row, path, info),
-            Types(TypeF::Dict(ty)) => {
-                if let (Types(TypeF::Flat(term)), Some(_)) = (&**ty, path.pop()) {
-                    find_fields_from_term(term, path, info)
-                } else {
-                    Vec::new()
+        .flat_map(|contract| {
+            let mut path_copy = path.clone();
+            match &contract.types {
+                Types(TypeF::Record(row)) => find_fields_from_type(row, &mut path_copy, info),
+                Types(TypeF::Dict(ty)) => {
+                    if let (Types(TypeF::Flat(term)), Some(_)) = (&**ty, path_copy.pop()) {
+                        find_fields_from_term(term, &mut path_copy, info)
+                    } else {
+                        Vec::new()
+                    }
                 }
+                Types(TypeF::Flat(term)) => find_fields_from_term(term, &mut path_copy, info),
+                _ => Vec::new(),
             }
-            Types(TypeF::Flat(term)) => find_fields_from_term(term, path, info),
-            _ => Vec::new(),
         })
         .collect()
 }


### PR DESCRIPTION
Depends on #990 

Currently, if we have the Nickel program below and we want to perform "context completion" inside the record, we only get correct completion identifiers from one of the contract.  
```nickel
let Client = import "client.ncl" in 
let Server = import "server.ncl" in 
{

   [.]

} | Client | Server

```

With this change, we get correct completion identifiers for all the contracts present. 
