### PR TITLE
Improve location of interpolation type errors

### DIFF
--- a/src/eval/mod.rs
+++ b/src/eval/mod.rs
@@ -102,7 +102,7 @@ pub mod stack;
 use callstack::*;
 use codespan::FileId;
 use operation::OperationCont;
-use stack::Stack;
+use stack::{Stack, StrAccData};
 
 use self::cache::{Cache, CacheIndex};
 
@@ -509,7 +509,12 @@ impl<R: ImportResolver, C: Cache> VirtualMachine<R, C> {
                             };
 
                             self.stack.push_str_chunks(chunks_iter.cloned());
-                            self.stack.push_str_acc(String::new(), indent, env.clone());
+                            self.stack.push_str_acc(StrAccData {
+                                acc: String::new(),
+                                env: env.clone(),
+                                curr_indent: indent,
+                                curr_pos: arg.pos,
+                            });
 
                             Closure {
                                 body: RichTerm::new(Term::Op1(UnaryOp::ChunksConcat(), arg), pos),


### PR DESCRIPTION
Closes #891.

Carry an additional position when evaluating string interpolation to be able to rightfully blame interpolated expressions that don't evaluate to a string. The error of the above issue is now:

```
error: type error
  ┌─ repl-input-0:1:28
  │
1 │ let n = 5 in "The number %{n}."
  │         -                  ^ this expression has type Num, but String was expected
  │         │                   
  │         evaluated to this
  │
  = interpolated string
```

As a future improvement, we could actually have a specific error variant, that would also point to the whole string, or at least give a useful note as to why this error happens.