### PR TITLE
ci: cancel previously running jobs

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -5,6 +5,9 @@ on:
       - master
   pull_request:
 
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build-and-test:


### PR DESCRIPTION
I'm not sure if this is the desired behaviour on master, but it definitely seems like the right thing to do on feature branches.