### PR TITLE
Enrich label custom reporting data

### DIFF
--- a/lsp/nls/src/linearization/completed.rs
+++ b/lsp/nls/src/linearization/completed.rs
@@ -168,14 +168,7 @@ impl Completed {
             if let Some(doc) = doc {
                 extra.push(doc.to_owned());
             }
-            if let Some(custom_contract_msg) = annotation
-                .types
-                .as_ref()
-                .and_then(|ty| ty.label.current_diagnostic())
-                .and_then(|diag| diag.message.as_ref())
-            {
-                extra.push(custom_contract_msg.clone());
-            }
+
             if let Some(contracts) = annotation.contracts_to_string() {
                 extra.push(contracts);
             }

--- a/lsp/nls/src/linearization/completed.rs
+++ b/lsp/nls/src/linearization/completed.rs
@@ -168,8 +168,13 @@ impl Completed {
             if let Some(doc) = doc {
                 extra.push(doc.to_owned());
             }
-            if let Some(types) = &annotation.types {
-                extra.push(types.label.tag.to_string());
+            if let Some(custom_contract_msg) = annotation
+                .types
+                .as_ref()
+                .and_then(|ty| ty.label.current_diagnostic())
+                .and_then(|diag| diag.message.as_ref())
+            {
+                extra.push(custom_contract_msg.clone());
             }
             if let Some(contracts) = annotation.contracts_to_string() {
                 extra.push(contracts);

--- a/src/error.rs
+++ b/src/error.rs
@@ -1321,16 +1321,6 @@ is None but last_arrow_elem is Some"),
             .filter(|diag| !label::ContractDiagnostic::is_empty(diag));
         let head_contract_diagnostic = contract_diagnostics.next();
 
-        // diagnostics.extend(label.diagnostics.into_iter().map(Diagnostic::from));
-        // // Contract diagnostics are pushed in-order: usually, the last one is the most
-        // // precise/relevant one. Thus, we want to show them in reverse order.
-        // diagnostics.reverse();
-
-        // We are going to work on the first diagnostic, so we ensure there is always one.
-        // if diagnostics.is_empty() {
-        //     diagnostics.push(Diagnostic::error());
-        // }
-
         let mut msg = format!("{}{msg_addendum}", title(&label));
 
         if let Some(contract_msg) = head_contract_diagnostic
@@ -1361,7 +1351,7 @@ is None but last_arrow_elem is Some"),
             if !notes_higher_order.is_empty() {
                 diagnostics.push(
                     Diagnostic::note()
-                        .with_message("this is a function fonctract violiation")
+                        .with_message("due to a function contract violiation")
                         .with_notes(notes_higher_order),
                 );
             }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1351,7 +1351,7 @@ is None but last_arrow_elem is Some"),
             if !notes_higher_order.is_empty() {
                 diagnostics.push(
                     Diagnostic::note()
-                        .with_message("due to a function contract violiation")
+                        .with_message("due to a function contract violation")
                         .with_notes(notes_higher_order),
                 );
             }
@@ -1367,7 +1367,7 @@ is None but last_arrow_elem is Some"),
         diagnostics.push(contract_bind_loc(&label));
 
         for ctr_diag in contract_diagnostics {
-            let mut msg = String::from("from a parent contract violiation");
+            let mut msg = String::from("from a parent contract violation");
 
             if let Some(msg_contract) = ctr_diag.message {
                 msg.push_str(": ");

--- a/src/eval/merge.rs
+++ b/src/eval/merge.rs
@@ -246,7 +246,15 @@ pub fn merge<C: Cache>(
                     let fields: Vec<String> =
                         left.keys().map(|field| format!("`{field}`")).collect();
                     let plural = if fields.len() == 1 { "" } else { "s" };
-                    lbl.tag = format!("extra field{} {}", plural, fields.join(","));
+                    let fields_list = fields.join(",");
+
+                    lbl.set_diagnostic_message(format!("extra field{plural} {fields_list}"));
+                    lbl.set_diagnostic_notes(vec![
+                        format!("Have you mispelled a field?"),
+                        String::from("The record contract might also be too strict. By default, record contracts exclude any field which is not listed.
+Append `, ..` at the end of the record contract, as in `{some_field | SomeContract, ..}`, to make it accept extra fields."),
+                    ]);
+
                     return Err(EvalError::BlameError {
                         evaluated_arg: lbl.get_evaluated_arg(cache),
                         label: lbl,

--- a/src/eval/merge.rs
+++ b/src/eval/merge.rs
@@ -250,7 +250,7 @@ pub fn merge<C: Cache>(
 
                     lbl.set_diagnostic_message(format!("extra field{plural} {fields_list}"));
                     lbl.set_diagnostic_notes(vec![
-                        format!("Have you mispelled a field?"),
+                        format!("Have you misspelled a field?"),
                         String::from("The record contract might also be too strict. By default, record contracts exclude any field which is not listed.
 Append `, ..` at the end of the record contract, as in `{some_field | SomeContract, ..}`, to make it accept extra fields."),
                     ]);

--- a/src/eval/operation.rs
+++ b/src/eval/operation.rs
@@ -1692,11 +1692,12 @@ impl<R: ImportResolver, C: Cache> VirtualMachine<R, C> {
             }
             BinaryOp::Tag() => match_sharedterm! {t1, with {
                     Term::Str(s) => match_sharedterm!{t2, with {
-                                Term::Lbl(l) => {
-                                    let mut l = l;
-                                    l.tag = s;
+                                Term::Lbl(label) => {
+                                    let mut label = label;
+                                    label.set_diagnostic_message(s);
+
                                     Ok(Closure::atomic_closure(RichTerm::new(
-                                        Term::Lbl(l),
+                                        Term::Lbl(label),
                                         pos_op_inh,
                                     )))
                                 }

--- a/src/label.rs
+++ b/src/label.rs
@@ -367,7 +367,7 @@ pub struct Label {
 }
 
 /// Custom reporting diagnostic that can be set by user-code through the `label` API. Used to
-/// customized contract error messages, and provide more context than "a contract has failed".
+/// customize contract error messages, and provide more context than "a contract has failed".
 #[derive(Debug, Clone, PartialEq, Default)]
 pub struct ContractDiagnostic {
     /// The main error message tag to be printed together with the error message.

--- a/src/parser/utils.rs
+++ b/src/parser/utils.rs
@@ -549,12 +549,8 @@ pub fn mk_pos(src_id: FileId, l: usize, r: usize) -> TermPos {
 pub fn mk_label(types: Types, src_id: FileId, l: usize, r: usize) -> Label {
     Label {
         types: Rc::new(types),
-        tag: String::new(),
         span: mk_span(src_id, l, r),
-        arg_idx: None,
-        arg_pos: TermPos::None,
-        polarity: true,
-        path: Vec::new(),
+        ..Default::default()
     }
 }
 

--- a/src/repl/simple_frontend.rs
+++ b/src/repl/simple_frontend.rs
@@ -47,7 +47,7 @@ pub fn input<R: Repl>(repl: &mut R, line: &str) -> Result<InputResult, InputErro
             ))),
             Ok(Command::Typecheck(exp)) => repl
                 .typecheck(&exp)
-                .map(|types| InputResult::Success(format!("Ok: {}", types)))
+                .map(|types| InputResult::Success(format!("Ok: {types}")))
                 .map_err(InputError::from),
             Ok(Command::Query { target, path }) => repl
                 .query(target, path)


### PR DESCRIPTION
First step of #1052. Enrich the label interface for custom error reporting, with the additional `notes` field. Put this field, together with the previous `tag` (now `message`) to a dedicated data structure, `ContractDiagnostic`. Finally, `Label` now stores a stack of such diagnostic, to help fix one issue of #1052 which is that subcontract might erase the message previously set by parent contract, although it could be relevant.

This PR doesn't add any primop to access this new interface yet: it mostly update the error reporting code to handle it. Adding primops is postponed to a subsequent PR.

I'm not totally sure yet what should go in the `ContractDiagnostic`s (should we also include `type_path` and `arg_idx`, to store the type path and argument to parent contracts as well, and enrich the corresponding "parent" diagnostics) ?. Should we add more fields than `notes` to the `label` interface?.

However, those questions need not be answered right away. We can improve later in a backward compatible manner: for now, the plan is to add at least `notes` to make it accessible to the user (in a subsequent PR), with a backward-compatible API. We can always:

- add more fields later (hints/suggestions, for example, or the label of the contract argument)
- move things form `Label` to `ContractDiagnostic`, allowing to store a stack of value instead of just the latest one, to improve the reporting of blame errors that have several contract diagnostics. This is invisible to user code, and thus can't break backward compatibility.