### PR TITLE
[Refactor] Make label polarity an explicit enum

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -1018,6 +1018,7 @@ mod blame_error {
         label::{
             self,
             ty_path::{self, PathSpan},
+            Polarity,
         },
         position::TermPos,
         term::RichTerm,
@@ -1031,9 +1032,9 @@ mod blame_error {
         if ty_path::has_no_arrow(&l.path) {
             // An empty path or a path that contains only fields necessarily corresponds to
             // a positive blame
-            assert!(l.polarity);
+            assert_eq!(l.polarity, Polarity::Positive);
             "contract broken by a value"
-        } else if l.polarity {
+        } else if l.polarity == Polarity::Positive {
             "contract broken by a function"
         } else {
             "contract broken by the caller"
@@ -1204,7 +1205,7 @@ mod blame_error {
             // The original contract contains an arrow, the subcontract is the domain of an
             // arrow, and the polarity is positive. The function is to be blamed for calling an
             // argument on a value of the wrong type.
-            (Some(_), Some(ty_path::Elem::Domain)) if l.polarity => {
+            (Some(_), Some(ty_path::Elem::Domain)) if l.polarity == Polarity::Positive => {
                 (
                     String::from("expected type of an argument of an inner call"),
                     vec![
@@ -1221,7 +1222,7 @@ mod blame_error {
             // arrow, and the polarity is positive. The function is to be blamed for calling a
             // higher-order function argument on a function which returns a value of the wrong
             // type.
-            (Some(_), Some(ty_path::Elem::Codomain)) if l.polarity => {
+            (Some(_), Some(ty_path::Elem::Codomain)) if l.polarity == Polarity::Positive => {
                 (
                     String::from("expected return type of a sub-function passed as an argument of an inner call"),
                     vec![

--- a/src/eval/operation.rs
+++ b/src/eval/operation.rs
@@ -369,7 +369,7 @@ impl<R: ImportResolver, C: Cache> VirtualMachine<R, C> {
             UnaryOp::ChangePolarity() => match_sharedterm! {t, with {
                     Term::Lbl(l) => {
                         let mut l = l;
-                        l.polarity = !l.polarity;
+                        l.polarity = l.polarity.flip();
                         Ok(Closure::atomic_closure(RichTerm::new(
                             Term::Lbl(l),
                             pos_op_inh,
@@ -387,7 +387,7 @@ impl<R: ImportResolver, C: Cache> VirtualMachine<R, C> {
             UnaryOp::Pol() => {
                 if let Term::Lbl(l) = &*t {
                     Ok(Closure::atomic_closure(RichTerm::new(
-                        Term::Bool(l.polarity),
+                        l.polarity.into(),
                         pos_op_inh,
                     )))
                 } else {

--- a/src/label.rs
+++ b/src/label.rs
@@ -7,7 +7,7 @@ use std::rc::Rc;
 use crate::{
     eval::cache::{Cache as EvalCache, CacheIndex},
     position::{RawSpan, TermPos},
-    term::RichTerm,
+    term::{RichTerm, Term},
     types::{TypeF, Types},
 };
 
@@ -362,9 +362,34 @@ pub struct Label {
     pub arg_pos: TermPos,
     /// The polarity, used for higher-order contracts, that specifies if the current contract is
     /// on the environment (ex, the argument of a function) or on the term.
-    pub polarity: bool,
+    pub polarity: Polarity,
     /// The path of the type being currently checked in the original type.
     pub path: ty_path::Path,
+}
+
+/// A polarity. See [`Label`]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Polarity {
+    Positive,
+    Negative,
+}
+
+impl Polarity {
+    pub fn flip(self) -> Self {
+        match self {
+            Polarity::Positive => Polarity::Negative,
+            Polarity::Negative => Polarity::Positive,
+        }
+    }
+}
+
+impl From<Polarity> for Term {
+    fn from(value: Polarity) -> Self {
+        match value {
+            Polarity::Positive => Term::Bool(true),
+            Polarity::Negative => Term::Bool(false),
+        }
+    }
 }
 
 /// Custom reporting diagnostic that can be set by user-code through the `label` API. Used to
@@ -419,7 +444,7 @@ impl Label {
                 start: 0.into(),
                 end: 1.into(),
             },
-            polarity: true,
+            polarity: Polarity::Positive,
             ..Default::default()
         }
     }
@@ -498,7 +523,7 @@ impl Default for Label {
                 start: 0.into(),
                 end: 1.into(),
             },
-            polarity: true,
+            polarity: Polarity::Positive,
             diagnostics: Default::default(),
             arg_idx: Default::default(),
             arg_pos: Default::default(),

--- a/src/label.rs
+++ b/src/label.rs
@@ -6,6 +6,7 @@ use std::rc::Rc;
 
 use crate::{
     eval::cache::{Cache as EvalCache, CacheIndex},
+    identifier::Ident,
     position::{RawSpan, TermPos},
     term::{RichTerm, Term},
     types::{TypeF, Types},
@@ -386,8 +387,8 @@ impl Polarity {
 impl From<Polarity> for Term {
     fn from(value: Polarity) -> Self {
         match value {
-            Polarity::Positive => Term::Bool(true),
-            Polarity::Negative => Term::Bool(false),
+            Polarity::Positive => Term::Enum(Ident::new("Positive")),
+            Polarity::Negative => Term::Enum(Ident::new("Negative")),
         }
     }
 }

--- a/src/typecheck/operation.rs
+++ b/src/typecheck/operation.rs
@@ -41,8 +41,8 @@ pub fn get_uop_type(
 
             (mk_uniftype::dynamic(), res)
         }
-        // Dyn -> Bool
-        UnaryOp::Pol() => (mk_uniftype::dynamic(), mk_uniftype::bool()),
+        // Dyn -> Polarity
+        UnaryOp::Pol() => (mk_uniftype::dynamic(), mk_uty_enum!("Positive", "Negative")),
         // forall rows. < | rows> -> <id | rows>
         UnaryOp::Embed(id) => {
             let row_var_id = state.table.fresh_erows_var_id();


### PR DESCRIPTION
This refactor makes label polarities an explicit enum `label::Polarity` instead of a confusion-prone `bool`.