### PR TITLE
Stringingable -> Stringable

### DIFF
--- a/stdlib/builtin.ncl
+++ b/stdlib/builtin.ncl
@@ -194,7 +194,7 @@
       "%
     = fun format x => %deserialize% format x,
 
-    to_string | string.Stringingable -> String
+    to_string | string.Stringable -> String
     | doc m%"
       Converts a stringable value to a string representation. Same as
       `string.from`.


### PR DESCRIPTION
Fixes a typo in the contract of `string.to_string`