### PR TITLE
Compile benchmarks via Nix

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -56,9 +56,5 @@ jobs:
       run: |
         nix flake check --print-build-logs
 
-    - name: Compile and typecheck benchmarks
-      run: |
-        nix develop
-        cargo bench --no-run
-
-        find benches -type f -name "*.ncl" -print0 | xargs -0 -I file nix run . -- -f file typecheck
+    - name: Typecheck benchmarks
+      run: find benches -type f -name "*.ncl" -print0 | xargs -0 -I file nix run . -- -f file typecheck

--- a/flake.nix
+++ b/flake.nix
@@ -222,9 +222,7 @@
 
             pnameSuffix = "-bench";
 
-            buildPhaseCargoCommand = ''
-              cargo bench --no-run
-            '';
+            buildPhaseCargoCommand = "cargo bench";
 
             doCheck = false;
             doInstallCargoArtifacts = false;
@@ -393,6 +391,7 @@
       packages = {
         inherit (mkCraneArtifacts { })
           nickel
+          benchmarks
           lsp-nls;
         default = pkgs.buildEnv {
           name = "nickel";
@@ -424,8 +423,10 @@
           nickel
           lsp-nls
           clippy
-          benchmarks
           rustfmt;
+        compileBenchmarks = (mkCraneArtifacts { }).benchmarks.overrideAttrs (old: {
+          buildPhase = "cargo bench --no-run";
+        });
         # An optimizing release build is long: eschew optimizations in checks by
         # building a dev profile
         nickelWasm = buildNickelWasm { profile = "dev"; };

--- a/flake.nix
+++ b/flake.nix
@@ -217,6 +217,19 @@
           nickel = buildPackage "nickel-lang";
           lsp-nls = buildPackage "nickel-lang-lsp";
 
+          benchmarks = craneLib.mkCargoDerivation {
+            inherit src cargoArtifacts;
+
+            pnameSuffix = "-bench";
+
+            buildPhaseCargoCommand = ''
+              cargo bench --no-run
+            '';
+
+            doCheck = false;
+            doInstallCargoArtifacts = false;
+          };
+
           rustfmt = craneLib.cargoFmt {
             # Notice that unlike other Crane derivations, we do not pass `cargoArtifacts` to `cargoFmt`, because it does not need access to dependencies to format the code.
             inherit src;
@@ -411,6 +424,7 @@
           nickel
           lsp-nls
           clippy
+          benchmarks
           rustfmt;
         # An optimizing release build is long: eschew optimizations in checks by
         # building a dev profile

--- a/flake.nix
+++ b/flake.nix
@@ -226,7 +226,6 @@
               cargo bench ${pkgs.lib.optionalString noRunBench "--no-run"}
             '';
 
-            doCheck = false;
             doInstallCargoArtifacts = false;
           };
 


### PR DESCRIPTION
This should speed up CI runs, as it reuses what's already been built and cached, and exploits build parallelism.

I've separated `cargo build` and `cargo build --no-run` in the second commit. The idea is that `cargo build` (which is available as `.#benchmarks`) could be used in the [benchmarking workflow](https://github.com/tweag/nickel/blob/master/.github/workflows/run-benchmark.yaml) (although it would require patching/forking [`criterion-compare-action`](https://github.com/boa-dev/criterion-compare-action)). Happy to revert in case of YAGNI.

Follow-up to #1104