### PR TITLE
Rename arguments in `stdlib/internals.ncl`

### DIFF
--- a/stdlib/internals.ncl
+++ b/stdlib/internals.ncl
@@ -3,50 +3,50 @@
   # valid starting character for an identifier.
 
   # Contract implementations
-  "$dyn" = fun l t => t,
+  "$dyn" = fun _label value => value,
 
-  "$num" = fun l t => if %typeof% t == `Number then t else %blame% l,
+  "$num" = fun label value => if %typeof% value == `Number then value else %blame% label,
 
-  "$bool" = fun l t => if %typeof% t == `Bool then t else %blame% l,
+  "$bool" = fun label value => if %typeof% value == `Bool then value else %blame% label,
 
-  "$string" = fun l t => if %typeof% t == `String then t else %blame% l,
+  "$string" = fun label value => if %typeof% value == `String then value else %blame% label,
 
-  "$fail" = fun l t => %blame% l,
+  "$fail" = fun label _value => %blame% label,
 
-  "$array" = fun elt l t =>
-    if %typeof% t == `Array then
-        %array_lazy_assume% (%go_array% l) t elt
+  "$array" = fun element-contract label value =>
+    if %typeof% value == `Array then
+        %array_lazy_assume% (%go_array% label) value element-contract
     else
-        %blame% l,
+        %blame% label,
 
-  "$func" = fun s t l e =>
-      if %typeof% e == `Function then
-          (fun x => %assume% t (%go_codom% l) (e (%assume% s (%chng_pol% (%go_dom% l)) x)))
+  "$func" = fun domain codomain label value =>
+      if %typeof% value == `Function then
+          (fun x => %assume% codomain (%go_codom% label) (value (%assume% domain (%chng_pol% (%go_dom% label)) x)))
       else
-          %blame% l,
+          %blame% label,
 
-  "$forall_var" = fun sy pol l t =>
-      let lPol = %polarity% l in
-      if pol == lPol then
-          %unseal% sy t (%blame% l)
+  "$forall_var" = fun sealing-key polarity label value =>
+      let current-polarity = %polarity% label in
+      if polarity == current-polarity then
+          %unseal% sealing-key value (%blame% label)
       else
           # Here, we know that this term should be sealed, but to give the right
           # blame for the contract, we have to change the polarity to match the
           # polarity of the `Forall`, because this is what's important for
           # blaming polymorphic contracts.
-          %seal% sy (%chng_pol% l) t,
+          %seal% sealing-key (%chng_pol% label) value,
 
-  "$enums" = fun case l t =>
-      if %typeof% t == `Enum then
-          %assume% case l t
+  "$enums" = fun case label value =>
+      if %typeof% value == `Enum then
+          %assume% case label value
       else
-          %blame% (%label_with_message% "not an enum tag" l),
+          %blame% (%label_with_message% "not an enum tag" label),
 
-  "$enum_fail" = fun l =>
-      %blame% (%label_with_message% "tag not included in the enum type" l),
+  "$enum_fail" = fun label =>
+      %blame% (%label_with_message% "tag not included in the enum type" label),
 
-  "$record" = fun field_contracts tail_contract l t =>
-    if %typeof% t == `Record then
+  "$record" = fun field_contracts tail_contract label value =>
+    if %typeof% value == `Record then
       # Returns the sub-record of `l` containing only those fields which are not
       # present in `r`. If `l` has a sealed polymorphic tail then it will be
       # preserved.
@@ -60,59 +60,59 @@
         (%fields% l)
       in
 
-      let contracts_not_in_t = field_diff field_contracts t in
-      let missing_fields = %fields% contracts_not_in_t in
+      let contracts_not_in_value = field_diff field_contracts value in
+      let missing_fields = %fields% contracts_not_in_value in
 
       if %length% missing_fields == 0 then
-        let tail_fields = field_diff t field_contracts in
+        let tail_fields = field_diff value field_contracts in
         let fields_with_contracts = array.fold_left
           (fun acc f =>
             if %has_field% f field_contracts then
               let contract = field_contracts."%{f}" in
-              let label = %go_field% f l in
-              let val = t."%{f}" in
+              let label = %go_field% f label in
+              let val = value."%{f}" in
               %record_insert% f acc (%assume% contract label val)
             else
               acc)
           {}
-          (%fields% t)
+          (%fields% value)
         in
-        tail_contract fields_with_contracts l tail_fields
+        tail_contract fields_with_contracts label tail_fields
       else
-        %blame% (%label_with_message% "missing field %{%head% missing_fields}" l)
+        %blame% (%label_with_message% "missing field %{%head% missing_fields}" label)
     else
-      %blame% (%label_with_message% "not a record" l),
+      %blame% (%label_with_message% "not a record" label),
 
-  "$dyn_record" = fun contr l t =>
-      if %typeof% t == `Record then
-          %dictionary_assume% (%go_dict% l) t contr
+  "$dyn_record" = fun contr label value =>
+      if %typeof% value == `Record then
+          %dictionary_assume% (%go_dict% label) value contr
       else
-          %blame% (%label_with_message% "not a record" l),
+          %blame% (%label_with_message% "not a record" label),
 
-  "$forall_tail" = fun sy pol acc l t =>
-      if pol == (%polarity% l) then
-          if t == {} then
-            let tagged_l = %label_with_message% "polymorphic tail mismatch" l in
-            let tail = %record_unseal_tail% sy tagged_l t in
+  "$forall_tail" = fun sealing-key polarity acc label value =>
+      if polarity == (%polarity% label) then
+          if value == {} then
+            let tagged_label = %label_with_message% "polymorphic tail mismatch" label in
+            let tail = %record_unseal_tail% sealing-key tagged_label value in
             acc & tail
           else
