### PR TITLE
More generic contract generation

### DIFF
--- a/lsp/nls/src/requests/completion.rs
+++ b/lsp/nls/src/requests/completion.rs
@@ -820,7 +820,7 @@ mod tests {
 
     #[test]
     fn test_extract_ident_with_path() {
-        use nickel_lang::{mk_uty_record, mk_uty_row, types::RecordRowsF};
+        use nickel_lang::{mk_uty_record, mk_uty_row};
         use std::convert::TryInto;
 
         // Representing the type: {a: {b : {c1 : Num, c2: Num}}}

--- a/src/eval/operation.rs
+++ b/src/eval/operation.rs
@@ -2752,7 +2752,7 @@ impl<R: ImportResolver, C: Cache> VirtualMachine<R, C> {
 
                 let Term::SealingKey(key) = t1 else {
                     return Err(EvalError::TypeError(
-                        String::from("Sym"),
+                        String::from("Symbol"),
                         String::from("lookup_type_variable, 1st argument"),
                         fst_pos,
                         RichTerm {
@@ -2764,7 +2764,7 @@ impl<R: ImportResolver, C: Cache> VirtualMachine<R, C> {
 
                 let Term::Lbl(label) = t2 else {
                     return Err(EvalError::TypeError(
-                        String::from("Lbl"),
+                        String::from("Label"),
                         String::from("lookup_type_variable, 2nd argument"),
                         snd_pos,
                         RichTerm {
@@ -3181,7 +3181,7 @@ impl<R: ImportResolver, C: Cache> VirtualMachine<R, C> {
 
                 let Term::SealingKey(key) = *key else {
                     return Err(EvalError::TypeError(
-                        String::from("Sym"),
+                        String::from("Symbol"),
                         String::from("insert_type_variable, 1st argument"),
                         key_pos,
                         RichTerm {
@@ -3205,7 +3205,7 @@ impl<R: ImportResolver, C: Cache> VirtualMachine<R, C> {
 
                 let Term::Lbl(label) = &*label else {
                     return Err(EvalError::TypeError(
-                        String::from("Lbl"),
+                        String::from("Label"),
                         String::from("insert_type_variable, 3rd argument"),
                         label_pos,
                         RichTerm {

--- a/src/label.rs
+++ b/src/label.rs
@@ -13,7 +13,7 @@ use crate::{
         record::{Field, RecordData},
         RichTerm, SealingKey, Term,
     },
-    typecheck::{HasUnifType, UnifType},
+    typecheck::{ReifyAsUnifType, UnifType},
     types::{TypeF, Types},
 };
 
@@ -396,13 +396,13 @@ impl From<&TypeVarData> for Term {
     }
 }
 
-impl HasUnifType for TypeVarData {
+impl ReifyAsUnifType for TypeVarData {
     fn unif_type() -> UnifType {
         mk_uty_record!(("polarity", Polarity::unif_type()))
     }
 }
 
-impl HasUnifType for Polarity {
+impl ReifyAsUnifType for Polarity {
     fn unif_type() -> UnifType {
         mk_uty_enum!("Positive", "Negative")
     }

--- a/src/parser/grammar.lalrpop
+++ b/src/parser/grammar.lalrpop
@@ -853,6 +853,7 @@ BOpPre: BinaryOp = {
     "label_with_message" => BinaryOp::LabelWithMessage(),
     "label_with_notes" => BinaryOp::LabelWithNotes(),
     "label_append_note" => BinaryOp::LabelAppendNote(),
+    "lookup_type_variable" => BinaryOp::LookupTypeVar(),
 }
 
 NOpPre<ArgRule>: UniTerm = {
@@ -866,6 +867,8 @@ NOpPre<ArgRule>: UniTerm = {
         UniTerm::from(mk_opn!(NAryOp::RecordSealTail(), t1, t2, t3, t4)),
     "record_unseal_tail" <t1: ArgRule> <t2: ArgRule> <t3: ArgRule> =>
         UniTerm::from(mk_opn!(NAryOp::RecordUnsealTail(), t1, t2, t3)),
+    "insert_type_variable" <key: ArgRule> <pol: ArgRule> <label: ArgRule> =>
+        UniTerm::from(mk_opn!(NAryOp::InsertTypeVar(), key, pol, label)),
 }
 
 TypeBuiltin: Types = {
@@ -1018,6 +1021,8 @@ extern {
         "rec_force_op" => Token::Normal(NormalToken::RecForceOp),
         "rec_default_op" => Token::Normal(NormalToken::RecDefaultOp),
         "trace" => Token::Normal(NormalToken::Trace),
+        "insert_type_variable" => Token::Normal(NormalToken::InsertTypeVar),
+        "lookup_type_variable" => Token::Normal(NormalToken::LookupTypeVar),
 
         "has_field" => Token::Normal(NormalToken::HasField),
         "map" => Token::Normal(NormalToken::Map),

--- a/src/parser/lexer.rs
+++ b/src/parser/lexer.rs
@@ -200,6 +200,10 @@ pub enum NormalToken<'input> {
     GoArray,
     #[token("%go_dict%")]
     GoDict,
+    #[token("%insert_type_variable%")]
+    InsertTypeVar,
+    #[token("%lookup_type_variable%")]
+    LookupTypeVar,
 
     #[token("%seal%")]
     Seal,

--- a/src/stdlib.rs
+++ b/src/stdlib.rs
@@ -119,6 +119,7 @@ pub mod contract {
     generate_accessor!(array);
     generate_accessor!(func);
     generate_accessor!(forall_var);
+    generate_accessor!(forall);
     generate_accessor!(fail);
     generate_accessor!(enums);
     generate_accessor!(enum_fail);

--- a/src/term/mod.rs
+++ b/src/term/mod.rs
@@ -1332,6 +1332,10 @@ pub enum BinaryOp {
     LabelWithNotes(),
     /// Append a note to the current diagnostic of a label.
     LabelAppendNote(),
+
+    /// Look up the [`TypeVarData`] associated with a [`SealingKey`] in the
+    /// type environment of a [label](Term::Lbl)
+    LookupTypeVar(),
 }
 
 impl BinaryOp {
@@ -1390,6 +1394,14 @@ pub enum NAryOp {
     ///     something goes wrong while unsealing,
     ///   - the [record](Term::Record) whose tail we wish to unseal.
     RecordUnsealTail(),
+    /// Insert type variable data into the [`type_environment`] of a [`Label`]
+    ///
+    /// Takes four arguments:
+    ///   - the [sealing key](Term::SealingKey) assigned to the type variable
+    ///   - the [introduction polarity](label::Polarity) of the type variable
+    ///   - the [kind](types::VarKind) of the type variable
+    ///   - a [label](Term::Label) on which to operate
+    InsertTypeVar(),
 }
 
 impl NAryOp {
@@ -1399,7 +1411,8 @@ impl NAryOp {
             | NAryOp::StrReplaceRegex()
             | NAryOp::StrSubstr()
             | NAryOp::MergeContract()
-            | NAryOp::RecordUnsealTail() => 3,
+            | NAryOp::RecordUnsealTail()
+            | NAryOp::InsertTypeVar() => 3,
             NAryOp::RecordSealTail() => 4,
         }
     }
@@ -1414,6 +1427,7 @@ impl fmt::Display for NAryOp {
             NAryOp::MergeContract() => write!(f, "mergeContract"),
             NAryOp::RecordSealTail() => write!(f, "%record_seal_tail%"),
             NAryOp::RecordUnsealTail() => write!(f, "%record_unseal_tail%"),
+            NAryOp::InsertTypeVar() => write!(f, "%insert_type_variable%"),
         }
     }
 }

--- a/src/typecheck/mk_uniftype.rs
+++ b/src/typecheck/mk_uniftype.rs
@@ -13,7 +13,7 @@ macro_rules! mk_uty_arrow {
         )
     };
     ( $fst:expr, $snd:expr , $( $types:expr ),+ ) => {
-        mk_uty_arrow!($fst, mk_uty_arrow!($snd, $( $types ),+))
+        $crate::mk_uty_arrow!($fst, $crate::mk_uty_arrow!($snd, $( $types ),+))
     };
 }
 
@@ -22,7 +22,7 @@ macro_rules! mk_uty_arrow {
 #[macro_export]
 macro_rules! mk_uty_enum_row {
     () => {
-        $crate::typecheck::UnifEnumRows::Concrete(EnumRowsF::Empty)
+        $crate::typecheck::UnifEnumRows::Concrete($crate::types::EnumRowsF::Empty)
     };
     (; $tail:expr) => {
         $crate::typecheck::UnifEnumRows::from($tail)
@@ -31,7 +31,7 @@ macro_rules! mk_uty_enum_row {
         $crate::typecheck::UnifEnumRows::Concrete(
             $crate::types::EnumRowsF::Extend {
                 row: Ident::from($id),
-                tail: Box::new(mk_uty_enum_row!($( $ids ),* $(; $tail)?))
+                tail: Box::new($crate::mk_uty_enum_row!($( $ids ),* $(; $tail)?))
             }
         )
     };
@@ -43,7 +43,7 @@ macro_rules! mk_uty_enum_row {
 #[macro_export]
 macro_rules! mk_uty_row {
     () => {
-        $crate::typecheck::UnifRecordRows::Concrete(RecordRowsF::Empty)
+        $crate::typecheck::UnifRecordRows::Concrete($crate::types::RecordRowsF::Empty)
     };
     (; $tail:expr) => {
         $crate::typecheck::UnifRecordRows::from($tail)
@@ -55,7 +55,7 @@ macro_rules! mk_uty_row {
                     id: Ident::from($id),
                     types: Box::new($ty.into()),
                 },
-                tail: Box::new(mk_uty_row!($(($ids, $tys)),* $(; $tail)?)),
+                tail: Box::new($crate::mk_uty_row!($(($ids, $tys)),* $(; $tail)?)),
             }
         )
     };
@@ -67,7 +67,7 @@ macro_rules! mk_uty_enum {
     ($( $ids:expr ),* $(; $tail:expr)?) => {
         $crate::typecheck::UnifType::Concrete(
             $crate::types::TypeF::Enum(
-                mk_uty_enum_row!($( $ids ),* $(; $tail)?)
+                $crate::mk_uty_enum_row!($( $ids ),* $(; $tail)?)
             )
         )
     };
@@ -79,7 +79,7 @@ macro_rules! mk_uty_record {
     ($(($ids:expr, $tys:expr)),* $(; $tail:expr)?) => {
         $crate::typecheck::UnifType::Concrete(
             $crate::types::TypeF::Record(
-                mk_uty_row!($(($ids, $tys)),* $(; $tail)?)
+                $crate::mk_uty_row!($(($ids, $tys)),* $(; $tail)?)
             )
         )
     };

--- a/src/typecheck/mod.rs
+++ b/src/typecheck/mod.rs
@@ -576,6 +576,10 @@ impl<'a> Iterator for EnumRowsIterator<'a, UnifEnumRows> {
     }
 }
 
+pub trait HasUnifType {
+    fn unif_type() -> UnifType;
+}
+
 /// The typing context is a structure holding the scoped, environment-like data structures required
 /// to perform typechecking.
 ///

--- a/src/typecheck/mod.rs
+++ b/src/typecheck/mod.rs
@@ -576,7 +576,7 @@ impl<'a> Iterator for EnumRowsIterator<'a, UnifEnumRows> {
     }
 }
 
-pub trait HasUnifType {
+pub trait ReifyAsUnifType {
     fn unif_type() -> UnifType;
 }
 

--- a/src/typecheck/operation.rs
+++ b/src/typecheck/operation.rs
@@ -2,10 +2,11 @@
 use super::*;
 use crate::{
     error::TypecheckError,
+    label::{Polarity, TypeVarData},
     term::{BinaryOp, NAryOp, RecordExtKind, UnaryOp},
     types::TypeF,
 };
-use crate::{mk_uty_arrow, mk_uty_enum, mk_uty_enum_row, mk_uty_record, mk_uty_row};
+use crate::{mk_uty_arrow, mk_uty_enum, mk_uty_record};
 
 /// Type of unary operations.
 pub fn get_uop_type(
@@ -425,6 +426,13 @@ pub fn get_bop_type(
             mk_uniftype::dynamic(),
             mk_uniftype::dynamic(),
         ),
+        // Morally: Sym -> Lbl -> TypeVarData
+        // Actual: Sym -> Dyn -> TypeVarData
+        BinaryOp::LookupTypeVar() => (
+            mk_uniftype::sym(),
+            mk_uniftype::dynamic(),
+            TypeVarData::unif_type(),
+        ),
     })
 }
 
@@ -464,5 +472,15 @@ pub fn get_nop_type(
         ),
         // This should not happen, as MergeContract() is only produced during evaluation.
         NAryOp::MergeContract() => panic!("cannot typecheck MergeContract()"),
+        // Morally: Sym -> Polarity -> Lbl -> Lbl
+        // Actual: Sym -> Polarity -> Dyn -> Dyn
+        NAryOp::InsertTypeVar() => (
+            vec![
+                mk_uniftype::sym(),
+                Polarity::unif_type(),
+                mk_uniftype::dynamic(),
+            ],
+            mk_uniftype::dynamic(),
+        ),
     })
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -137,6 +137,29 @@ pub enum VarKind {
     RecordRows,
 }
 
+impl From<VarKind> for Term {
+    fn from(value: VarKind) -> Self {
+        match value {
+            VarKind::Type => Term::Enum(Ident::new("Type")),
+            VarKind::EnumRows => Term::Enum(Ident::new("EnumRows")),
+            VarKind::RecordRows => Term::Enum(Ident::new("RecordRows")),
+        }
+    }
+}
+
+impl TryFrom<&Term> for VarKind {
+    type Error = ();
+
+    fn try_from(value: &Term) -> Result<Self, Self::Error> {
+        match value {
+            Term::Enum(type_) if type_.label() == "Type" => Ok(Self::Type),
+            Term::Enum(enum_rows) if enum_rows.label() == "EnumRows" => Ok(Self::EnumRows),
+            Term::Enum(record_rows) if record_rows.label() == "RecordRows" => Ok(Self::RecordRows),
+            _ => Err(()),
+        }
+    }
+}
+
 /// A Nickel type.
 ///
 /// # Generic representation (functor)

--- a/stdlib/internals.ncl
+++ b/stdlib/internals.ncl
@@ -25,9 +25,10 @@
       else
           %blame% label,
 
-  "$forall_var" = fun sealing_key polarity label value =>
-      let current-polarity = %polarity% label in
-      if polarity == current-polarity then
+  "$forall_var" = fun sealing_key label value =>
+      let current_polarity = %polarity% label in
+      let {polarity, ..} = %lookup_type_variable% sealing_key label in
+      if polarity == current_polarity then
           %unseal% sealing_key value (%blame% label)
       else
           # Here, we know that this term should be sealed, but to give the right
@@ -35,6 +36,9 @@
           # polarity of the `Forall`, because this is what's important for
           # blaming polymorphic contracts.
           %seal% sealing_key (%chng_pol% label) value,
+
+  "$forall" = fun sealing_key polarity contract label value =>
+    contract (%insert_type_variable% sealing_key polarity label) value,
 
   "$enums" = fun case label value =>
       if %typeof% value == `Enum then
@@ -89,8 +93,10 @@
       else
           %blame% (%label_with_message% "not a record" label),
 
-  "$forall_tail" = fun sealing_key polarity acc label value =>
-      if polarity == (%polarity% label) then
+  "$forall_tail" = fun sealing_key acc label value =>
+      let current_polarity = %polarity% label in
+      let {polarity, ..} = %lookup_type_variable% sealing_key label in
+      if polarity == current_polarity then
           if value == {} then
             let tagged_label = %label_with_message% "polymorphic tail mismatch" label in
             let tail = %record_unseal_tail% sealing_key tagged_label value in

--- a/stdlib/internals.ncl
+++ b/stdlib/internals.ncl
@@ -27,7 +27,7 @@
 
   "$forall_var" = fun sealing_key label value =>
       let current_polarity = %polarity% label in
-      let {polarity, ..} = %lookup_type_variable% sealing_key label in
+      let polarity = (%lookup_type_variable% sealing_key label).polarity in
       if polarity == current_polarity then
           %unseal% sealing_key value (%blame% label)
       else
@@ -95,7 +95,7 @@
 
   "$forall_tail" = fun sealing_key acc label value =>
       let current_polarity = %polarity% label in
-      let {polarity, ..} = %lookup_type_variable% sealing_key label in
+      let polarity = (%lookup_type_variable% sealing_key label).polarity in
       if polarity == current_polarity then
           if value == {} then
             let tagged_label = %label_with_message% "polymorphic tail mismatch" label in


### PR DESCRIPTION
This PR introduces a type variable environment into labels and makes the tracking type variable polarities for contract generation dynamic. Additionally, it introduces two new primops to manipulate this environment.

This is preparatory work for #1177.