### PR TITLE
Use a custom debug instance for Closure

### DIFF
--- a/src/eval/mod.rs
+++ b/src/eval/mod.rs
@@ -821,10 +821,18 @@ pub enum IdentKind {
 }
 
 /// A closure, a term together with an environment.
-#[derive(Debug, PartialEq)]
+#[derive(PartialEq)]
 pub struct Closure {
     pub body: RichTerm,
     pub env: Environment,
+}
+
+impl std::fmt::Debug for Closure {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Closure")
+            .field("body", &self.body)
+            .finish_non_exhaustive()
+    }
 }
 
 impl Clone for Closure {


### PR DESCRIPTION
This instance hides the `env` field in `Closure` when printing. Usually the environment is too large to be helpful on a quick inspection and in fact causes stack overflows because of its deeply recursive structure in some cases.