### PR TITLE
[Refactor] Add a position field to types in the AST

### DIFF
--- a/lsp/nls/src/linearization/mod.rs
+++ b/lsp/nls/src/linearization/mod.rs
@@ -563,8 +563,8 @@ impl<'a> Linearizer for AnalysisHost<'a> {
             });
 
         fn transform_wildcard(wildcars: &[Types], t: Types) -> Types {
-            match t {
-                Types(TypeF::Wildcard(i)) => wildcars.get(i).unwrap_or(&t).clone(),
+            match t.ty {
+                TypeF::Wildcard(i) => wildcars.get(i).unwrap_or(&t).clone(),
                 _ => t,
             }
         }

--- a/lsp/nls/src/linearization/mod.rs
+++ b/lsp/nls/src/linearization/mod.rs
@@ -562,9 +562,9 @@ impl<'a> Linearizer for AnalysisHost<'a> {
                 id_mapping.insert(*id, index);
             });
 
-        fn transform_wildcard(wildcars: &[Types], t: Types) -> Types {
+        fn transform_wildcard(wildcards: &[Types], t: Types) -> Types {
             match t.ty {
-                TypeF::Wildcard(i) => wildcars.get(i).unwrap_or(&t).clone(),
+                TypeF::Wildcard(i) => wildcards.get(i).unwrap_or(&t).clone(),
                 _ => t,
             }
         }

--- a/lsp/nls/src/linearization/mod.rs
+++ b/lsp/nls/src/linearization/mod.rs
@@ -563,7 +563,7 @@ impl<'a> Linearizer for AnalysisHost<'a> {
             });
 
         fn transform_wildcard(wildcards: &[Types], t: Types) -> Types {
-            match t.ty {
+            match t.types {
                 TypeF::Wildcard(i) => wildcards.get(i).unwrap_or(&t).clone(),
                 _ => t,
             }

--- a/lsp/nls/src/requests/completion.rs
+++ b/lsp/nls/src/requests/completion.rs
@@ -731,10 +731,7 @@ mod tests {
             env: Environment::new(),
             id,
             pos: TermPos::None,
-            ty: Types {
-                ty: TypeF::Dyn,
-                pos: TermPos::None,
-            },
+            ty: Types::with_default_pos(TypeF::Dyn),
             kind,
             metadata,
         }

--- a/lsp/nls/src/requests/completion.rs
+++ b/lsp/nls/src/requests/completion.rs
@@ -57,7 +57,7 @@ impl From<&str> for IdentWithType {
     fn from(ident: &str) -> Self {
         IdentWithType {
             ident: Ident::from(ident),
-            ty: Types::with_default_post(TypeF::Dyn),
+            ty: Types::with_default_pos(TypeF::Dyn),
             meta: None,
         }
     }

--- a/lsp/nls/src/requests/completion.rs
+++ b/lsp/nls/src/requests/completion.rs
@@ -336,10 +336,7 @@ fn find_fields_from_term(
                     ident: *ident,
                     // This Dyn type is only displayed if the metadata's
                     // contract or type annotation is not present.
-                    ty: Types {
-                        ty: TypeF::Dyn,
-                        pos: TermPos::None,
-                    },
+                    ty: Types::with_default_pos(TypeF::Dyn),
                     meta: Some(field.metadata.clone()),
                 })
                 .collect(),

--- a/lsp/nls/src/requests/completion.rs
+++ b/lsp/nls/src/requests/completion.rs
@@ -10,7 +10,6 @@ use lsp_types::{
 };
 use nickel_lang::{
     identifier::Ident,
-    position::TermPos,
     term::{
         record::{Field, FieldMetadata},
         RichTerm, Term, TypeAnnotation, UnaryOp,

--- a/lsp/nls/src/requests/completion.rs
+++ b/lsp/nls/src/requests/completion.rs
@@ -58,10 +58,7 @@ impl From<&str> for IdentWithType {
     fn from(ident: &str) -> Self {
         IdentWithType {
             ident: Ident::from(ident),
-            ty: Types {
-                ty: TypeF::Dyn,
-                pos: TermPos::None,
-            },
+            ty: Types::with_default_post(TypeF::Dyn),
             meta: None,
         }
     }

--- a/lsp/nls/src/requests/completion.rs
+++ b/lsp/nls/src/requests/completion.rs
@@ -48,10 +48,7 @@ impl From<Ident> for IdentWithType {
     fn from(ident: Ident) -> Self {
         IdentWithType {
             ident,
-            ty: Types {
-                ty: TypeF::Dyn,
-                pos: TermPos::None,
-            },
+            ty: Types::with_default_pos(TypeF::Dyn),
             meta: None,
         }
     }

--- a/lsp/nls/src/requests/completion.rs
+++ b/lsp/nls/src/requests/completion.rs
@@ -246,7 +246,7 @@ fn find_fields_from_type(
     path: &mut Vec<Ident>,
     info @ ComplCtx { .. }: &'_ ComplCtx<'_>,
 ) -> Vec<IdentWithType> {
-    match &ty.ty {
+    match &ty.types {
         TypeF::Record(row) => find_fields_from_rrows(row, path, info),
         TypeF::Dict(ty) => match path.pop() {
             Some(..) => find_fields_from_type(ty, path, info),
@@ -271,11 +271,11 @@ fn find_fields_from_rrows(
 
         match type_of_current {
             Some(Types {
-                ty: TypeF::Record(rrows_current),
+                types: TypeF::Record(rrows_current),
                 ..
             }) => find_fields_from_rrows(&rrows_current, path, info),
             Some(Types {
-                ty: TypeF::Flat(term),
+                types: TypeF::Flat(term),
                 ..
             }) => find_fields_from_term(&term, path, info),
             _ => Vec::new(),
@@ -453,7 +453,7 @@ fn collect_record_info(
         .get_item(id, lin_cache)
         .map(|item| {
             let (ty, _) = linearization.resolve_item_type_meta(item, lin_cache);
-            match (&item.kind, &ty.ty) {
+            match (&item.kind, &ty.types) {
                 // Get record fields from static type info
                 (_, TypeF::Record(rrows)) => find_fields_from_rrows(rrows, path, &info),
                 (

--- a/lsp/nls/src/requests/completion.rs
+++ b/lsp/nls/src/requests/completion.rs
@@ -10,6 +10,7 @@ use lsp_types::{
 };
 use nickel_lang::{
     identifier::Ident,
+    position::TermPos,
     term::{
         record::{Field, FieldMetadata},
         RichTerm, Term, TypeAnnotation, UnaryOp,
@@ -47,7 +48,10 @@ impl From<Ident> for IdentWithType {
     fn from(ident: Ident) -> Self {
         IdentWithType {
             ident,
-            ty: Types(TypeF::Dyn),
+            ty: Types {
+                ty: TypeF::Dyn,
+                pos: TermPos::None,
+            },
             meta: None,
         }
     }
@@ -57,7 +61,10 @@ impl From<&str> for IdentWithType {
     fn from(ident: &str) -> Self {
         IdentWithType {
             ident: Ident::from(ident),
-            ty: Types(TypeF::Dyn),
+            ty: Types {
+                ty: TypeF::Dyn,
+                pos: TermPos::None,
+            },
             meta: None,
         }
     }
@@ -246,13 +253,13 @@ fn find_fields_from_type(
     path: &mut Vec<Ident>,
     info @ ComplCtx { .. }: &'_ ComplCtx<'_>,
 ) -> Vec<IdentWithType> {
-    match ty {
-        Types(TypeF::Record(row)) => find_fields_from_rrows(row, path, info),
-        Types(TypeF::Dict(ty)) => match path.pop() {
+    match &ty.ty {
+        TypeF::Record(row) => find_fields_from_rrows(row, path, info),
+        TypeF::Dict(ty) => match path.pop() {
             Some(..) => find_fields_from_type(ty, path, info),
             _ => Vec::new(),
         },
-        Types(TypeF::Flat(term)) => find_fields_from_term(term, path, info),
+        TypeF::Flat(term) => find_fields_from_term(term, path, info),
         _ => Vec::new(),
     }
 }
@@ -270,10 +277,14 @@ fn find_fields_from_rrows(
         });
 
         match type_of_current {
-            Some(Types(TypeF::Record(rrows_current))) => {
-                find_fields_from_rrows(&rrows_current, path, info)
-            }
-            Some(Types(TypeF::Flat(term))) => find_fields_from_term(&term, path, info),
+            Some(Types {
+                ty: TypeF::Record(rrows_current),
+                ..
+            }) => find_fields_from_rrows(&rrows_current, path, info),
+            Some(Types {
+                ty: TypeF::Flat(term),
+                ..
+            }) => find_fields_from_term(&term, path, info),
             _ => Vec::new(),
         }
     } else {
@@ -331,7 +342,10 @@ fn find_fields_from_term(
                     ident: *ident,
                     // This Dyn type is only displayed if the metadata's
                     // contract or type annotation is not present.
-                    ty: Types(TypeF::Dyn),
+                    ty: Types {
+                        ty: TypeF::Dyn,
+                        pos: TermPos::None,
+                    },
                     meta: Some(field.metadata.clone()),
                 })
                 .collect(),
@@ -449,9 +463,9 @@ fn collect_record_info(
         .get_item(id, lin_cache)
         .map(|item| {
             let (ty, _) = linearization.resolve_item_type_meta(item, lin_cache);
-            match (&item.kind, ty) {
+            match (&item.kind, &ty.ty) {
                 // Get record fields from static type info
-                (_, Types(TypeF::Record(rrows))) => find_fields_from_rrows(&rrows, path, &info),
+                (_, TypeF::Record(rrows)) => find_fields_from_rrows(&rrows, path, &info),
                 (
                     TermKind::Declaration {
                         value: ValueState::Known(body_id),
@@ -726,7 +740,10 @@ mod tests {
             env: Environment::new(),
             id,
             pos: TermPos::None,
-            ty: Types(TypeF::Dyn),
+            ty: Types {
+                ty: TypeF::Dyn,
+                pos: TermPos::None,
+            },
             kind,
             metadata,
         }

--- a/lsp/nls/src/requests/completion.rs
+++ b/lsp/nls/src/requests/completion.rs
@@ -465,7 +465,7 @@ fn collect_record_info(
             let (ty, _) = linearization.resolve_item_type_meta(item, lin_cache);
             match (&item.kind, &ty.ty) {
                 // Get record fields from static type info
-                (_, TypeF::Record(rrows)) => find_fields_from_rrows(&rrows, path, &info),
+                (_, TypeF::Record(rrows)) => find_fields_from_rrows(rrows, path, &info),
                 (
                     TermKind::Declaration {
                         value: ValueState::Known(body_id),

--- a/lsp/nls/src/requests/completion.rs
+++ b/lsp/nls/src/requests/completion.rs
@@ -47,7 +47,7 @@ impl From<Ident> for IdentWithType {
     fn from(ident: Ident) -> Self {
         IdentWithType {
             ident,
-            ty: Types::with_default_pos(TypeF::Dyn),
+            ty: Types::from(TypeF::Dyn),
             meta: None,
         }
     }
@@ -57,7 +57,7 @@ impl From<&str> for IdentWithType {
     fn from(ident: &str) -> Self {
         IdentWithType {
             ident: Ident::from(ident),
-            ty: Types::with_default_pos(TypeF::Dyn),
+            ty: Types::from(TypeF::Dyn),
             meta: None,
         }
     }
@@ -335,7 +335,7 @@ fn find_fields_from_term(
                     ident: *ident,
                     // This Dyn type is only displayed if the metadata's
                     // contract or type annotation is not present.
-                    ty: Types::with_default_pos(TypeF::Dyn),
+                    ty: Types::from(TypeF::Dyn),
                     meta: Some(field.metadata.clone()),
                 })
                 .collect(),
@@ -730,7 +730,7 @@ mod tests {
             env: Environment::new(),
             id,
             pos: TermPos::None,
-            ty: Types::with_default_pos(TypeF::Dyn),
+            ty: Types::from(TypeF::Dyn),
             kind,
             metadata,
         }

--- a/src/destructuring.rs
+++ b/src/destructuring.rs
@@ -4,7 +4,7 @@
 use crate::{
     identifier::Ident,
     label::Label,
-    position::RawSpan,
+    position::{RawSpan, TermPos},
     term::{
         record::{Field, RecordAttrs, RecordData},
         LabeledType, Term,
@@ -66,16 +66,19 @@ impl RecordPattern {
 
     fn into_contract_with_lbl(self, label: Label) -> LabeledType {
         let is_open = self.is_open();
-
+        let pos = TermPos::Original(self.span);
         LabeledType {
-            types: Types(TypeF::Flat(
-                Term::Record(RecordData::new(
-                    self.inner().into_iter().map(Match::as_binding).collect(),
-                    RecordAttrs { open: is_open },
-                    None,
-                ))
-                .into(),
-            )),
+            types: Types {
+                ty: TypeF::Flat(
+                    Term::Record(RecordData::new(
+                        self.inner().into_iter().map(Match::as_binding).collect(),
+                        RecordAttrs { open: is_open },
+                        None,
+                    ))
+                    .into(),
+                ),
+                pos,
+            },
             label,
         }
     }

--- a/src/destructuring.rs
+++ b/src/destructuring.rs
@@ -69,7 +69,7 @@ impl RecordPattern {
         let pos = TermPos::Original(self.span);
         LabeledType {
             types: Types {
-                ty: TypeF::Flat(
+                types: TypeF::Flat(
                     Term::Record(RecordData::new(
                         self.inner().into_iter().map(Match::as_binding).collect(),
                         RecordAttrs { open: is_open },

--- a/src/error.rs
+++ b/src/error.rs
@@ -1550,13 +1550,13 @@ impl IntoDiagnostics<FileId> for TypecheckError {
             ,
             TypecheckError::TypeMismatch(expd, actual, span_opt) => {
                 fn addendum(ty: &Types) -> &str {
-                    if ty.0.is_flat() {
+                    if ty.ty.is_flat() {
                         " (a contract)"
                     } else {
                         ""
                     }
                 }
-                let last_note = if expd.0.is_flat() ^ actual.0.is_flat() {
+                let last_note = if expd.ty.is_flat() ^ actual.ty.is_flat() {
                     "Static types and contracts are not compatible"
                 } else {
                     "These types are not compatible"
@@ -1609,7 +1609,7 @@ impl IntoDiagnostics<FileId> for TypecheckError {
                 let row_msg = |word, field, ty| format!("The type of the expression was {word} to have the row `{field}: {ty}`");
                 let default_msg = |word, ty| format!("The type of the expression was {word} to be `{ty}`");
 
-                let note1 = if let TypeF::Record(rrows) = &expd.0 {
+                let note1 = if let TypeF::Record(rrows) = &expd.ty {
                     match rrows.row_find_path(path.as_slice()) {
                         Some(ty) => row_msg("expected", &field, ty),
                         None => default_msg("expected", &expd),
@@ -1618,7 +1618,7 @@ impl IntoDiagnostics<FileId> for TypecheckError {
                     default_msg("expected", &expd)
                 };
 
-                let note2 = if let TypeF::Record(rrows) = &actual.0 {
+                let note2 = if let TypeF::Record(rrows) = &actual.ty {
                     match rrows.row_find_path(path.as_slice()) {
                         Some(ty) => row_msg("inferred", &field, ty),
                         None => default_msg("inferred", &expd),

--- a/src/error.rs
+++ b/src/error.rs
@@ -1550,13 +1550,13 @@ impl IntoDiagnostics<FileId> for TypecheckError {
             ,
             TypecheckError::TypeMismatch(expd, actual, span_opt) => {
                 fn addendum(ty: &Types) -> &str {
-                    if ty.ty.is_flat() {
+                    if ty.types.is_flat() {
                         " (a contract)"
                     } else {
                         ""
                     }
                 }
-                let last_note = if expd.ty.is_flat() ^ actual.ty.is_flat() {
+                let last_note = if expd.types.is_flat() ^ actual.types.is_flat() {
                     "Static types and contracts are not compatible"
                 } else {
                     "These types are not compatible"
@@ -1609,7 +1609,7 @@ impl IntoDiagnostics<FileId> for TypecheckError {
                 let row_msg = |word, field, ty| format!("The type of the expression was {word} to have the row `{field}: {ty}`");
                 let default_msg = |word, ty| format!("The type of the expression was {word} to be `{ty}`");
 
-                let note1 = if let TypeF::Record(rrows) = &expd.ty {
+                let note1 = if let TypeF::Record(rrows) = &expd.types {
                     match rrows.row_find_path(path.as_slice()) {
                         Some(ty) => row_msg("expected", &field, ty),
                         None => default_msg("expected", &expd),
@@ -1618,7 +1618,7 @@ impl IntoDiagnostics<FileId> for TypecheckError {
                     default_msg("expected", &expd)
                 };
 
-                let note2 = if let TypeF::Record(rrows) = &actual.ty {
+                let note2 = if let TypeF::Record(rrows) = &actual.types {
                     match rrows.row_find_path(path.as_slice()) {
                         Some(ty) => row_msg("inferred", &field, ty),
                         None => default_msg("inferred", &expd),

--- a/src/label.rs
+++ b/src/label.rs
@@ -138,7 +138,7 @@ pub mod ty_path {
         // peek() returns a reference, and hence keeps a mutable borrow of `path_it` which forbids
         // to call to next() in the same region. This is why we need to split the match in two
         // different blocks.
-        let forall_offset = match (&ty.ty, path_it.peek()) {
+        let forall_offset = match (&ty.types, path_it.peek()) {
             (_, None) => {
                 let repr = format!("{ty}");
                 return PathSpan {
@@ -151,7 +151,7 @@ pub mod ty_path {
             (TypeF::Forall { .. }, Some(_)) => {
                 // The length of "forall" plus the final separating dot and whitespace ". "
                 let mut result = 8;
-                while let TypeF::Forall { var, body, .. } = &ty.ty {
+                while let TypeF::Forall { var, body, .. } = &ty.types {
                     // The length of the identifier plus the preceding whitespace
                     result += var.to_string().len() + 1;
                     ty = body.as_ref();
@@ -162,7 +162,7 @@ pub mod ty_path {
             _ => 0,
         };
 
-        match (&ty.ty, path_it.next()) {
+        match (&ty.types, path_it.next()) {
             (TypeF::Arrow(dom, codom), Some(next)) => {
                 // The potential shift of the start position of the domain introduced by the couple
                 // of parentheses around the domain. Parentheses are added when printing a function
@@ -170,7 +170,7 @@ pub mod ty_path {
                 // For example, `Arrow(Arrow(Num, Num), Num)` is rendered as "(Num -> Num) -> Num".
                 // In this case, the position of the sub-type "Num -> Num" starts at 1 instead of
                 // 0.
-                let paren_offset = match dom.ty {
+                let paren_offset = match dom.types {
                     TypeF::Arrow(_, _) => 1,
                     _ => 0,
                 };
@@ -251,7 +251,7 @@ but this field doesn't exist in {}",
                     Types::from(TypeF::Record(rows.clone())),
                 )
             }
-            (TypeF::Array(ty), Some(Elem::Array)) if ty.as_ref().ty == TypeF::Dyn =>
+            (TypeF::Array(ty), Some(Elem::Array)) if ty.as_ref().types == TypeF::Dyn =>
             // Dyn shouldn't be the target of any blame
             {
                 panic!("span(): unexpected blame of a dyn contract inside an array")

--- a/src/label.rs
+++ b/src/label.rs
@@ -249,10 +249,7 @@ pub mod ty_path {
                     "span: current type path element indicates to go to field `{}`,\
 but this field doesn't exist in {}",
                     ident,
-                    Types {
-                        ty: TypeF::Record(rows.clone()),
-                        pos: TermPos::None
-                    }
+                    Types::with_default_pos(TypeF::Record(rows.clone())),
                 )
             }
             (TypeF::Array(ty), Some(Elem::Array)) if ty.as_ref().ty == TypeF::Dyn =>

--- a/src/label.rs
+++ b/src/label.rs
@@ -477,15 +477,9 @@ impl Label {
 impl Default for Label {
     fn default() -> Label {
         Label {
-<<<<<<< HEAD
-            types: Rc::new(Types(TypeF::Dyn)),
-=======
-            types: Rc::new(Types {
-                ty: TypeF::Dyn,
-                pos: TermPos::None,
-            }),
-            tag: "".to_string(),
->>>>>>> bedbab36 (Add `pos` field to all `Type`, and fix for all modules.)
+
+
+            types: Rc::new(Types::from(TypeF::Dyn)),
             span: RawSpan {
                 src_id: Files::new().add("<null>", String::from("")),
                 start: 0.into(),

--- a/src/label.rs
+++ b/src/label.rs
@@ -48,7 +48,6 @@ pub mod ty_path {
 
     use crate::{
         identifier::Ident,
-        position::TermPos,
         types::{RecordRowF, RecordRowsIteratorItem, TypeF, Types},
     };
 

--- a/src/label.rs
+++ b/src/label.rs
@@ -248,7 +248,7 @@ pub mod ty_path {
                     "span: current type path element indicates to go to field `{}`,\
 but this field doesn't exist in {}",
                     ident,
-                    Types::with_default_pos(TypeF::Record(rows.clone())),
+                    Types::from(TypeF::Record(rows.clone())),
                 )
             }
             (TypeF::Array(ty), Some(Elem::Array)) if ty.as_ref().ty == TypeF::Dyn =>

--- a/src/label.rs
+++ b/src/label.rs
@@ -477,8 +477,6 @@ impl Label {
 impl Default for Label {
     fn default() -> Label {
         Label {
-
-
             types: Rc::new(Types::from(TypeF::Dyn)),
             span: RawSpan {
                 src_id: Files::new().add("<null>", String::from("")),

--- a/src/parser/grammar.lalrpop
+++ b/src/parser/grammar.lalrpop
@@ -863,10 +863,10 @@ NOpPre<ArgRule>: UniTerm = {
 }
 
 TypeBuiltin: Types = {
-    <l: @L> "Dyn" <r: @R> => Types { ty: TypeF::Dyn, pos: mk_pos(src_id, l, r) },
-    <l: @L> "Num" <r: @R>  => Types { ty: TypeF::Num, pos: mk_pos(src_id, l, r) },
-    <l: @L> "Bool" <r: @R>  => Types { ty: TypeF::Bool, pos: mk_pos(src_id, l, r) },
-    <l: @L> "Str" <r: @R>  => Types { ty: TypeF::Str, pos: mk_pos(src_id, l, r) },
+    <l: @L> "Dyn" <r: @R> => Types { types: TypeF::Dyn, pos: mk_pos(src_id, l, r) },
+    <l: @L> "Num" <r: @R>  => Types { types: TypeF::Num, pos: mk_pos(src_id, l, r) },
+    <l: @L> "Bool" <r: @R>  => Types { types: TypeF::Bool, pos: mk_pos(src_id, l, r) },
+    <l: @L> "Str" <r: @R>  => Types { types: TypeF::Str, pos: mk_pos(src_id, l, r) },
 }
 
 TypeAtom: Types = {
@@ -889,12 +889,12 @@ TypeAtom: Types = {
                 |erows, row| EnumRows(EnumRowsF::Extend { row, tail: Box::new(erows) })
             );
         let pos = mk_pos(src_id, l, r);
-        Types { ty: TypeF::Enum(ty), pos }
+        Types { types: TypeF::Enum(ty), pos }
     },
     <l: @L> "{" "_" ":" <t: WithPos<Types>> "}" <r: @R> => {  
         let pos = mk_pos(src_id, l, r);
         Types { 
-            ty:TypeF::Dict(Box::new(t)), 
+            types:TypeF::Dict(Box::new(t)), 
             pos, 
         } 
     },
@@ -903,7 +903,7 @@ TypeAtom: Types = {
         *next_wildcard_id += 1;
         let pos = mk_pos(src_id, l, r);
         Types {
-            ty: TypeF::Wildcard(id), 
+            types: TypeF::Wildcard(id), 
             pos, 
         }
     },

--- a/src/parser/grammar.lalrpop
+++ b/src/parser/grammar.lalrpop
@@ -821,7 +821,7 @@ InfixExpr: UniTerm = {
     InfixLazyBOpApp<InfixLazyBOp10, InfixExpr, InfixExpr>,
 
     #[precedence(level="11")] #[assoc(side="right")]
-    <s: WithPos<AsType<InfixExpr>>> "->" <t: WithPos<AsType<InfixExpr>>> =>
+    <s: AsType<InfixExpr>> "->" <t: AsType<InfixExpr>> =>
         UniTerm::from(Types::from(TypeF::Arrow(Box::new(s), Box::new(t)))),
 }
 

--- a/src/parser/grammar.lalrpop
+++ b/src/parser/grammar.lalrpop
@@ -298,7 +298,7 @@ Applicative: UniTerm = {
 };
 
 // The parametrized array type.
-TypeArray: Types = "Array" <t: WithPos<<AsType<RecordOperand>>>> =>
+TypeArray: Types = "Array" <t: AsType<RecordOperand>> =>
     Types::from(TypeF::Array(Box::new(t)));
 
 RecordOperand: UniTerm = {

--- a/src/parser/grammar.lalrpop
+++ b/src/parser/grammar.lalrpop
@@ -259,7 +259,7 @@ Forall: Types =
             // The variable kind will be determined during the `fix_type_vars`
             // phase. For now, we put a random one (which is also the default
             // one, for unused type variables)
-            |acc, var| Types::with_default_pos(TypeF::Forall { var, var_kind: VarKind::Type, body: Box::new(acc) })
+            |acc, var| Types::from(TypeF::Forall { var, var_kind: VarKind::Type, body: Box::new(acc) })
         )
     };
 

--- a/src/parser/grammar.lalrpop
+++ b/src/parser/grammar.lalrpop
@@ -259,7 +259,7 @@ Forall: Types =
             // The variable kind will be determined during the `fix_type_vars`
             // phase. For now, we put a random one (which is also the default
             // one, for unused type variables)
-            |acc, var| Types(TypeF::Forall { var, var_kind: VarKind::Type, body: Box::new(acc) })
+            |acc, var| Types::with_default_pos(TypeF::Forall { var, var_kind: VarKind::Type, body: Box::new(acc) })
         )
     };
 
@@ -298,8 +298,15 @@ Applicative: UniTerm = {
 };
 
 // The parametrized array type.
-TypeArray: Types = "Array" <AsType<RecordOperand>> =>
-    Types(TypeF::Array(Box::new(<>)));
+TypeArray: Types = {
+     <l: @L> "Array" <t: AsType<RecordOperand>>  <r: @R> => {
+        let pos = mk_pos(src_id, l, r);
+        Types {
+            ty: TypeF::Array(Box::new(t)),
+            pos, 
+        }
+    }
+};
 
 RecordOperand: UniTerm = {
     Atom,
@@ -821,8 +828,14 @@ InfixExpr: UniTerm = {
     InfixLazyBOpApp<InfixLazyBOp10, InfixExpr, InfixExpr>,
 
     #[precedence(level="11")] #[assoc(side="right")]
-    <s: AsType<InfixExpr>> "->" <t: AsType<InfixExpr>> =>
-        UniTerm::from(Types(TypeF::Arrow(Box::new(s), Box::new(t)))),
+    <l: @L> <s: AsType<InfixExpr>> "->" <t: AsType<InfixExpr>> <r: @R> =>
+       {
+            let pos = mk_pos(src_id, l, r);
+            UniTerm::from(Types {
+                ty:TypeF::Arrow(Box::new(s), Box::new(t)), 
+                pos,
+            })
+        }
 }
 
 BOpPre: BinaryOp = {
@@ -863,15 +876,15 @@ NOpPre<ArgRule>: UniTerm = {
 }
 
 TypeBuiltin: Types = {
-    "Dyn" => Types(TypeF::Dyn),
-    "Num" => Types(TypeF::Num),
-    "Bool" => Types(TypeF::Bool),
-    "Str" => Types(TypeF::Str),
+    <l: @L> "Dyn" <r: @R> => Types { ty: TypeF::Dyn, pos: mk_pos(src_id, l, r) },
+    <l: @L> "Num" <r: @R>  => Types { ty: TypeF::Num, pos: mk_pos(src_id, l, r) },
+    <l: @L> "Bool" <r: @R>  => Types { ty: TypeF::Bool, pos: mk_pos(src_id, l, r) },
+    <l: @L> "Str" <r: @R>  => Types { ty: TypeF::Str, pos: mk_pos(src_id, l, r) },
 }
 
 TypeAtom: Types = {
     <TypeBuiltin>,
-    "[|" <rows:(<EnumTag> ",")*> <last: (<EnumTag>)?> <tail: (";" <Ident>)?> "|]" => {
+    <l: @L> "[|" <rows:(<EnumTag> ",")*> <last: (<EnumTag>)?> <tail: (";" <Ident>)?> "|]" <r: @R> => {
         let ty = rows.into_iter()
             .chain(last.into_iter())
             // As we build row types as a linked list via a fold on the original
@@ -888,13 +901,24 @@ TypeAtom: Types = {
                 ),
                 |erows, row| EnumRows(EnumRowsF::Extend { row, tail: Box::new(erows) })
             );
-        Types(TypeF::Enum(ty))
+        let pos = mk_pos(src_id, l, r);
+        Types { ty: TypeF::Enum(ty), pos }
     },
-    "{" "_" ":" <Types> "}" => Types(TypeF::Dict(Box::new(<>))),
-    "_" => {
+    <l: @L> "{" "_" ":" <t: Types> "}" <r: @R> => {  
+        let pos = mk_pos(src_id, l, r);
+        Types { 
+            ty:TypeF::Dict(Box::new(t)), 
+            pos, 
+        } 
+    },
+    <l: @L> "_" <r: @R> => {
         let id = *next_wildcard_id;
         *next_wildcard_id += 1;
-        Types(TypeF::Wildcard(id))
+        let pos = mk_pos(src_id, l, r);
+        Types {
+            ty: TypeF::Wildcard(id), 
+            pos, 
+        }
     },
 }
 

--- a/src/parser/grammar.lalrpop
+++ b/src/parser/grammar.lalrpop
@@ -367,7 +367,7 @@ Atom: UniTerm = {
 
         UniTerm::from(Term::Array(terms, Default::default()))
     },
-    AsUniTerm<TypeAtom>,
+    AsUniTerm<WithPos<TypeAtom>>,
 };
 
 // A record field definition. The is the only place where we don't fix the type
@@ -863,10 +863,10 @@ NOpPre<ArgRule>: UniTerm = {
 }
 
 TypeBuiltin: Types = {
-    <l: @L> "Dyn" <r: @R> => Types { types: TypeF::Dyn, pos: mk_pos(src_id, l, r) },
-    <l: @L> "Num" <r: @R>  => Types { types: TypeF::Num, pos: mk_pos(src_id, l, r) },
-    <l: @L> "Bool" <r: @R>  => Types { types: TypeF::Bool, pos: mk_pos(src_id, l, r) },
-    <l: @L> "Str" <r: @R>  => Types { types: TypeF::Str, pos: mk_pos(src_id, l, r) },
+     "Dyn" => Types::from(TypeF::Dyn),
+     "Num" => Types::from(TypeF::Num),
+     "Bool" => Types::from(TypeF::Bool),
+     "Str" => Types::from(TypeF::Str),
 }
 
 TypeAtom: Types = {

--- a/src/parser/grammar.lalrpop
+++ b/src/parser/grammar.lalrpop
@@ -299,6 +299,9 @@ Applicative: UniTerm = {
 
 // The parametrized array type.
 TypeArray: Types = "Array" <t: AsType<RecordOperand>> =>
+    // For some reason, we have to bind the type into a `t`
+    // rather than using the usual `<>` placeholder, otherwise,
+    // it doens't compile.
     Types::from(TypeF::Array(Box::new(t)));
 
 RecordOperand: UniTerm = {

--- a/src/parser/grammar.lalrpop
+++ b/src/parser/grammar.lalrpop
@@ -871,7 +871,7 @@ TypeBuiltin: Types = {
 
 TypeAtom: Types = {
     <TypeBuiltin>,
-    <l: @L> "[|" <rows:(<EnumTag> ",")*> <last: (<EnumTag>)?> <tail: (";" <Ident>)?> "|]" <r: @R> => {
+    "[|" <rows:(<EnumTag> ",")*> <last: (<EnumTag>)?> <tail: (";" <Ident>)?> "|]" => {
         let ty = rows.into_iter()
             .chain(last.into_iter())
             // As we build row types as a linked list via a fold on the original
@@ -888,24 +888,15 @@ TypeAtom: Types = {
                 ),
                 |erows, row| EnumRows(EnumRowsF::Extend { row, tail: Box::new(erows) })
             );
-        let pos = mk_pos(src_id, l, r);
-        Types { types: TypeF::Enum(ty), pos }
+ 	    Types::from(TypeF::Enum(ty))
     },
-    <l: @L> "{" "_" ":" <t: WithPos<Types>> "}" <r: @R> => {  
-        let pos = mk_pos(src_id, l, r);
-        Types { 
-            types:TypeF::Dict(Box::new(t)), 
-            pos, 
-        } 
+    "{" "_" ":" <t: WithPos<Types>> "}" => {
+        Types::from(TypeF::Dict(Box::new(t)))
     },
-    <l: @L> "_" <r: @R> => {
+    "_" => {
         let id = *next_wildcard_id;
-        *next_wildcard_id += 1;
-        let pos = mk_pos(src_id, l, r);
-        Types {
-            types: TypeF::Wildcard(id), 
-            pos, 
-        }
+        *next_wildcard_id += 1;        
+        Types::from(TypeF::Wildcard(id))
     },
 }
 

--- a/src/parser/grammar.lalrpop
+++ b/src/parser/grammar.lalrpop
@@ -298,15 +298,8 @@ Applicative: UniTerm = {
 };
 
 // The parametrized array type.
-TypeArray: Types = {
-     <l: @L> "Array" <t: AsType<RecordOperand>>  <r: @R> => {
-        let pos = mk_pos(src_id, l, r);
-        Types {
-            ty: TypeF::Array(Box::new(t)),
-            pos, 
-        }
-    }
-};
+TypeArray: Types = "Array" <t: WithPos<<AsType<RecordOperand>>>> =>
+    Types::from(TypeF::Array(Box::new(t)));
 
 RecordOperand: UniTerm = {
     Atom,
@@ -828,14 +821,8 @@ InfixExpr: UniTerm = {
     InfixLazyBOpApp<InfixLazyBOp10, InfixExpr, InfixExpr>,
 
     #[precedence(level="11")] #[assoc(side="right")]
-    <l: @L> <s: AsType<InfixExpr>> "->" <t: AsType<InfixExpr>> <r: @R> =>
-       {
-            let pos = mk_pos(src_id, l, r);
-            UniTerm::from(Types {
-                ty:TypeF::Arrow(Box::new(s), Box::new(t)), 
-                pos,
-            })
-        }
+    <s: WithPos<AsType<InfixExpr>>> "->" <t: WithPos<AsType<InfixExpr>>> =>
+        UniTerm::from(Types::from(TypeF::Arrow(Box::new(s), Box::new(t)))),
 }
 
 BOpPre: BinaryOp = {
@@ -904,7 +891,7 @@ TypeAtom: Types = {
         let pos = mk_pos(src_id, l, r);
         Types { ty: TypeF::Enum(ty), pos }
     },
-    <l: @L> "{" "_" ":" <t: Types> "}" <r: @R> => {  
+    <l: @L> "{" "_" ":" <t: WithPos<Types>> "}" <r: @R> => {  
         let pos = mk_pos(src_id, l, r);
         Types { 
             ty:TypeF::Dict(Box::new(t)), 

--- a/src/parser/uniterm.rs
+++ b/src/parser/uniterm.rs
@@ -80,13 +80,13 @@ impl TryFrom<UniTerm> for Types {
     fn try_from(ut: UniTerm) -> Result<Self, ParseError> {
         match ut.node {
             UniTermNode::Var(id) => Ok(Types {
-                ty: TypeF::Var(id),
+                types: TypeF::Var(id),
                 pos: ut.pos,
             }),
             UniTermNode::Record(r) => Types::try_from(r),
             UniTermNode::Types(ty) => Ok(ty),
             UniTermNode::Term(rt) => Ok(Types {
-                ty: TypeF::Flat(rt),
+                types: TypeF::Flat(rt),
                 pos: ut.pos,
             }),
         }
@@ -275,7 +275,7 @@ impl UniRecord {
                 },
             )?;
         Ok(Types {
-            ty: TypeF::Record(rrows),
+            types: TypeF::Record(rrows),
             pos: self.pos,
         })
     }
@@ -351,7 +351,7 @@ impl TryFrom<UniRecord> for Types {
             let pos = ur.pos;
             ur.clone().into_type_strict().or_else(|_| {
                 RichTerm::try_from(ur).map(|rt| Types {
-                    ty: TypeF::Flat(rt),
+                    types: TypeF::Flat(rt),
                     pos,
                 })
             })
@@ -513,7 +513,7 @@ impl FixTypeVars for Types {
         mut bound_vars: BoundVarEnv,
         span: RawSpan,
     ) -> Result<(), ParseError> {
-        match self.ty {
+        match self.types {
             TypeF::Dyn
             | TypeF::Num
             | TypeF::Bool
@@ -533,7 +533,7 @@ impl FixTypeVars for Types {
                 } else {
                     let id = *id;
                     let pos = id.pos;
-                    self.ty = TypeF::Flat(RichTerm::new(Term::Var(id), pos));
+                    self.types = TypeF::Flat(RichTerm::new(Term::Var(id), pos));
                 }
                 Ok(())
             }

--- a/src/parser/uniterm.rs
+++ b/src/parser/uniterm.rs
@@ -135,9 +135,10 @@ impl From<Term> for UniTerm {
 
 impl From<Types> for UniTerm {
     fn from(ty: Types) -> Self {
+        let pos = ty.pos;
         UniTerm {
             node: UniTermNode::Types(ty),
-            pos: TermPos::None,
+            pos,
         }
     }
 }
@@ -347,10 +348,11 @@ impl TryFrom<UniRecord> for Types {
                     )
                 })
         } else {
+            let pos = ur.pos;
             ur.clone().into_type_strict().or_else(|_| {
                 RichTerm::try_from(ur).map(|rt| Types {
                     ty: TypeF::Flat(rt),
-                    pos: ur.pos,
+                    pos,
                 })
             })
         }

--- a/src/parser/uniterm.rs
+++ b/src/parser/uniterm.rs
@@ -79,10 +79,16 @@ impl TryFrom<UniTerm> for Types {
 
     fn try_from(ut: UniTerm) -> Result<Self, ParseError> {
         match ut.node {
-            UniTermNode::Var(id) => Ok(Types(TypeF::Var(id))),
+            UniTermNode::Var(id) => Ok(Types {
+                ty: TypeF::Var(id),
+                pos: ut.pos,
+            }),
             UniTermNode::Record(r) => Types::try_from(r),
             UniTermNode::Types(ty) => Ok(ty),
-            UniTermNode::Term(rt) => Ok(Types(TypeF::Flat(rt))),
+            UniTermNode::Term(rt) => Ok(Types {
+                ty: TypeF::Flat(rt),
+                pos: ut.pos,
+            }),
         }
     }
 }
@@ -267,7 +273,10 @@ impl UniRecord {
                     }
                 },
             )?;
-        Ok(Types(TypeF::Record(rrows)))
+        Ok(Types {
+            ty: TypeF::Record(rrows),
+            pos: self.pos,
+        })
     }
 
     pub fn with_pos(mut self, pos: TermPos) -> Self {
@@ -338,9 +347,12 @@ impl TryFrom<UniRecord> for Types {
                     )
                 })
         } else {
-            ur.clone()
-                .into_type_strict()
-                .or_else(|_| RichTerm::try_from(ur).map(|rt| Types(TypeF::Flat(rt))))
+            ur.clone().into_type_strict().or_else(|_| {
+                RichTerm::try_from(ur).map(|rt| Types {
+                    ty: TypeF::Flat(rt),
+                    pos: ur.pos,
+                })
+            })
         }
     }
 }
@@ -499,7 +511,7 @@ impl FixTypeVars for Types {
         mut bound_vars: BoundVarEnv,
         span: RawSpan,
     ) -> Result<(), ParseError> {
-        match self.0 {
+        match self.ty {
             TypeF::Dyn
             | TypeF::Num
             | TypeF::Bool
@@ -519,7 +531,7 @@ impl FixTypeVars for Types {
                 } else {
                     let id = *id;
                     let pos = id.pos;
-                    self.0 = TypeF::Flat(RichTerm::new(Term::Var(id), pos));
+                    self.ty = TypeF::Flat(RichTerm::new(Term::Var(id), pos));
                 }
                 Ok(())
             }

--- a/src/parser/utils.rs
+++ b/src/parser/utils.rs
@@ -317,7 +317,7 @@ pub fn combine_match_annots(
             let dummy_annot = TypeAnnotation {
                 contracts: vec![LabeledType {
                     types: Types {
-                        ty: TypeF::Dyn,
+                        types: TypeF::Dyn,
                         pos: TermPos::Original(span),
                     },
                     label: Label {

--- a/src/parser/utils.rs
+++ b/src/parser/utils.rs
@@ -316,7 +316,10 @@ pub fn combine_match_annots(
         (None, None) => {
             let dummy_annot = TypeAnnotation {
                 contracts: vec![LabeledType {
-                    types: Types(TypeF::Dyn),
+                    types: Types {
+                        ty: TypeF::Dyn,
+                        pos: TermPos::Original(span),
+                    },
                     label: Label {
                         span,
                         ..Default::default()

--- a/src/pretty.rs
+++ b/src/pretty.rs
@@ -796,7 +796,7 @@ where
 {
     fn pretty(self, allocator: &'a D) -> DocBuilder<'a, D, A> {
         use TypeF::*;
-        match self.0 {
+        match self.ty {
             Dyn => allocator.text("Dyn"),
             Num => allocator.text("Num"),
             Bool => allocator.text("Bool"),
@@ -816,7 +816,11 @@ where
             Forall { var, ref body, .. } => {
                 let mut curr = body.as_ref();
                 let mut foralls = vec![&var];
-                while let Types(Forall { var, ref body, .. }) = curr {
+                while let Types {
+                    ty: Forall { var, ref body, .. },
+                    ..
+                } = curr
+                {
                     foralls.push(var);
                     curr = body;
                 }
@@ -843,7 +847,7 @@ where
                 .append(ty.pretty(allocator))
                 .append(allocator.line())
                 .braces(),
-            Arrow(dom, codom) => match dom.0 {
+            Arrow(dom, codom) => match dom.ty {
                 Arrow(..) | Forall { .. } => dom
                     .pretty(allocator)
                     .parens()

--- a/src/pretty.rs
+++ b/src/pretty.rs
@@ -796,7 +796,7 @@ where
 {
     fn pretty(self, allocator: &'a D) -> DocBuilder<'a, D, A> {
         use TypeF::*;
-        match self.ty {
+        match self.types {
             Dyn => allocator.text("Dyn"),
             Num => allocator.text("Num"),
             Bool => allocator.text("Bool"),
@@ -817,7 +817,7 @@ where
                 let mut curr = body.as_ref();
                 let mut foralls = vec![&var];
                 while let Types {
-                    ty: Forall { var, ref body, .. },
+                    types: Forall { var, ref body, .. },
                     ..
                 } = curr
                 {
@@ -847,7 +847,7 @@ where
                 .append(ty.pretty(allocator))
                 .append(allocator.line())
                 .braces(),
-            Arrow(dom, codom) => match dom.ty {
+            Arrow(dom, codom) => match dom.types {
                 Arrow(..) | Forall { .. } => dom
                     .pretty(allocator)
                     .parens()

--- a/src/term/mod.rs
+++ b/src/term/mod.rs
@@ -1960,7 +1960,7 @@ mod tests {
 
         let inner = TypeAnnotation {
             types: Some(LabeledType {
-                types: Types(TypeF::Num),
+                types: Types::with_default_pos(TypeF::Num),
                 label: Label::dummy(),
             }),
             ..Default::default()

--- a/src/term/mod.rs
+++ b/src/term/mod.rs
@@ -1960,7 +1960,7 @@ mod tests {
 
         let inner = TypeAnnotation {
             types: Some(LabeledType {
-                types: Types::with_default_pos(TypeF::Num),
+                types: Types::from(TypeF::Num),
                 label: Label::dummy(),
             }),
             ..Default::default()

--- a/src/term/mod.rs
+++ b/src/term/mod.rs
@@ -615,7 +615,7 @@ impl Term {
             }
             Annotated(ref mut annot, ref mut t) => {
                 annot.iter_mut().for_each(|LabeledType { types, .. }| {
-                    if let TypeF::Flat(ref mut rt) = types.ty {
+                    if let TypeF::Flat(ref mut rt) = types.types {
                         func(rt)
                     }
                 });

--- a/src/term/mod.rs
+++ b/src/term/mod.rs
@@ -615,7 +615,7 @@ impl Term {
             }
             Annotated(ref mut annot, ref mut t) => {
                 annot.iter_mut().for_each(|LabeledType { types, .. }| {
-                    if let TypeF::Flat(ref mut rt) = types.0 {
+                    if let TypeF::Flat(ref mut rt) = types.ty {
                         func(rt)
                     }
                 });

--- a/src/transform/free_vars.rs
+++ b/src/transform/free_vars.rs
@@ -178,7 +178,7 @@ impl CollectFreeVars for RichTerm {
 
 impl CollectFreeVars for Types {
     fn collect_free_vars(&mut self, set: &mut HashSet<Ident>) {
-        match &mut self.ty {
+        match &mut self.types {
             TypeF::Dyn
             | TypeF::Num
             | TypeF::Bool

--- a/src/transform/free_vars.rs
+++ b/src/transform/free_vars.rs
@@ -178,7 +178,7 @@ impl CollectFreeVars for RichTerm {
 
 impl CollectFreeVars for Types {
     fn collect_free_vars(&mut self, set: &mut HashSet<Ident>) {
-        match &mut self.0 {
+        match &mut self.ty {
             TypeF::Dyn
             | TypeF::Num
             | TypeF::Bool

--- a/src/transform/substitute_wildcards.rs
+++ b/src/transform/substitute_wildcards.rs
@@ -56,7 +56,7 @@ fn get_wildcard_type(wildcards: &Wildcards, id: usize) -> Types {
     wildcards
         .get(id)
         .cloned()
-        .unwrap_or(Types::with_default_pos(TypeF::Dyn))
+        .unwrap_or(Types::from(TypeF::Dyn))
 }
 
 trait SubstWildcard {

--- a/src/transform/substitute_wildcards.rs
+++ b/src/transform/substitute_wildcards.rs
@@ -68,7 +68,7 @@ impl SubstWildcard for Types {
     fn subst_wildcards(self, wildcards: &Wildcards) -> Types {
         self.traverse::<_, _, Infallible>(
             &|ty: Types, _| {
-                if let TypeF::Wildcard(id) = ty.ty {
+                if let TypeF::Wildcard(id) = ty.types {
                     Ok(get_wildcard_type(wildcards, id))
                 } else {
                     Ok(ty)

--- a/src/transform/substitute_wildcards.rs
+++ b/src/transform/substitute_wildcards.rs
@@ -9,7 +9,6 @@ use std::{convert::Infallible, rc::Rc};
 use crate::{
     label::Label,
     match_sharedterm,
-    position::TermPos,
     term::{
         record::{Field, FieldMetadata, RecordData},
         LabeledType, RichTerm, Term, Traverse, TraverseOrder, TypeAnnotation,
@@ -54,7 +53,10 @@ pub fn transform_one(rt: RichTerm, wildcards: &Wildcards) -> RichTerm {
 
 /// Get the inferred type for a wildcard, or `Dyn` if no type was inferred.
 fn get_wildcard_type(wildcards: &Wildcards, id: usize) -> Types {
-    wildcards.get(id).cloned().unwrap_or(Types::with_default_pos(TypeF::Dyn))
+    wildcards
+        .get(id)
+        .cloned()
+        .unwrap_or(Types::with_default_pos(TypeF::Dyn))
 }
 
 trait SubstWildcard {

--- a/src/transform/substitute_wildcards.rs
+++ b/src/transform/substitute_wildcards.rs
@@ -54,10 +54,7 @@ pub fn transform_one(rt: RichTerm, wildcards: &Wildcards) -> RichTerm {
 
 /// Get the inferred type for a wildcard, or `Dyn` if no type was inferred.
 fn get_wildcard_type(wildcards: &Wildcards, id: usize) -> Types {
-    wildcards.get(id).cloned().unwrap_or(Types {
-        ty: TypeF::Dyn,
-        pos: TermPos::None,
-    })
+    wildcards.get(id).cloned().unwrap_or(Types::with_default_pos(TypeF::Dyn))
 }
 
 trait SubstWildcard {

--- a/src/typecheck/mod.rs
+++ b/src/typecheck/mod.rs
@@ -1709,10 +1709,7 @@ impl From<ApparentType> for Types {
             ApparentType::Annotated(ty)
             | ApparentType::Inferred(ty)
             | ApparentType::Approximated(ty) => ty,
-            ApparentType::FromEnv(uty) => uty.try_into().ok().unwrap_or(Types {
-                ty: TypeF::Dyn,
-                pos: TermPos::None,
-            }),
+            ApparentType::FromEnv(uty) => uty.try_into().ok().unwrap_or(Types::with_default_pos(TypeF::Dyn)),
         }
     }
 }

--- a/src/typecheck/mod.rs
+++ b/src/typecheck/mod.rs
@@ -459,10 +459,7 @@ impl UnifType {
                     pos: TermPos::None,
                 }
             }
-            UnifType::Contract(t, _) => Types {
-                ty: TypeF::Flat(t),
-                pos: TermPos::None,
-            },
+            UnifType::Contract(t, _) => Types::with_default_pos(TypeF::Flat(t)),
         }
     }
 

--- a/src/typecheck/mod.rs
+++ b/src/typecheck/mod.rs
@@ -1705,11 +1705,16 @@ pub enum ApparentType {
 impl From<ApparentType> for Types {
     fn from(at: ApparentType) -> Self {
         match at {
-            ApparentType::Annotated(ty) if has_wildcards(&ty) => Types::with_default_pos(TypeF::Dyn),
+            ApparentType::Annotated(ty) if has_wildcards(&ty) => {
+                Types::with_default_pos(TypeF::Dyn)
+            }
             ApparentType::Annotated(ty)
             | ApparentType::Inferred(ty)
             | ApparentType::Approximated(ty) => ty,
-            ApparentType::FromEnv(uty) => uty.try_into().ok().unwrap_or(Types::with_default_pos(TypeF::Dyn)),
+            ApparentType::FromEnv(uty) => uty
+                .try_into()
+                .ok()
+                .unwrap_or(Types::with_default_pos(TypeF::Dyn)),
         }
     }
 }
@@ -1734,7 +1739,9 @@ fn field_apparent_type(
                 .as_ref()
                 .map(|v| apparent_type(v.as_ref(), env, resolver))
         })
-        .unwrap_or(ApparentType::Approximated(Types::with_default_pos(TypeF::Dyn)))
+        .unwrap_or(ApparentType::Approximated(Types::with_default_pos(
+            TypeF::Dyn,
+        )))
 }
 
 /// Determine the apparent type of a let-bound expression.

--- a/src/typecheck/mod.rs
+++ b/src/typecheck/mod.rs
@@ -439,10 +439,7 @@ impl UnifType {
         match self {
             UnifType::UnifVar(p) => match table.root_type(p) {
                 t @ UnifType::Concrete(_) => t.into_type(table),
-                _ => Types {
-                    ty: TypeF::Dyn,
-                    pos: TermPos::None,
-                },
+                _ => Types::with_default_pos(TypeF::Dyn),
             },
             UnifType::Constant(_) => Types {
                 ty: TypeF::Dyn,

--- a/src/typecheck/mod.rs
+++ b/src/typecheck/mod.rs
@@ -441,7 +441,7 @@ impl UnifType {
                 t @ UnifType::Concrete(_) => t.into_type(table),
                 _ => Types::from(TypeF::Dyn),
             },
-            UnifType::Constant(_) => Types::with_default_pos(TypeF::Dyn),
+            UnifType::Constant(_) => Types::from(TypeF::Dyn),
             UnifType::Concrete(t) => {
                 let mapped = t.map(
                     |btyp| Box::new(btyp.into_type(table)),

--- a/src/typecheck/mod.rs
+++ b/src/typecheck/mod.rs
@@ -448,10 +448,7 @@ impl UnifType {
                     |urrows| urrows.into_rrows(table),
                     |uerows| uerows.into_erows(table),
                 );
-                Types {
-                    ty: mapped,
-                    pos: TermPos::None,
-                }
+                Types::with_default_pos(mapped)
             }
             UnifType::Contract(t, _) => Types::with_default_pos(TypeF::Flat(t)),
         }

--- a/src/typecheck/mod.rs
+++ b/src/typecheck/mod.rs
@@ -441,10 +441,7 @@ impl UnifType {
                 t @ UnifType::Concrete(_) => t.into_type(table),
                 _ => Types::with_default_pos(TypeF::Dyn),
             },
-            UnifType::Constant(_) => Types {
-                ty: TypeF::Dyn,
-                pos: TermPos::None,
-            },
+            UnifType::Constant(_) => Types::with_default_pos(TypeF::Dyn),
             UnifType::Concrete(t) => {
                 let mapped = t.map(
                     |btyp| Box::new(btyp.into_type(table)),

--- a/src/typecheck/mod.rs
+++ b/src/typecheck/mod.rs
@@ -1705,10 +1705,7 @@ pub enum ApparentType {
 impl From<ApparentType> for Types {
     fn from(at: ApparentType) -> Self {
         match at {
-            ApparentType::Annotated(ty) if has_wildcards(&ty) => Types {
-                ty: TypeF::Dyn,
-                pos: TermPos::None,
-            },
+            ApparentType::Annotated(ty) if has_wildcards(&ty) => Types::with_default_pos(TypeF::Dyn),
             ApparentType::Annotated(ty)
             | ApparentType::Inferred(ty)
             | ApparentType::Approximated(ty) => ty,

--- a/src/typecheck/mod.rs
+++ b/src/typecheck/mod.rs
@@ -1734,10 +1734,7 @@ fn field_apparent_type(
                 .as_ref()
                 .map(|v| apparent_type(v.as_ref(), env, resolver))
         })
-        .unwrap_or(ApparentType::Approximated(Types {
-            ty: TypeF::Dyn,
-            pos: TermPos::None,
-        }))
+        .unwrap_or(ApparentType::Approximated(Types::with_default_pos(TypeF::Dyn)))
 }
 
 /// Determine the apparent type of a let-bound expression.

--- a/src/typecheck/mod.rs
+++ b/src/typecheck/mod.rs
@@ -184,10 +184,7 @@ impl<E: TermEnvironment + Clone> std::convert::TryInto<Types> for GenericUnifTyp
                     GenericUnifRecordRows::try_into,
                     UnifEnumRows::try_into,
                 )?;
-                Ok(Types {
-                    ty: converted,
-                    pos: TermPos::None,
-                })
+                Ok(Types::with_default_pos(converted))
             }
             GenericUnifType::Contract(t, _) => {
                 let pos = t.pos;

--- a/src/typecheck/mod.rs
+++ b/src/typecheck/mod.rs
@@ -189,10 +189,13 @@ impl<E: TermEnvironment + Clone> std::convert::TryInto<Types> for GenericUnifTyp
                     pos: TermPos::None,
                 })
             }
-            GenericUnifType::Contract(t, _) => Ok(Types {
-                ty: TypeF::Flat(t),
-                pos: t.pos,
-            }),
+            GenericUnifType::Contract(t, _) => {
+                let pos = t.pos;
+                Ok(Types {
+                    ty: TypeF::Flat(t),
+                    pos,
+                })
+            }
             _ => Err(()),
         }
     }

--- a/src/typecheck/reporting.rs
+++ b/src/typecheck/reporting.rs
@@ -163,12 +163,8 @@ pub fn to_type(
     let ty = ty.into_root(table);
 
     match ty {
-        UnifType::UnifVar(p) => {
-            Types::with_default_pos(TypeF::Var(var_name(reported_names, names, p)))
-        }
-        UnifType::Constant(c) => {
-            Types::with_default_pos(TypeF::Var(cst_name(reported_names, names, c)))
-        }
+        UnifType::UnifVar(p) => Types::from(TypeF::Var(var_name(reported_names, names, p))),
+        UnifType::Constant(c) => Types::from(TypeF::Var(cst_name(reported_names, names, c))),
         UnifType::Concrete(t) => {
             let mapped = t.map_state(
                 |btyp, names| Box::new(to_type(table, reported_names, names, *btyp)),
@@ -176,8 +172,8 @@ pub fn to_type(
                 |erows, names| erows_to_type(table, reported_names, names, erows),
                 names,
             );
-            Types::with_default_pos(mapped)
+            Types::from(mapped)
         }
-        UnifType::Contract(t, _) => Types::with_default_pos(TypeF::Flat(t)),
+        UnifType::Contract(t, _) => Types::from(TypeF::Flat(t)),
     }
 }

--- a/src/typecheck/reporting.rs
+++ b/src/typecheck/reporting.rs
@@ -163,8 +163,12 @@ pub fn to_type(
     let ty = ty.into_root(table);
 
     match ty {
-        UnifType::UnifVar(p) => Types(TypeF::Var(var_name(reported_names, names, p))),
-        UnifType::Constant(c) => Types(TypeF::Var(cst_name(reported_names, names, c))),
+        UnifType::UnifVar(p) => {
+            Types::with_default_pos(TypeF::Var(var_name(reported_names, names, p)))
+        }
+        UnifType::Constant(c) => {
+            Types::with_default_pos(TypeF::Var(cst_name(reported_names, names, c)))
+        }
         UnifType::Concrete(t) => {
             let mapped = t.map_state(
                 |btyp, names| Box::new(to_type(table, reported_names, names, *btyp)),
@@ -172,8 +176,8 @@ pub fn to_type(
                 |erows, names| erows_to_type(table, reported_names, names, erows),
                 names,
             );
-            Types(mapped)
+            Types::with_default_pos(mapped)
         }
-        UnifType::Contract(t, _) => Types(TypeF::Flat(t)),
+        UnifType::Contract(t, _) => Types::with_default_pos(TypeF::Flat(t)),
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -835,6 +835,11 @@ impl From<TypeF<Box<Types>, RecordRows, EnumRows>> for Types {
 }
 
 impl Types {
+    /// Creates a `Type` with the specified position
+    pub fn with_pos(self, pos: TermPos) -> Types {
+        Types { pos, ..self }
+    }
+
     /// Return the contract corresponding to a type, either as a function or a record. Said
     /// contract must then be applied using the `Assume` primitive operation.
     pub fn contract(&self) -> Result<RichTerm, UnboundTypeVariableError> {

--- a/src/types.rs
+++ b/src/types.rs
@@ -826,9 +826,9 @@ impl RecordRows {
 }
 
 impl From<TypeF<Box<Types>, RecordRows, EnumRows>> for Types {
-    fn from(ty: TypeF<Box<Types>, RecordRows, EnumRows>) -> Self {
+    fn from(types: TypeF<Box<Types>, RecordRows, EnumRows>) -> Self {
         Types {
-            types: ty,
+            types,
             pos: TermPos::None,
         }
     }

--- a/src/types.rs
+++ b/src/types.rs
@@ -825,15 +825,16 @@ impl RecordRows {
     }
 }
 
-impl Types {
-    /// Create a type with the specified `ty`, and has a `None` position.
-    pub fn with_default_pos(ty: TypeF<Box<Types>, RecordRows, EnumRows>) -> Types {
+impl From<TypeF<Box<Types>, RecordRows, EnumRows>> for Types {
+    fn from(ty: TypeF<Box<Types>, RecordRows, EnumRows>) -> Self {
         Types {
             ty,
             pos: TermPos::None,
         }
     }
+}
 
+impl Types {
     /// Return the contract corresponding to a type, either as a function or a record. Said
     /// contract must then be applied using the `Assume` primitive operation.
     pub fn contract(&self) -> Result<RichTerm, UnboundTypeVariableError> {
@@ -941,7 +942,7 @@ impl Traverse<Types> for Types {
                     state,
                 )?;
 
-                Ok(Types::with_default_pos(inner))
+                Ok(Types::from(inner))
             }
             TraverseOrder::BottomUp => {
                 let traversed_depth_first = self.ty.try_map_state(
@@ -951,7 +952,7 @@ impl Traverse<Types> for Types {
                     state,
                 )?;
 
-                f(Types::with_default_pos(traversed_depth_first), state)
+                f(Types::from(traversed_depth_first), state)
             }
         }
     }
@@ -963,9 +964,7 @@ impl Traverse<RichTerm> for Types {
         F: Fn(RichTerm, &mut S) -> Result<RichTerm, E>,
     {
         let f_on_type = |ty: Types, s: &mut S| match ty.ty {
-            TypeF::Flat(t) => t
-                .traverse(f, s, order)
-                .map(|t| Types::with_default_pos(TypeF::Flat(t))),
+            TypeF::Flat(t) => t.traverse(f, s, order).map(|t| Types::from(TypeF::Flat(t))),
             _ => Ok(ty),
         };
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -264,9 +264,6 @@ pub type RecordRow = RecordRowF<Box<Types>>;
 /// Concrete, recursive definition for record rows.
 pub struct RecordRows(pub RecordRowsF<Box<Types>, Box<RecordRows>>);
 
-// #[derive(Clone, PartialEq, Debug)]
-// pub struct Types(pub TypeF<Box<Types>, RecordRows, EnumRows>);
-
 /// Concrete, recursive type for a Nickel type.
 #[derive(Clone, PartialEq, Debug)]
 pub struct Types {
@@ -845,7 +842,7 @@ impl Types {
 
     /// Returns true if this type is a function type, false otherwise.
     pub fn is_function_type(&self) -> bool {
-        match self.ty {
+        match &self.ty {
             TypeF::Forall { body, .. } => body.is_function_type(),
             TypeF::Arrow(..) => true,
             _ => false,

--- a/src/types.rs
+++ b/src/types.rs
@@ -826,6 +826,7 @@ impl RecordRows {
 }
 
 impl Types {
+    /// Create a type with the specified `ty`, and has a `None` position.
     pub fn with_default_pos(ty: TypeF<Box<Types>, RecordRows, EnumRows>) -> Types {
         Types {
             ty,

--- a/tests/integration/typecheck_fail.rs
+++ b/tests/integration/typecheck_fail.rs
@@ -287,8 +287,11 @@ let g : Num = f 0 in
 g"#
         ),
         Err(TypecheckError::TypeMismatch(
-            Types { ty: TypeF::Arrow(_, _), .. },
-            Types { ty:TypeF::Dyn, .. },
+            Types {
+                ty: TypeF::Arrow(_, _),
+                ..
+            },
+            Types { ty: TypeF::Dyn, .. },
             _
         ))
     );
@@ -304,8 +307,14 @@ fn locally_different_flat_types() {
              foo : lib.Contract"
         ),
         Err(TypecheckError::TypeMismatch(
-            Types { ty:TypeF::Flat(..), .. },
-            Types { ty:TypeF::Flat(..), .. },
+            Types {
+                ty: TypeF::Flat(..),
+                ..
+            },
+            Types {
+                ty: TypeF::Flat(..),
+                ..
+            },
             _
         ))
     );

--- a/tests/integration/typecheck_fail.rs
+++ b/tests/integration/typecheck_fail.rs
@@ -288,10 +288,13 @@ g"#
         ),
         Err(TypecheckError::TypeMismatch(
             Types {
-                ty: TypeF::Arrow(_, _),
+                types: TypeF::Arrow(_, _),
                 ..
             },
-            Types { ty: TypeF::Dyn, .. },
+            Types {
+                types: TypeF::Dyn,
+                ..
+            },
             _
         ))
     );
@@ -308,11 +311,11 @@ fn locally_different_flat_types() {
         ),
         Err(TypecheckError::TypeMismatch(
             Types {
-                ty: TypeF::Flat(..),
+                types: TypeF::Flat(..),
                 ..
             },
             Types {
-                ty: TypeF::Flat(..),
+                types: TypeF::Flat(..),
                 ..
             },
             _

--- a/tests/integration/typecheck_fail.rs
+++ b/tests/integration/typecheck_fail.rs
@@ -287,8 +287,8 @@ let g : Num = f 0 in
 g"#
         ),
         Err(TypecheckError::TypeMismatch(
-            Types(TypeF::Arrow(_, _)),
-            Types(TypeF::Dyn),
+            Types { ty: TypeF::Arrow(_, _), .. },
+            Types { ty:TypeF::Dyn, .. },
             _
         ))
     );
@@ -304,8 +304,8 @@ fn locally_different_flat_types() {
              foo : lib.Contract"
         ),
         Err(TypecheckError::TypeMismatch(
-            Types(TypeF::Flat(..)),
-            Types(TypeF::Flat(..)),
+            Types { ty:TypeF::Flat(..), .. },
+            Types { ty:TypeF::Flat(..), .. },
             _
         ))
     );


### PR DESCRIPTION
In the Nickel AST, `Types` do not keep track of their position, and this can make error reporting for blame errors, in some cases, quite involved. This pull request adds a position field to `Types`