### PR TITLE
Add not_exported to the list of KEYWORDS

### DIFF
--- a/src/parser/lexer.rs
+++ b/src/parser/lexer.rs
@@ -336,9 +336,31 @@ pub enum NormalToken<'input> {
 }
 
 pub const KEYWORDS: &[&str] = &[
-    "Dyn", "Num", "Bool", "Str", "Array", "if", "then", "else", "forall", "in", "let", "rec",
-    "match", "null", "true", "false", "fun", "import", "merge", "default", "doc", "optional",
-    "priority", "force",
+    "Dyn",
+    "Num",
+    "Bool",
+    "Str",
+    "Array",
+    "if",
+    "then",
+    "else",
+    "forall",
+    "in",
+    "let",
+    "rec",
+    "match",
+    "null",
+    "true",
+    "false",
+    "fun",
+    "import",
+    "merge",
+    "default",
+    "doc",
+    "optional",
+    "priority",
+    "force",
+    "not_exported",
 ];
 
 #[derive(Debug, Clone, PartialEq)]


### PR DESCRIPTION
I forgot to add `not_exported` to the list `KEYWORDS`, that I introduced for the pretty printer 🤦.