-            %blame% (%label_with_message% "extra field `%{%head% (%fields% t)}`" l)
+            %blame% (%label_with_message% "extra field `%{%head% (%fields% value)}`" label)
       else
           # Note: in order to correctly attribute blame, the polarity of `l`
           # must match the polarity of the `forall` which introduced the
           # polymorphic contract (i.e. `pol`). Since we know in this branch
           # that `pol` and `%polarity% l` differ, we swap `l`'s polarity before
           # we continue.
-          %record_seal_tail% sy (%chng_pol% l) acc t,
+          %record_seal_tail% sealing-key (%chng_pol% label) acc value,
 
-  "$dyn_tail" = fun acc l t => acc & t,
+  "$dyn_tail" = fun acc label value => acc & value,
 
-  "$empty_tail" = fun acc l t =>
-      if t == {} then acc
-      else %blame% (%label_with_message% "extra field `%{%head% (%fields% t)}`" l),
+  "$empty_tail" = fun acc label value =>
+      if value == {} then acc
+      else %blame% (%label_with_message% "extra field `%{%head% (%fields% value)}`" label),
 
   # Recursive priorities operators
 
-  "$rec_force" = fun val => %rec_force% (%force% val),
-  "$rec_default" = fun val => %rec_default% (%force% val),
+  "$rec_force" = fun value => %rec_force% (%force% value),
+  "$rec_default" = fun value => %rec_default% (%force% value),
 }

--- a/stdlib/internals.ncl
+++ b/stdlib/internals.ncl
@@ -50,14 +50,14 @@
       # Returns the sub-record of `l` containing only those fields which are not
       # present in `r`. If `l` has a sealed polymorphic tail then it will be
       # preserved.
-      let field_diff = fun l r => array.fold_left
-        (fun acc f =>
-          if %has_field% f r then
+      let field_diff = fun left right => array.fold_left
+        (fun acc field =>
+          if %has_field% field right then
             acc
           else
-            %record_insert% f acc (l."%{f}"))
-        (%record_empty_with_tail% l)
-        (%fields% l)
+            %record_insert% field acc (left."%{field}"))
+        (%record_empty_with_tail% left)
+        (%fields% left)
       in
 
       let contracts_not_in_value = field_diff field_contracts value in
@@ -66,12 +66,12 @@
       if %length% missing_fields == 0 then
         let tail_fields = field_diff value field_contracts in
         let fields_with_contracts = array.fold_left
-          (fun acc f =>
-            if %has_field% f field_contracts then
-              let contract = field_contracts."%{f}" in
-              let label = %go_field% f label in
-              let val = value."%{f}" in
-              %record_insert% f acc (%assume% contract label val)
+          (fun acc field =>
+            if %has_field% field field_contracts then
+              let contract = field_contracts."%{field}" in
+              let label = %go_field% field label in
+              let val = value."%{field}" in
+              %record_insert% field acc (%assume% contract label val)
             else
               acc)
           {}
@@ -83,9 +83,9 @@
     else
       %blame% (%label_with_message% "not a record" label),
 
-  "$dyn_record" = fun contr label value =>
+  "$dyn_record" = fun contract label value =>
       if %typeof% value == `Record then
-          %dictionary_assume% (%go_dict% label) value contr
+          %dictionary_assume% (%go_dict% label) value contract
       else
           %blame% (%label_with_message% "not a record" label),
 

--- a/stdlib/internals.ncl
+++ b/stdlib/internals.ncl
@@ -13,9 +13,9 @@
 
   "$fail" = fun label _value => %blame% label,
 
-  "$array" = fun element-contract label value =>
+  "$array" = fun element_contract label value =>
     if %typeof% value == `Array then
-        %array_lazy_assume% (%go_array% label) value element-contract
+        %array_lazy_assume% (%go_array% label) value element_contract
     else
         %blame% label,
 
@@ -25,16 +25,16 @@
       else
           %blame% label,
 
-  "$forall_var" = fun sealing-key polarity label value =>
+  "$forall_var" = fun sealing_key polarity label value =>
       let current-polarity = %polarity% label in
       if polarity == current-polarity then
-          %unseal% sealing-key value (%blame% label)
+          %unseal% sealing_key value (%blame% label)
       else
           # Here, we know that this term should be sealed, but to give the right
           # blame for the contract, we have to change the polarity to match the
           # polarity of the `Forall`, because this is what's important for
           # blaming polymorphic contracts.
-          %seal% sealing-key (%chng_pol% label) value,
+          %seal% sealing_key (%chng_pol% label) value,
 
   "$enums" = fun case label value =>
       if %typeof% value == `Enum then
@@ -89,11 +89,11 @@
       else
           %blame% (%label_with_message% "not a record" label),
 
-  "$forall_tail" = fun sealing-key polarity acc label value =>
+  "$forall_tail" = fun sealing_key polarity acc label value =>
       if polarity == (%polarity% label) then
           if value == {} then
             let tagged_label = %label_with_message% "polymorphic tail mismatch" label in
-            let tail = %record_unseal_tail% sealing-key tagged_label value in
+            let tail = %record_unseal_tail% sealing_key tagged_label value in
             acc & tail
           else
             %blame% (%label_with_message% "extra field `%{%head% (%fields% value)}`" label)
@@ -103,7 +103,7 @@
           # polymorphic contract (i.e. `pol`). Since we know in this branch
           # that `pol` and `%polarity% l` differ, we swap `l`'s polarity before
           # we continue.
-          %record_seal_tail% sealing-key (%chng_pol% label) acc value,
+          %record_seal_tail% sealing_key (%chng_pol% label) acc value,
 
   "$dyn_tail" = fun acc label value => acc & value,
 


### PR DESCRIPTION
Move away from single letter or abbreviated argument names in `stdlib/internals.ncl` for better readability.