### PR TITLE
direnv: init .envrc file

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake


### PR DESCRIPTION
Uses [nix-direnv](https://github.com/nix-community/nix-direnv) to automatically enter `nix develop` shell on `cd`.