### PR TITLE
flake: filter .github and .vscode dirs

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -166,7 +166,15 @@
           snapFilter = mkFilter ".*snap$";
         in
         pkgs.lib.cleanSourceWith {
-          src = pkgs.lib.cleanSource ./.;
+          # Exclude paths that would trigger unnecessary rebuilds
+          src = pkgs.lib.cleanSourceWith {
+            src = pkgs.lib.cleanSource ./.;
+
+            filter = path: _type:
+              let basename = builtins.baseNameOf path; in
+
+              basename != ".github" && basename != ".vscode";
+          };
 
           # Combine our custom filters with the default one from Crane
           # See https://github.com/ipetkov/crane/blob/master/docs/API.md#libfiltercargosources


### PR DESCRIPTION
Prevents them from being copied to the store, and triggering rebuilds.