### PR TITLE
Remove `MergePriority` from all LSP outputs

### DIFF
--- a/lsp/nls/src/linearization/completed.rs
+++ b/lsp/nls/src/linearization/completed.rs
@@ -158,10 +158,7 @@ impl Completed {
         };
 
         if let Some(FieldMetadata {
-            doc,
-            annotation,
-            priority,
-            ..
+            doc, annotation, ..
         }) = item.metadata.as_ref()
         {
             if let Some(doc) = doc {
@@ -173,8 +170,6 @@ impl Completed {
             if let Some(contracts) = annotation.contracts_to_string() {
                 extra.push(contracts);
             }
-
-            extra.push(format!("Merge Priority: {:?}", priority));
         }
 
         (item.ty.to_owned(), extra)

--- a/lsp/nls/src/requests/completion.rs
+++ b/lsp/nls/src/requests/completion.rs
@@ -98,7 +98,7 @@ impl IdentWithType {
             let doc = meta.doc.as_ref()?;
             let doc = Documentation::MarkupContent(MarkupContent {
                 kind: MarkupKind::Markdown,
-                value: format!("{}\nMerge Priority {}", doc.clone(), meta.priority),
+                value: doc.clone(),
             });
             Some(doc)
         };


### PR DESCRIPTION
Currently, when the LSP provides a list of completion identifiers, it displays types, contracts, documentation, and the merge priority along with each identifier. The merge priority doesn't not add any information required for interactive program development, so I think we should remove it.