### PR TITLE
Use arbitrary precision rationals as the underlying representation of numbers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,7 +24,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f"
 dependencies = [
  "cfg-if",
- "getrandom",
+ "getrandom 0.2.8",
  "once_cell",
  "version_check",
 ]
@@ -120,6 +120,12 @@ dependencies = [
 
 [[package]]
 name = "base64"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+
+[[package]]
+name = "base64"
 version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
@@ -162,12 +168,28 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "block-buffer"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
+dependencies = [
+ "block-padding",
+ "generic-array",
+]
+
+[[package]]
+name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
 ]
+
+[[package]]
+name = "block-padding"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
 
 [[package]]
 name = "bumpalo"
@@ -277,8 +299,8 @@ checksum = "44bec8e5c9d09e439c4335b1af0abaab56dcf3b94999a936e1bb47b9134288f0"
 dependencies = [
  "heck 0.4.1",
  "proc-macro-error",
- "proc-macro2 1.0.51",
- "quote 1.0.23",
+ "proc-macro2 1.0.52",
+ "quote 1.0.24",
  "syn 1.0.109",
 ]
 
@@ -427,7 +449,7 @@ dependencies = [
  "clap 2.34.0",
  "criterion-plot 0.4.5",
  "csv",
- "itertools",
+ "itertools 0.10.5",
  "lazy_static",
  "num-traits",
  "oorandom",
@@ -454,7 +476,7 @@ dependencies = [
  "ciborium",
  "clap 3.2.23",
  "criterion-plot 0.5.0",
- "itertools",
+ "itertools 0.10.5",
  "lazy_static",
  "num-traits",
  "oorandom",
@@ -475,7 +497,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2673cc8207403546f45f5fd319a974b1e6983ad1a3ee7e6041650013be041876"
 dependencies = [
  "cast",
- "itertools",
+ "itertools 0.10.5",
 ]
 
 [[package]]
@@ -485,7 +507,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
 dependencies = [
  "cast",
- "itertools",
+ "itertools 0.10.5",
 ]
 
 [[package]]
@@ -623,7 +645,7 @@ version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d2301688392eb071b0bf1a37be05c469d3cc4dbbd95df672fe28ab021e6a096"
 dependencies = [
- "quote 1.0.23",
+ "quote 1.0.24",
  "syn 1.0.109",
 ]
 
@@ -643,8 +665,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
 dependencies = [
  "convert_case",
- "proc-macro2 1.0.51",
- "quote 1.0.23",
+ "proc-macro2 1.0.52",
+ "quote 1.0.24",
  "rustc_version",
  "syn 1.0.109",
 ]
@@ -663,11 +685,20 @@ checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
 name = "digest"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "digest"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
 dependencies = [
- "block-buffer",
+ "block-buffer 0.10.4",
  "crypto-common",
 ]
 
@@ -726,6 +757,18 @@ name = "either"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
+
+[[package]]
+name = "embed-doc-image"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af36f591236d9d822425cb6896595658fa558fcebf5ee8accac1d4b92c47166e"
+dependencies = [
+ "base64 0.13.1",
+ "proc-macro2 1.0.52",
+ "quote 1.0.24",
+ "syn 1.0.109",
+]
 
 [[package]]
 name = "ena"
@@ -883,13 +926,24 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.9.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -1052,6 +1106,15 @@ dependencies = [
 
 [[package]]
 name = "itertools"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "284f18f85651fe11e8a991b2adb42cb078325c996ed026d994719efcfca1d54b"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
@@ -1075,6 +1138,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "keccak"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3afef3b6eff9ce9d8ff9b3601125eec7f0c8cbac7abd14f355d053fa56c98768"
+dependencies = [
+ "cpufeatures",
+]
+
+[[package]]
 name = "lalrpop"
 version = "0.19.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1085,7 +1157,7 @@ dependencies = [
  "bit-set",
  "diff",
  "ena",
- "itertools",
+ "itertools 0.10.5",
  "lalrpop-util",
  "petgraph",
  "pico-args",
@@ -1175,8 +1247,8 @@ checksum = "a1d849148dbaf9661a6151d1ca82b13bb4c4c128146a88d05253b38d4e2f496c"
 dependencies = [
  "beef",
  "fnv",
- "proc-macro2 1.0.51",
- "quote 1.0.23",
+ "proc-macro2 1.0.52",
+ "quote 1.0.24",
  "regex-syntax",
  "syn 1.0.109",
 ]
@@ -1207,12 +1279,60 @@ dependencies = [
 ]
 
 [[package]]
+name = "malachite"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6cf7f4730c30071ba374fac86ad35b1cb7a0716f774737768667ea3fa1828e3"
+dependencies = [
+ "malachite-base",
+ "malachite-nz",
+ "malachite-q",
+]
+
+[[package]]
+name = "malachite-base"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b06bfa98a4b4802af5a4263b4ad4660e28e51e8490f6354eb9336c70767e1c5"
+dependencies = [
+ "itertools 0.9.0",
+ "rand",
+ "rand_chacha",
+ "ryu",
+ "sha3",
+]
+
+[[package]]
+name = "malachite-nz"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c89e21c64b7af5be3dc8cef16f786243faf59459fe4ba93b44efdeb264e5ade4"
+dependencies = [
+ "embed-doc-image",
+ "itertools 0.9.0",
+ "malachite-base",
+ "serde",
+]
+
+[[package]]
+name = "malachite-q"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3755e541d5134b5016594c9043094172c4dda9259b3ce824a7b8101941850360"
+dependencies = [
+ "itertools 0.9.0",
+ "malachite-base",
+ "malachite-nz",
+ "serde",
+]
+
+[[package]]
 name = "md-5"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6365506850d44bff6e2fbcb5176cf63650e48bd45ef2fe2665ae1570e0f4b9ca"
 dependencies = [
- "digest",
+ "digest 0.10.6",
 ]
 
 [[package]]
@@ -1274,7 +1394,7 @@ checksum = "5b9d9a46eff5b4ff64b45a9e316a6d1e0bc719ef429cbec4dc630684212bfdf9"
 dependencies = [
  "libc",
  "log",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.45.0",
 ]
 
@@ -1309,6 +1429,7 @@ dependencies = [
  "lalrpop",
  "lalrpop-util",
  "logos",
+ "malachite",
  "md-5",
  "nickel-lang-utilities",
  "once_cell",
@@ -1464,6 +1585,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
+name = "opaque-debug"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
+
+[[package]]
 name = "os_str_bytes"
 version = "6.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1535,8 +1662,8 @@ checksum = "75a1ef20bf3193c15ac345acb32e26b3dc3223aff4d77ae4fc5359567683796b"
 dependencies = [
  "pest",
  "pest_meta",
- "proc-macro2 1.0.51",
- "quote 1.0.23",
+ "proc-macro2 1.0.52",
+ "quote 1.0.24",
  "syn 1.0.109",
 ]
 
@@ -1588,7 +1715,7 @@ version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffac6a51110e97610dd3ac73e34a65b27e56a1e305df41bad1f616d8e1cb22f4"
 dependencies = [
- "base64",
+ "base64 0.21.0",
  "indexmap",
  "line-wrap",
  "quick-xml 0.27.1",
@@ -1647,6 +1774,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+
+[[package]]
 name = "precomputed-hash"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1683,8 +1816,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
 dependencies = [
  "proc-macro-error-attr",
- "proc-macro2 1.0.51",
- "quote 1.0.23",
+ "proc-macro2 1.0.52",
+ "quote 1.0.24",
  "syn 1.0.109",
  "version_check",
 ]
@@ -1695,8 +1828,8 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
 dependencies = [
- "proc-macro2 1.0.51",
- "quote 1.0.23",
+ "proc-macro2 1.0.52",
+ "quote 1.0.24",
  "version_check",
 ]
 
@@ -1711,9 +1844,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.51"
+version = "1.0.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d727cae5b39d21da60fa540906919ad737832fe0b1c165da3a34d6548c849d6"
+checksum = "1d0e1ae9e836cc3beddd63db0df682593d7e2d3d891ae8c9083d2113e1744224"
 dependencies = [
  "unicode-ident",
 ]
@@ -1770,9 +1903,9 @@ version = "0.17.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94144a1266e236b1c932682136dc35a9dee8d3589728f68130c7c3861ef96b28"
 dependencies = [
- "proc-macro2 1.0.51",
+ "proc-macro2 1.0.52",
  "pyo3-macros-backend",
- "quote 1.0.23",
+ "quote 1.0.24",
  "syn 1.0.109",
 ]
 
@@ -1782,8 +1915,8 @@ version = "0.17.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8df9be978a2d2f0cdebabb03206ed73b11314701a5bfe71b0d753b81997777f"
 dependencies = [
- "proc-macro2 1.0.51",
- "quote 1.0.23",
+ "proc-macro2 1.0.52",
+ "quote 1.0.24",
  "syn 1.0.109",
 ]
 
@@ -1816,11 +1949,11 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.23"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
+checksum = "50686e0021c4136d1d453b2dfe059902278681512a34d4248435dc34b6b5c8ec"
 dependencies = [
- "proc-macro2 1.0.51",
+ "proc-macro2 1.0.52",
 ]
 
 [[package]]
@@ -1831,6 +1964,47 @@ checksum = "c069c179fcdc6a2fe24d8d18305cf085fdbd4f922c041943e203685d6a1c58fd"
 dependencies = [
  "endian-type",
  "nibble_vec",
+]
+
+[[package]]
+name = "rand"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
+dependencies = [
+ "getrandom 0.1.16",
+ "libc",
+ "rand_chacha",
+ "rand_core",
+ "rand_hc",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
+dependencies = [
+ "getrandom 0.1.16",
+]
+
+[[package]]
+name = "rand_hc"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
+dependencies = [
+ "rand_core",
 ]
 
 [[package]]
@@ -1870,7 +2044,7 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.8",
  "redox_syscall",
  "thiserror",
 ]
@@ -1965,8 +2139,8 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8218eaf5d960e3c478a1b0f129fa888dd3d8d22eb3de097e9af14c1ab4438024"
 dependencies = [
- "proc-macro2 1.0.51",
- "quote 1.0.23",
+ "proc-macro2 1.0.52",
+ "quote 1.0.24",
  "syn 1.0.109",
 ]
 
@@ -1999,15 +2173,15 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "semver"
-version = "1.0.16"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58bc9567378fc7690d6b2addae4e60ac2eeea07becb2c64b9f218b53865cba2a"
+checksum = "bebd363326d05ec3e2f532ab7660680f3b02130d780c299bca73469d521bc0ed"
 
 [[package]]
 name = "serde"
-version = "1.0.154"
+version = "1.0.155"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cdd151213925e7f1ab45a9bbfb129316bd00799784b174b7cc7bcd16961c49e"
+checksum = "71f2b4817415c6d4210bfe1c7bfcf4801b2d904cb4d0e1a8fdb651013c9e86b8"
 dependencies = [
  "serde_derive",
 ]
@@ -2035,12 +2209,12 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.154"
+version = "1.0.155"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fc80d722935453bcafdc2c9a73cd6fac4dc1938f0346035d84bf99fa9e33217"
+checksum = "d071a94a3fac4aff69d023a7f411e33f40f3483f8c5190b1953822b6b76d7630"
 dependencies = [
- "proc-macro2 1.0.51",
- "quote 1.0.23",
+ "proc-macro2 1.0.52",
+ "quote 1.0.24",
  "syn 1.0.109",
 ]
 
@@ -2061,8 +2235,8 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "395627de918015623b32e7669714206363a7fc00382bf477e72c1f7533e8eafc"
 dependencies = [
- "proc-macro2 1.0.51",
- "quote 1.0.23",
+ "proc-macro2 1.0.52",
+ "quote 1.0.24",
  "syn 1.0.109",
 ]
 
@@ -2096,7 +2270,7 @@ checksum = "f5058ada175748e33390e40e872bd0fe59a19f265d0158daa551c5a88a76009c"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest",
+ "digest 0.10.6",
 ]
 
 [[package]]
@@ -2107,7 +2281,19 @@ checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest",
+ "digest 0.10.6",
+]
+
+[[package]]
+name = "sha3"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f81199417d4e5de3f04b1e871023acea7389672c4135918f05aa9cbf2f2fa809"
+dependencies = [
+ "block-buffer 0.9.0",
+ "digest 0.9.0",
+ "keccak",
+ "opaque-debug",
 ]
 
 [[package]]
@@ -2247,8 +2433,8 @@ checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
 dependencies = [
  "heck 0.3.3",
  "proc-macro-error",
- "proc-macro2 1.0.51",
- "quote 1.0.23",
+ "proc-macro2 1.0.52",
+ "quote 1.0.24",
  "syn 1.0.109",
 ]
 
@@ -2292,8 +2478,8 @@ version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
 dependencies = [
- "proc-macro2 1.0.51",
- "quote 1.0.23",
+ "proc-macro2 1.0.52",
+ "quote 1.0.24",
  "unicode-ident",
 ]
 
@@ -2426,8 +2612,8 @@ version = "1.0.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5420d42e90af0c38c3290abcca25b9b3bdf379fc9f55c528f53a269d9c9a267e"
 dependencies = [
- "proc-macro2 1.0.51",
- "quote 1.0.23",
+ "proc-macro2 1.0.52",
+ "quote 1.0.24",
  "syn 1.0.109",
 ]
 
@@ -2515,9 +2701,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.19.4"
+version = "0.19.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a1eb0622d28f4b9c90adc4ea4b2b46b47663fde9ac5fafcb14a1369d5508825"
+checksum = "7082a95d48029677a28f181e5f6422d0c8339ad8396a39d3f33d62a90c1f6c30"
 dependencies = [
  "indexmap",
  "serde",
@@ -2662,6 +2848,12 @@ dependencies = [
 
 [[package]]
 name = "wasi"
+version = "0.9.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
+
+[[package]]
+name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
@@ -2687,8 +2879,8 @@ dependencies = [
  "bumpalo",
  "log",
  "once_cell",
- "proc-macro2 1.0.51",
- "quote 1.0.23",
+ "proc-macro2 1.0.52",
+ "quote 1.0.24",
  "syn 1.0.109",
  "wasm-bindgen-shared",
 ]
@@ -2699,7 +2891,7 @@ version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "052be0f94026e6cbc75cdefc9bae13fd6052cdcaf532fa6c45e7ae33a1e6c810"
 dependencies = [
- "quote 1.0.23",
+ "quote 1.0.24",
  "wasm-bindgen-macro-support",
 ]
 
@@ -2709,8 +2901,8 @@ version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07bc0c051dc5f23e307b13285f9d75df86bfdf816c5721e573dec1f9b8aa193c"
 dependencies = [
- "proc-macro2 1.0.51",
- "quote 1.0.23",
+ "proc-macro2 1.0.52",
+ "quote 1.0.24",
  "syn 1.0.109",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1430,6 +1430,7 @@ dependencies = [
  "lalrpop-util",
  "logos",
  "malachite",
+ "malachite-q",
  "md-5",
  "nickel-lang-utilities",
  "once_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,7 @@ pretty = "0.11.3"
 comrak = { version = "0.16.0", optional = true, features = [] }
 once_cell = "1.17.1"
 typed-arena = "2.0.2"
+malachite = { version = "0.3.2", features = ["enable_serde"] }
 
 [dev-dependencies]
 pretty_assertions = "1.3.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,8 @@ pretty = "0.11.3"
 comrak = { version = "0.16.0", optional = true, features = [] }
 once_cell = "1.17.1"
 typed-arena = "2.0.2"
-malachite = { version = "0.3.2", features = ["enable_serde"] }
+malachite = {version = "0.3.2", features = ["enable_serde"] }
+malachite-q = "0.3.2"
 
 [dev-dependencies]
 pretty_assertions = "1.3.0"

--- a/benches/arrays.rs
+++ b/benches/arrays.rs
@@ -3,7 +3,7 @@ use std::rc::Rc;
 use criterion::{criterion_main, Criterion};
 use nickel_lang::term::{
     array::{Array, ArrayAttrs},
-    RichTerm, Term,
+    RichTerm, Term, Number
 };
 use nickel_lang_utilities::{ncl_bench_group, EvalMode};
 use pprof::criterion::{Output, PProfProfiler};
@@ -20,7 +20,7 @@ fn ncl_random_array(len: usize) -> String {
 
     for _ in 0..len {
         acc = (a * acc + c) % m;
-        numbers.push(RichTerm::from(Term::Num(acc as f64)));
+        numbers.push(RichTerm::from(Term::Num(Number::from(acc))));
     }
 
     let xs = RichTerm::from(Term::Array(

--- a/benches/arrays.rs
+++ b/benches/arrays.rs
@@ -3,7 +3,7 @@ use std::rc::Rc;
 use criterion::{criterion_main, Criterion};
 use nickel_lang::term::{
     array::{Array, ArrayAttrs},
-    RichTerm, Term, Number
+    Number, RichTerm, Term,
 };
 use nickel_lang_utilities::{ncl_bench_group, EvalMode};
 use pprof::criterion::{Output, PProfProfiler};

--- a/doc/manual/syntax.md
+++ b/doc/manual/syntax.md
@@ -22,8 +22,20 @@ There are four basic kinds of values in Nickel :
 ### Numeric values
 
 Nickel has a support for numbers, positive and negative, with or without
-decimals. Internally, those numbers are stored as 64-bits floating point
-numbers, following the IEEE 754 standard.
+decimals. Internally, those numbers are stored as arbitrary precision rational
+numbers, meaning that basic arithmetic operations (addition, subtraction,
+division and multiplication) don't incur rounding errors. Numbers are
+deserialized as 64-bits floating point numbers.
+
+Raising to a non-integer power is one operation which can incur rounding errors:
+both operands need to be converted to the nearest 64-bits floating point
+numbers, the power is computed as a 64-bits floating point number as well,
+and converted back to an arbitrary precision rational number.
+
+Numbers are serialized as integers whenever possible (when they fit exactly into
+a 64-bits signed integer or a 64-bits unsigned integer), and as a 64 bits float
+otherwise. The latter conversion might lose precision as well, for example when
+serializing `1/3`.
 
 Examples:
 

--- a/doc/manual/typing.md
+++ b/doc/manual/typing.md
@@ -162,7 +162,10 @@ Let us now have a quick tour of the type system. The basic types are:
 
 - `Dyn`: the dynamic type. This is the type given to most expressions outside of
   a typed block. A value of type `Dyn` can be pretty much anything.
-- `Number`: the only number type. Currently implemented as a 64bits float.
+- `Number`: the only number type. Currently implemented as arbitrary precision
+    rationals. Common arithmetic operations are exact. The power function using
+    a non-integer exponent might is computed on floating point values, which
+    might incur rounding errors.
 - `String`: a string, which must always be valid UTF8.
 - `Bool`: a boolean, that is either `true` or `false`.
 <!-- - `Lbl`: a contract label. You usually don't need to use it or worry about it,-->

--- a/doc/manual/typing.md
+++ b/doc/manual/typing.md
@@ -164,7 +164,7 @@ Let us now have a quick tour of the type system. The basic types are:
   a typed block. A value of type `Dyn` can be pretty much anything.
 - `Number`: the only number type. Currently implemented as arbitrary precision
     rationals. Common arithmetic operations are exact. The power function using
-    a non-integer exponent might is computed on floating point values, which
+    a non-integer exponent is computed on floating point values, which
     might incur rounding errors.
 - `String`: a string, which must always be valid UTF8.
 - `Bool`: a boolean, that is either `true` or `false`.

--- a/src/deserialize.rs
+++ b/src/deserialize.rs
@@ -34,15 +34,10 @@ macro_rules! deserialize_number {
 /// An error occurred during deserialization to Rust.
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub enum RustDeserializationError {
-    InvalidType {
-        expected: String,
-        occurred: String,
-    },
+    InvalidType { expected: String, occurred: String },
     MissingValue,
     EmptyRecordField,
-    UnimplementedType {
-        occurred: String,
-    },
+    UnimplementedType { occurred: String },
     InvalidRecordLength(usize),
     InvalidArrayLength(usize),
     Other(String),

--- a/src/eval/merge.rs
+++ b/src/eval/merge.rs
@@ -131,7 +131,7 @@ pub fn merge<C: Cache>(
             }
         }
         (Term::Num(n1), Term::Num(n2)) => {
-            if (n1 - n2).abs() < f64::EPSILON {
+            if n1 == n2 {
                 Ok(Closure::atomic_closure(RichTerm::new(
                     Term::Num(n1),
                     pos_op.into_inherited(),

--- a/src/eval/operation.rs
+++ b/src/eval/operation.rs
@@ -25,7 +25,7 @@ use crate::{
     stdlib::internals,
     term::{
         array::{Array, ArrayAttrs},
-        make as mk_term, number_approx_to_string,
+        make as mk_term,
         record::{self, Field, FieldMetadata, RecordAttrs, RecordData},
         BinaryOp, MergePriority, NAryOp, Number, PendingContract, RecordExtKind, RichTerm,
         SharedTerm, StrChunk, Term, UnaryOp,
@@ -34,8 +34,13 @@ use crate::{
 };
 
 use malachite::{
-    num::arithmetic::traits::Pow, num::basic::traits::One, num::basic::traits::Zero,
-    num::conversion::traits::RoundingFrom, rounding_modes::RoundingMode, Integer,
+    num::{
+        arithmetic::traits::Pow,
+        basic::traits::{One, Zero},
+        conversion::traits::{RoundingFrom, ToSci},
+    },
+    rounding_modes::RoundingMode,
+    Integer,
 };
 
 use md5::digest::Digest;
@@ -1047,7 +1052,7 @@ impl<R: ImportResolver, C: Cache> VirtualMachine<R, C> {
             }
             UnaryOp::ToStr() => {
                 let result = match_sharedterm! {t, with {
-                    Term::Num(n) => Ok(Term::Str(number_approx_to_string(&n))),
+                    Term::Num(n) => Ok(Term::Str(format!("{}", n.to_sci()))),
                     Term::Str(s) => Ok(Term::Str(s)),
                     Term::Bool(b) => Ok(Term::Str(b.to_string())),
                     Term::Enum(id) => Ok(Term::Str(id.to_string())),

--- a/src/eval/operation.rs
+++ b/src/eval/operation.rs
@@ -1066,7 +1066,7 @@ impl<R: ImportResolver, C: Cache> VirtualMachine<R, C> {
             }
             UnaryOp::NumFromStr() => {
                 if let Term::Str(s) = &*t {
-                    let n = parse_rational(&s).map_err(|_| {
+                    let n = parse_rational(s).map_err(|_| {
                         EvalError::Other(format!("num_from_string: invalid num literal `{s}`"), pos)
                     })?;
                     Ok(Closure::atomic_closure(RichTerm::new(

--- a/src/eval/operation.rs
+++ b/src/eval/operation.rs
@@ -18,7 +18,7 @@ use crate::{
     identifier::Ident,
     label::ty_path,
     match_sharedterm, mk_app, mk_fun, mk_opn, mk_record,
-    parser::utils::parse_rational,
+    parser::utils::parse_number,
     position::TermPos,
     serialize,
     serialize::ExportFormat,
@@ -1066,7 +1066,7 @@ impl<R: ImportResolver, C: Cache> VirtualMachine<R, C> {
             }
             UnaryOp::NumFromStr() => {
                 if let Term::Str(s) = &*t {
-                    let n = parse_rational(s).map_err(|_| {
+                    let n = parse_number(s).map_err(|_| {
                         EvalError::Other(format!("num_from_string: invalid num literal `{s}`"), pos)
                     })?;
                     Ok(Closure::atomic_closure(RichTerm::new(

--- a/src/eval/operation.rs
+++ b/src/eval/operation.rs
@@ -27,15 +27,15 @@ use crate::{
         array::{Array, ArrayAttrs},
         make as mk_term, number_approx_to_string,
         record::{self, Field, FieldMetadata, RecordAttrs, RecordData},
-        BinaryOp, MergePriority, NAryOp, PendingContract, RecordExtKind, RichTerm, SharedTerm,
-        StrChunk, Term, UnaryOp,
+        BinaryOp, MergePriority, NAryOp, Number, PendingContract, RecordExtKind, RichTerm,
+        SharedTerm, StrChunk, Term, UnaryOp,
     },
     transform::Closurizable,
 };
 
 use malachite::{
     num::arithmetic::traits::Pow, num::basic::traits::One, num::basic::traits::Zero,
-    num::conversion::traits::RoundingFrom, rounding_modes::RoundingMode, Integer, Rational,
+    num::conversion::traits::RoundingFrom, rounding_modes::RoundingMode, Integer,
 };
 
 use md5::digest::Digest;
@@ -618,7 +618,7 @@ impl<R: ImportResolver, C: Cache> VirtualMachine<R, C> {
                     ))
                 };
 
-                if n < &Rational::ZERO {
+                if n < &Number::ZERO {
                     return Err(EvalError::Other(
                         format!(
                             "generate: expected the 1st argument to be a positive number, got {n}"
@@ -1191,7 +1191,7 @@ impl<R: ImportResolver, C: Cache> VirtualMachine<R, C> {
                         //FIXME: what should we return when there's no match?
                         mk_record!(
                             ("matched", Term::Str(String::new())),
-                            ("index", Term::Num(Rational::from(-1))),
+                            ("index", Term::Num(Number::from(-1))),
                             (
                                 "groups",
                                 Term::Array(Array::default(), ArrayAttrs::default())
@@ -1498,7 +1498,7 @@ impl<R: ImportResolver, C: Cache> VirtualMachine<R, C> {
             BinaryOp::Div() => {
                 if let Term::Num(ref n1) = *t1 {
                     if let Term::Num(ref n2) = *t2 {
-                        if n2 == &Rational::ZERO {
+                        if n2 == &Number::ZERO {
                             Err(EvalError::Other(String::from("division by zero"), pos_op))
                         } else {
                             Ok(Closure::atomic_closure(RichTerm::new(
@@ -1554,12 +1554,12 @@ impl<R: ImportResolver, C: Cache> VirtualMachine<R, C> {
                     ))
                 };
 
-                if n2 == &Rational::ZERO {
+                if n2 == &Number::ZERO {
                     return Err(EvalError::Other(String::from("division by zero (%)"), pos2));
                 }
 
-                // This is the equivalent of `truncate()` for `Rational`
-                let quotient = Rational::from(Integer::rounding_from(n1 / n2, RoundingMode::Down));
+                // This is the equivalent of `truncate()` for `Number`
+                let quotient = Number::from(Integer::rounding_from(n1 / n2, RoundingMode::Down));
 
                 Ok(Closure::atomic_closure(RichTerm::new(
                     Term::Num(n1 - quotient * n2),
@@ -1585,7 +1585,7 @@ impl<R: ImportResolver, C: Cache> VirtualMachine<R, C> {
                             let result_as_f64 = f64::rounding_from(n1, RoundingMode::Nearest)
                                 .powf(f64::rounding_from(n2, RoundingMode::Nearest));
                             // The following conversion fails if the result is NaN or +/-infinity
-                            Rational::try_from_float_simplest(result_as_f64).map_err(|_|
+                            Number::try_from_float_simplest(result_as_f64).map_err(|_|
                               EvalError::Other(
                                   format!("invalid arithmetic operation: {n1}^{n2} returned {result_as_f64}, but {result_as_f64} isn't representable in Nickel"),
                                   pos_op
@@ -2889,7 +2889,7 @@ impl<R: ImportResolver, C: Cache> VirtualMachine<R, C> {
                         }
 
                         if end <= start || !s.is_char_boundary(end_as_usize) {
-                            return Err(EvalError::Other(format!("substring: index out of bounds. Expected the 3rd argument (end) to be between {} and {}, got {}", start + Rational::ONE, s.len(), end), pos_op));
+                            return Err(EvalError::Other(format!("substring: index out of bounds. Expected the 3rd argument (end) to be between {} and {}, got {}", start + Number::ONE, s.len(), end), pos_op));
                         };
 
                         Ok(Closure::atomic_closure(RichTerm::new(

--- a/src/eval/tests.rs
+++ b/src/eval/tests.rs
@@ -5,7 +5,7 @@ use crate::error::ImportError;
 use crate::label::Label;
 use crate::parser::{grammar, lexer};
 use crate::term::make as mk_term;
-use crate::term::Rational;
+use crate::term::Number;
 use crate::term::{BinaryOp, StrChunk, UnaryOp};
 use crate::transform::import_resolution::strict::resolve_imports;
 use crate::{mk_app, mk_fun};
@@ -30,7 +30,7 @@ fn parse(s: &str) -> Option<RichTerm> {
 
 #[test]
 fn identity_over_values() {
-    let num = Term::Num(Rational::try_from(45.3).unwrap());
+    let num = Term::Num(Number::try_from(45.3).unwrap());
     assert_eq!(Ok(num.clone()), eval_no_import(num.into()));
 
     let boolean = Term::Bool(true);
@@ -69,19 +69,19 @@ fn only_fun_are_applicable() {
 #[test]
 fn simple_app() {
     let t = mk_app!(mk_term::id(), mk_term::integer(5));
-    assert_eq!(Ok(Term::Num(Rational::from(5))), eval_no_import(t));
+    assert_eq!(Ok(Term::Num(Number::from(5))), eval_no_import(t));
 }
 
 #[test]
 fn simple_let() {
     let t = mk_term::let_in("x", mk_term::integer(5), mk_term::var("x"));
-    assert_eq!(Ok(Term::Num(Rational::from(5))), eval_no_import(t));
+    assert_eq!(Ok(Term::Num(Number::from(5))), eval_no_import(t));
 }
 
 #[test]
 fn simple_ite() {
     let t = mk_term::if_then_else(Term::Bool(true), mk_term::integer(5), Term::Bool(false));
-    assert_eq!(Ok(Term::Num(Rational::from(5))), eval_no_import(t));
+    assert_eq!(Ok(Term::Num(Number::from(5))), eval_no_import(t));
 }
 
 #[test]
@@ -89,10 +89,10 @@ fn simple_plus() {
     let t = mk_term::op2(
         BinaryOp::Plus(),
         mk_term::integer(5),
-        Term::Num(Rational::try_from(7.5).unwrap()),
+        Term::Num(Number::try_from(7.5).unwrap()),
     );
     assert_eq!(
-        Ok(Term::Num(Rational::try_from(12.5).unwrap())),
+        Ok(Term::Num(Number::try_from(12.5).unwrap())),
         eval_no_import(t)
     );
 }
@@ -101,7 +101,7 @@ fn simple_plus() {
 fn asking_for_various_types() {
     let num = mk_term::op1(
         UnaryOp::Typeof(),
-        Term::Num(Rational::try_from(45.3).unwrap()),
+        Term::Num(Number::try_from(45.3).unwrap()),
     );
     assert_eq!(Ok(Term::Enum("Number".into())), eval_no_import(num));
 

--- a/src/eval/tests.rs
+++ b/src/eval/tests.rs
@@ -5,8 +5,8 @@ use crate::error::ImportError;
 use crate::label::Label;
 use crate::parser::{grammar, lexer};
 use crate::term::make as mk_term;
-use crate::term::{BinaryOp, StrChunk, UnaryOp};
 use crate::term::Rational;
+use crate::term::{BinaryOp, StrChunk, UnaryOp};
 use crate::transform::import_resolution::strict::resolve_imports;
 use crate::{mk_app, mk_fun};
 use codespan::Files;
@@ -86,13 +86,23 @@ fn simple_ite() {
 
 #[test]
 fn simple_plus() {
-    let t = mk_term::op2(BinaryOp::Plus(), mk_term::integer(5), Term::Num(Rational::try_from(7.5).unwrap()));
-    assert_eq!(Ok(Term::Num(Rational::try_from(12.5).unwrap())), eval_no_import(t));
+    let t = mk_term::op2(
+        BinaryOp::Plus(),
+        mk_term::integer(5),
+        Term::Num(Rational::try_from(7.5).unwrap()),
+    );
+    assert_eq!(
+        Ok(Term::Num(Rational::try_from(12.5).unwrap())),
+        eval_no_import(t)
+    );
 }
 
 #[test]
 fn asking_for_various_types() {
-    let num = mk_term::op1(UnaryOp::Typeof(), Term::Num(Rational::try_from(45.3).unwrap()));
+    let num = mk_term::op1(
+        UnaryOp::Typeof(),
+        Term::Num(Rational::try_from(45.3).unwrap()),
+    );
     assert_eq!(Ok(Term::Enum("Number".into())), eval_no_import(num));
 
     let boolean = mk_term::op1(UnaryOp::Typeof(), Term::Bool(true));

--- a/src/parser/grammar.lalrpop
+++ b/src/parser/grammar.lalrpop
@@ -71,6 +71,11 @@ use crate::{
     label::Label,
 };
 
+use malachite::{
+    Rational,
+    num::basic::traits::Zero,
+};
+
 grammar<'input, 'err, 'wcard>(
     src_id: FileId,
     errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, ParseError>>,
@@ -141,8 +146,7 @@ SimpleFieldAnnotAtom<TypeRule>: FieldMetadata = {
         ..Default::default()
     },
     "|" "priority" <SignedNumLiteral> => FieldMetadata {
-        // unwrap(): a literal can't be NaN
-        priority: MergePriority::Numeral(NumeralPriority::try_from(<>).unwrap()),
+        priority: MergePriority::Numeral(<>),
         ..Default::default()
     },
     "|" "optional" => FieldMetadata {
@@ -789,7 +793,7 @@ InfixExpr: UniTerm = {
 
     #[precedence(level="1")]
     "-" <AsTerm<InfixExpr>> =>
-        UniTerm::from(mk_term::op2(BinaryOp::Sub(), Term::Num(0.0), <>)),
+        UniTerm::from(mk_term::op2(BinaryOp::Sub(), Term::Num(Rational::ZERO), <>)),
 
     #[precedence(level="2")] #[assoc(side="left")]
     InfixBOpApp<InfixBOp2, InfixExpr, InfixExpr>,
@@ -894,19 +898,20 @@ TypeAtom: Types = {
                 ),
                 |erows, row| EnumRows(EnumRowsF::Extend { row, tail: Box::new(erows) })
             );
- 	    Types::from(TypeF::Enum(ty))
+
+        Types::from(TypeF::Enum(ty))
     },
     "{" "_" ":" <t: WithPos<Types>> "}" => {
         Types::from(TypeF::Dict(Box::new(t)))
     },
     "_" => {
         let id = *next_wildcard_id;
-        *next_wildcard_id += 1;        
+        *next_wildcard_id += 1;
         Types::from(TypeF::Wildcard(id))
     },
 }
 
-SignedNumLiteral: f64 = <sign: "-"?> <value: "num literal"> => {
+SignedNumLiteral: Rational = <sign: "-"?> <value: "num literal"> => {
     if sign.is_some() {
         -value
     } else {
@@ -923,7 +928,7 @@ extern {
         "str literal" => Token::Str(StringToken::Literal(<&'input str>)),
         "str esc char" => Token::Str(StringToken::EscapedChar(<char>)),
         "multstr literal" => Token::MultiStr(MultiStringToken::Literal(<&'input str>)),
-        "num literal" => Token::Normal(NormalToken::NumLiteral(<f64>)),
+        "num literal" => Token::Normal(NormalToken::NumLiteral(<Rational>)),
 
         "raw enum tag" => Token::Normal(NormalToken::RawEnumTag(<&'input str>)),
         "`\"" => Token::Normal(NormalToken::StrEnumTagBegin),

--- a/src/parser/grammar.lalrpop
+++ b/src/parser/grammar.lalrpop
@@ -71,10 +71,7 @@ use crate::{
     label::Label,
 };
 
-use malachite::{
-    Rational,
-    num::basic::traits::Zero,
-};
+use malachite::num::basic::traits::Zero;
 
 grammar<'input, 'err, 'wcard>(
     src_id: FileId,
@@ -793,7 +790,7 @@ InfixExpr: UniTerm = {
 
     #[precedence(level="1")]
     "-" <AsTerm<InfixExpr>> =>
-        UniTerm::from(mk_term::op2(BinaryOp::Sub(), Term::Num(Rational::ZERO), <>)),
+        UniTerm::from(mk_term::op2(BinaryOp::Sub(), Term::Num(Number::ZERO), <>)),
 
     #[precedence(level="2")] #[assoc(side="left")]
     InfixBOpApp<InfixBOp2, InfixExpr, InfixExpr>,
@@ -911,7 +908,7 @@ TypeAtom: Types = {
     },
 }
 
-SignedNumLiteral: Rational = <sign: "-"?> <value: "num literal"> => {
+SignedNumLiteral: Number = <sign: "-"?> <value: "num literal"> => {
     if sign.is_some() {
         -value
     } else {
@@ -928,7 +925,7 @@ extern {
         "str literal" => Token::Str(StringToken::Literal(<&'input str>)),
         "str esc char" => Token::Str(StringToken::EscapedChar(<char>)),
         "multstr literal" => Token::MultiStr(MultiStringToken::Literal(<&'input str>)),
-        "num literal" => Token::Normal(NormalToken::NumLiteral(<Rational>)),
+        "num literal" => Token::Normal(NormalToken::NumLiteral(<Number>)),
 
         "raw enum tag" => Token::Normal(NormalToken::RawEnumTag(<&'input str>)),
         "`\"" => Token::Normal(NormalToken::StrEnumTagBegin),

--- a/src/parser/lexer.rs
+++ b/src/parser/lexer.rs
@@ -33,8 +33,8 @@ use super::{
     error::{LexicalError, ParseError},
     utils::parse_rational,
 };
+use crate::term::Number;
 use logos::Logos;
-use malachite::Rational;
 use std::ops::Range;
 
 fn symbolic_string_prefix_and_length<'input>(
@@ -72,7 +72,7 @@ pub enum NormalToken<'input> {
     // unwrap(): try_from_float_simplest only fails on NaN or infinity, but those values aren't
     // representable as a number literal.
     #[regex("[0-9]*\\.?[0-9]+", |lex| parse_rational(lex.slice()))]
-    NumLiteral(Rational),
+    NumLiteral(Number),
 
     // **IMPORTANT**
     // This regex should be kept in sync with the one for Identifier above.

--- a/src/parser/lexer.rs
+++ b/src/parser/lexer.rs
@@ -31,8 +31,8 @@
 //! that the coming characters must be lexed as string tokens, and not as normal tokens.
 use crate::parser::error::{LexicalError, ParseError};
 use logos::Logos;
-use std::ops::Range;
 use malachite::Rational;
+use std::ops::Range;
 
 fn symbolic_string_prefix_and_length<'input>(
     lex: &mut logos::Lexer<'input, NormalToken<'input>>,

--- a/src/parser/lexer.rs
+++ b/src/parser/lexer.rs
@@ -29,7 +29,10 @@
 //! `0`, this is the end of the current interpolated expressions, and we leave the normal mode and
 //! go back to string mode. In our example, this is the second `}`: at this point, the lexer knows
 //! that the coming characters must be lexed as string tokens, and not as normal tokens.
-use crate::parser::error::{LexicalError, ParseError};
+use super::{
+    error::{LexicalError, ParseError},
+    utils::parse_rational,
+};
 use logos::Logos;
 use malachite::Rational;
 use std::ops::Range;
@@ -66,7 +69,9 @@ pub enum NormalToken<'input> {
     // regex for checking identifiers at ../lsp/nls/src/requests/completion.rs
     #[regex("_?[a-zA-Z][_a-zA-Z0-9-']*")]
     Identifier(&'input str),
-    #[regex("[0-9]*\\.?[0-9]+", |lex| lex.slice().parse())]
+    // unwrap(): try_from_float_simplest only fails on NaN or infinity, but those values aren't
+    // representable as a number literal.
+    #[regex("[0-9]*\\.?[0-9]+", |lex| parse_rational(lex.slice()))]
     NumLiteral(Rational),
 
     // **IMPORTANT**

--- a/src/parser/lexer.rs
+++ b/src/parser/lexer.rs
@@ -31,7 +31,7 @@
 //! that the coming characters must be lexed as string tokens, and not as normal tokens.
 use super::{
     error::{LexicalError, ParseError},
-    utils::parse_rational,
+    utils::parse_number,
 };
 use crate::term::Number;
 use logos::Logos;
@@ -69,9 +69,7 @@ pub enum NormalToken<'input> {
     // regex for checking identifiers at ../lsp/nls/src/requests/completion.rs
     #[regex("_?[a-zA-Z][_a-zA-Z0-9-']*")]
     Identifier(&'input str),
-    // unwrap(): try_from_float_simplest only fails on NaN or infinity, but those values aren't
-    // representable as a number literal.
-    #[regex("[0-9]*\\.?[0-9]+", |lex| parse_rational(lex.slice()))]
+    #[regex("[0-9]*\\.?[0-9]+", |lex| parse_number(lex.slice()))]
     NumLiteral(Number),
 
     // **IMPORTANT**

--- a/src/parser/lexer.rs
+++ b/src/parser/lexer.rs
@@ -32,6 +32,7 @@
 use crate::parser::error::{LexicalError, ParseError};
 use logos::Logos;
 use std::ops::Range;
+use malachite::Rational;
 
 fn symbolic_string_prefix_and_length<'input>(
     lex: &mut logos::Lexer<'input, NormalToken<'input>>,
@@ -66,7 +67,7 @@ pub enum NormalToken<'input> {
     #[regex("_?[a-zA-Z][_a-zA-Z0-9-']*")]
     Identifier(&'input str),
     #[regex("[0-9]*\\.?[0-9]+", |lex| lex.slice().parse())]
-    NumLiteral(f64),
+    NumLiteral(Rational),
 
     // **IMPORTANT**
     // This regex should be kept in sync with the one for Identifier above.

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -72,7 +72,7 @@ fn numbers() {
     assert_eq!(parse_without_pos("22.0"), mk_term::integer(22));
     assert_eq!(
         parse_without_pos("22.22"),
-        Num(Rational::try_from(22.22).unwrap()).into()
+        Num(Rational::try_from_float_simplest(22.22).unwrap()).into()
     );
     assert_eq!(parse_without_pos("(22)"), mk_term::integer(22));
     assert_eq!(parse_without_pos("((22))"), mk_term::integer(22));

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -6,7 +6,7 @@ use crate::error::ParseError;
 use crate::identifier::Ident;
 use crate::parser::error::ParseError as InternalParseError;
 use crate::term::array::Array;
-use crate::term::Rational;
+use crate::term::Number;
 use crate::term::Term::*;
 use crate::term::{make as mk_term, Term};
 use crate::term::{record, BinaryOp, RichTerm, StrChunk, UnaryOp};
@@ -72,7 +72,7 @@ fn numbers() {
     assert_eq!(parse_without_pos("22.0"), mk_term::integer(22));
     assert_eq!(
         parse_without_pos("22.22"),
-        Num(Rational::try_from_float_simplest(22.22).unwrap()).into()
+        Num(Number::try_from_float_simplest(22.22).unwrap()).into()
     );
     assert_eq!(parse_without_pos("(22)"), mk_term::integer(22));
     assert_eq!(parse_without_pos("((22))"), mk_term::integer(22));
@@ -377,7 +377,7 @@ fn string_lexing() {
                 Token::Normal(NormalToken::DoubleQuote),
                 Token::Str(StringToken::Literal("1 + ")),
                 Token::Str(StringToken::Interpolation),
-                Token::Normal(NormalToken::NumLiteral(Rational::from(1))),
+                Token::Normal(NormalToken::NumLiteral(Number::from(1))),
                 Token::Normal(NormalToken::RBrace),
                 Token::Str(StringToken::Literal(" + 2")),
                 Token::Normal(NormalToken::DoubleQuote),
@@ -392,7 +392,7 @@ fn string_lexing() {
                 Token::Str(StringToken::Interpolation),
                 Token::Normal(NormalToken::DoubleQuote),
                 Token::Str(StringToken::Interpolation),
-                Token::Normal(NormalToken::NumLiteral(Rational::from(1))),
+                Token::Normal(NormalToken::NumLiteral(Number::from(1))),
                 Token::Normal(NormalToken::RBrace),
                 Token::Normal(NormalToken::DoubleQuote),
                 Token::Normal(NormalToken::RBrace),
@@ -430,7 +430,7 @@ fn string_lexing() {
                 })),
                 Token::MultiStr(MultiStringToken::Literal("text ")),
                 Token::MultiStr(MultiStringToken::Interpolation),
-                Token::Normal(NormalToken::NumLiteral(Rational::from(1))),
+                Token::Normal(NormalToken::NumLiteral(Number::from(1))),
                 Token::Normal(NormalToken::RBrace),
                 Token::MultiStr(MultiStringToken::Literal(" etc.")),
                 Token::MultiStr(MultiStringToken::End),

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -6,10 +6,10 @@ use crate::error::ParseError;
 use crate::identifier::Ident;
 use crate::parser::error::ParseError as InternalParseError;
 use crate::term::array::Array;
+use crate::term::Rational;
 use crate::term::Term::*;
 use crate::term::{make as mk_term, Term};
 use crate::term::{record, BinaryOp, RichTerm, StrChunk, UnaryOp};
-use crate::term::Rational;
 
 use crate::{mk_app, mk_match};
 use assert_matches::assert_matches;
@@ -70,7 +70,10 @@ fn mk_symbolic_single_chunk(prefix: &str, s: &str) -> RichTerm {
 fn numbers() {
     assert_eq!(parse_without_pos("22"), mk_term::integer(22));
     assert_eq!(parse_without_pos("22.0"), mk_term::integer(22));
-    assert_eq!(parse_without_pos("22.22"), Num(Rational::try_from(22.22).unwrap()).into());
+    assert_eq!(
+        parse_without_pos("22.22"),
+        Num(Rational::try_from(22.22).unwrap()).into()
+    );
     assert_eq!(parse_without_pos("(22)"), mk_term::integer(22));
     assert_eq!(parse_without_pos("((22))"), mk_term::integer(22));
 }

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -298,7 +298,7 @@ fn record_terms() {
                 .collect()
             ),
             vec![(
-                StrChunks(vec![StrChunk::expr(RichTerm::from(mk_term::integer(123)))]).into(),
+                StrChunks(vec![StrChunk::expr(mk_term::integer(123))]).into(),
                 Field::from(mk_app!(
                     mk_term::op1(UnaryOp::Ite(), mk_term::integer(4)),
                     mk_term::integer(5),

--- a/src/parser/utils.rs
+++ b/src/parser/utils.rs
@@ -25,18 +25,12 @@ use crate::{
     types::{TypeF, Types},
 };
 
-pub enum ParseRationalError {
-    ParseFloatError(String),
-    RationalConversionError,
-}
+use malachite::num::conversion::traits::FromSciString;
 
-pub fn parse_rational(slice: &str) -> Result<Rational, ParseRationalError> {
-    let as_f64 = slice
-        .parse::<f64>()
-        .map_err(|err| ParseRationalError::ParseFloatError(err.to_string()))?;
+pub struct ParseNumberError;
 
-    Rational::try_from_float_simplest(as_f64)
-        .map_err(|_| ParseRationalError::RationalConversionError)
+pub fn parse_number(slice: &str) -> Result<Rational, ParseNumberError> {
+    Rational::from_sci_string(slice).ok_or(ParseNumberError)
 }
 
 /// Distinguish between the standard string opening delimiter `"`, the multi-line string

--- a/src/parser/utils.rs
+++ b/src/parser/utils.rs
@@ -18,11 +18,26 @@ use crate::{
     position::{RawSpan, TermPos},
     term::{
         make as mk_term,
+        Rational,
         record::{Field, FieldMetadata, RecordAttrs, RecordData},
         BinaryOp, LabeledType, LetMetadata, RichTerm, StrChunk, Term, TypeAnnotation, UnaryOp,
     },
     types::{TypeF, Types},
 };
+
+pub enum ParseRationalError {
+    ParseFloatError(String),
+    RationalConversionError,
+}
+
+pub fn parse_rational(slice: &str) -> Result<Rational, ParseRationalError> {
+    let as_f64 = slice
+        .parse::<f64>()
+        .map_err(|err| ParseRationalError::ParseFloatError(err.to_string()))?;
+
+    Rational::try_from_float_simplest(as_f64)
+        .map_err(|_| ParseRationalError::RationalConversionError)
+}
 
 /// Distinguish between the standard string opening delimiter `"`, the multi-line string
 /// opening delimter `m%"`, and the symbolic string opening delimiter `s%"`.

--- a/src/parser/utils.rs
+++ b/src/parser/utils.rs
@@ -18,9 +18,9 @@ use crate::{
     position::{RawSpan, TermPos},
     term::{
         make as mk_term,
-        Rational,
         record::{Field, FieldMetadata, RecordAttrs, RecordData},
-        BinaryOp, LabeledType, LetMetadata, RichTerm, StrChunk, Term, TypeAnnotation, UnaryOp,
+        BinaryOp, LabeledType, LetMetadata, Rational, RichTerm, StrChunk, Term, TypeAnnotation,
+        UnaryOp,
     },
     types::{TypeF, Types},
 };

--- a/src/pretty.rs
+++ b/src/pretty.rs
@@ -3,6 +3,7 @@ use crate::identifier::Ident;
 use crate::parser::lexer::KEYWORDS;
 
 use crate::term::{
+    number_approx_to_string,
     record::{Field, FieldMetadata},
     BinaryOp, MergePriority, RichTerm, StrChunk, Term, TypeAnnotation, UnaryOp,
 };
@@ -436,7 +437,7 @@ where
         match self.as_ref() {
             Null => allocator.text("null"),
             Bool(v) => allocator.as_string(v),
-            Num(v) => allocator.as_string(v),
+            Num(n) => allocator.as_string(number_approx_to_string(n)),
             Str(v) => allocator.escaped_string(v).double_quotes(),
             StrChunks(chunks) => allocator.chunks(
                 chunks,

--- a/src/pretty.rs
+++ b/src/pretty.rs
@@ -3,13 +3,12 @@ use crate::identifier::Ident;
 use crate::parser::lexer::KEYWORDS;
 
 use crate::term::{
-    number_approx_to_string,
     record::{Field, FieldMetadata},
     BinaryOp, MergePriority, Number, RichTerm, StrChunk, Term, TypeAnnotation, UnaryOp,
 };
 use crate::types::{EnumRows, EnumRowsF, RecordRowF, RecordRows, RecordRowsF, TypeF, Types};
 
-use malachite::num::basic::traits::Zero;
+use malachite::num::{basic::traits::Zero, conversion::traits::ToSci};
 pub use pretty::{DocAllocator, DocBuilder, Pretty};
 use regex::Regex;
 
@@ -437,7 +436,7 @@ where
         match self.as_ref() {
             Null => allocator.text("null"),
             Bool(v) => allocator.as_string(v),
-            Num(n) => allocator.as_string(number_approx_to_string(n)),
+            Num(n) => allocator.as_string(format!("{}", n.to_sci())),
             Str(v) => allocator.escaped_string(v).double_quotes(),
             StrChunks(chunks) => allocator.chunks(
                 chunks,

--- a/src/pretty.rs
+++ b/src/pretty.rs
@@ -7,9 +7,16 @@ use crate::term::{
     BinaryOp, MergePriority, RichTerm, StrChunk, Term, TypeAnnotation, UnaryOp,
 };
 use crate::types::{EnumRows, EnumRowsF, RecordRowF, RecordRows, RecordRowsF, TypeF, Types};
+
 pub use pretty::{DocAllocator, DocBuilder, Pretty};
 use regex::Regex;
+use malachite::{
+    Rational,
+    num::basic::traits::Zero,
+};
+
 use std::collections::HashMap;
+
 
 #[derive(Clone, Copy, Eq, PartialEq)]
 enum StringRenderStyle {
@@ -178,7 +185,7 @@ where
             } else {
                 self.nil()
             })
-            .append(match metadata.priority {
+            .append(match &metadata.priority {
                 MergePriority::Bottom => self.line().append(self.text("| default")),
                 MergePriority::Neutral => self.nil(),
                 MergePriority::Numeral(p) => self
@@ -668,7 +675,7 @@ where
                     .append(op.pretty(allocator))
                     .append(rtl.to_owned().pretty(allocator))
             } else {
-                if (&BinaryOp::Sub(), &Num(0.0)) == (op, rtl.as_ref()) {
+                if (&BinaryOp::Sub(), &Num(Rational::ZERO)) == (op, rtl.as_ref()) {
                     allocator.text("-")
                 } else if let crate::term::OpPos::Prefix = op.pos() {
                     op.pretty(allocator)

--- a/src/pretty.rs
+++ b/src/pretty.rs
@@ -8,15 +8,11 @@ use crate::term::{
 };
 use crate::types::{EnumRows, EnumRowsF, RecordRowF, RecordRows, RecordRowsF, TypeF, Types};
 
+use malachite::{num::basic::traits::Zero, Rational};
 pub use pretty::{DocAllocator, DocBuilder, Pretty};
 use regex::Regex;
-use malachite::{
-    Rational,
-    num::basic::traits::Zero,
-};
 
 use std::collections::HashMap;
-
 
 #[derive(Clone, Copy, Eq, PartialEq)]
 enum StringRenderStyle {

--- a/src/pretty.rs
+++ b/src/pretty.rs
@@ -5,11 +5,11 @@ use crate::parser::lexer::KEYWORDS;
 use crate::term::{
     number_approx_to_string,
     record::{Field, FieldMetadata},
-    BinaryOp, MergePriority, RichTerm, StrChunk, Term, TypeAnnotation, UnaryOp,
+    BinaryOp, MergePriority, Number, RichTerm, StrChunk, Term, TypeAnnotation, UnaryOp,
 };
 use crate::types::{EnumRows, EnumRowsF, RecordRowF, RecordRows, RecordRowsF, TypeF, Types};
 
-use malachite::{num::basic::traits::Zero, Rational};
+use malachite::num::basic::traits::Zero;
 pub use pretty::{DocAllocator, DocBuilder, Pretty};
 use regex::Regex;
 
@@ -672,7 +672,7 @@ where
                     .append(op.pretty(allocator))
                     .append(rtl.to_owned().pretty(allocator))
             } else {
-                if (&BinaryOp::Sub(), &Num(Rational::ZERO)) == (op, rtl.as_ref()) {
+                if (&BinaryOp::Sub(), &Num(Number::ZERO)) == (op, rtl.as_ref()) {
                     allocator.text("-")
                 } else if let crate::term::OpPos::Prefix = op.pos() {
                     op.pretty(allocator)

--- a/src/program.rs
+++ b/src/program.rs
@@ -559,7 +559,10 @@ mod tests {
 
     #[test]
     fn evaluation_full() {
-        use crate::{mk_array, mk_record, term::{Term, make as mk_term}};
+        use crate::{
+            mk_array, mk_record,
+            term::{make as mk_term, Term},
+        };
 
         let t = eval_full("[(1 + 1), (\"a\" ++ \"b\"), ([ 1, [1 + 2] ])]").unwrap();
 

--- a/src/program.rs
+++ b/src/program.rs
@@ -559,17 +559,17 @@ mod tests {
 
     #[test]
     fn evaluation_full() {
-        use crate::{mk_array, mk_record, term::Term};
+        use crate::{mk_array, mk_record, term::{Term, make as mk_term}};
 
         let t = eval_full("[(1 + 1), (\"a\" ++ \"b\"), ([ 1, [1 + 2] ])]").unwrap();
 
         // [2, "ab", [1, [3]]]
         let expd = mk_array!(
-            Term::Num(2_f64),
+            mk_term::integer(2),
             Term::Str(String::from("ab")),
             mk_array!(
-                Term::Num(1_f64),
-                mk_array!(Term::Num(3_f64); ArrayAttrs::new().closurized());
+                mk_term::integer(1),
+                mk_array!(mk_term::integer(3); ArrayAttrs::new().closurized());
                 ArrayAttrs::new().closurized()
             );
             ArrayAttrs::new().closurized()
@@ -581,7 +581,7 @@ mod tests {
         // Records are parsed as RecRecords, so we need to build one by hand
         let expd = mk_record!((
             "foo",
-            mk_record!(("bar", mk_record!(("baz", Term::Num(2.0)))))
+            mk_record!(("bar", mk_record!(("baz", mk_term::integer(2)))))
         ));
         assert_eq!(t.without_pos(), expd);
 

--- a/src/serialize.rs
+++ b/src/serialize.rs
@@ -6,7 +6,7 @@ use crate::{
     term::{
         array::{Array, ArrayAttrs},
         record::RecordData,
-        Rational, RichTerm, Term, TypeAnnotation,
+        Number, RichTerm, Term, TypeAnnotation,
     },
 };
 
@@ -79,7 +79,7 @@ impl FromStr for ExportFormat {
 /// If the number doesn't fit into an `i64` or `u64`, we approximate it by the nearest `f64` and
 /// serialize this value. This may incur a loss of precision, but this is expected: we can't
 /// represent something like e.g. `1/3` exactly in JSON anyway.
-pub fn serialize_num<S>(n: &Rational, serializer: S) -> Result<S::Ok, S::Error>
+pub fn serialize_num<S>(n: &Number, serializer: S) -> Result<S::Ok, S::Error>
 where
     S: Serializer,
 {
@@ -97,12 +97,12 @@ where
 }
 
 /// Deserialize for an Array. Required to set the default attributes.
-pub fn deserialize_num<'de, D>(deserializer: D) -> Result<Rational, D::Error>
+pub fn deserialize_num<'de, D>(deserializer: D) -> Result<Number, D::Error>
 where
     D: Deserializer<'de>,
 {
     let as_f64 = f64::deserialize(deserializer)?;
-    Rational::try_from_float_simplest(as_f64).map_err(|_| {
+    Number::try_from_float_simplest(as_f64).map_err(|_| {
         serde::de::Error::custom(format!(
             "couldn't conver {as_f64} to a Nickel number: Nickel doesn't support NaN nor infinity"
         ))

--- a/src/serialize.rs
+++ b/src/serialize.rs
@@ -88,10 +88,8 @@ where
             if let Ok(n_as_integer) = i64::try_from(n) {
                 return n_as_integer.serialize(serializer);
             }
-        } else {
-            if let Ok(n_as_uinteger) = u64::try_from(n) {
-                return n_as_uinteger.serialize(serializer);
-            }
+        } else if let Ok(n_as_uinteger) = u64::try_from(n) {
+            return n_as_uinteger.serialize(serializer);
         }
     }
 

--- a/src/serialize.rs
+++ b/src/serialize.rs
@@ -1,12 +1,12 @@
 //! Serialization of an evaluated program to various data format.
-use malachite::{rounding_modes::RoundingMode, num::conversion::traits::RoundingFrom};
+use malachite::{num::conversion::traits::RoundingFrom, rounding_modes::RoundingMode};
 
 use crate::{
     error::SerializationError,
     term::{
         array::{Array, ArrayAttrs},
         record::RecordData,
-        Rational, Integer, RichTerm, Term, TypeAnnotation,
+        Integer, Rational, RichTerm, Term, TypeAnnotation,
     },
 };
 
@@ -80,8 +80,7 @@ where
 {
     if let Ok(n_as_integer) = Integer::try_from(n) {
         n_as_integer.serialize(serializer)
-    }
-    else {
+    } else {
         let n_as_f64 = f64::rounding_from(n, RoundingMode::Nearest);
         n_as_f64.serialize(serializer)
     }

--- a/src/serialize.rs
+++ b/src/serialize.rs
@@ -96,7 +96,7 @@ where
     f64::rounding_from(n, RoundingMode::Nearest).serialize(serializer)
 }
 
-/// Deserialize for an Array. Required to set the default attributes.
+/// Deserialize a Nickel number. As for parsing, we convert the number from a 64bits float
 pub fn deserialize_num<'de, D>(deserializer: D) -> Result<Number, D::Error>
 where
     D: Deserializer<'de>,
@@ -104,7 +104,7 @@ where
     let as_f64 = f64::deserialize(deserializer)?;
     Number::try_from_float_simplest(as_f64).map_err(|_| {
         serde::de::Error::custom(format!(
-            "couldn't conver {as_f64} to a Nickel number: Nickel doesn't support NaN nor infinity"
+            "couldn't convert {as_f64} to a Nickel number: Nickel doesn't support NaN nor infinity"
         ))
     })
 }

--- a/src/term/mod.rs
+++ b/src/term/mod.rs
@@ -240,10 +240,8 @@ pub fn number_approx_to_string(n: &Number) -> String {
             if let Ok(n_as_integer) = i64::try_from(n) {
                 return n_as_integer.to_string();
             }
-        } else {
-            if let Ok(n_as_uinteger) = u64::try_from(n) {
-                return n_as_uinteger.to_string();
-            }
+        } else if let Ok(n_as_uinteger) = u64::try_from(n) {
+            return n_as_uinteger.to_string();
         }
     }
 

--- a/src/term/mod.rs
+++ b/src/term/mod.rs
@@ -37,7 +37,7 @@ use codespan::FileId;
 pub use malachite::{
     num::{
         basic::traits::Zero,
-        conversion::traits::{IsInteger, RoundingFrom},
+        conversion::traits::{IsInteger, RoundingFrom, ToSci},
     },
     rounding_modes::RoundingMode,
     Integer, Rational,
@@ -216,6 +216,7 @@ pub enum Term {
 
 /// A unique sealing key, introduced by polymorphic contracts.
 pub type SealingKey = i32;
+
 /// The underlying type representing Nickel numbers. Currently, numbers are arbitrary precision
 /// rationals.
 ///
@@ -231,22 +232,6 @@ pub type SealingKey = i32;
 ///     lose precision. Otherwise, the number is converted to the nearest 64bit float and then
 ///     serialized/printed, which can incur a loss of information.
 pub type Number = Rational;
-
-/// Convert a Nickel number to a string. Same behavior as [crate::serialize::serialize_num].See
-/// [^number-serialization].
-pub fn number_approx_to_string(n: &Number) -> String {
-    if n.is_integer() {
-        if *n < 0 {
-            if let Ok(n_as_integer) = i64::try_from(n) {
-                return n_as_integer.to_string();
-            }
-        } else if let Ok(n_as_uinteger) = u64::try_from(n) {
-            return n_as_uinteger.to_string();
-        }
-    }
-
-    f64::rounding_from(n, RoundingMode::Nearest).to_string()
-}
 
 /// Type of let-binding. This only affects run-time behavior. Revertible bindings introduce
 /// revertible cache elements at evaluation, which are devices used for the implementation of recursive
@@ -671,7 +656,7 @@ impl Term {
             Term::Null => String::from("null"),
             Term::Bool(true) => String::from("true"),
             Term::Bool(false) => String::from("false"),
-            Term::Num(n) => format!("{n}"),
+            Term::Num(n) => format!("{}", n.to_sci()),
             Term::Str(s) => format!("\"{s}\""),
             Term::StrChunks(chunks) => {
                 let chunks_str: Vec<String> = chunks

--- a/src/term/mod.rs
+++ b/src/term/mod.rs
@@ -35,7 +35,7 @@ use crate::{
 };
 
 use codespan::FileId;
-pub use malachite::Rational;
+pub use malachite::{Rational, Integer};
 
 use serde::{Deserialize, Serialize};
 
@@ -61,7 +61,7 @@ pub enum Term {
     /// A boolean value.
     Bool(bool),
     /// A floating-point value.
-    // #[serde(serialize_with = "crate::serialize::serialize_num")]
+    #[serde(serialize_with = "crate::serialize::serialize_num")]
     Num(Rational),
     /// A literal string.
     Str(String),

--- a/src/term/mod.rs
+++ b/src/term/mod.rs
@@ -35,7 +35,7 @@ use crate::{
 };
 
 use codespan::FileId;
-pub use malachite::{Rational, Integer};
+pub use malachite::{Integer, Rational};
 
 use serde::{Deserialize, Serialize};
 

--- a/stdlib/number.ncl
+++ b/stdlib/number.ncl
@@ -192,6 +192,19 @@
         pow 2 8 =>
           256
       ```
+
+      # Precision
+
+      Nickel numbers are arbitrary precision rationals. If the exponent `y` is
+      an integer which fits in a 64-bits signed or unsigned integer (that is, if
+      `y` is an integer between `−2^63` and `2^64-1`), the result is computed
+      exactly.
+
+      Otherwise, both operands `x` and `y` are converted to the nearest 64 bits
+      float (excluding `NaN` and infinity), and we compute the result as a 64
+      bits float. This result is then converted back to a rational. In this
+      case, **be aware that both the conversion from rationals to floats, and
+      the power operation, might incur rounding errors**.
       "%
     = fun x n => %pow% x n,
   }

--- a/tests/integration/imports.rs
+++ b/tests/integration/imports.rs
@@ -1,6 +1,6 @@
 use assert_matches::assert_matches;
 use nickel_lang::error::{Error, EvalError, ImportError, TypecheckError};
-use nickel_lang::term::Term;
+use nickel_lang::term::{RichTerm, make as mk_term, Term};
 use nickel_lang_utilities::TestProgram;
 use std::io::BufReader;
 use std::path::PathBuf;
@@ -21,7 +21,10 @@ fn nested() {
         "should_be = 3",
     )
     .unwrap();
-    assert_eq!(prog.eval().map(Term::from), Ok(Term::Num(3.)));
+    assert_eq!(
+        prog.eval().map(RichTerm::without_pos),
+        Ok(mk_term::integer(3))
+    );
 }
 
 #[test]
@@ -31,7 +34,10 @@ fn root_path() {
         "should_be = 44",
     )
     .unwrap();
-    assert_eq!(prog.eval().map(Term::from), Ok(Term::Num(44.)));
+    assert_eq!(
+        prog.eval().map(RichTerm::without_pos),
+        Ok(mk_term::integer(44))
+    );
 }
 
 #[test]
@@ -41,7 +47,10 @@ fn multi_imports() {
         "should_be = 5",
     )
     .unwrap();
-    assert_eq!(prog.eval().map(Term::from), Ok(Term::Num(5.)));
+    assert_eq!(
+        prog.eval().map(RichTerm::without_pos),
+        Ok(mk_term::integer(5))
+    );
 }
 
 #[test]

--- a/tests/integration/imports.rs
+++ b/tests/integration/imports.rs
@@ -1,6 +1,6 @@
 use assert_matches::assert_matches;
 use nickel_lang::error::{Error, EvalError, ImportError, TypecheckError};
-use nickel_lang::term::{RichTerm, make as mk_term, Term};
+use nickel_lang::term::{make as mk_term, RichTerm, Term};
 use nickel_lang_utilities::TestProgram;
 use std::io::BufReader;
 use std::path::PathBuf;

--- a/tests/integration/query.rs
+++ b/tests/integration/query.rs
@@ -1,6 +1,7 @@
 use nickel_lang::term::{
+    make as mk_term,
     record::{Field, FieldMetadata},
-    SharedTerm, Term, TypeAnnotation,
+    TypeAnnotation,
 };
 use nickel_lang_utilities::TestProgram;
 
@@ -14,7 +15,7 @@ pub fn test_query_metadata_basic() {
     let result = program.query(Some(String::from("val"))).unwrap();
 
     assert_eq!(result.metadata.doc, Some(String::from("Test basic")));
-    assert_eq!(result.value.unwrap().term, SharedTerm::new(Term::Num(2.0)));
+    assert_eq!(result.value.unwrap().without_pos(), mk_term::integer(2));
 }
 
 #[test]


### PR DESCRIPTION
Closes #1163.

This pull request introduces arbitrary precision rationals as the underlying number representation for Nickel, instead of the current 64-bits float. The motivation and the rationale of the specific design choices are detailed in #1163.

## Choice of the arithmetic library

There are a few Rust crates for doing arbitrary-precision arithmetic:

- [rust-gmp](https://crates.io/crates/rust-gmp) is a direct binding to the well established GMP C library. It's however quite dry and low-level. Doesn't support a WASM build
- [rug](https://docs.rs/rug/latest/rug/#) is a high-level interface to GMP, MPFR and MPC. Because of its C binding, Rug doesn't support a WASM build.
- [ibig](https://crates.io/crates/ibig) is pure Rust, but only support big integers.
- [malachite](https://github.com/mhogrefe/malachite) is suggested in one of the previous's crate documentation if you need WASM. It seems quite complete and reasonably performant, also it doesn't have the same order of magnitude of usages/downloads.
- [scientific](https://github.com/alexkazik/scientific) could work as well, but looks small (2 stars, no issues, no PRs on the repo).

Among the crates that are both WASM-capable and handle arbitrary precision rationals, I chose to go with `malachite` which seemed to be the more solid. It's not out of the question to migrate to a different library anyway, if needed.