### PR TITLE
Fix LSP crash when a resolved import term fails to typecheck

### DIFF
--- a/lsp/nls/src/cache.rs
+++ b/lsp/nls/src/cache.rs
@@ -3,7 +3,7 @@ use std::{collections::HashMap, ffi::OsString, io};
 use codespan::FileId;
 use nickel_lang::{
     cache::{Cache, CacheError, CacheOp, CachedTerm, EntryState},
-    error::Error,
+    error::{Error, ImportError},
     typecheck::{self, linearization::Linearization},
 };
 
@@ -48,8 +48,17 @@ impl CacheExt for Cache {
         if let Ok(CacheOp::Done((ids, errors))) = self.resolve_imports(file_id) {
             import_errors = errors;
             for id in ids {
-                self.typecheck_with_analysis(id, initial_ctxt, initial_env, lin_cache)
-                    .unwrap();
+                match self.typecheck_with_analysis(id, initial_ctxt, initial_env, lin_cache) {
+                    Ok(_) => (),
+                    Err(error) => {
+                        // for now just unwrap
+                        let pos = self.get_ref(id).unwrap().pos;
+                        let f = String::from("<somefile>");
+                        let msg = String::from("Couldn't type check this imports content");
+                        let err = ImportError::IOError(f, msg, pos);
+                        import_errors.push(err);
+                    }
+                }
             }
         }
 

--- a/lsp/nls/src/cache.rs
+++ b/lsp/nls/src/cache.rs
@@ -4,7 +4,6 @@ use codespan::FileId;
 use nickel_lang::{
     cache::{Cache, CacheError, CacheOp, CachedTerm, EntryState},
     error::{Error, ImportError},
-    position::TermPos,
     term::{RichTerm, Term, Traverse, TraverseOrder},
     typecheck::{self, linearization::Linearization},
 };
@@ -58,12 +57,16 @@ impl CacheExt for Cache {
         }
 
         // After self.parse(), the cache must be populated
-        let CachedTerm { term, .. } = self.terms().get(&file_id).unwrap();
-        let mut errors: Vec<(String, TermPos)> = Vec::new();
+        let CachedTerm {
+            term,
+            state,
+            parse_errs,
+        } = self.terms_mut().remove(&file_id).unwrap();
 
-        let term = term.clone(); // Don't like this
-
-        term.traverse::<_, _, ()>(
+        // We do this to get a list of the imports that have been resolved
+        // but don't typecheck, and output an appriopiate diagnostics
+        let mut errors = Vec::new();
+        let term = term.traverse::<_, _, ()>(
             // O(n) every time
             &|rt, errors: &mut Vec<_>| {
                 let RichTerm { ref term, pos } = rt;
@@ -80,6 +83,15 @@ impl CacheExt for Cache {
             TraverseOrder::TopDown,
         )
         .unwrap();
+
+        self.terms_mut().insert(
+            file_id,
+            CachedTerm {
+                term,
+                state,
+                parse_errs,
+            },
+        );
 
         let message = "This import could not be resolved because its content either failed to parse or typecheck correctly.";
         let errors = errors

--- a/lsp/nls/src/cache.rs
+++ b/lsp/nls/src/cache.rs
@@ -48,8 +48,8 @@ impl CacheExt for Cache {
         if let Ok(CacheOp::Done((ids, errors))) = self.resolve_imports(file_id) {
             import_errors = errors;
             for id in ids {
-                self.typecheck_with_analysis(id, initial_ctxt, initial_env, lin_cache)
-                    .unwrap();
+                // Don't crash when an import doens't type check
+                let _ = self.typecheck_with_analysis(id, initial_ctxt, initial_env, lin_cache);
             }
         }
 

--- a/lsp/nls/src/cache.rs
+++ b/lsp/nls/src/cache.rs
@@ -3,7 +3,7 @@ use std::{collections::HashMap, ffi::OsString, io};
 use codespan::FileId;
 use nickel_lang::{
     cache::{Cache, CacheError, CacheOp, CachedTerm, EntryState},
-    error::{Error, ImportError},
+    error::Error,
     typecheck::{self, linearization::Linearization},
 };
 
@@ -48,17 +48,8 @@ impl CacheExt for Cache {
         if let Ok(CacheOp::Done((ids, errors))) = self.resolve_imports(file_id) {
             import_errors = errors;
             for id in ids {
-                match self.typecheck_with_analysis(id, initial_ctxt, initial_env, lin_cache) {
-                    Ok(_) => (),
-                    Err(error) => {
-                        // for now just unwrap
-                        let pos = self.get_ref(id).unwrap().pos;
-                        let f = String::from("<somefile>");
-                        let msg = String::from("Couldn't type check this imports content");
-                        let err = ImportError::IOError(f, msg, pos);
-                        import_errors.push(err);
-                    }
-                }
+                self.typecheck_with_analysis(id, initial_ctxt, initial_env, lin_cache)
+                    .unwrap();
             }
         }
 

--- a/lsp/nls/src/cache.rs
+++ b/lsp/nls/src/cache.rs
@@ -4,8 +4,6 @@ use codespan::FileId;
 use nickel_lang::{
     cache::{Cache, CacheError, CacheOp, CachedTerm, EntryState},
     error::{Error, ImportError},
-    position::TermPos,
-    term::{RichTerm, Term, Traverse, TraverseOrder},
     typecheck::{self, linearization::Linearization},
 };
 
@@ -52,35 +50,13 @@ impl CacheExt for Cache {
             for id in ids {
                 match self.typecheck_with_analysis(id, initial_ctxt, initial_env, lin_cache) {
                     Ok(_) => (),
-                    Err(..) => {
-                        // After self.parse(), the cache must be populated
-                        let CachedTerm { term, .. } = self.terms().get(&file_id).unwrap();
-                        let mut errors: Vec<(String, TermPos)> = Vec::new();
-
-                        let term = term.clone(); // Don't like this
-                        term.traverse::<_, _, ()>(
-                            &|rt, errors: &mut Vec<_>| {
-                                let RichTerm { ref term, pos } = rt;
-                                match term.as_ref() {
-                                    Term::ResolvedImport(id) if !lin_cache.contains_key(id) => {
-                                        let name: String = self.name(*id).to_str().unwrap().into();
-                                        errors.push((name, pos));
-                                        Ok(rt)
-                                    }
-                                    _ => Ok(rt),
-                                }
-                            },
-                            &mut errors,
-                            TraverseOrder::TopDown,
-                        )
-                        .unwrap();
-
-                        let message = "This import could not be resolved because its content either failed to parse or typecheck correctly.";
-                        let errors = errors.into_iter().map(|(name, pos)| {
-                            ImportError::IOError(name, String::from(message), pos)
-                        });
-
-                        import_errors.extend(errors);
+                    Err(error) => {
+                        // for now just unwrap
+                        let pos = self.get_ref(id).unwrap().pos;
+                        let f = String::from("<somefile>");
+                        let msg = String::from("Couldn't type check this imports content");
+                        let err = ImportError::IOError(f, msg, pos);
+                        import_errors.push(err);
                     }
                 }
             }

--- a/lsp/nls/src/cache.rs
+++ b/lsp/nls/src/cache.rs
@@ -52,39 +52,41 @@ impl CacheExt for Cache {
             for id in ids {
                 match self.typecheck_with_analysis(id, initial_ctxt, initial_env, lin_cache) {
                     Ok(_) => (),
-                    Err(..) => {
-                        // After self.parse(), the cache must be populated
-                        let CachedTerm { term, .. } = self.terms().get(&file_id).unwrap();
-                        let mut errors: Vec<(String, TermPos)> = Vec::new();
-
-                        let term = term.clone(); // Don't like this
-                        term.traverse::<_, _, ()>(
-                            &|rt, errors: &mut Vec<_>| {
-                                let RichTerm { ref term, pos } = rt;
-                                match term.as_ref() {
-                                    Term::ResolvedImport(id) if !lin_cache.contains_key(id) => {
-                                        let name: String = self.name(*id).to_str().unwrap().into();
-                                        errors.push((name, pos));
-                                        Ok(rt)
-                                    }
-                                    _ => Ok(rt),
-                                }
-                            },
-                            &mut errors,
-                            TraverseOrder::TopDown,
-                        )
-                        .unwrap();
-
-                        let message = "This import could not be resolved because its content either failed to parse or typecheck correctly.";
-                        let errors = errors.into_iter().map(|(name, pos)| {
-                            ImportError::IOError(name, String::from(message), pos)
-                        });
-
-                        import_errors.extend(errors);
-                    }
+                    Err(..) => {} // we'll handle this error later on
                 }
             }
         }
+
+        // After self.parse(), the cache must be populated
+        let CachedTerm { term, .. } = self.terms().get(&file_id).unwrap();
+        let mut errors: Vec<(String, TermPos)> = Vec::new();
+
+        let term = term.clone(); // Don't like this
+
+        term.traverse::<_, _, ()>(
+            // O(n) every time
+            &|rt, errors: &mut Vec<_>| {
+                let RichTerm { ref term, pos } = rt;
+                match term.as_ref() {
+                    Term::ResolvedImport(id) if !lin_cache.contains_key(id) => {
+                        let name: String = self.name(*id).to_str().unwrap().into();
+                        errors.push((name, pos));
+                        Ok(rt)
+                    }
+                    _ => Ok(rt),
+                }
+            },
+            &mut errors,
+            TraverseOrder::TopDown,
+        )
+        .unwrap();
+
+        let message = "This import could not be resolved because its content either failed to parse or typecheck correctly.";
+        let errors = errors
+            .into_iter()
+            .map(|(name, pos)| ImportError::IOError(name, String::from(message), pos));
+
+        import_errors.extend(errors);
 
         // After self.parse(), the cache must be populated
         let CachedTerm { term, state, .. } = self.terms().get(&file_id).unwrap();

--- a/lsp/nls/src/cache.rs
+++ b/lsp/nls/src/cache.rs
@@ -49,8 +49,10 @@ impl CacheExt for Cache {
         if let Ok(CacheOp::Done((ids, errors))) = self.resolve_imports(file_id) {
             import_errors = errors;
             for id in ids {
-                // Ignore the results, and check for errors after resolution
-                let _ = self.typecheck_with_analysis(id, initial_ctxt, initial_env, lin_cache);
+                match self.typecheck_with_analysis(id, initial_ctxt, initial_env, lin_cache) {
+                    Ok(_) => (),
+                    Err(..) => {} // we'll handle this error later on
+                }
             }
         }
 
@@ -62,14 +64,10 @@ impl CacheExt for Cache {
         } = self.terms_mut().remove(&file_id).unwrap();
 
         // We do this to get a list of the imports that have been resolved
-        // but don't typecheck, and then, we give an appriopiate diagnostics
+        // but don't typecheck, and output an appriopiate diagnostics
         let mut errors = Vec::new();
         let term = term.traverse::<_, _, ()>(
-            // O(n) every time, where n is the size of the term
-            // Alternatively, we can get the list of resolved imports of this file 
-            // that do not have a corresponding entry in `lin_cache`, but with that 
-            // we cannot know the correct location of the import term, which is more 
-            // important for resporting diagnostics.
+            // O(n) every time
             &|rt, errors: &mut Vec<_>| {
                 let RichTerm { ref term, pos } = rt;
                 match term.as_ref() {
@@ -95,7 +93,7 @@ impl CacheExt for Cache {
             },
         );
 
-        let message = "This import could not be resolved because its content have either failed to parse or typecheck correctly.";
+        let message = "This import could not be resolved because its content either failed to parse or typecheck correctly.";
         let errors = errors
             .into_iter()
             .map(|(name, pos)| ImportError::IOError(name, String::from(message), pos));
@@ -121,7 +119,7 @@ impl CacheExt for Cache {
             lin_cache.insert(file_id, linearized);
             Ok(CacheOp::Done(()))
         } else {
-            unreachable!()
+            panic!()
         };
         if import_errors.is_empty() {
             result


### PR DESCRIPTION
Currently, when we open a Nickel file and some of content of one or more imports don't typecheck, the LSP crashes. 

This pull request fixes that.