### PR TITLE
Non-exported record fields

### DIFF
--- a/lsp/nls/src/requests/completion.rs
+++ b/lsp/nls/src/requests/completion.rs
@@ -1049,6 +1049,7 @@ mod tests {
                 contracts: Vec::new(),
             },
             opt: false,
+            not_exported: false,
             priority: MergePriority::Neutral,
         };
 

--- a/src/eval/merge.rs
+++ b/src/eval/merge.rs
@@ -432,6 +432,8 @@ fn merge_fields<'a, C: Cache, I: DoubleEndedIterator<Item = &'a Ident> + Clone>(
         // If one of the record requires this field, then it musn't be optional. The
         // resulting field is optional iff both are.
         opt: metadata1.opt && metadata2.opt,
+        // The resulting field will be suppressed from serialization if either of the fields to be merged is.
+        not_exported: metadata1.not_exported || metadata2.not_exported,
         priority,
     };
 

--- a/src/parser/grammar.lalrpop
+++ b/src/parser/grammar.lalrpop
@@ -149,6 +149,10 @@ SimpleFieldAnnotAtom<TypeRule>: FieldMetadata = {
         opt: true,
         ..Default::default()
     },
+    "|" "not_exported" => FieldMetadata {
+        not_exported: true,
+        ..Default::default()
+    },
 }
 
 // A single field metadata annotation.
@@ -1009,6 +1013,7 @@ extern {
         "doc" => Token::Normal(NormalToken::Doc),
         "optional" => Token::Normal(NormalToken::Optional),
         "priority" => Token::Normal(NormalToken::Priority),
+        "not_exported" => Token::Normal(NormalToken::NotExported),
 
         "hash" => Token::Normal(NormalToken::OpHash),
         "serialize" => Token::Normal(NormalToken::Serialize),

--- a/src/parser/lexer.rs
+++ b/src/parser/lexer.rs
@@ -263,6 +263,8 @@ pub enum NormalToken<'input> {
     Priority,
     #[token("force")]
     Force,
+    #[token("not_exported")]
+    NotExported,
 
     #[token("%hash%")]
     OpHash,

--- a/src/parser/uniterm.rs
+++ b/src/parser/uniterm.rs
@@ -189,6 +189,7 @@ impl UniRecord {
                                     contracts,
                                 },
                             opt: false,
+                            not_exported: false,
                             priority: MergePriority::Neutral,
                         },
                     // At this stage, this field should always be empty. It's a run-time thing, and

--- a/src/serialize.rs
+++ b/src/serialize.rs
@@ -103,7 +103,7 @@ where
     S: Serializer,
 {
     let mut entries = record
-        .iter_without_opts()
+        .iter_serializable()
         .collect::<Result<Vec<_>, _>>()
         .map_err(|missing_def_err| {
             Error::custom(format!(
@@ -195,7 +195,7 @@ pub fn validate(format: ExportFormat, t: &RichTerm) -> Result<(), SerializationE
             Null => Err(SerializationError::UnsupportedNull(format, t.clone())),
             Bool(_) | Num(_) | Str(_) | Enum(_) => Ok(()),
             Record(record) => {
-                record.iter_without_opts().try_for_each(|binding| {
+                record.iter_serializable().try_for_each(|binding| {
                     // unwrap(): terms must be fully evaluated before being validated for
                     // serialization. Otherwise, it's an internal error.
                     let (_, rt) = binding.unwrap_or_else(|err| panic!("encountered field without definition `{}` during pre-serialization validation", err.id));
@@ -427,10 +427,10 @@ mod tests {
             json!({"baz": {"subfoo": true, "subbar": 0}})
         );
 
-        // assert_json_eq!(
-        //     "{a = {b | default = {}} & {b.c | not_exported = false} & {b.d = true}}",
-        //     json!({"a": {"b": {"d": true}}})
-        // );
+        assert_json_eq!(
+            "{a = {b | default = {}} & {b.c | not_exported = false} & {b.d = true}}",
+            json!({"a": {"b": {"d": true}}})
+        );
     }
 
     #[test]

--- a/src/serialize.rs
+++ b/src/serialize.rs
@@ -426,6 +426,11 @@ mod tests {
             "{baz | default = {subfoo | default = !false} & {subbar | default = 1 - 1}}",
             json!({"baz": {"subfoo": true, "subbar": 0}})
         );
+
+        // assert_json_eq!(
+        //     "{a = {b | default = {}} & {b.c | not_exported = false} & {b.d = true}}",
+        //     json!({"a": {"b": {"d": true}}})
+        // );
     }
 
     #[test]

--- a/src/term/record.rs
+++ b/src/term/record.rs
@@ -83,6 +83,8 @@ pub struct FieldMetadata {
     pub annotation: TypeAnnotation,
     /// If the field is optional.
     pub opt: bool,
+    /// If the field is serialized.
+    pub not_exported: bool,
     pub priority: MergePriority,
 }
 
@@ -133,6 +135,7 @@ impl FieldMetadata {
                 contracts: outer.annotation.contracts,
             },
             opt: outer.opt || inner.opt,
+            not_exported: outer.not_exported || inner.not_exported,
             priority,
         }
     }


### PR DESCRIPTION
This PR adds a `not_exported` field to record field metadata along with syntax to set it to true. The field is set to `false` by default and a metadata annotation in a record like
```nickel
{
  foo = 1,
  bar | not_exported = 2,
}
```
will set it to `true`. Upon merging it infects everything, i.e. when a field marked as `not_exported` is merged with any other field, the result will be `not_exported`.