### PR TITLE
[Fix] Fix query command in the REPL

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -410,11 +410,6 @@ pub enum ReplError {
         cmd: repl::command::CommandType,
         msg_opt: Option<String>,
     },
-    InvalidArg {
-        cmd: repl::command::CommandType,
-        argument: String,
-        expected_format: String,
-    },
     InvalidQueryPath(ParseError),
 }
 
@@ -1755,24 +1750,12 @@ impl ToDiagnostic<FileId> for ReplError {
         files: &mut Files<String>,
         contract_id: Option<FileId>,
     ) -> Vec<Diagnostic<FileId>> {
-        const AVAILABLE_CMDS_NOTE: &str = "type `:?` or `:help` for a list of available commands.";
-        let mk_cmd_help_note =
-            |cmd| format!("type `:? {cmd}` or `:help {cmd}` for more information.");
-
         match self {
             ReplError::UnknownCommand(s) => vec![Diagnostic::error()
                 .with_message(format!("unknown command `{s}`"))
-                .with_notes(vec![String::from(AVAILABLE_CMDS_NOTE)])],
-            ReplError::InvalidArg {
-                cmd,
-                argument,
-                expected_format,
-            } => vec![Diagnostic::error()
-                .with_message(format!("invalid argument `{argument}` to command `{cmd}`"))
-                .with_notes(vec![
-                    format!("{cmd} expects this argument to be a {expected_format}."),
-                    mk_cmd_help_note(cmd),
-                ])],
+                .with_notes(vec![String::from(
+                    "type `:?` or `:help` for a list of available commands.",
+                )])],
             ReplError::InvalidQueryPath(err) => err.to_diagnostic(files, contract_id),
             ReplError::MissingArg { cmd, msg_opt } => {
                 let mut notes = msg_opt

--- a/src/repl/command.rs
+++ b/src/repl/command.rs
@@ -13,6 +13,12 @@ pub enum CommandType {
     Exit,
 }
 
+impl CommandType {
+    pub fn all() -> Vec<&'static str> {
+        vec!["load", "typecheck", "query", "print", "help", "exit"]
+    }
+}
+
 /// A parsed command with corresponding argument(s). Required argument are checked for
 /// non-emptiness.
 #[derive(Clone, Eq, PartialEq, Debug)]

--- a/src/repl/command.rs
+++ b/src/repl/command.rs
@@ -25,7 +25,10 @@ impl CommandType {
 pub enum Command {
     Load(OsString),
     Typecheck(String),
-    Query(String),
+    Query {
+        target: String,
+        path: Option<String>,
+    },
     Print(String),
     Help(Option<String>),
     Exit,
@@ -127,7 +130,22 @@ impl FromStr for Command {
             }
             CommandType::Query => {
                 require_arg(cmd, &arg, None)?;
-                Ok(Command::Query(arg))
+                let mut args_iter = arg.chars();
+
+                let first_arg = args_iter.by_ref().take_while(|c| *c != ' ').collect();
+                let rest = args_iter.collect::<String>();
+                let rest = rest.trim();
+
+                let path = if !rest.is_empty() {
+                    Some(String::from(rest))
+                } else {
+                    None
+                };
+
+                Ok(Command::Query {
+                    target: first_arg,
+                    path,
+                })
             }
             CommandType::Print => {
                 require_arg(cmd, &arg, None)?;
@@ -154,7 +172,7 @@ impl Command {
         match self {
             Load(..) => CommandType::Load,
             Typecheck(..) => CommandType::Typecheck,
-            Query(..) => CommandType::Query,
+            Query { .. } => CommandType::Query,
             Print(..) => CommandType::Print,
             Help(..) => CommandType::Help,
             Exit => CommandType::Exit,

--- a/src/repl/mod.rs
+++ b/src/repl/mod.rs
@@ -426,9 +426,15 @@ pub fn print_help(out: &mut impl Write, arg: Option<&str>) -> std::io::Result<()
                 )?;
             }
             Ok(c @ CommandType::Query) => {
-                writeln!(out, ":{c} <expression>")?;
+                writeln!(out, ":{c} <identifier> [field path]")?;
                 print_aliases(out, c)?;
-                writeln!(out, "Print the metadata attached to an attribute")?;
+                writeln!(out, "Print the metadata attached to a field")?;
+                writeln!(
+                    out,
+                    "<identifier> is valid Nickel identifier representing the record to look into."
+                )?;
+                writeln!(out, "<field path> is a dot-separated sequence of identifiers pointing to a field.\n")?;
+                writeln!(out, "Example: `:{c} mylib contracts.\"special#chars\".bar`")?;
             }
             Ok(c @ CommandType::Load) => {
                 writeln!(out, ":{c} <file>")?;
@@ -459,7 +465,11 @@ pub fn print_help(out: &mut impl Write, arg: Option<&str>) -> std::io::Result<()
             }
             Err(UnknownCommandError {}) => {
                 writeln!(out, "Unknown command `{arg}`.")?;
-                writeln!(out, "Available commands: ? help query load typecheck")?;
+                writeln!(
+                    out,
+                    "Available commands: ? {}",
+                    CommandType::all().join(" ")
+                )?;
             }
         };
 

--- a/src/repl/rustyline_frontend.rs
+++ b/src/repl/rustyline_frontend.rs
@@ -89,7 +89,7 @@ pub fn repl(histfile: PathBuf, color_opt: ColorOpt) -> Result<(), InitError> {
                     Ok(Command::Typecheck(exp)) => {
                         repl.typecheck(&exp).map(|types| println!("Ok: {types}"))
                     }
-                    Ok(Command::Query(exp)) => repl.query(&exp).map(|field| {
+                    Ok(Command::Query {target, path}) => repl.query(target, path).map(|field| {
                         query_print::write_query_result(
                             &mut stdout,
                             &field,

--- a/src/repl/simple_frontend.rs
+++ b/src/repl/simple_frontend.rs
@@ -49,7 +49,7 @@ pub fn input<R: Repl>(repl: &mut R, line: &str) -> Result<InputResult, InputErro
                 .typecheck(&exp)
                 .map(|types| InputResult::Success(format!("Ok: {}", types)))
                 .map_err(InputError::from),
-            Ok(Command::Query(exp)) => repl
+            Ok(Command::Query { target, path }) => repl
                 .query(&exp)
                 .map(|t| {
                     let mut buffer = Cursor::new(Vec::<u8>::new());

--- a/src/repl/simple_frontend.rs
+++ b/src/repl/simple_frontend.rs
@@ -50,7 +50,7 @@ pub fn input<R: Repl>(repl: &mut R, line: &str) -> Result<InputResult, InputErro
                 .map(|types| InputResult::Success(format!("Ok: {}", types)))
                 .map_err(InputError::from),
             Ok(Command::Query { target, path }) => repl
-                .query(&exp)
+                .query(target, path)
                 .map(|t| {
                     let mut buffer = Cursor::new(Vec::<u8>::new());
                     query_print::write_query_result(


### PR DESCRIPTION
Closes #1115.

After the implementation of RFC005, the structure of metadata queries have changed. Before, one could simply query an arbitrary value. Now that metadata are attached to record fields only, the user must provide a base record (or expression) as well as a path pointing to a field. This commit fix the previously broken metadata queries for the REPL by updating to this new interface.