### PR TITLE
Reformat the .ncl files of the repo with Topiary

### DIFF
--- a/benches/mantis/deploy-example.ncl
+++ b/benches/mantis/deploy-example.ncl
@@ -1,1 +1,1 @@
-import "deploy.ncl" {namespace = "mantis-staging", job="miner", role=`miner}
+import "deploy.ncl" { namespace = "mantis-staging", job = "miner", role = `miner }

--- a/benches/mantis/deploy.ncl
+++ b/benches/mantis/deploy.ncl
@@ -1,83 +1,99 @@
 let lib = import "lib.ncl" in
-
 fun vars =>
-  let defaultLoggers = {
-    "io.netty" = "WARN",
-    "io.iohk.scalanet" = "INFO",
-    "io.iohk.ethereum.blockchain.sync.SyncController" = "INFO",
-    "io.iohk.ethereum.network.PeerActor" = "${LOGSLEVEL}",
-    "io.iohk.ethereum.network.rlpx.RLPxConnectionHandler" = "${LOGSLEVEL}",
-    "io.iohk.ethereum.vm.VM" = "OFF",
-    "org.jupnp.QueueingThreadPoolExecutor" = "WARN",
-    "org.jupnp.util.SpecificationViolationReporter" = "ERROR",
-    "org.jupnp.protocol.RetrieveRemoteDescriptors" = "ERROR",
-    "io.iohk.scalanet.discovery.ethereum.v4.DiscoveryService" = "WARN",
-  } in
-
-  let bootstrapNodes = {
-    "mantis-testnet" = [
-      "enode://f92aa66337ab1993cc7269d4295d296aefe6199b34e900eac08c514c947ec7340d46a5648ffc2da10325dbaba16bdf92aa9c0b5e51d97a7818c3f495d478ddad@mantis-testnet-0.mantis.ws:9001?discport=9501",
-      "enode://d8a010f019db37dcaf2e1fb98d4fcbf1f57dbd7e2a7f065e92fbe77dca8b9120d6e79f1617e98fa6134e6af8858ac8f3735b1e70a5708eb14f228080356eb0a7@mantis-testnet-1.mantis.ws:9002?discport=9502",
-      "enode://442e2bd50eece65f90dee0d5c6075da4e1b4bc62e36b261a52e7f393dae6a68241e4dbad868c7ecc14fed277ed72e99a289a811b6172f35fb18bdca0b7a5602c@mantis-testnet-2.mantis.ws:9003?discport=9503",
-      "enode://ff86741b7b35087b2b53f44a612b233336490d5fae10b1434619b7714fe2d5346c71427a5e126cd27b9422a4d4376c1534ef66e88c5e62d6441d2541f63de0cf@mantis-testnet-3.mantis.ws:9004?discport=9504",
-      "enode://af97643f364b805d5b0e32b5356578a16afcc4fb9d1b6622998e9441eeb7795e8daf8e6b0ff3330da9879034112be56954f9269164513ece0f7394b805be3633@mantis-testnet-4.mantis.ws:9005?discport=9505",
-    ],
-    "mantis-e2e" = [
-      "enode://c6ea9b9a96cdd6ab6b8b98bb1dc6db163d1d2006629c5cb2b6e9cb64e44b398741bfe4787963e75d6a01618af1f92330882a873d3c9198de04ba028b5abe4485@mantis-e2e-0.mantis.ws:35000?discport=35500",
-      "enode://c93b354a4d0782cc61f3e55132540ad8f83678ca1cd1d5fdc301eda60a770e793149e3166ba95065f0ae8cda054988a34906b3c906d4c713c373c001b90e40c1@mantis-e2e-1.mantis.ws:35001?discport=35501",
-      "enode://763eba5440b57f008316801cb4e5cc6428c3073ebc72563432b8210e0fb378fc84ae0f639d31f60b01c19e989a2103453eaee449fd469a511d8ed98e97f653d6@mantis-e2e-2.mantis.ws:35002?discport=35502",
-      "enode://8536966bc1e115d0628b7d582e4bc6b538b043135eb5297e6fe2eff2ea27ac4d31b23d0f7dfcc44cef4fef0a820c56d3cb3bd61a6267416c6541cbc78bcf88ac@mantis-e2e-3.mantis.ws:35003?discport=35503",
-      "enode://0088ef3a87c1883699fdd6cc36391338b3f162695b94112ffd2c71e1f2c63570dbb2f17a0e0c63d3123c56835af7b48dc2e5a22fc71396c53d59eb7772495a10@mantis-e2e-4.mantis.ws:35004?discport=35504",
-    ],
-    "mantis-staging" = [
-      "enode://39b925ba0beffdb80859a0ab34895c98bb61bd20d686ccd27f8c5a04dddc82b712081fd11bfd43f3bc08b00423a5ff8fee70b8a22dcc95e85537b2084dc6816a@mantis-staging-0.mantis.ws:33000?discport=33500",
-      "enode://cbd80c7f72a889101b7f23d51be2de7e3f1f46ad3b25c438e959e24e08f03bd9fe833460e84b60174d4eb120af3b127389c4606f81c842943c4922cab384a234@mantis-staging-1.mantis.ws:33001?discport=33501",
-      "enode://0e63642be49c5a092569aa01663fcda1505362cd0ac41e24ff9296ab80c97af135fb6fb247273631a3a11257774f39ed882d72a20fd45131e53e9015adf6b9e5@mantis-staging-2.mantis.ws:33002?discport=33502",
-      "enode://3ee3641a25cfc611ba54a898260af7768ecf0643f06aefedf853864ed433d5ad6265eeb24abcc4d6f6ee90a1eac6c1fbf157fc05fd8e28e194dfc864cb56058e@mantis-staging-3.mantis.ws:33003?discport=33503",
-      "enode://907842e336fc757bbfde70368aef329714aa627e72e5da687f31b097fa71a59f36404aebbc83885c9b515270042e025a6788b700c314ee8bc68099dcff32afcd@mantis-staging-4.mantis.ws:33004?discport=33504",
-    ],
-  } in
-
-  let params = {
-    namespace = vars.namespace,
-    datacenters | Array (lib.contracts.OneOf [
-        "eu-central-1",
-        "us-east-2",
-        "eu-west-2"])
-                | default = ["eu-central-1", "us-east-2"],
-    fqdn = "mantis.ws",
-    networkConfig | String
-                  | default = m%"
+  let defaultLoggers =
+    {
+      "io.netty" = "WARN",
+      "io.iohk.scalanet" = "INFO",
+      "io.iohk.ethereum.blockchain.sync.SyncController" = "INFO",
+      "io.iohk.ethereum.network.PeerActor" = "${LOGSLEVEL}",
+      "io.iohk.ethereum.network.rlpx.RLPxConnectionHandler" = "${LOGSLEVEL}",
+      "io.iohk.ethereum.vm.VM" = "OFF",
+      "org.jupnp.QueueingThreadPoolExecutor" = "WARN",
+      "org.jupnp.util.SpecificationViolationReporter" = "ERROR",
+      "org.jupnp.protocol.RetrieveRemoteDescriptors" = "ERROR",
+      "io.iohk.scalanet.discovery.ethereum.v4.DiscoveryService" = "WARN",
+    }
+  in
+  let bootstrapNodes =
+    {
+      "mantis-testnet" = [
+        "enode://f92aa66337ab1993cc7269d4295d296aefe6199b34e900eac08c514c947ec7340d46a5648ffc2da10325dbaba16bdf92aa9c0b5e51d97a7818c3f495d478ddad@mantis-testnet-0.mantis.ws:9001?discport=9501",
+        "enode://d8a010f019db37dcaf2e1fb98d4fcbf1f57dbd7e2a7f065e92fbe77dca8b9120d6e79f1617e98fa6134e6af8858ac8f3735b1e70a5708eb14f228080356eb0a7@mantis-testnet-1.mantis.ws:9002?discport=9502",
+        "enode://442e2bd50eece65f90dee0d5c6075da4e1b4bc62e36b261a52e7f393dae6a68241e4dbad868c7ecc14fed277ed72e99a289a811b6172f35fb18bdca0b7a5602c@mantis-testnet-2.mantis.ws:9003?discport=9503",
+        "enode://ff86741b7b35087b2b53f44a612b233336490d5fae10b1434619b7714fe2d5346c71427a5e126cd27b9422a4d4376c1534ef66e88c5e62d6441d2541f63de0cf@mantis-testnet-3.mantis.ws:9004?discport=9504",
+        "enode://af97643f364b805d5b0e32b5356578a16afcc4fb9d1b6622998e9441eeb7795e8daf8e6b0ff3330da9879034112be56954f9269164513ece0f7394b805be3633@mantis-testnet-4.mantis.ws:9005?discport=9505",
+      ],
+      "mantis-e2e" = [
+        "enode://c6ea9b9a96cdd6ab6b8b98bb1dc6db163d1d2006629c5cb2b6e9cb64e44b398741bfe4787963e75d6a01618af1f92330882a873d3c9198de04ba028b5abe4485@mantis-e2e-0.mantis.ws:35000?discport=35500",
+        "enode://c93b354a4d0782cc61f3e55132540ad8f83678ca1cd1d5fdc301eda60a770e793149e3166ba95065f0ae8cda054988a34906b3c906d4c713c373c001b90e40c1@mantis-e2e-1.mantis.ws:35001?discport=35501",
+        "enode://763eba5440b57f008316801cb4e5cc6428c3073ebc72563432b8210e0fb378fc84ae0f639d31f60b01c19e989a2103453eaee449fd469a511d8ed98e97f653d6@mantis-e2e-2.mantis.ws:35002?discport=35502",
+        "enode://8536966bc1e115d0628b7d582e4bc6b538b043135eb5297e6fe2eff2ea27ac4d31b23d0f7dfcc44cef4fef0a820c56d3cb3bd61a6267416c6541cbc78bcf88ac@mantis-e2e-3.mantis.ws:35003?discport=35503",
+        "enode://0088ef3a87c1883699fdd6cc36391338b3f162695b94112ffd2c71e1f2c63570dbb2f17a0e0c63d3123c56835af7b48dc2e5a22fc71396c53d59eb7772495a10@mantis-e2e-4.mantis.ws:35004?discport=35504",
+      ],
+      "mantis-staging" = [
+        "enode://39b925ba0beffdb80859a0ab34895c98bb61bd20d686ccd27f8c5a04dddc82b712081fd11bfd43f3bc08b00423a5ff8fee70b8a22dcc95e85537b2084dc6816a@mantis-staging-0.mantis.ws:33000?discport=33500",
+        "enode://cbd80c7f72a889101b7f23d51be2de7e3f1f46ad3b25c438e959e24e08f03bd9fe833460e84b60174d4eb120af3b127389c4606f81c842943c4922cab384a234@mantis-staging-1.mantis.ws:33001?discport=33501",
+        "enode://0e63642be49c5a092569aa01663fcda1505362cd0ac41e24ff9296ab80c97af135fb6fb247273631a3a11257774f39ed882d72a20fd45131e53e9015adf6b9e5@mantis-staging-2.mantis.ws:33002?discport=33502",
+        "enode://3ee3641a25cfc611ba54a898260af7768ecf0643f06aefedf853864ed433d5ad6265eeb24abcc4d6f6ee90a1eac6c1fbf157fc05fd8e28e194dfc864cb56058e@mantis-staging-3.mantis.ws:33003?discport=33503",
+        "enode://907842e336fc757bbfde70368aef329714aa627e72e5da687f31b097fa71a59f36404aebbc83885c9b515270042e025a6788b700c314ee8bc68099dcff32afcd@mantis-staging-4.mantis.ws:33004?discport=33504",
+      ],
+    }
+  in
+  let params =
+    {
+      namespace = vars.namespace,
+      datacenters
+        | Array (
+          lib.contracts.OneOf
+            [
+              "eu-central-1",
+              "us-east-2",
+              "eu-west-2"
+            ]
+        )
+        | default
+        = [ "eu-central-1", "us-east-2" ],
+      fqdn = "mantis.ws",
+      networkConfig
+        | String
+        | default
+        = m%"
                     mantis.blockchains.testnet-internal-nomad.bootstrap-nodes = [
                       %{string.join ",\n" bootstrapNodes."%{vars.namespace}"})
                     ]
-                    "%,
-    logLevel | default = "INFO",
-    loggers = defaultLoggers,
-    job = vars.job,
-    role | [| `passive, `miner, `backup |] = vars.role,
-  } in
-
-  let jobDefs = {
-    Mantis = import "jobs/mantis.ncl" params,
-  } in
-
-  let revisions = {
-    mantisOpsRev = "7404801c6fcb3f12438d3c82e34ad1918bb5f0a5",
-    mantisRev = "d6cada089a10e3d9988e27d695259a216f6e21f8",
-    morphoRev = "e47b74d5e7a78bf665758927336a28a915b3e596",
-  } in
-
-  let miner_ = jobDefs.Mantis & {
-    role = `miner,
-    mantisRev = revisions.mantisRev
-  } in
-
-  let namespaces = {
-    "mantis-staging".jobs = {
-      miner = miner_,
-      passive | (passive & {count = 1})
-    },
-  } in
-
+                    "%
+      ,
+      logLevel | default = "INFO",
+      loggers = defaultLoggers,
+      job = vars.job,
+      role | [| `passive, `miner, `backup |] = vars.role,
+    }
+  in
+  let jobDefs =
+    {
+      Mantis = import "jobs/mantis.ncl" params,
+    }
+  in
+  let revisions =
+    {
+      mantisOpsRev = "7404801c6fcb3f12438d3c82e34ad1918bb5f0a5",
+      mantisRev = "d6cada089a10e3d9988e27d695259a216f6e21f8",
+      morphoRev = "e47b74d5e7a78bf665758927336a28a915b3e596",
+    }
+  in
+  let miner_ =
+    jobDefs.Mantis
+    & {
+      role = `miner,
+      mantisRev = revisions.mantisRev
+    }
+  in
+  let namespaces =
+    {
+      "mantis-staging".jobs = {
+        miner = miner_,
+        passive | (passive & { count = 1 })
+      },
+    }
+  in
   namespaces."%{params.namespace}".jobs."%{params.job}"

--- a/benches/mantis/jobs/mantis.ncl
+++ b/benches/mantis/jobs/mantis.ncl
@@ -5,69 +5,87 @@ let lib = import "../lib.ncl" in
 
 # Temporary dummy value
 let baseTags = [""] in
+let Params =
+  {
+    count
+      | number.Nat
+      | default
+      = 5,
+    role | [| `passive, `miner, `backup |],
+    datacenters | Dyn,
+    job | Dyn,
+    namespace | String,
+    logLevel | String,
+    mantisRev | String,
+    fqdn | String,
+    loggers | { _ : String },
+    network
+      | lib.contracts.OneOf [ "testnet-internal-nomad", "etc" ]
+      | default
+      = "testnet-internal-nomad",
+    networkConfig | String,
 
-let Params = {
-  count | number.Nat
-        | default = 5,
-  role | [| `passive, `miner, `backup |],
-  datacenters | Dyn,
-  job | Dyn,
-  namespace | String,
-  logLevel | String,
-  mantisRev | String,
-  fqdn | String,
-  loggers | {_: String},
-  network | lib.contracts.OneOf ["testnet-internal-nomad", "etc"]
-          | default = "testnet-internal-nomad",
-  networkConfig | String,
-
-  fastSync | Bool
-           | default = false,
-  reschedule | {..}
-               #{_ : lib.contracts.PseudoOr [
-               #         lib.contracts.OrableFromPred builtin.is_string,
-               #         lib.contracts.OrableFromPred builtin.is_number,
-               #         lib.contracts.OrableFromPred builtin.is_bool,
-               #         {
-               #           pred = builtin.is_record,
-               #           contract = {
-               #             attempts = 0,
-               #             unlimited = true,
-               #           },
-               #         }
-               #       ]
-               # },
-} in
-
+    fastSync
+      | Bool
+      | default
+      = false,
+    reschedule | { .. }
+    #{_ : lib.contracts.PseudoOr [
+    #         lib.contracts.OrableFromPred builtin.is_string,
+    #         lib.contracts.OrableFromPred builtin.is_number,
+    #         lib.contracts.OrableFromPred builtin.is_bool,
+    #         {
+    #           pred = builtin.is_record,
+    #           contract = {
+    #             attempts = 0,
+    #             unlimited = true,
+    #           },
+    #         }
+    #       ]
+    # },
+  }
+in
 fun params =>
   let params | Params = params in
-  types.stanza.job & {
+  types.stanza.job
+  & {
     namespace = params.namespace,
     datacenters = params.datacenters,
-  } & (if params.network == "etc" then {
-      type = `batch,
-      periodic = {
-        prohibit_overlap = true,
-        cron = "@daily",
-        time_zone = `UTC,
+  }
+  & (
+    if params.network == "etc" then
+      {
+        type = `batch,
+        periodic = {
+          prohibit_overlap = true,
+          cron = "@daily",
+          time_zone = `UTC,
+        }
       }
-    } else {})
-   & (if params.network != "etc" then {
-      type = `service,
+    else
+      {}
+  )
+  & (
+    if params.network != "etc" then
+      {
+        type = `service,
 
-      update = {
-        max_parallel = 1,
-        health_check = `checks,
-        min_healthy_time = "1m", # Give enough time for the DAG generation
-        healthy_deadline = "15m",
-        progress_deadline = "30m",
-        auto_revert = false,
-        auto_promote = false,
-        canary = 0,
-        stagger = "20m",
-      },
-    } else {})
-
+        update = {
+          max_parallel = 1,
+          health_check = `checks,
+          min_healthy_time = "1m",
+          # Give enough time for the DAG generation
+          healthy_deadline = "15m",
+          progress_deadline = "30m",
+          auto_revert = false,
+          auto_promote = false,
+          canary = 0,
+          stagger = "20m",
+        },
+      }
+    else
+      {}
+  )
   & {
     group.mantis = {
       count = params.count,
@@ -86,24 +104,31 @@ fun params =>
         migrate = true,
         sticky = true,
       }
-    } & (if params.network == "etc" then {
-        restart = {
-          interval = "1m",
-          attempts = 0,
-          delay = "1m",
-          mode = "fail",
+    }
+    & (
+      if params.network == "etc" then
+        {
+          restart = {
+            interval = "1m",
+            attempts = 0,
+            delay = "1m",
+            mode = "fail",
+          }
         }
-      } else {})
+      else
+        {}
+    )
     & {
       reschedule = params.reschedule,
 
       task.telegraf | Telegraf
         = {
-        #infinte rec?
-        # #namespace = namespace,
-        name = "%{string.from_enum params.role}-${NOMAD_ALLOC_INDEX}",
-        prometheusPort = "metrics",
-      },
+          #infinte rec?
+          # #namespace = namespace,
+          name = "%{string.from_enum params.role}-${NOMAD_ALLOC_INDEX}"
+          ,
+          prometheusPort = "metrics",
+        },
 
       # Do we really need this?
       #task.mantis | tasks.#Mantis = {
@@ -121,81 +146,127 @@ fun params =>
 
       #same?
       # #baseTags: [namespace, #role, "mantis-${NOMAD_ALLOC_INDEX}"]
-    } & (if params.role == `passive then {
-      #TODO: dependent if
-      service."%{params.namespace}-mantis-%{string.from_enum params.role}-rpc" = {
-        address_mode = `host,
-        port = "rpc",
-        tags = [
-            "rpc",
-            "ingress",
-            "traefik.enable=true",
-            "traefik.http.routers.%{params.namespace}-mantis-%{string.from_enum params.role}.rule=Host(`%{params.namespace}-%{string.from_enum params.role}.%{params.fqdn}`)",
-            "traefik.http.routers.%{params.namespace}-mantis-%{string.from_enum params.role}.entrypoints=https",
-            "traefik.http.routers.%{params.namespace}-mantis-%{string.from_enum params.role}.tls=true",
-        ] @ baseTags,
-      }
-    } else {})
+    }
+    & (
+      if params.role == `passive then
+        {
+          #TODO: dependent if
+          service."%{params.namespace}-mantis-%{string.from_enum params.role}-rpc"
+          = {
+            address_mode = `host,
+            port = "rpc",
+            tags = [
+              "rpc",
+              "ingress",
+              "traefik.enable=true",
+              "traefik.http.routers.%{params.namespace}-mantis-%{string.from_enum params.role}.rule=Host(`%{params.namespace}-%{string.from_enum params.role}.%{params.fqdn}`)"
+              ,
+              "traefik.http.routers.%{params.namespace}-mantis-%{string.from_enum params.role}.entrypoints=https"
+              ,
+              "traefik.http.routers.%{params.namespace}-mantis-%{string.from_enum params.role}.tls=true"
+              ,
+            ]
+            @ baseTags,
+          }
+        }
+      else
+        {}
+    )
     & {
       #TODO: dependent if
       #For now, redefining namespace
-      service."%{params.namespace}-mantis-%{string.from_enum params.role}-rpc" = {
+      service."%{params.namespace}-mantis-%{string.from_enum params.role}-rpc"
+      = {
         check.rpc = {
           address_mode = `host,
-            interval = "10s",
-            port = "rpc",
-            timeout = "3s",
-            type = `http,
-            path = "/healthcheck",
-          } & (if params.network != "etc" then {
+          interval = "10s",
+          port = "rpc",
+          timeout = "3s",
+          type = `http,
+          path = "/healthcheck",
+        }
+        & (
+          if params.network != "etc" then
+            {
               check_restart = {
                 limit = 5,
                 grace = "10m",
               }
-            } else {}),
+            }
+          else
+            {}
+        ),
       }
-    } & (if params.role == `miner then {
-       # TODO: dependent if
-       service."%{params.namespace}-mantis-%{string.from_enum params.role}-rpc" = {
-         address_mode = `host,
-         port = "rpc",
-         tags = ["rpc"] @ baseTags,
-       }
-    } else {})
+    }
+    & (
+      if params.role == `miner then
+        {
+          # TODO: dependent if
+          service."%{params.namespace}-mantis-%{string.from_enum params.role}-rpc"
+          = {
+            address_mode = `host,
+            port = "rpc",
+            tags = ["rpc"] @ baseTags,
+          }
+        }
+      else
+        {}
+    )
     & {
       service = {
-        "%{params.namespace}-mantis-%{string.from_enum params.role}-prometheus" = {
+        "%{params.namespace}-mantis-%{string.from_enum params.role}-prometheus"
+        = {
           address_mode = `host,
           port = "metrics",
           tags = ["prometheus"] @ baseTags,
         },
 
-        "%{params.namespace}-%{string.from_enum params.role}-${NOMAD_ALLOC_INDEX}" = {
+        "%{params.namespace}-%{string.from_enum params.role}-${NOMAD_ALLOC_INDEX}"
+        = {
           address_mode = `host,
           port = "rpc",
           tags = [
-              "rpc",
-              "ingress",
-              "traefik.enable=true",
-              "traefik.http.routers.%{params.namespace}-%{string.from_enum params.role}-${NOMAD_ALLOC_INDEX}.rule=Host(`%{params.namespace}-%{string.from_enum params.role}-${NOMAD_ALLOC_INDEX}.%{params.fqdn}`)",
-              "traefik.http.routers.%{params.namespace}-%{string.from_enum params.role}-${NOMAD_ALLOC_INDEX}.entrypoints=https",
-              "traefik.http.routers.%{params.namespace}-%{string.from_enum params.role}-${NOMAD_ALLOC_INDEX}.tls=true",
-          ] @ baseTags,
+            "rpc",
+            "ingress",
+            "traefik.enable=true",
+            "traefik.http.routers.%{params.namespace}-%{string.from_enum params.role}-${NOMAD_ALLOC_INDEX}.rule=Host(`%{params.namespace}-%{string.from_enum params.role}-${NOMAD_ALLOC_INDEX}.%{params.fqdn}`)"
+            ,
+            "traefik.http.routers.%{params.namespace}-%{string.from_enum params.role}-${NOMAD_ALLOC_INDEX}.entrypoints=https"
+            ,
+            "traefik.http.routers.%{params.namespace}-%{string.from_enum params.role}-${NOMAD_ALLOC_INDEX}.tls=true"
+            ,
+          ]
+          @ baseTags,
         },
 
-        "%{params.namespace}-mantis-%{string.from_enum params.role}-discovery-${NOMAD_ALLOC_INDEX}" = {
+        "%{params.namespace}-mantis-%{string.from_enum params.role}-discovery-${NOMAD_ALLOC_INDEX}"
+        = {
           port = "discovery",
-        } & (if params.role == `miner then {
-            tags = ["ingress", "discovery",
-              "traefik.enable=true",
-              # TODO: Dependent if (refer to namespace)
-              "traefik.tcp.routers.%{params.namespace}-discovery-${NOMAD_ALLOC_INDEX}.rule=HostSNI(`*`)",
-              "traefik.tcp.routers.%{params.namespace}-discovery-${NOMAD_ALLOC_INDEX}.entrypoints=%{params.namespace}-discovery-${NOMAD_ALLOC_INDEX}",
-            ] @ baseTags
-          } else {})
-        & (if params.role == `passive then {
-            tags = ["discovery"] @ baseTags
-          } else {})
+        }
+        & (
+          if params.role == `miner then
+            {
+              tags = [
+                "ingress",
+                "discovery",
+                "traefik.enable=true",
+                # TODO: Dependent if (refer to namespace)
+                "traefik.tcp.routers.%{params.namespace}-discovery-${NOMAD_ALLOC_INDEX}.rule=HostSNI(`*`)",
+                "traefik.tcp.routers.%{params.namespace}-discovery-${NOMAD_ALLOC_INDEX}.entrypoints=%{params.namespace}-discovery-${NOMAD_ALLOC_INDEX}",
+              ]
+              @ baseTags
+            }
+          else
+            {}
+        )
+        & (
+          if params.role == `passive then
+            {
+              tags = ["discovery"] @ baseTags
+            }
+          else
+            {}
+        )
         & {
           meta = {
             Name = "mantis-${NOMAD_ALLOC_INDEX}",
@@ -203,22 +274,38 @@ fun params =>
           }
         },
 
-        "%{params.namespace}-mantis-%{string.from_enum params.role}-server-${NOMAD_ALLOC_INDEX}" = {
+        "%{params.namespace}-mantis-%{string.from_enum params.role}-server-${NOMAD_ALLOC_INDEX}"
+        = {
           address_mode = `host,
           port = "server",
-        } & (if params.role == `miner then {
-            tags = ["ingress", "server",
-              "traefik.enable=true",
-              "traefik.tcp.routers.%{params.namespace}-server-${NOMAD_ALLOC_INDEX}.rule=HostSNI(`*`)",
-              "traefik.tcp.routers.%{params.namespace}-server-${NOMAD_ALLOC_INDEX}.entrypoints=%{params.namespace}-server-${NOMAD_ALLOC_INDEX}",
-            ] @ baseTags,
-          } else {})
-        & (if params.role == `passive then {
-            tags = ["server"] @ baseTags,
-          } else {})
+        }
+        & (
+          if params.role == `miner then
+            {
+              tags = [
+                "ingress",
+                "server",
+                "traefik.enable=true",
+                "traefik.tcp.routers.%{params.namespace}-server-${NOMAD_ALLOC_INDEX}.rule=HostSNI(`*`)",
+                "traefik.tcp.routers.%{params.namespace}-server-${NOMAD_ALLOC_INDEX}.entrypoints=%{params.namespace}-server-${NOMAD_ALLOC_INDEX}",
+              ]
+              @ baseTags,
+            }
+          else
+            {}
+        )
+        & (
+          if params.role == `passive then
+            {
+              tags = ["server"] @ baseTags,
+            }
+          else
+            {}
+        )
         & {
           meta = {
-            Name = "mantis-%{string.from_enum params.role}-${NOMAD_ALLOC_INDEX}",
+            Name = "mantis-%{string.from_enum params.role}-${NOMAD_ALLOC_INDEX}"
+            ,
             PublicIp = "${attr.unique.platform.aws.public-ipv4}",
           },
 
@@ -228,25 +315,33 @@ fun params =>
             port = "server",
             timeout = "3s",
             type = `tcp,
-          } & (if params.network != "etc" then {
-              check_restart = {
-                limit = 5,
-                grace = "10m",
+          }
+          & (
+            if params.network != "etc" then
+              {
+                check_restart = {
+                  limit = 5,
+                  grace = "10m",
+                }
               }
-            } else {}),
+            else
+              {}
+          ),
         },
 
-        "%{params.namespace}-mantis-%{string.from_enum params.role}-server" = {
+        "%{params.namespace}-mantis-%{string.from_enum params.role}-server"
+        = {
           address_mode = `host,
           port = "server",
-          tags = ["ingress", "server"] @ baseTags,
+          tags = [ "ingress", "server" ] @ baseTags,
           meta = {
             Name = "mantis-${NOMAD_ALLOC_INDEX}",
             PublicIp = "${attr.unique.platform.aws.public-ipv4}",
           }
         },
 
-        "%{params.namespace}-mantis-%{string.from_enum params.role}" = {
+        "%{params.namespace}-mantis-%{string.from_enum params.role}"
+        = {
           address_mode = `host,
           port = "server",
           tags = ["server"] @ baseTags,

--- a/benches/mantis/lib.ncl
+++ b/benches/mantis/lib.ncl
@@ -1,13 +1,29 @@
 {
   contracts = {
-    AllOf = fun contracts label value => array.fold_right (fun c acc => c label
-      acc) contracts value,
+    AllOf = fun contracts label value =>
+      array.fold_right
+        (
+          fun c acc =>
+            c
+              label
+              acc
+        )
+        contracts
+        value,
     Dummy = fun label value => value,
-    OneOf = fun values => contract.from_predicate (fun value => array.elem value
-      values),
+    OneOf = fun values =>
+      contract.from_predicate
+        (
+          fun value =>
+            array.elem
+              value
+              values
+        ),
     Nullable = fun ctr label value =>
-      if value == null then null
-      else contract.apply ctr label value,
+      if value == null then
+        null
+      else
+        contract.apply ctr label value,
     NotEq = fun x => contract.from_predicate (fun y => x != y),
     GreaterEq = fun x => contract.from_predicate (fun y => y >= x),
     Greater = fun x => contract.from_predicate (fun y => y > x),
@@ -20,20 +36,25 @@
           value
         else
           contract.blame_with_message "no match" label
-      else contract.blame_with_message "not a string" label,
+      else
+        contract.blame_with_message "not a string" label,
     PseudoOr = fun alts label value =>
-      array.fold_right (fun ctr rest =>
-        if ctr.pred value then
-          ctr.contract value
-        else
-          rest)
+      array.fold_right
+        (
+          fun ctr rest =>
+            if ctr.pred value then
+              ctr.contract value
+            else
+              rest
+        )
         (contract.blame_with_message "no alternative matched" label),
-    OrableFromPred : (Dyn -> Bool)
-                     -> {pred : Dyn -> Bool, contract: Dyn -> Dyn -> Dyn },
-    OrableFromPred = fun pred_ => {
-      pred = pred_,
-      contract = fun _lbl value => value,
-    },
+    OrableFromPred
+      : (Dyn -> Bool) -> { pred : Dyn -> Bool, contract : Dyn -> Dyn -> Dyn },
+    OrableFromPred = fun pred_ =>
+      {
+        pred = pred_,
+        contract = fun _lbl value => value,
+      },
   },
 
   records = {
@@ -42,9 +63,9 @@
       |> record.map f
       |> record.values,
 
-   toList = fun r =>
-     r
-     |> record.fields
-     |> array.map (fun key_ => {key = key_, value = r."%{key}"}),
+    toList = fun r =>
+      r
+      |> record.fields
+      |> array.map (fun key_ => { key = key_, value = r."%{key}" }),
   }
 }

--- a/benches/mantis/run.ncl
+++ b/benches/mantis/run.ncl
@@ -1,7 +1,7 @@
-
 {
   run = import "deploy.ncl",
-  serialize.run = fun args => (
-        builtin.serialize `Json (run args)
+  serialize.run = fun args =>
+    (
+      builtin.serialize `Json (run args)
     )
 }

--- a/benches/mantis/schemas/nomad/types.ncl
+++ b/benches/mantis/schemas/nomad/types.ncl
@@ -1,201 +1,345 @@
 let lib = import "../../lib.ncl" in
 
 # DUMMY
-let time = {
-  parseDurationSecond = fun arg => 0 | String,
-} in
+let time =
+  {
+    parseDurationSecond = fun arg => 0 | String,
+  }
+in
 
 # DUMMY
 # let stanza = {} in
-
 {
   json = {
     Job = {
-       Namespace | String,
-       Id | Name,
-       Name | String,
-       Type | [| `service, `system, `batch |],
-       Priority | number.Nat,
-       Datacenters | array.NonEmpty,
-       TaskGroups | Array TaskGroup
-                  | default = [],
-       Affinities | Array Affinity
-                  | default = [],
-       Constraints | Array Constraint
-                   | default = [],
-       Spreads | Array Spread
-               | default = [],
-       ConsulToken | lib.contracts.Nullable String,
-       VaultToken | lib.contracts.Nullable String,
-       Vault     | lib.contracts.Nullable json.Vault
-                 | default = null,
-       Update    | lib.contracts.Nullable json.Update
-                 | default = null,
-       Migrate   | lib.contracts.Nullable json.Migrate
-                 | default = null,
-       Periodic  | lib.contracts.Nullable json.Periodic
-                 | default = null,
+      Namespace | String,
+      Id | Name,
+      Name | String,
+      Type | [| `service, `system, `batch |],
+      Priority | number.Nat,
+      Datacenters | array.NonEmpty,
+      TaskGroups
+        | Array TaskGroup
+        | default
+        = [],
+      Affinities
+        | Array Affinity
+        | default
+        = [],
+      Constraints
+        | Array Constraint
+        | default
+        = [],
+      Spreads
+        | Array Spread
+        | default
+        = [],
+      ConsulToken | lib.contracts.Nullable String,
+      VaultToken | lib.contracts.Nullable String,
+      Vault
+        | lib.contracts.Nullable json.Vault
+        | default
+        = null,
+      Update
+        | lib.contracts.Nullable json.Update
+        | default
+        = null,
+      Migrate
+        | lib.contracts.Nullable json.Migrate
+        | default
+        = null,
+      Periodic
+        | lib.contracts.Nullable json.Periodic
+        | default
+        = null,
     },
 
     Affinity = {
       LTarget | String,
       RTargety | String,
-      Operand | (lib.contracts.OneOf [
-        "regexp", "set_contains_all", "set_contains", "set_contains_any", "=",
-        "==", "is", "!=", "not", ">", ">=", "<", "<=", "version"]),
-      Weight | number.Nat
-             | lib.contracts.NotEq 0
-             | lib.contracts.GreaterEq -100
-             | lib.contracts.SmallerEq 100,
+      Operand
+        | (
+          lib.contracts.OneOf
+            [
+              "regexp",
+              "set_contains_all",
+              "set_contains",
+              "set_contains_any",
+              "=",
+              "==",
+              "is",
+              "!=",
+              "not",
+              ">",
+              ">=",
+              "<",
+              "<=",
+              "version"
+            ]
+        ),
+      Weight
+        | number.Nat
+        | lib.contracts.NotEq 0
+        | lib.contracts.GreaterEq
+        - 100
+        | lib.contracts.SmallerEq 100,
     },
 
     Constraint = {
-      LTarget | lib.contracts.Nullable String
-              | default = null,
+      LTarget
+        | lib.contracts.Nullable String
+        | default
+        = null,
       RTarget | String,
-      Operand | (lib.contracts.OneOf [
-        "regexp", "set_contains", "distinct_hosts", "distinct_property", "=",
-        "==", "is", "!=", "not", ">", ">=", "<", "<="]),
+      Operand
+        | (
+          lib.contracts.OneOf
+            [
+              "regexp",
+              "set_contains",
+              "distinct_hosts",
+              "distinct_property",
+              "=",
+              "==",
+              "is",
+              "!=",
+              "not",
+              ">",
+              ">=",
+              "<",
+              "<="
+            ]
+        ),
     },
 
     Spread = {
       Attribute | String,
-      Weight | lib.contracts.Nullable (lib.contracts.AllOf [
-                 number.Nat,
-                 lib.contracts.GreaterEq -100,
-                 lib.contracts.LesserEq 100])
-             | default = null,
-      SpreadTarget | Array SpreadTargetElem
-                   | default = [],
+      Weight
+        | lib.contracts.Nullable
+          (
+            lib.contracts.AllOf
+              [
+                number.Nat,
+                lib.contracts.GreaterEq - 100,
+                lib.contracts.LesserEq 100
+              ]
+          )
+        | default
+        = null,
+      SpreadTarget
+        | Array SpreadTargetElem
+        | default
+        = [],
     },
 
     SpreadTargetElem = {
       Value | String,
-      Percent | lib.contracts.Nullable (lib.contracts.AllOf [
-                 number.PosNat,
-                 lib.contracts.LesserEq 100])
-              | default = null,
+      Percent
+        | lib.contracts.Nullable
+          (
+            lib.contracts.AllOf
+              [
+                number.PosNat,
+                lib.contracts.LesserEq 100
+              ]
+          )
+        | default
+        = null,
     },
 
     RestartPolicy = {
       Attempts | number.Nat,
       Interval | number.Nat,
       Delay | number.Nat,
-      Mode | (lib.contracts.OneOf ["delay", "fail"]),
+      Mode | (lib.contracts.OneOf [ "delay", "fail" ]),
     },
 
     Volume = {
       Name | String,
-      Type | (lib.contracts.OneOf [null, "host", "csi"]),
+      Type | (lib.contracts.OneOf [ null, "host", "csi" ]),
       Source | String,
-      ReadOnly | Bool
-               | default = false,
+      ReadOnly
+        | Bool
+        | default
+        = false,
       MountOptions
-        | lib.contracts.Nullable {
-            FsType | lib.contracts.Nullable String
-                   | default = null,
-            mountFlags | lib.contracts.Nullable String
-                       | default = null
+        | lib.contracts.Nullable
+          {
+            FsType
+              | lib.contracts.Nullable String
+              | default
+              = null,
+            mountFlags
+              | lib.contracts.Nullable String
+              | default
+              = null
           }
-        | default = null,
+        | default
+        = null,
     },
 
     ReschedulePolicy = {
-      Attempts       | lib.contracts.Nullable number.Nat
-                     | default = null,
-      DelayFunction  | lib.contracts.Nullable (lib.contracts.OneOf [
-        "constant", "exponential", "fibonacci"])
-                     | default = null,
-      Delay          | lib.contracts.Nullable (lib.contracts.AllOf [
-                        number.Nat,
-                        lib.contracts.GreaterEq 5*1000]) # >=time.ParseDuration("5s")
-                     | default = null,
-      Interval       | lib.contracts.Nullable number.Nat
-                     | default = null,
-      MaxDelay       | lib.contracts.Nullable number.Nat
-                     | default = null,
-      Unlimited      | lib.contracts.Nullable Bool
-                     | default = null,
+      Attempts
+        | lib.contracts.Nullable number.Nat
+        | default
+        = null,
+      DelayFunction
+        | lib.contracts.Nullable
+          (
+            lib.contracts.OneOf
+              [
+                "constant",
+                "exponential",
+                "fibonacci"
+              ]
+          )
+        | default
+        = null,
+      Delay
+        | lib.contracts.Nullable
+          (
+            lib.contracts.AllOf
+              [
+                number.Nat,
+                lib.contracts.GreaterEq 5 * 1000
+              ]
+          ) # >=time.ParseDuration("5s")
+        | default
+        = null,
+      Interval
+        | lib.contracts.Nullable number.Nat
+        | default
+        = null,
+      MaxDelay
+        | lib.contracts.Nullable number.Nat
+        | default
+        = null,
+      Unlimited
+        | lib.contracts.Nullable Bool
+        | default
+        = null,
     },
 
     Migrate = {
-      HealthCheck      | [| `checks, `task_states |]
-                       | default = `checks,
-      HealthyDeadline  | number.Nat
-                       | default = 500000000000,
-      MaxParallel      | number.Nat
-                       | default = 1,
-      MinHealthyTime   | number.Nat
-                       | default = 10000000000,
+      HealthCheck
+        | [| `checks, `task_states |]
+        | default
+        = `checks,
+      HealthyDeadline
+        | number.Nat
+        | default
+        = 500000000000,
+      MaxParallel
+        | number.Nat
+        | default
+        = 1,
+      MinHealthyTime
+        | number.Nat
+        | default
+        = 10000000000,
     },
 
     Periodic = {
-      Enabled          | Bool
-                       | default = false,
-      TimeZone         | String
-                       | default = "UTC",
-      SpecType         = "cron",
-      Spec             | String,
-      ProhibitOverlap  | Bool
-                       | default = false,
+      Enabled
+        | Bool
+        | default
+        = false,
+      TimeZone
+        | String
+        | default
+        = "UTC",
+      SpecType = "cron",
+      Spec | String,
+      ProhibitOverlap
+        | Bool
+        | default
+        = false,
     },
 
     Update = {
-      AutoPromote       | Bool | default = false,
-      AutoRevert        | Bool | default = false,
-      Canary            | number.Nat | default = 0,
-      HealthCheck       | [| `checks, `task_states, `manual |]
-                        | default = `checks,
-      HealthyDeadline   | lib.contracts.Nullable number.Nat | default = null,
-      MaxParallel       | number.Nat | default = 1,
-      MinHealthyTime    | lib.contracts.Nullable number.Nat | default = null,
-      ProgressDeadline  | lib.contracts.Nullable number.Nat | default = null,
-      Stagger           | lib.contracts.Nullable number.Nat | default = null,
+      AutoPromote | Bool | default = false,
+      AutoRevert | Bool | default = false,
+      Canary | number.Nat | default = 0,
+      HealthCheck
+        | [| `checks, `task_states, `manual |]
+        | default
+        = `checks,
+      HealthyDeadline | lib.contracts.Nullable number.Nat | default = null,
+      MaxParallel | number.Nat | default = 1,
+      MinHealthyTime | lib.contracts.Nullable number.Nat | default = null,
+      ProgressDeadline | lib.contracts.Nullable number.Nat | default = null,
+      Stagger | lib.contracts.Nullable number.Nat | default = null,
     },
 
     TaskGroup = {
-      Affinities | Array Affinity
-                 | default = [],
-      Constraints | Array Constraint
-                  | default = [],
-      Spreads | Array Spread
-              | default = [],
-      Count | number.Nat
-            | lib.contracts.Greater 0,
+      Affinities
+        | Array Affinity
+        | default
+        = [],
+      Constraints
+        | Array Constraint
+        | default
+        = [],
+      Spreads
+        | Array Spread
+        | default
+        = [],
+      Count
+        | number.Nat
+        | lib.contracts.Greater 0,
       # TODO: Meta  [string]  string
-      Name  | String,
-      RestartPolicy  | lib.contracts.Nullable json.RestartPolicy
-                     | default = null,
-      Services  | Array Service
-                | default = [],
-      ShutdownDelay  | number.Nat | default = 0,
-      Tasks | Array Task
-            | default = [],
+      Name | String,
+      RestartPolicy
+        | lib.contracts.Nullable json.RestartPolicy
+        | default
+        = null,
+      Services
+        | Array Service
+        | default
+        = [],
+      ShutdownDelay | number.Nat | default = 0,
+      Tasks
+        | Array Task
+        | default
+        = [],
       # TODO Volumes: [string]:  #json.Volume
       ReschedulePolicy | json.ReschedulePolicy,
       EphemeralDisk
-        | lib.contracts.Nullable {
+        | lib.contracts.Nullable
+          {
             Migrate | Bool,
-            SizeMB  | number.Nat,
-            Sticky  | Bool,
+            SizeMB | number.Nat,
+            Sticky | Bool,
           }
-        | default = null,
-      Migrate | lib.contracts.Nullable json.Migrate
-              | default = null,
-      Update | lib.contracts.Nullable json.Update
-             | default = null,
-      Networks | Array json.Network
-               | default = [],
-      StopAfterClientDisconnect | lib.contracts.Nullable number.Nat
-                                | default = null,
+        | default
+        = null,
+      Migrate
+        | lib.contracts.Nullable json.Migrate
+        | default
+        = null,
+      Update
+        | lib.contracts.Nullable json.Update
+        | default
+        = null,
+      Networks
+        | Array json.Network
+        | default
+        = [],
+      StopAfterClientDisconnect
+        | lib.contracts.Nullable number.Nat
+        | default
+        = null,
       Scaling = null,
-      Vault | lib.contracts.Nullable json.Vault
-            | default = null,
+      Vault
+        | lib.contracts.Nullable json.Vault
+        | default
+        = null,
     },
 
     Port = {
       Label | String,
-      Value | lib.contracts.Nullable number.Nat | default = null, # used for static ports
+      Value | lib.contracts.Nullable number.Nat | default = null,
+      # used for static ports
       To | lib.contracts.Nullable number.Nat | default = null,
       HostNetwork | String | default = "",
     },
@@ -207,7 +351,7 @@ let time = {
       IP | String | default = "",
       DNS = null,
       ReservedPorts | lib.contracts.Nullable (Array json.Port) | default = null,
-      DynamicPorts  | lib.contracts.Nullable (Array json.Port) | default = null,
+      DynamicPorts | lib.contracts.Nullable (Array json.Port) | default = null,
       MBits = null,
     },
 
@@ -225,7 +369,7 @@ let time = {
       Name | String | default = "",
       Path | String | default = "",
       PortLabel | String,
-      Protocol  | String | default = "",
+      Protocol | String | default = "",
       SuccessBeforePassing | number.Nat | default = 0,
       TaskName | String | default = "",
       Timeout | number.Nat,
@@ -235,35 +379,47 @@ let time = {
       # TODO  Header  [string]  [...string]
     },
 
-    CheckRestart | lib.contracts.Nullable {
-      Limit | number.Nat | default = 0,
-      Grace | number.Nat | default = 10000000000,
-      IgnoreWarnings | Bool | default = false,
-    },
+    CheckRestart
+      | lib.contracts.Nullable
+        {
+          Limit | number.Nat | default = 0,
+          Grace | number.Nat | default = 10000000000,
+          IgnoreWarnings | Bool | default = false,
+        },
 
     Lifecycle = {
       Hook | [| `prestart, `poststart, `poststop |],
       Sidecar | lib.contracts.Nullable Bool | default = null,
     },
 
-    LogConfig | lib.contracts.Nullable {
-      MaxFiles | number.PosNat,
-      MaxFileSizeMB | number.PosNat,
-    },
+    LogConfig
+      | lib.contracts.Nullable
+        {
+          MaxFiles | number.PosNat,
+          MaxFileSizeMB | number.PosNat,
+        },
 
     Service = {
       Id | String | default = "",
       Name | String,
-      Tags | Array String
-           | default = [],
-      CanaryTags | Array String
-                 | default = [],
-      EnableTagOverride | Bool
-                        | default = false,
+      Tags
+        | Array String
+        | default
+        = [],
+      CanaryTags
+        | Array String
+        | default
+        = [],
+      EnableTagOverride
+        | Bool
+        | default
+        = false,
       PortLabel | String,
       AddressMode | [| `alloc, `auto, `driver, `host |],
-      Checks | Array ServiceCheck
-             | default = [],
+      Checks
+        | Array ServiceCheck
+        | default
+        = [],
       CheckRestart | json.CheckRestart,
       Connect = null,
       # TODO Meta: [string]: string
@@ -273,24 +429,37 @@ let time = {
     Task = {
       Name | String,
       Driver | [| `exec, `docker, `nspawn |],
-      Config | stanza.taskConfig
-             | {driver | Driver},
-      Constraints | Array Constraint
-                  | default = [],
-      Affinities | Array Affinity
-                 | default = [],
+      Config
+        | stanza.taskConfig
+        | { driver | Driver },
+      Constraints
+        | Array Constraint
+        | default
+        = [],
+      Affinities
+        | Array Affinity
+        | default
+        = [],
       # TODO: Env: [string]: string
-      Services | Array Service
-               | default = [],
+      Services
+        | Array Service
+        | default
+        = [],
       Resources = {
-        CPU | number.Nat
-            | lib.contracts.GreaterEq 100
-            | default = 100,
-        MemoryMB | number.Nat
-                 | lib.contracts.GreaterEq 32
-                 | default = 300,
-        DiskMB | lib.contracts.Nullable number.Nat
-               | default = null,
+        CPU
+          | number.Nat
+          | lib.contracts.GreaterEq 100
+          | default
+          = 100,
+        MemoryMB
+          | number.Nat
+          | lib.contracts.GreaterEq 32
+          | default
+          = 300,
+        DiskMB
+          | lib.contracts.Nullable number.Nat
+          | default
+          = null,
       },
       Meta = {},
       RestartPolicy | lib.contracts.Nullable json.RestartPolicy | default = null,
@@ -299,13 +468,19 @@ let time = {
       Lifecycle | lib.contracts.Nullable json.Lifecycle | default = null,
       KillTimeout | lib.contracts.Nullable number.Nat | default = null,
       LogConfig | json.LogConfig,
-      Artifacts | Array json.Artifact
-                | default = [],
-      Templates | Array json.Template
-                | default = [],
+      Artifacts
+        | Array json.Artifact
+        | default
+        = [],
+      Templates
+        | Array json.Template
+        | default
+        = [],
       DispatchPayload = null,
-      VolumeMounts | Array json.VolumeMount
-                   | default = [],
+      VolumeMounts
+        | Array json.VolumeMount
+        | default
+        = [],
       Leader | Bool | default = false,
       KillSignal | String,
       ScalingPolicies = null,
@@ -351,10 +526,10 @@ let time = {
 
   Duration = lib.contracts.MatchRegexp "^[1-9]\\d*[hms]$",
   GitRevision = lib.contracts.MatchRegexp "^[a-f0-9]{40}$",
-  Flake =
-    lib.contracts.MatchRegexp "^(github|git\\+ssh|git):[0-9a-zA-Z_-]+/[0-9a-zA-Z_-]+",
+  Flake = lib.contracts.MatchRegexp "^(github|git\\+ssh|git):[0-9a-zA-Z_-]+/[0-9a-zA-Z_-]+",
 
-  toJson = json.Job & {
+  toJson = json.Job
+  & {
     job = stanza.job,
     jobName | String,
     Name = jobName,
@@ -414,366 +589,647 @@ let time = {
     #   }
     # }
 
-    Affinities = array.map (fun a => {
-      LTarget = a.attribute,
-      RTarget = a.value,
-      Operand = a.operator,
-      Weight = a.weight}) job.affinities,
-
-    Constraints = array.map (fun c => {
-      LTarget = c.attribute,
-      RTarget = c.value,
-      Operand = c.operator}) job.constraints,
-
-    Spreads = array.map (fun s => {
-      Attribute = s.attribute,
-      Weight = s.weight,
-      SpreadTarget = array.map (fun t => {
-        Value = t.value,
-        Percent = t.percent}) s.target,
-    }) job.spreads,
-
-    TaskGroups = lib.records.mapToArray (fun tgName tg => {
-      Name = tgName,
-      Count = tg.count,
-
-      Affinities = array.map (fun a => {
-        LTarget = a.attribute,
-        RTarget = a.value,
-        Operand = a.operator,
-        Weight = a.weight,
-      }) tg.affinities,
-
-      Constraints = array.map (fun c => {
-        LTarget = c.attribute,
-        RTarget = c.value,
-        Operand = c.operator,
-      }) tg.constraints,
-
-      Spreads = array.map (fun s => {
-        Attribute = s.attribute,
-        Weight = s.weight,
-        SpreadTarget = array.map (fun t => {
-          Value = t.value,
-          Percent = t.percent,
-        }) s.target,
-      }) tg.spreads,
-    } & (if tg.reschedule != null then {
-        ReschedulePolicy = {
-          Attempts = tg.reschedule.attempts,
-          DelayFunction = tg.reschedule.delay_function,
-          Unlimited = tg.reschedule.unlimited,
-    } & (if tg.reschedule.delay != null then {
-            # test above was: != _|_. Not sure what is the difference? Should
-            # we test for the presence of the field?
-            Delay = time.ParseDuration tg.reschedule.delay
-      } else {})
-    & (if tg.reschedule.interval != null then {
-            # test above was: != _|_. Not sure what is the difference? Should
-            # we test for the presence of the field?
-            Interval = time.ParseDuration tg.reschedule.interval
-      } else {})
-    & (if tg.reschedule.max_delay != null then {
-            # test above was: != _|_. Not sure what is the difference? Should
-            # we test for the presence of the field?
-            MaxDelay = time.ParseDuration tg.reschedule.max_delay
-      } else {})
-    } else {})
-    & (if tg.ephemeral_disk != null then {
-        EphemeralDisk = {
-          SizeMB =  tg.ephemeral_disk.size,
-          Migrate = tg.ephemeral_disk.migrate,
-          Sticky = tg.ephemeral_disk.sticky,
-        }
-      } else { })
-    & (if tg.restart != null then {
-        RestartPolicy = {
-          Interval = time.ParseDuration tg.restart.interval,
-          Attempts = tg.restart.attempts,
-          Delay = time.ParseDuration tg.restart.delay,
-          Mode = tg.restart.mode,
-        }
-      } else { })
-      # only one network can be specified at group level, and we never use
-      # deprecated task level ones.
-      & (if tg.network != null then
-        let ports = tg.network.port
-          |> lib.records.toArray
-          |> array.partition tg.network.port (fun entry =>
-            entry.value.static != null) in
-        # would be better with destructuring
-        let mkPort = fun {key, value={static, to, host_network}, ..} => {
-          Label = key,
-          Value = static,
-          To = to,
-          HostNetwork = host_network,
-        } in
-        {
-          Networks = [{
-            Mode = tg.network.mode,
-            ReservedPorts = array.map mkPort ports.right,
-            DynamicPorts = array.map mkPort ports.wrong,
-          }]
-        } else { })
-      & {
-       Services = array.map (fun sName s => {
-          Name = sName,
-          TaskName = s.task,
-          Tags = s.tags,
-          AddressMode = s.address_mode,
-        }
-        & (if s.check_restart != null then {
-          CheckRestart = {
-            Limit = s.check_restart.limit,
-            Grace = time.ParseDuration(s.check_restart.grace),
-            IgnoreWarnings = s.check_restart.ignore_warnings,
+    Affinities = array.map
+      (
+        fun a =>
+          {
+            LTarget = a.attribute,
+            RTarget = a.value,
+            Operand = a.operator,
+            Weight = a.weight
           }
-         }
-         else {})
-        & {
-          Checks = lib.records.mapToArray (fun cName c => {
-            AddressMode = c.address_mode,
-            Type = c.type,
-            PortLabel = c.port,
-            Interval = time.ParseDuration(c.interval)}
-          & (if c.type == "http" then {
-              Path = c.path,
-              Method = c.method,
-              Protocol = c.protocol
-            } else {})
-          & {
-            Timeout = time.ParseDuration(c.timeout),
-            SuccessBeforePassing = c.success_before_passing,
-            FailuresBeforeCritical = c.failures_before_critical,
-            TLSSkipVerify = c.tls_skip_verify,
-            InitialStatus = c.initial_status,
-            Header = c.header,
-            Body = c.body,
+      )
+      job.affinities,
+
+    Constraints = array.map
+      (
+        fun c =>
+          {
+            LTarget = c.attribute,
+            RTarget = c.value,
+            Operand = c.operator
           }
-          & (if c.check_restart != null then {
-              CheckRestart = {
-                Limit = c.check_restart.limit,
-                Grace = time.ParseDuration(c.check_restart.grace),
-                IgnoreWarnings = c.check_restart.ignore_warnings,
+      )
+      job.constraints,
+
+    Spreads = array.map
+      (
+        fun s =>
+          {
+            Attribute = s.attribute,
+            Weight = s.weight,
+            SpreadTarget = array.map
+              (
+                fun t =>
+                  {
+                    Value = t.value,
+                    Percent = t.percent
+                  }
+              )
+              s.target,
+          }
+      )
+      job.spreads,
+
+    TaskGroups = lib.records.mapToArray
+      (
+        fun tgName tg =>
+          {
+            Name = tgName,
+            Count = tg.count,
+
+            Affinities = array.map
+              (
+                fun a =>
+                  {
+                    LTarget = a.attribute,
+                    RTarget = a.value,
+                    Operand = a.operator,
+                    Weight = a.weight,
+                  }
+              )
+              tg.affinities,
+
+            Constraints = array.map
+              (
+                fun c =>
+                  {
+                    LTarget = c.attribute,
+                    RTarget = c.value,
+                    Operand = c.operator,
+                  }
+              )
+              tg.constraints,
+
+            Spreads = array.map
+              (
+                fun s =>
+                  {
+                    Attribute = s.attribute,
+                    Weight = s.weight,
+                    SpreadTarget = array.map
+                      (
+                        fun t =>
+                          {
+                            Value = t.value,
+                            Percent = t.percent,
+                          }
+                      )
+                      s.target,
+                  }
+              )
+              tg.spreads,
+          }
+          & (
+            if tg.reschedule != null then
+              {
+                ReschedulePolicy = {
+                  Attempts = tg.reschedule.attempts,
+                  DelayFunction = tg.reschedule.delay_function,
+                  Unlimited = tg.reschedule.unlimited,
+                }
+                & (
+                  if tg.reschedule.delay != null then
+                    {
+                      # test above was: != _|_. Not sure what is the difference? Should
+                      # we test for the presence of the field?
+                      Delay = time.ParseDuration tg.reschedule.delay
+                    }
+                  else
+                    {}
+                )
+                & (
+                  if tg.reschedule.interval != null then
+                    {
+                      # test above was: != _|_. Not sure what is the difference? Should
+                      # we test for the presence of the field?
+                      Interval = time.ParseDuration tg.reschedule.interval
+                    }
+                  else
+                    {}
+                )
+                & (
+                  if tg.reschedule.max_delay != null then
+                    {
+                      # test above was: != _|_. Not sure what is the difference? Should
+                      # we test for the presence of the field?
+                      MaxDelay = time.ParseDuration tg.reschedule.max_delay
+                    }
+                  else
+                    {}
+                )
               }
-            } else {})) s.check,
+            else
+              {}
+          )
+          & (
+            if tg.ephemeral_disk != null then
+              {
+                EphemeralDisk = {
+                  SizeMB = tg.ephemeral_disk.size,
+                  Migrate = tg.ephemeral_disk.migrate,
+                  Sticky = tg.ephemeral_disk.sticky,
+                }
+              }
+            else
+              {}
+          )
+          & (
+            if tg.restart != null then
+              {
+                RestartPolicy = {
+                  Interval = time.ParseDuration tg.restart.interval,
+                  Attempts = tg.restart.attempts,
+                  Delay = time.ParseDuration tg.restart.delay,
+                  Mode = tg.restart.mode,
+                }
+              }
+            else
+              {}
+          )
+          # only one network can be specified at group level, and we never use
+          # deprecated task level ones.
+          & (
+            if tg.network != null then
+              let ports =
+                tg.network.port
+                |> lib.records.toArray
+                |> array.partition
+                  tg.network.port
+                  (
+                    fun entry =>
+                      entry.value.static != null
+                  )
+              in
+              # would be better with destructuring
+              let mkPort =
+                fun { key, value = { static, to, host_network }, .. } =>
+                  {
+                    Label = key,
+                    Value = static,
+                    To = to,
+                    HostNetwork = host_network,
+                  }
+              in
+              {
+                Networks = [{
+                  Mode = tg.network.mode,
+                  ReservedPorts = array.map mkPort ports.right,
+                  DynamicPorts = array.map mkPort ports.wrong,
+                }]
+              }
+            else
+              {}
+          )
+          & {
+            Services = array.map
+              (
+                fun sName s =>
+                  {
+                    Name = sName,
+                    TaskName = s.task,
+                    Tags = s.tags,
+                    AddressMode = s.address_mode,
+                  }
+                  & (
+                    if s.check_restart != null then
+                      {
+                        CheckRestart = {
+                          Limit = s.check_restart.limit,
+                          Grace = time.ParseDuration (s.check_restart.grace),
+                          IgnoreWarnings = s.check_restart.ignore_warnings,
+                        }
+                      }
+                    else
+                      {}
+                  )
+                  & {
+                    Checks = lib.records.mapToArray
+                      (
+                        fun cName c =>
+                          {
+                            AddressMode = c.address_mode,
+                            Type = c.type,
+                            PortLabel = c.port,
+                            Interval = time.ParseDuration (c.interval)
+                          }
+                          & (
+                            if c.type == "http" then
+                              {
+                                Path = c.path,
+                                Method = c.method,
+                                Protocol = c.protocol
+                              }
+                            else
+                              {}
+                          )
+                          & {
+                            Timeout = time.ParseDuration (c.timeout),
+                            SuccessBeforePassing = c.success_before_passing,
+                            FailuresBeforeCritical = c.failures_before_critical,
+                            TLSSkipVerify = c.tls_skip_verify,
+                            InitialStatus = c.initial_status,
+                            Header = c.header,
+                            Body = c.body,
+                          }
+                          & (
+                            if c.check_restart != null then
+                              {
+                                CheckRestart = {
+                                  Limit = c.check_restart.limit,
+                                  Grace = time.ParseDuration (c.check_restart.grace),
+                                  IgnoreWarnings = c.check_restart.ignore_warnings,
+                                }
+                              }
+                            else
+                              {}
+                          )
+                      )
+                      s.check,
 
-          PortLabel = s.port,
-          Meta = s.meta,
-        }) tg.service,
+                    PortLabel = s.port,
+                    Meta = s.meta,
+                  }
+              )
+              tg.service,
 
-        Tasks = lib.records.mapToArray (fun tName t => {
-          Name = tName,
-          Driver = t.driver,
-          Config = t.config,
-          Env = t.env,
-          KillSignal = t.kill_signal,
-        } & (if t.kill_timeout != null then {
-          KillTimeout = time.ParseDuration(t.kill_timeout)}
-          else {})
-        & {
-          Affinities = array.map (fun {attribute, value, operator, weight, ..} => {
-            LTarget = attribute,
-            RTarget = value,
-            Operand = operator,
-            Weight = weight,
-          }) t.affinities,
-          # END AFFINITIES
+            Tasks = lib.records.mapToArray
+              (
+                fun tName t =>
+                  {
+                    Name = tName,
+                    Driver = t.driver,
+                    Config = t.config,
+                    Env = t.env,
+                    KillSignal = t.kill_signal,
+                  }
+                  & (
+                    if t.kill_timeout != null then
+                      {
+                        KillTimeout = time.ParseDuration (t.kill_timeout)
+                      }
+                    else
+                      {}
+                  )
+                  & {
+                    Affinities = array.map
+                      (
+                        fun { attribute, value, operator, weight, .. } =>
+                          {
+                            LTarget = attribute,
+                            RTarget = value,
+                            Operand = operator,
+                            Weight = weight,
+                          }
+                      )
+                      t.affinities,
+                    # END AFFINITIES
 
-          Constraints = lib.records.mapToArray (fun {attribute, value, operator} => {
-            LTarget = attribute,
-            RTarget = value,
-            Operand = operator,
-          }) t.constraints,
-          # END CONSTRAINTS
-        }
-        & (if t.logs != null then {
-            LogConfig = {
-              MaxFiles = t.logs.max_files,
-              MaxFileSizeMB = t.logs.max_file_size,
-            }
-          } else {})
-        & (if t.restart != null then {
-            RestartPolicy = {
-              Interval = time.ParseDuration(t.restart.interval),
-              Attempts = t.restart.attempts,
-              Delay = time.ParseDuration(t.restart.delay),
-              Mode = t.restart.mode,
-            }
-          } else {})
-        & (if t.lifecycle != null then {
-            Lifecycle = {
-              Hook = t.lifecycle.hook,
-              Sidecar = t.lifecycle.sidecar,
-            }
-          } else {})
-        & {
-          Resources = {
-            CPU = t.resources.cpu,
-            MemoryMB = t.resources.memory,
-          },
+                    Constraints = lib.records.mapToArray
+                      (
+                        fun { attribute, value, operator } =>
+                          {
+                            LTarget = attribute,
+                            RTarget = value,
+                            Operand = operator,
+                          }
+                      )
+                      t.constraints,
+                    # END CONSTRAINTS
+                  }
+                  & (
+                    if t.logs != null then
+                      {
+                        LogConfig = {
+                          MaxFiles = t.logs.max_files,
+                          MaxFileSizeMB = t.logs.max_file_size,
+                        }
+                      }
+                    else
+                      {}
+                  )
+                  & (
+                    if t.restart != null then
+                      {
+                        RestartPolicy = {
+                          Interval = time.ParseDuration (t.restart.interval),
+                          Attempts = t.restart.attempts,
+                          Delay = time.ParseDuration (t.restart.delay),
+                          Mode = t.restart.mode,
+                        }
+                      }
+                    else
+                      {}
+                  )
+                  & (
+                    if t.lifecycle != null then
+                      {
+                        Lifecycle = {
+                          Hook = t.lifecycle.hook,
+                          Sidecar = t.lifecycle.sidecar,
+                        }
+                      }
+                    else
+                      {}
+                  )
+                  & {
+                    Resources = {
+                      CPU = t.resources.cpu,
+                      MemoryMB = t.resources.memory,
+                    },
 
-          Leader = t.leader,
+                    Leader = t.leader,
 
-          Templates = lib.records.mapToArray (fun tplName tpl => {
-            DestPath = tplName,
-            EmbeddedTmpl = tpl.data,
-            SourcePath = tpl.source,
-            Envvars = tpl.env,
-            ChangeMode = tpl.change_mode,
-            ChangeSignal = tpl.change_signal,
-            Perms = tpl.perms,
-            LeftDelim = tpl.left_delimiter,
-            RightDelim = tpl.right_delimiter,
-          }) t.template,
+                    Templates = lib.records.mapToArray
+                      (
+                        fun tplName tpl =>
+                          {
+                            DestPath = tplName,
+                            EmbeddedTmpl = tpl.data,
+                            SourcePath = tpl.source,
+                            Envvars = tpl.env,
+                            ChangeMode = tpl.change_mode,
+                            ChangeSignal = tpl.change_signal,
+                            Perms = tpl.perms,
+                            LeftDelim = tpl.left_delimiter,
+                            RightDelim = tpl.right_delimiter,
+                          }
+                      )
+                      t.template,
 
-          Artifacts = lib.records.mapToArray (fun artName art => {
-            GetterHeaders = art.headers,
-            GetterMode = art.mode,
-            GetterOptions = art.options,
-            GetterSource = art.source,
-            RelativeDest = artName,
-          }) t.artifact,
-        }
-        & (if t.vault != null then {
-            Vault = {
-              ChangeMode = t.vault.change_mode,
-              ChangeSignal = t.vault.change_signal,
-              Env = t.vault.env,
-              Namespace = t.vault.namespace,
-              Policies = t.vault.policies,
-            }
-          } else {})
-        & {
-          VolumeMounts = lib.records.mapToArray (fun volName vol => {
-            Destination = vol.destination,
-            PropagationMode = "private",
-            ReadOnly = vol.read_only,
-            Volume = volName,
-          }) t.volume_mount,
-        }) tg.task,
-        # END TASKS
-      }
-    & (if tg.vault != null then {
-        Vault = {
-          ChangeMode = tg.vault.change_mode,
-          ChangeSignal = tg.vault.change_signal,
-          Env = tg.vault.env,
-          Namespace = tg.vault.namespace,
-          Policies = tg.vault.policies,
-        }
-      } else {})
-    & lib.records.mapToArray (fun volName vol => {
-        Volumes."#{volName}" = {
-          Name = volName,
-          Type = vol.type,
-          Source = vol.source,
-          ReadOnly = vol.read_only,
+                    Artifacts = lib.records.mapToArray
+                      (
+                        fun artName art =>
+                          {
+                            GetterHeaders = art.headers,
+                            GetterMode = art.mode,
+                            GetterOptions = art.options,
+                            GetterSource = art.source,
+                            RelativeDest = artName,
+                          }
+                      )
+                      t.artifact,
+                  }
+                  & (
+                    if t.vault != null then
+                      {
+                        Vault = {
+                          ChangeMode = t.vault.change_mode,
+                          ChangeSignal = t.vault.change_signal,
+                          Env = t.vault.env,
+                          Namespace = t.vault.namespace,
+                          Policies = t.vault.policies,
+                        }
+                      }
+                    else
+                      {}
+                  )
+                  & {
+                    VolumeMounts = lib.records.mapToArray
+                      (
+                        fun volName vol =>
+                          {
+                            Destination = vol.destination,
+                            PropagationMode = "private",
+                            ReadOnly = vol.read_only,
+                            Volume = volName,
+                          }
+                      )
+                      t.volume_mount,
+                  }
+              )
+              tg.task,
+            # END TASKS
           }
-          & (if vol.type == "csi" then {
-            MountOptions = {
-              FsType = vol.mount_options.fs_type,
-              mountFlags = vol.mount_options.mount_flags,
-            }
-          } else {})
-        }) tg.volume
-    ) job.group,
+          & (
+            if tg.vault != null then
+              {
+                Vault = {
+                  ChangeMode = tg.vault.change_mode,
+                  ChangeSignal = tg.vault.change_signal,
+                  Env = tg.vault.env,
+                  Namespace = tg.vault.namespace,
+                  Policies = tg.vault.policies,
+                }
+              }
+            else
+              {}
+          )
+          & lib.records.mapToArray
+            (
+              fun volName vol =>
+                {
+                  Volumes."#{volName}" = {
+                    Name = volName,
+                    Type = vol.type,
+                    Source = vol.source,
+                    ReadOnly = vol.read_only,
+                  }
+                  & (
+                    if vol.type == "csi" then
+                      {
+                        MountOptions = {
+                          FsType = vol.mount_options.fs_type,
+                          mountFlags = vol.mount_options.mount_flags,
+                        }
+                      }
+                    else
+                      {}
+                  )
+                }
+            )
+            tg.volume
+      )
+      job.group,
   },
 
   stanza = {
-    job = let type_schema = [| `batch, `service, `system |] in {
+    job = let type_schema = [| `batch, `service, `system |] in
+    {
       datacenters | array.NonEmpty,
       namespace | String,
-      type | type_schema
-           | default = `service,
-      affinities | Array stanza.affinity
-                 | default = [],
-      constraints | Array stanza.constraint
-                  | default = [],
-      spreads | Array stanza.spread
-              | default = [],
-      group | {_: stanza.group & {type | type_schema | default =
-`service}},
-      update | lib.contracts.Nullable stanza.update
-             | default = null,
-      vaultc | lib.contracts.Nullable stanza.vault
-             | default = null,
-      priority_ | number.Nat
-                | default = 50,
-      periodic | lib.contracts.Nullable stanza.periodic
-               | default = null,
-      migrate | lib.contracts.Nullable stanza.migrate
-              | default = null,
+      type
+        | type_schema
+        | default
+        = `service,
+      affinities
+        | Array stanza.affinity
+        | default
+        = [],
+      constraints
+        | Array stanza.constraint
+        | default
+        = [],
+      spreads
+        | Array stanza.spread
+        | default
+        = [],
+      group
+        | {
+          _ : stanza.group
+          & {
+            type | type_schema | default = `service
+          }
+        },
+      update
+        | lib.contracts.Nullable stanza.update
+        | default
+        = null,
+      vaultc
+        | lib.contracts.Nullable stanza.vault
+        | default
+        = null,
+      priority_
+        | number.Nat
+        | default
+        = 50,
+      periodic
+        | lib.contracts.Nullable stanza.periodic
+        | default
+        = null,
+      migrate
+        | lib.contracts.Nullable stanza.migrate
+        | default
+        = null,
     },
 
     migrate = {
-      health_check | [| `checks, `task_states |]
-                   | default = `checks,
-      healthy_deadline | number.Nat
-                       | default = 500000000000,
-      max_parallel | number.Nat
-                   | default = 1,
-      min_healthy_time  | number.Nat
-                        | default = 10000000000,
+      health_check
+        | [| `checks, `task_states |]
+        | default
+        = `checks,
+      healthy_deadline
+        | number.Nat
+        | default
+        = 500000000000,
+      max_parallel
+        | number.Nat
+        | default
+        = 1,
+      min_healthy_time
+        | number.Nat
+        | default
+        = 10000000000,
     },
 
     periodic = {
-      time_zone | String
-                | default = "UTC",
-      prohibit_overlap | Bool
-                       | default = false,
+      time_zone
+        | String
+        | default
+        = "UTC",
+      prohibit_overlap
+        | Bool
+        | default
+        = false,
       cron | String,
     },
 
     affinity = {
-      LTarget | String
-              | default = null,
+      LTarget
+        | String
+        | default
+        = null,
       RTarget | String,
-      Operand | lib.contracts.OneOf
-        ["regexp", "set_contains_all", "set_contains", "set_contains_any", "=",
-        "==", "is", "!=", "not", ">", ">=", "<", "<=", "version"]
-              | default = "=",
-      Weight | number.Nat
-             | lib.contracts.NotEq 0
-             | lib.contracts.GreaterEq -100
-             | lib.contracts.SmallerEq 100,
+      Operand
+        | lib.contracts.OneOf
+          [
+            "regexp",
+            "set_contains_all",
+            "set_contains",
+            "set_contains_any",
+            "=",
+            "==",
+            "is",
+            "!=",
+            "not",
+            ">",
+            ">=",
+            "<",
+            "<=",
+            "version"
+          ]
+        | default
+        = "=",
+      Weight
+        | number.Nat
+        | lib.contracts.NotEq 0
+        | lib.contracts.GreaterEq
+        - 100
+        | lib.contracts.SmallerEq 100,
     },
 
     constraint = {
-      attribute | String
-                | default = null,
+      attribute
+        | String
+        | default
+        = null,
       value | String,
-      operator | lib.contracts.OneOf
-                 ["=", "!=", ">", ">=", "<", "<=", "distinct_hosts", "distinct_property",
-                 "regexp", "set_contains", "version", "semver", "is_set",
-                 "is_not_set"]
-               | default = "=",
+      operator
+        | lib.contracts.OneOf
+          [
+            "=",
+            "!=",
+            ">",
+            ">=",
+            "<",
+            "<=",
+            "distinct_hosts",
+            "distinct_property",
+            "regexp",
+            "set_contains",
+            "version",
+            "semver",
+            "is_set",
+            "is_not_set"
+          ]
+        | default
+        = "=",
     },
 
     spread = {
-      attribute | lib.contracts.Nullable String
-                | default = null,
-      weight | lib.contracts.Nullable (lib.contracts.AllOf
-                 [number.Nat,
-                  lib.contracts.GreaterEq -100,
-                  lib.contracts.SmallerEq 100])
-             | default = null,
-      target | Array stanza.targetElem
-             | default = [],
+      attribute
+        | lib.contracts.Nullable String
+        | default
+        = null,
+      weight
+        | lib.contracts.Nullable
+          (
+            lib.contracts.AllOf
+              [
+                number.Nat,
+                lib.contracts.GreaterEq - 100,
+                lib.contracts.SmallerEq 100
+              ]
+          )
+        | default
+        = null,
+      target
+        | Array stanza.targetElem
+        | default
+        = [],
     },
 
     targetElem = {
-      value | lib.contracts.Nullable String
-            | default = null,
-      percent | lib.contracts.Nullable (lib.contracts.AllOf [
+      value
+        | lib.contracts.Nullable String
+        | default
+        = null,
+      percent
+        | lib.contracts.Nullable
+          (
+            lib.contracts.AllOf
+              [
                 number.Nat,
-                lib.contracts.GreaterEq -100,
-                lib.contracts.SmallerEq 100])
-              | default = null,
+                lib.contracts.GreaterEq - 100,
+                lib.contracts.SmallerEq 100
+              ]
+          )
+        | default
+        = null,
     },
 
-    ephemeral_disk =
-        lib.contracts.Nullable {
+    ephemeral_disk = lib.contracts.Nullable
+      {
         size | number.PosNat,
         migrate | Bool | default = false,
         sticky | Bool | default = false,
@@ -781,32 +1237,51 @@ let time = {
 
     group = {
       type | [| `service, `batch, `system |],
-      affinities | Array stanza.affinity
-                 | default = [],
-      constraints | Array stanza.constraint
-                  | default = [],
-      spreads | Array stanza.spread
-              | default = [],
+      affinities
+        | Array stanza.affinity
+        | default
+        = [],
+      constraints
+        | Array stanza.constraint
+        | default
+        = [],
+      spreads
+        | Array stanza.spread
+        | default
+        = [],
       ephemeral_disk | stanza.ephemeral_disk | default = null,
-      network | lib.contracts.Nullable stanza.network
-              | default = null,
-      service | {_: stanza.service},
-      task | {_: stanza.task},
+      network
+        | lib.contracts.Nullable stanza.network
+        | default
+        = null,
+      service | { _ : stanza.service },
+      task | { _ : stanza.task },
       count | number.Nat,
-      volume | {_: stanza.volume} | default = {},
-      vault | lib.contracts.Nullable stanza.vault
-            | default = null,
-      restart | lib.contracts.Nullable stanza.restart
-              | default = null,
-      restart_policy | lib.contracts.Nullable stanza.restart
-                     | default = null,
-      reschedule | stanza.reschedule & {type | [| `service, `batch, `system |]}
-                 | default = {},
+      volume | { _ : stanza.volume } | default = {},
+      vault
+        | lib.contracts.Nullable stanza.vault
+        | default
+        = null,
+      restart
+        | lib.contracts.Nullable stanza.restart
+        | default
+        = null,
+      restart_policy
+        | lib.contracts.Nullable stanza.restart
+        | default
+        = null,
+      reschedule
+        | stanza.reschedule
+        & { type | [| `service, `batch, `system |] }
+        | default
+        = {},
     },
 
     reschedule = {
-      type | [| `batch, `service, `system |]
-           | default = `service,
+      type
+        | [| `batch, `service, `system |]
+        | default
+        = `service,
 
       # TODO: convert with ifs or sth
       # if #type == "batch" {
@@ -830,66 +1305,100 @@ let time = {
 
     network = {
       mode | [| `host, `bridge |],
-      dns | lib.contracts.Nullable {
-              servers | Array String
-                      | default = []
-            }
-          | default = null,
-      port | {_: {
-                 static | lib.contracts.Nullable number.Nat
-                        | default = null,
-                 to | lib.contracts.Nullable number.Nat
-                    | default = null,
-                 host_network | String
-                              | default = "",
-               }
-             },
+      dns
+        | lib.contracts.Nullable
+          {
+            servers
+              | Array String
+              | default
+              = []
+          }
+        | default
+        = null,
+      port
+        | {
+          _ : {
+            static
+              | lib.contracts.Nullable number.Nat
+              | default
+              = null,
+            to
+              | lib.contracts.Nullable number.Nat
+              | default
+              = null,
+            host_network
+              | String
+              | default
+              = "",
+          }
+        },
     },
 
     check_restart = {
-         limit | number.PosNat,
-         grace | Duration,
-         ignore_warnings | Bool
-                         | default = false,
-       },
+      limit | number.PosNat,
+      grace | Duration,
+      ignore_warnings
+        | Bool
+        | default
+        = false,
+    },
 
     service = {
-      check_restart | lib.contracts.Nullable stanza.check_restart
-                    | default = null,
+      check_restart
+        | lib.contracts.Nullable stanza.check_restart
+        | default
+        = null,
       port | String,
-      address_mode | [| `alloc, `driver, `auto, `host |]
-                   | default = `auto,
-      tags | Array String
-           | default = [],
-      task | String
-           | default = "",
-      check | {_: stanza.check} | default = {},
-      meta | {_: String} | default = {},
+      address_mode
+        | [| `alloc, `driver, `auto, `host |]
+        | default
+        = `auto,
+      tags
+        | Array String
+        | default
+        = [],
+      task
+        | String
+        | default
+        = "",
+      check | { _ : stanza.check } | default = {},
+      meta | { _ : String } | default = {},
     },
 
     check = {
-      address_mode | [| `alloc, `driver, `host |]
-                   | default = `driver,
+      address_mode
+        | [| `alloc, `driver, `host |]
+        | default
+        = `driver,
       type | [| `http, `tcp, `script, `grpc |],
       port | String,
       interval | Duration,
       timeout | Duration,
-      check_restart | lib.contracts.Nullable stanza.check_restart
-                    | default = null,
-      header | {_: Array String} | default = {},
-      body | lib.contracts.Nullable String
-           | default = null,
-      initial_status | (lib.contracts.OneOf ["passing", "warning", "critical", ""])
-                     | default = "",
-      success_before_passing | number.Nat
-                             | default = 0,
-      failures_before_critical | number.Nat
-                               | default = 0,
-      tls_skip_verify | Bool
-                      | default = false,
-
-
-
+      check_restart
+        | lib.contracts.Nullable stanza.check_restart
+        | default
+        = null,
+      header | { _ : Array String } | default = {},
+      body
+        | lib.contracts.Nullable String
+        | default
+        = null,
+      initial_status
+        | (lib.contracts.OneOf [ "passing", "warning", "critical", "" ])
+        | default
+        = "",
+      success_before_passing
+        | number.Nat
+        | default
+        = 0,
+      failures_before_critical
+        | number.Nat
+        | default
+        = 0,
+      tls_skip_verify
+        | Bool
+        | default
+        = false,
 
       #TODO: convert once we can do it
       #if type == "http" {
@@ -914,29 +1423,41 @@ let time = {
     execConfig = {
       flake | String,
       command | String,
-      args | Array String
-           | default = [],
+      args
+        | Array String
+        | default
+        = [],
     },
 
-    label = {_: String},
+    label = { _ : String },
 
     dockerConfig = {
       image | String,
-      command | lib.contracts.Nullable String
-              | default = null,
-      args | Array String
-           | default = [],
-      ports | Array String
-            | default = [],
-      labels | Array label
-             | default = [],
+      command
+        | lib.contracts.Nullable String
+        | default
+        = null,
+      args
+        | Array String
+        | default
+        = [],
+      ports
+        | Array String
+        | default
+        = [],
+      labels
+        | Array label
+        | default
+        = [],
       logging | dockerConfigLogging
     },
 
     dockerConfigLogging = {
       type = "journald",
-      config | Array dockerConfigLoggingConfig
-             | default = [],
+      config
+        | Array dockerConfigLoggingConfig
+        | default
+        = [],
     },
 
     dockerConfigLoggingConfig = {
@@ -946,8 +1467,10 @@ let time = {
 
     lifecycle = {
       hook | [| `prestart, `poststart, `poststop |],
-      sidecar | lib.contracts.Nullable Bool
-              | default = null,
+      sidecar
+        | lib.contracts.Nullable Bool
+        | default
+        = null,
     },
 
     logs = {
@@ -956,23 +1479,33 @@ let time = {
     },
 
     task = {
-      affinities | Array stanza.affinity
-                 | default = [],
-      constraints | Array stanza.constraint
-                  | default = [],
+      affinities
+        | Array stanza.affinity
+        | default
+        = [],
+      constraints
+        | Array stanza.constraint
+        | default
+        = [],
 
       #TODO: contracts on field names
       #artifact: [Destination=_]: {
-      artifact | {_: {
-                   # actually, the key must be the destination
-                   # destination | Destination,
-                   headers | {_: String},
-                   mode | [| `any, `file, `dir |]
-                        | default = `any,
-                   options | {_: String},
-                   source | String,
-                 }
-               } | default = {},
+      artifact
+        | {
+          _ : {
+            # actually, the key must be the destination
+            # destination | Destination,
+            headers | { _ : String },
+            mode
+              | [| `any, `file, `dir |]
+              | default
+              = `any,
+            options | { _ : String },
+            source | String,
+          }
+        }
+        | default
+        = {},
 
       #TODO: dependent if
       #if driver == "docker" {
@@ -984,74 +1517,113 @@ let time = {
       #}
 
       # meantime, allow config field:
-      config | {..},
+      config | { .. },
 
       driver | [| `exec, `docker, `nspawn |],
 
-      env | {_: String}
-          | default = {},
+      env
+        | { _ : String }
+        | default
+        = {},
 
-      kill_signal | String
-                  | default = "SIGINT",
+      kill_signal
+        | String
+        | default
+        = "SIGINT",
 
       #TODO
       #if driver == "docker" {
       #  kill_signal: "SIGTERM"
       #}
 
-      kill_timeout | lib.contracts.Nullable Duration
-                   | default = null,
+      kill_timeout
+        | lib.contracts.Nullable Duration
+        | default
+        = null,
 
-      lifecycle | lib.contracts.Nullable stanza.lifecycle
-                | default = null,
+      lifecycle
+        | lib.contracts.Nullable stanza.lifecycle
+        | default
+        = null,
 
-      logs | lib.contracts.Nullable stanza.logs
-           | default = null,
+      logs
+        | lib.contracts.Nullable stanza.logs
+        | default
+        = null,
 
       resources = {
-        cpu | number.Nat
-            | lib.contracts.GreaterEq 100,
+        cpu
+          | number.Nat
+          | lib.contracts.GreaterEq 100,
         memory
-            | number.Nat
-            | lib.contracts.GreaterEq 32,
+          | number.Nat
+          | lib.contracts.GreaterEq 32,
       },
 
       #TODO: contracts on fields
       #template: [Destination=_]: {
-      template | {_: {
-                   # Actually, the key must be a destination, there is no
-                   # destination field
-                   # destination | Destination,
-                   data | String
-                        | default = "",
-                   source | String
-                          | default = "",
-                   env | Bool
-                       | default = false,
-                   change_mode | [| `restart, `noop, `signal |]
-                               | default = `restart,
-                   change_signal | String
-                                 | default = "",
-                   perms | (lib.contracts.MatchRegexp "^[0-7]{4}$")
-                         | default = "0644",
-                   left_delimiter | String
-                                  | default = "{{",
-                   right_delimiter | String
-                                   | default = "}}",
-                   splay | Duration
-                         | default = "3s",
-                 }
-               },
+      template
+        | {
+          _ : {
+            # Actually, the key must be a destination, there is no
+            # destination field
+            # destination | Destination,
+            data
+              | String
+              | default
+              = "",
+            source
+              | String
+              | default
+              = "",
+            env
+              | Bool
+              | default
+              = false,
+            change_mode
+              | [| `restart, `noop, `signal |]
+              | default
+              = `restart,
+            change_signal
+              | String
+              | default
+              = "",
+            perms
+              | (lib.contracts.MatchRegexp "^[0-7]{4}$")
+              | default
+              = "0644",
+            left_delimiter
+              | String
+              | default
+              = "{{",
+            right_delimiter
+              | String
+              | default
+              = "}}",
+            splay
+              | Duration
+              | default
+              = "3s",
+          }
+        },
 
-      vault | lib.contracts.Nullable stanza.vault
-            | default = null,
-      volume_mount | {_: stanza.volume_mount} | default = {},
-      restart | lib.contracts.Nullable stanza.restart
-              | default = null,
-      restart_policy | lib.contracts.Nullable stanza.restart
-                     | default = null,
-      leader | Bool
-             | default = false,
+      vault
+        | lib.contracts.Nullable stanza.vault
+        | default
+        = null,
+      volume_mount | { _ : stanza.volume_mount } | default = {},
+      restart
+        | lib.contracts.Nullable stanza.restart
+        | default
+        = null,
+      restart_policy
+        | lib.contracts.Nullable stanza.restart
+        | default
+        = null,
+      leader
+        | Bool
+        | default
+        = false,
 
       ..
     },
@@ -1064,44 +1636,74 @@ let time = {
     },
 
     update = {
-      auto_promote | Bool
-                   | default = false,
-      auto_revert | Bool
-                  | default = false,
-      canary | number.Nat
-             | default = 0,
-      health_check | [| `checks, `task_states, `manual |]
-                   | default = `checks,
-      healthy_deadline | Duration
-                       | default = "5m",
-      max_parallel | number.Nat
-                   | default = 1,
-      min_healthy_time | Duration
-                       | default = "10s",
-      progress_deadline | Duration
-                        | default = "10m",
-      stagger | Duration
-              | default = "30s",
+      auto_promote
+        | Bool
+        | default
+        = false,
+      auto_revert
+        | Bool
+        | default
+        = false,
+      canary
+        | number.Nat
+        | default
+        = 0,
+      health_check
+        | [| `checks, `task_states, `manual |]
+        | default
+        = `checks,
+      healthy_deadline
+        | Duration
+        | default
+        = "5m",
+      max_parallel
+        | number.Nat
+        | default
+        = 1,
+      min_healthy_time
+        | Duration
+        | default
+        = "10s",
+      progress_deadline
+        | Duration
+        | default
+        = "10m",
+      stagger
+        | Duration
+        | default
+        = "30s",
     },
 
     vault = {
-      change_mode | [| `noop, `restart, `signal |]
-                  | default = `restart,
-      change_signal | String
-                    | default = "",
-      env | Bool
-          | default = true,
-      namespace | String
-                | default = "",
-      policies | Array String
-               | default = [],
+      change_mode
+        | [| `noop, `restart, `signal |]
+        | default
+        = `restart,
+      change_signal
+        | String
+        | default
+        = "",
+      env
+        | Bool
+        | default
+        = true,
+      namespace
+        | String
+        | default
+        = "",
+      policies
+        | Array String
+        | default
+        = [],
     },
 
     volume = {
       type | [| `host, `csi |],
       source | String,
-      read_only | Bool
-                | default = false,
+      read_only
+        | Bool
+        | default
+        = false,
       #TODO: dependent if
       #if type == "csi" {
       #  mount_options: {
@@ -1113,19 +1715,25 @@ let time = {
 
     volume_mount = {
       # Specifies the group volume that the mount is going to access.
-      volume | String
-             | default = "",
+      volume
+        | String
+        | default
+        = "",
 
       # Specifies where the volume should be mounted inside the task's
       # allocation.
-      destination | String
-                  | default = "",
+      destination
+        | String
+        | default
+        = "",
       foo : String = destination ++ volume,
 
       # When a group volume is writeable, you may specify that it is read_only
       # on a per mount level using the read_only option here.
-      read_only | Bool
-                | default = false,
+      read_only
+        | Bool
+        | default
+        = false,
     },
   },
 }

--- a/benches/mantis/tasks/promtail.ncl
+++ b/benches/mantis/tasks/promtail.ncl
@@ -1,6 +1,6 @@
 let types = import "../schemas/nomad/types.ncl" in
-
-types.stanza.task & {
+types.stanza.task
+& {
   driver = `exec,
 
   resources = {
@@ -11,41 +11,39 @@ types.stanza.task & {
   config = {
     flake = "github:input-output-hk/mantis-ops/cue#grafana-loki",
     command = "/bin/promtail",
-    args = ["-config.file", "local/config.yaml"],
+    args = [ "-config.file", "local/config.yaml" ],
   },
 
-  template."local/config.yaml".data = builtin.serialize `Yaml {
-    server = {
-      http_listen_port = 0,
-      grpc_listen_port = 0,
-    },
-    positions.filename = "/local/positions.yaml",
-    client.url = "http://172.16.0.20:3100/loki/api/v1/push",
-    scrape_configs = [
-      {
+  template."local/config.yaml".data = builtin.serialize
+    `Yaml
+    {
+      server = {
+        http_listen_port = 0,
+        grpc_listen_port = 0,
+      },
+      positions.filename = "/local/positions.yaml",
+      client.url = "http://172.16.0.20:3100/loki/api/v1/push",
+      scrape_configs = [{
         job_name = "{{ env \"NOMAD_JOB_NAME\" }}-{{ env \"NOMAD_ALLOC_INDEX\"
 }}",
         pipeline_stages = null,
-        static_configs = [
-          {
-            labels = {
-              nomad_alloc_id = "{{ env \"NOMAD_ALLOC_ID\" }}",
-              nomad_alloc_index = "{{ env \"NOMAD_ALLOC_INDEX\" }}",
-              nomad_alloc_name = "{{ env \"NOMAD_ALLOC_NAME\" }}",
-              nomad_dc = "{{ env \"NOMAD_DC\" }}",
-              nomad_group_name = "{{ env \"NOMAD_GROUP_NAME\" }}",
-              nomad_job_id = "{{ env \"NOMAD_JOB_ID\" }}",
-              nomad_job_name = "{{ env \"NOMAD_JOB_NAME\" }}",
-              nomad_job_parent_id = "{{ env \"NOMAD_JOB_PARENT_ID\" }}",
-              nomad_namespace = "{{ env \"NOMAD_NAMESPACE\" }}",
-              nomad_region = "{{ env \"NOMAD_REGION\" }}",
-              # This is currently always "promtail", so this label wouldn't be of any use
-              # nomad_task_name:     "{{ env \"NOMAD_TASK_NAME\" }}"
-              "__path__" = "/alloc/logs/*.std*.[0-9]*",
-            }
+        static_configs = [{
+          labels = {
+            nomad_alloc_id = "{{ env \"NOMAD_ALLOC_ID\" }}",
+            nomad_alloc_index = "{{ env \"NOMAD_ALLOC_INDEX\" }}",
+            nomad_alloc_name = "{{ env \"NOMAD_ALLOC_NAME\" }}",
+            nomad_dc = "{{ env \"NOMAD_DC\" }}",
+            nomad_group_name = "{{ env \"NOMAD_GROUP_NAME\" }}",
+            nomad_job_id = "{{ env \"NOMAD_JOB_ID\" }}",
+            nomad_job_name = "{{ env \"NOMAD_JOB_NAME\" }}",
+            nomad_job_parent_id = "{{ env \"NOMAD_JOB_PARENT_ID\" }}",
+            nomad_namespace = "{{ env \"NOMAD_NAMESPACE\" }}",
+            nomad_region = "{{ env \"NOMAD_REGION\" }}",
+            # This is currently always "promtail", so this label wouldn't be of any use
+            # nomad_task_name:     "{{ env \"NOMAD_TASK_NAME\" }}"
+            "__path__" = "/alloc/logs/*.std*.[0-9]*",
           }
-        ]
-      }
-    ]
-  }
+        }]
+      }]
+    }
 }

--- a/benches/mantis/tasks/telegraf.ncl
+++ b/benches/mantis/tasks/telegraf.ncl
@@ -1,9 +1,10 @@
 let types = import "../schemas/nomad/types.ncl" in
-
 {
   prometheusPort | String,
-  clientId | String
-           | default = "{{ env \"NOMAD_JOB_NAME\" }}-{{ env \"NOMAD_ALLOC_INDEX\" }}",
+  clientId
+    | String
+    | default
+    = "{{ env \"NOMAD_JOB_NAME\" }}-{{ env \"NOMAD_ALLOC_INDEX\" }}",
 
   driver = `exec,
 
@@ -20,7 +21,7 @@ let types = import "../schemas/nomad/types.ncl" in
   config = {
     flake = "github:NixOS/nixpkgs/nixos-21.05#telegraf",
     command = "/bin/telegraf",
-    args = ["-config", "/local/telegraf.config"],
+    args = [ "-config", "/local/telegraf.config" ],
   },
 
   template."local/telegraf.config" = {

--- a/stdlib/array.ncl
+++ b/stdlib/array.ncl
@@ -13,15 +13,16 @@
         ```
         "%
       = fun label value =>
-       if %typeof% value == `Array then
-         if %length% value != 0 then
-           value
-         else
-           %blame% (%label_with_message% "empty array" label)
-       else
-         %blame% (%label_with_message% "not a array" label),
+        if %typeof% value == `Array then
+          if %length% value != 0 then
+            value
+          else
+            %blame% (%label_with_message% "empty array" label)
+        else
+          %blame% (%label_with_message% "not a array" label),
 
-    first : forall a. Array a -> a
+    first
+      : forall a. Array a -> a
       | doc m%"
         Results in the first element of the given array.
 
@@ -34,7 +35,8 @@
         "%
       = fun array => %elem_at% array 0,
 
-    last : forall a. Array a -> a
+    last
+      : forall a. Array a -> a
       | doc m%"
         Results in the last element of the given array.
 
@@ -47,7 +49,8 @@
         "%
       = fun array => %elem_at% array (%length% array - 1),
 
-    drop_first : forall a. Array a -> Array a
+    drop_first
+      : forall a. Array a -> Array a
       | doc m%"
         Results in the given array without the first element.
 
@@ -59,7 +62,8 @@
         "%
       = fun array => %array_slice% 1 (%length% array) array,
 
-    drop_last : forall a. Array a -> Array a
+    drop_last
+      : forall a. Array a -> Array a
       | doc m%"
         Results in the given array without the last element.
 
@@ -71,7 +75,8 @@
         "%
       = fun array => %array_slice% 0 (%length% array - 1) array,
 
-    length : forall a. Array a -> Number
+    length
+      : forall a. Array a -> Number
       | doc m%"
         Results in a number representing the length of the given array.
 
@@ -83,7 +88,8 @@
         "%
       = fun l => %length% l,
 
-    map : forall a b. (a -> b) -> Array a -> Array b
+    map
+      : forall a b. (a -> b) -> Array a -> Array b
       | doc m%"
         `map f [x1, x2, ..., xn]` applies function `f` to every element in the array,
         resulting in `[f x1, f x2, ... f xn]`
@@ -96,7 +102,8 @@
         "%
       = fun f l => %map% l f,
 
-    at : forall a. Number -> Array a -> a
+    at
+      : forall a. Number -> Array a -> a
       | doc m%"
         Retrieves the n'th element from a array (0-indexed).
 
@@ -108,7 +115,8 @@
         "%
       = fun n l => %elem_at% l n,
 
-    concat : forall a. Array a -> Array a -> Array a
+    concat
+      : forall a. Array a -> Array a -> Array a
       | doc m%"
         Concatenates two arrays such that the second array is appended to the first.
 
@@ -120,7 +128,8 @@
         "%
       = fun l1 l2 => l1 @ l2,
 
-    fold_left : forall a b. (a -> b -> a) -> a -> Array b -> a
+    fold_left
+      : forall a b. (a -> b -> a) -> a -> Array b -> a
       | doc m%"
         Fold a function over an array. Folds serve a similar purpose to loops or
         iterators in a functional language like Nickel. `fold_left` iterates over
@@ -184,19 +193,23 @@
             6
         ```
         "%
-    = fun f acc l =>
+      = fun f acc l =>
         let length = %length% l in
-        if length == 0 then acc
+        if length == 0 then
+          acc
         else
-          let rec go = fun acc n =>
-            if n == length then acc
-            else
-              let next_acc = %elem_at% l n |> f acc in
-              %seq% next_acc (go next_acc (n+1))
+          let rec go =
+            fun acc n =>
+              if n == length then
+                acc
+              else
+                let next_acc = %elem_at% l n |> f acc in
+                %seq% next_acc (go next_acc (n + 1))
           in
           go acc 0,
 
-    fold_right : forall a b. (a -> b -> b) -> b -> Array a -> b
+    fold_right
+      : forall a b. (a -> b -> b) -> b -> Array a -> b
       | doc m%"
         Fold a function over an array. Folds serve a similar purpose to loops or
         iterators in a functional language like Nickel. `fold_right` iterates
@@ -221,15 +234,17 @@
         "%
       = fun f fst l =>
         let length = %length% l in
-        let rec go = fun n =>
-          if n == length then
-            fst
-          else
-            go (n+1)
-            |> f (%elem_at% l n)
+        let rec go =
+          fun n =>
+            if n == length then
+              fst
+            else
+              go (n + 1)
+              |> f (%elem_at% l n)
         in go 0,
 
-    prepend : forall a. a -> Array a -> Array a
+    prepend
+      : forall a. a -> Array a -> Array a
       | doc m%"
         Construct an array given the first element and the rest of the array.
 
@@ -241,7 +256,8 @@
         "%
       = fun x l => [x] @ l,
 
-    append : forall a. a -> Array a -> Array a
+    append
+      : forall a. a -> Array a -> Array a
       | doc m%"
         Construct an array given the last element and the rest of the array.
 
@@ -253,8 +269,8 @@
         "%
       = fun x l => l @ [x],
 
-
-    reverse : forall a. Array a -> Array a
+    reverse
+      : forall a. Array a -> Array a
       | doc m%"
         Reverses the order of a array.
 
@@ -266,7 +282,8 @@
         "%
       = fun l => fold_left (fun acc e => [e] @ acc) [] l,
 
-    filter : forall a. (a -> Bool) -> Array a -> Array a
+    filter
+      : forall a. (a -> Bool) -> Array a -> Array a
       | doc m%"
         `filter f xs` keeps all elements from `xs` given that satisfy `f`.
 
@@ -278,7 +295,8 @@
         "%
       = fun pred l => fold_left (fun acc x => if pred x then acc @ [x] else acc) [] l,
 
-    flatten : forall a. Array (Array a) -> Array a
+    flatten
+      : forall a. Array (Array a) -> Array a
       | doc m%"
         Flatten a array of arrays to a single array, essentially concatenating all arrays in the original array.
 
@@ -290,7 +308,8 @@
         "%
       = fun l => fold_right (fun l acc => l @ acc) [] l,
 
-    all : forall a. (a -> Bool) -> Array a -> Bool
+    all
+      : forall a. (a -> Bool) -> Array a -> Bool
       | doc m%"
         Results in true if all elements in the given array satisfy the predicate, false otherwise.
 
@@ -304,7 +323,8 @@
         "%
       = fun pred l => fold_right (fun x acc => if pred x then acc else false) true l,
 
-    any : forall a. (a -> Bool) -> Array a -> Bool
+    any
+      : forall a. (a -> Bool) -> Array a -> Bool
       | doc m%"
         Results in false if no elements in the given array satisfy the predicate, true otherwise.
 
@@ -318,7 +338,8 @@
         "%
       = fun pred l => fold_right (fun x acc => if pred x then true else acc) false l,
 
-    elem : forall a. a -> Array a -> Bool
+    elem
+      : forall a. a -> Array a -> Bool
       | doc m%"
         Results in true if the given element is a member of the array, false otherwise.
 
@@ -330,7 +351,8 @@
         "%
       = fun elt => any (fun x => x == elt),
 
-    partition : forall a. (a -> Bool) -> Array a -> {right: Array a, wrong: Array a}
+    partition
+      : forall a. (a -> Bool) -> Array a -> { right : Array a, wrong : Array a }
       | doc m%"
         Partitions the given array in two new arrays: those containing the elements that satisfy the predicate, and those
         that do not.
@@ -342,15 +364,17 @@
         ```
         "%
       = fun pred l =>
-        let aux = fun acc x =>
-          if (pred x) then
-            {right = acc.right @ [x], wrong = acc.wrong}
-          else
-            {right = acc.right, wrong = acc.wrong @ [x]}
+        let aux =
+          fun acc x =>
+            if (pred x) then
+              { right = acc.right @ [x], wrong = acc.wrong }
+            else
+              { right = acc.right, wrong = acc.wrong @ [x] }
         in
-        fold_left aux {right = [], wrong = []} l,
+        fold_left aux { right = [], wrong = [] } l,
 
-    generate : forall a. (Number -> a) -> Number -> Array a
+    generate
+      : forall a. (Number -> a) -> Number -> Array a
       | doc m%"
         `generate f n` produces a array of length `n` by applying `f` on increasing numbers:
          `[ f 0, f 1, ..., f (n - 1) ]`.
@@ -363,7 +387,8 @@
         "%
       = fun f n => %generate% n f,
 
-    sort | forall a. (a -> a -> [| `Lesser, `Equal, `Greater |]) -> Array a -> Array a
+    sort
+      | forall a. (a -> a -> [| `Lesser, `Equal, `Greater |]) -> Array a -> Array a
       | doc m%"
         Sorts the given arrays based on the provided comparison operator.
 
@@ -380,11 +405,12 @@
         let rest = %array_slice% 1 length array in
         let parts = partition (fun x => (cmp x first == `Lesser)) rest in
         if length <= 1 then
-          array 
+          array
         else
           (sort cmp (parts.right)) @ [first] @ (sort cmp (parts.wrong)),
 
-    flat_map : forall a b. (a -> Array b) -> Array a -> Array b
+    flat_map
+      : forall a b. (a -> Array b) -> Array a -> Array b
       | doc m%"
         First maps the given function over the array and then flattens the
         result.
@@ -397,7 +423,8 @@
       "%
       = fun f xs => map f xs |> flatten,
 
-    intersperse : forall a. a -> Array a -> Array a
+    intersperse
+      : forall a. a -> Array a -> Array a
       | doc m%"
         Intersperse the passed value between the elements of an array.
 
@@ -414,11 +441,11 @@
       = fun v array =>
         let length = %length% array in
         if length <= 1 then
-          array 
+          array
         else
           let first = %elem_at% array 0 in
           let rest = %array_slice% 1 length array in
-          [ first ] @ (flat_map (fun a => [v, a]) rest),
+          [first] @ (flat_map (fun a => [ v, a ]) rest),
 
     slice
       : forall a. Number -> Number -> Array a -> Array a
@@ -445,7 +472,7 @@
       = fun start end value => %array_slice% start end value,
 
     split_at
-      : forall a. Number -> Array a -> {left: Array a, right: Array a}
+      : forall a. Number -> Array a -> { left : Array a, right : Array a }
       | doc m%"
           Splits an array in two at a given index, and puts all the elements
           to the left of the element at the given index (excluded) in the
@@ -467,10 +494,11 @@
             => { left = [ "Hello", "world", "!" ], right = [  ] }
           ```
         "%
-      = fun index value => {
-        left = %array_slice% 0 index value,
-        right = %array_slice% index (%length% value) value
-      },
+      = fun index value =>
+        {
+          left = %array_slice% 0 index value,
+          right = %array_slice% index (%length% value) value
+        },
 
     replicate
       : forall a. Number -> a -> Array a
@@ -511,9 +539,10 @@
            => [ -1.5, -1, -0.5, 0, 0.5, 1, 1.5 ]
           ```
         "%
-      = fun start end step => %generate%
+      = fun start end step =>
+        %generate%
           ((end - start) / step |> number.floor)
-          (fun i => start + i*step),
+          (fun i => start + i * step),
 
     range
       : Number -> Number -> Array Number
@@ -603,9 +632,9 @@
         ```
         "%
       = fun f array =>
-         let last_index = %length% array - 1 in
-         let last =  %elem_at% array last_index in
-         let rest = %array_slice% 0 last_index array in
-         fold_right f last rest,
+        let last_index = %length% array - 1 in
+        let last = %elem_at% array last_index in
+        let rest = %array_slice% 0 last_index array in
+        fold_right f last rest,
   }
 }

--- a/stdlib/builtin.ncl
+++ b/stdlib/builtin.ncl
@@ -1,7 +1,8 @@
 {
   builtin = {
-    is_number : Dyn -> Bool
-    | doc m%"
+    is_number
+      : Dyn -> Bool
+      | doc m%"
       Checks if the given value is a number.
 
       For example:
@@ -12,10 +13,11 @@
           false
       ```
       "%
-    = fun x => %typeof% x == `Number,
+      = fun x => %typeof% x == `Number,
 
-    is_bool : Dyn -> Bool
-    | doc m%"
+    is_bool
+      : Dyn -> Bool
+      | doc m%"
       Checks if the given value is a boolean.
 
       For example:
@@ -26,10 +28,11 @@
           false
       ```
       "%
-    = fun x => %typeof% x == `Bool,
+      = fun x => %typeof% x == `Bool,
 
-    is_string : Dyn -> Bool
-    | doc m%"
+    is_string
+      : Dyn -> Bool
+      | doc m%"
       Checks if the given value is a string.
 
       For example:
@@ -40,10 +43,11 @@
           true
       ```
       "%
-    = fun x => %typeof% x == `String,
+      = fun x => %typeof% x == `String,
 
-    is_enum : Dyn -> Bool
-    | doc m%"
+    is_enum
+      : Dyn -> Bool
+      | doc m%"
       Checks if the given value is an enum tag.
 
       For example:
@@ -54,11 +58,11 @@
           true
       ```
       "%
+      = fun x => %typeof% x == `Enum,
 
-    = fun x => %typeof% x == `Enum,
-
-    is_function : Dyn -> Bool
-    | doc m%"
+    is_function
+      : Dyn -> Bool
+      | doc m%"
       Checks if the given value is a function.
 
       For example
@@ -69,10 +73,11 @@
           false
       ```
       "%
-    = fun x => %typeof% x == `Function,
+      = fun x => %typeof% x == `Function,
 
-    is_array : Dyn -> Bool
-    | doc m%"
+    is_array
+      : Dyn -> Bool
+      | doc m%"
       Checks if the given value is a array.
 
       For example
@@ -83,10 +88,11 @@
           false
       ```
       "%
-    = fun x => %typeof% x == `Array,
+      = fun x => %typeof% x == `Array,
 
-    is_record : Dyn -> Bool
-    | doc m%"
+    is_record
+      : Dyn -> Bool
+      | doc m%"
       Checks if the given value is a record.
 
       For example
@@ -97,9 +103,10 @@
           true
       ```
       "%
-    = fun x => %typeof% x == `Record,
+      = fun x => %typeof% x == `Record,
 
-    typeof : Dyn -> [|
+    typeof
+      : Dyn -> [|
         `Number,
         `Bool,
         `String,
@@ -110,7 +117,7 @@
         `Record,
         `Other
       |]
-    | doc m%"
+      | doc m%"
       Results in a value representing the type of the typed value.
 
       For example:
@@ -121,10 +128,11 @@
           `Function
       ```
       "%
-    = fun x => %typeof% x,
+      = fun x => %typeof% x,
 
-    seq : forall a. Dyn -> a -> a
-    | doc m%"
+    seq
+      : forall a. Dyn -> a -> a
+      | doc m%"
       `seq x y` forces the evaluation of `x`, before resulting in `y`.
 
       For example:
@@ -137,10 +145,11 @@
           37
       ```
       "%
-    = fun x y => %seq% x y,
+      = fun x y => %seq% x y,
 
-    deep_seq : forall a. Dyn -> a -> a
-    | doc m%"
+    deep_seq
+      : forall a. Dyn -> a -> a
+      | doc m%"
       `deep_seq x y` forces a deep evaluation `x`, before resulting in `y`.
 
       For example:
@@ -153,10 +162,11 @@
           error
       ```
       "%
-    = fun x y => %deep_seq% x y,
+      = fun x y => %deep_seq% x y,
 
-    hash : [| `Md5, `Sha1, `Sha256, `Sha512 |] -> String -> String
-    | doc m%"
+    hash
+      : [| `Md5, `Sha1, `Sha256, `Sha512 |] -> String -> String
+      | doc m%"
       Hashes the given string provided the desired hash algorithm.
 
       For example:
@@ -165,10 +175,11 @@
           "2ab96390c7dbe3439de74d0c9b0b1767"
       ```
       "%
-    = fun type s => %hash% type s,
+      = fun type s => %hash% type s,
 
-    serialize : [| `Json, `Toml, `Yaml |] -> Dyn -> String
-    | doc m%"
+    serialize
+      : [| `Json, `Toml, `Yaml |] -> Dyn -> String
+      | doc m%"
       Serializes the given value to the desired representation.
 
       For example:
@@ -180,10 +191,11 @@
           }"
       ```
       "%
-    = fun format x => %serialize% format (%force% x),
+      = fun format x => %serialize% format (%force% x),
 
-    deserialize : [| `Json, `Toml, `Yaml |] -> String -> Dyn
-    | doc m%"
+    deserialize
+      : [| `Json, `Toml, `Yaml |] -> String -> Dyn
+      | doc m%"
       Deserializes the given string to a nickel value given the encoding of the string.
 
       For example:
@@ -192,10 +204,11 @@
           { hello = "Hello", world = "World" }
       ```
       "%
-    = fun format x => %deserialize% format x,
+      = fun format x => %deserialize% format x,
 
-    to_string | string.Stringable -> String
-    | doc m%"
+    to_string
+      | string.Stringable -> String
+      | doc m%"
       Converts a stringable value to a string representation. Same as
       `string.from`.
 
@@ -209,10 +222,11 @@
         "null"
       ```
       "%
-    = fun x => %to_str% x,
+      = fun x => %to_str% x,
 
-    trace : forall a. String -> a -> a
-    | doc m%"
+    trace
+      : forall a. String -> a -> a
+      | doc m%"
       `builtin.trace msg x` prints `msg` to standard output when encountered by the evaluator,
       and proceed with the evaluation of `x`.
 
@@ -223,10 +237,10 @@
         true
       ```
       "%
-    = fun msg x => %trace% msg x,
+      = fun msg x => %trace% msg x,
 
     FailWith
-    | doc m%"
+      | doc m%"
       A contract that always fails with a given message.
 
       For example:
@@ -244,10 +258,11 @@
           │ ^ applied to this expression
       ```
     "%
-    = fun msg label value => contract.blame_with_message msg label,
+      = fun msg label value => contract.blame_with_message msg label,
 
-    fail_with | String -> Dyn
-    | doc m%"
+    fail_with
+      | String -> Dyn
+      | doc m%"
       Unconditionally abort evaluation with the given message.
 
       For example:
@@ -256,7 +271,6 @@
         error: contract broken by a value: message
       ```
     "%
-    = fun msg => null | FailWith msg,
-
+      = fun msg => null | FailWith msg,
   },
 }

--- a/stdlib/contract.ncl
+++ b/stdlib/contract.ncl
@@ -19,35 +19,41 @@
          => ERROR (contract broken by a value)
         ```
       "%
-    = fun constant =>
-      %typeof% constant
-      |> match {
-        `Record =>
-          #TODO: lazy version for records. The difficulty is not to make it lazy
-          #right now, but to make it preserve recursivity as well. We might need
-          #something like a recursivity-preserving map, or a primop for
-          # per-field contract application, like %array_lazy_assume%.
-          from_predicate ((==) constant),
-        `Array =>
-          fun label' value =>
-            if %typeof% value == `Array then
-              let value_length = %length% value in
-              if value_length == %length% constant then
-                %generate% value_length (fun i =>
-                  contract.apply (Equal (%elem_at% constant i)) label' value)
+      = fun constant =>
+        %typeof% constant
+        |> match {
+          `Record =>
+            #TODO: lazy version for records. The difficulty is not to make it lazy
+            #right now, but to make it preserve recursivity as well. We might need
+            #something like a recursivity-preserving map, or a primop for
+            # per-field contract application, like %array_lazy_assume%.
+            from_predicate ((==) constant),
+          `Array =>
+            fun label' value =>
+              if %typeof% value == `Array then
+                let value_length = %length% value in
+                if value_length == %length% constant then
+                  %generate%
+                    value_length
+                    (
+                      fun i =>
+                        contract.apply (Equal (%elem_at% constant i)) label' value
+                    )
+                else
+                  label'
+                  |> label.with_message  "array length mismatch (expected `%{%to_str% (%length% constant)}`, got `%{%to_str% value_length}`)"
+
+                  |> label.append_note "`Equal some_array` requires that the checked value is equal to the array `some_array`, but their lengths differ."
+                  |> blame
               else
                 label'
-                |> label.with_message "array length mismatch (expected `%{%to_str% (%length% constant)}`, got `%{%to_str% value_length}`)"
-                |> label.append_note "`Equal some_array` requires that the checked value is equal to the array `some_array`, but their lengths differ."
-                |> blame
-            else
-              label'
                 |> label.with_message "expected Array, got %{%to_str% (%typeof% value)}"
+
                 |> label.append_note "`Equal some_array` requires that the checked value is equal to the array `some_array`, but the provided value isn't an array."
                 |> blame,
-        # Outside of lazy data structure, we just use (==)
-        _ => from_predicate ((==) constant),
-      },
+          # Outside of lazy data structure, we just use (==)
+          _ => from_predicate ((==) constant),
+        },
 
     blame
       | doc m%"
@@ -236,7 +242,7 @@
               (for technical reasons, this function isn't actually statically typed)
             "%
           = fun note label => %label_append_note% note label,
-    },
+      },
 
     apply
       | doc m%"

--- a/stdlib/enum.ncl
+++ b/stdlib/enum.ncl
@@ -1,7 +1,7 @@
 {
-    enum = {
-      Tag
-        | doc m%"
+  enum = {
+    Tag
+      | doc m%"
           Contract to enforce the value is an enum tag.
 
           # Examples
@@ -15,10 +15,10 @@
               error
           ```
           "%
-        = contract.from_predicate builtin.is_enum,
+      = contract.from_predicate builtin.is_enum,
 
-      TagOrString
-        | doc m%%"
+    TagOrString
+      | doc m%%"
             Accepts both enum tags and strings. Strings are automatically
             converted to an enum tag.
 
@@ -49,14 +49,15 @@
             serialized | Schema
             ```
           "%%
-        = fun label value =>
-          %typeof% value
-          |> match {
-            `String => %enum_from_str% value,
-            `Enum => value,
-             _ => contract.blame_with_message
-               "expected either a string or an enum tag"
-               label,
-            },
-    }
+      = fun label value =>
+        %typeof% value
+        |> match {
+          `String => %enum_from_str% value,
+          `Enum => value,
+          _ =>
+            contract.blame_with_message
+              "expected either a string or an enum tag"
+              label,
+        },
+  }
 }

--- a/stdlib/function.ncl
+++ b/stdlib/function.ncl
@@ -1,17 +1,19 @@
 {
   function = {
-    id : forall a. a -> a
-    | doc m%"
+    id
+      : forall a. a -> a
+      | doc m%"
     The identity function, that is
     ```nickel
     id x == x
     ```
     for any value `x`.
     "%
-    = fun x => x,
+      = fun x => x,
 
-    const : forall a b. a -> b -> a
-    | doc m%"
+    const
+      : forall a b. a -> b -> a
+      | doc m%"
     Results in the first argument.
 
     For example:
@@ -19,47 +21,52 @@
     const 5 42 == 5
     ```
     "%
-    = fun x y => x,
+      = fun x y => x,
 
-    compose : forall a b c. (b -> c) -> (a -> b) -> (a -> c)
-    | doc m%"
+    compose
+      : forall a b c. (b -> c) -> (a -> b) -> (a -> c)
+      | doc m%"
     Function composition, right to left. That is,
     ```nickel
     compose f g x == f (g x)
     ```
     "%
-    = fun g f x => x |> f |> g,
+      = fun g f x => x |> f |> g,
 
-    flip : forall a b c. (a -> b -> c) -> b -> a -> c
-    | doc m%%"
+    flip
+      : forall a b c. (a -> b -> c) -> b -> a -> c
+      | doc m%%"
     Flip the argument order for a two-argument function. For example,
     ```nickel
     flip (fun x y => "%{x} %{y}") "world!" "Hello,"
       => "Hello, world!"
     ```
     "%%
-    = fun f x y => f y x,
+      = fun f x y => f y x,
 
-    first : forall a b. a -> b -> a
-    | doc m%"
+    first
+      : forall a b. a -> b -> a
+      | doc m%"
     Always returns the first argument:
     ```nickel
     first 5 7 => 5
     ```
     "%
-    = const,
+      = const,
 
-    second : forall a b. a -> b -> b
-    | doc m%"
+    second
+      : forall a b. a -> b -> b
+      | doc m%"
     Always returns the second argument:
     ```nickel
     second 5 7 => 7
     ```
     "%
-    = flip const,
+      = flip const,
 
-    pipe : forall a. a -> Array (a -> a) -> a
-    | doc m%%"
+    pipe
+      : forall a. a -> Array (a -> a) -> a
+      | doc m%%"
       Apply an array of functions to a value, in order.
 
       For example:
@@ -70,6 +77,6 @@
         => "Hello, World!"
       ```
     "%%
-    = fun x fs => array.fold_left (|>) x fs,
+      = fun x fs => array.fold_left (|>) x fs,
   }
 }

--- a/stdlib/internals.ncl
+++ b/stdlib/internals.ncl
@@ -15,86 +15,93 @@
 
   "$array" = fun element_contract label value =>
     if %typeof% value == `Array then
-        %array_lazy_assume% (%go_array% label) value element_contract
+      %array_lazy_assume% (%go_array% label) value element_contract
     else
-        %blame% label,
+      %blame% label,
 
   "$func" = fun domain codomain label value =>
-      if %typeof% value == `Function then
-          (fun x => %assume% codomain (%go_codom% label) (value (%assume% domain (%chng_pol% (%go_dom% label)) x)))
-      else
-          %blame% label,
+    if %typeof% value == `Function then
+      (fun x => %assume% codomain (%go_codom% label) (value (%assume% domain (%chng_pol% (%go_dom% label)) x)))
+    else
+      %blame% label,
 
   "$forall_var" = fun sealing_key label value =>
-      let current_polarity = %polarity% label in
-      let polarity = (%lookup_type_variable% sealing_key label).polarity in
-      if polarity == current_polarity then
-          %unseal% sealing_key value (%blame% label)
-      else
-          # Here, we know that this term should be sealed, but to give the right
-          # blame for the contract, we have to change the polarity to match the
-          # polarity of the `Forall`, because this is what's important for
-          # blaming polymorphic contracts.
-          %seal% sealing_key (%chng_pol% label) value,
+    let current_polarity = %polarity% label in
+    let polarity = (%lookup_type_variable% sealing_key label).polarity in
+    if polarity == current_polarity then
+      %unseal% sealing_key value (%blame% label)
+    else
+      # Here, we know that this term should be sealed, but to give the right
+      # blame for the contract, we have to change the polarity to match the
+      # polarity of the `Forall`, because this is what's important for
+      # blaming polymorphic contracts.
+      %seal% sealing_key (%chng_pol% label) value,
 
-  "$forall" =
-    let flip = match {
+  "$forall" = let flip =
+    match {
       `Positive => `Negative,
       `Negative => `Positive,
-    } in
-    fun sealing_key polarity contract label value =>
+    }
+  in
+  fun sealing_key polarity contract label value =>
     let polarity = if %dualize% label then flip polarity else polarity in
     contract (%insert_type_variable% sealing_key polarity label) value,
 
   "$enums" = fun case label value =>
-      if %typeof% value == `Enum then
-          %assume% case label value
-      else
-          %blame% (%label_with_message% "not an enum tag" label),
+    if %typeof% value == `Enum then
+      %assume% case label value
+    else
+      %blame% (%label_with_message% "not an enum tag" label),
 
   "$enum_fail" = fun label =>
-      %blame% (%label_with_message% "tag not included in the enum type" label),
+    %blame% (%label_with_message% "tag not included in the enum type" label),
 
   "$record" = fun field_contracts tail_contract label value =>
     if %typeof% value == `Record then
       # Returns the sub-record of `l` containing only those fields which are not
       # present in `r`. If `l` has a sealed polymorphic tail then it will be
       # preserved.
-      let field_diff = fun left right => array.fold_left
-        (fun acc field =>
-          if %has_field% field right then
-            acc
-          else
-            %record_insert% field acc (left."%{field}"))
-        (%record_empty_with_tail% left)
-        (%fields% left)
+      let field_diff =
+        fun left right =>
+          array.fold_left
+            (
+              fun acc field =>
+                if %has_field% field right then
+                  acc
+                else
+                  %record_insert% field acc (left."%{field}")
+            )
+            (%record_empty_with_tail% left)
+            (%fields% left)
       in
-
       let contracts_not_in_value = field_diff field_contracts value in
       let missing_fields = %fields% contracts_not_in_value in
-
       if %length% missing_fields == 0 then
         let tail_fields = field_diff value field_contracts in
-        let fields_with_contracts = array.fold_left
-          (fun acc field =>
-            if %has_field% field field_contracts then
-              let contract = field_contracts."%{field}" in
-              let label = %go_field% field label in
-              let val = value."%{field}" in
-              %record_insert% field acc (%assume% contract label val)
-            else
-              acc)
-          {}
-          (%fields% value)
+        let fields_with_contracts =
+          array.fold_left
+            (
+              fun acc field =>
+                if %has_field% field field_contracts then
+                  let contract = field_contracts."%{field}" in
+                  let label = %go_field% field label in
+                  let val = value."%{field}" in
+                  %record_insert% field acc (%assume% contract label val)
+                else
+                  acc
+            )
+            {}
+            (%fields% value)
         in
         tail_contract fields_with_contracts label tail_fields
       else
         let plural = if %length% missing_fields == 1 then "" else "s" in
-        %blame% (
-          %label_with_message%
-            "missing field%{plural} `%{string.join ", " missing_fields}`"
-            label
-        )
+        %blame%
+          (
+            %label_with_message%
+              "missing field%{plural} `%{string.join ", " missing_fields}`"
+              label
+          )
     else
       %blame% (%label_with_message% "not a record" label),
 
@@ -105,28 +112,29 @@
       %blame% (%label_with_message% "not a record" label),
 
   "$forall_tail" = fun sealing_key acc label value =>
-      let current_polarity = %polarity% label in
-      let polarity = (%lookup_type_variable% sealing_key label).polarity in
-      if polarity == current_polarity then
-          if value == {} then
-            let tagged_label = %label_with_message% "polymorphic tail mismatch" label in
-            let tail = %record_unseal_tail% sealing_key tagged_label value in
-            acc & tail
-          else
-            let extra_fields = %fields% value in
-            let plural = if %length% extra_fields == 1 then "" else "s" in
-            %blame% (
-              %label_with_message%
+    let current_polarity = %polarity% label in
+    let polarity = (%lookup_type_variable% sealing_key label).polarity in
+    if polarity == current_polarity then
+      if value == {} then
+        let tagged_label = %label_with_message% "polymorphic tail mismatch" label in
+        let tail = %record_unseal_tail% sealing_key tagged_label value in
+        acc & tail
+      else
+        let extra_fields = %fields% value in
+        let plural = if %length% extra_fields == 1 then "" else "s" in
+        %blame%
+          (
+            %label_with_message%
               "extra field%{plural} `%{string.join ", " extra_fields}`"
               label
-            )
-      else
-          # Note: in order to correctly attribute blame, the polarity of `l`
-          # must match the polarity of the `forall` which introduced the
-          # polymorphic contract (i.e. `pol`). Since we know in this branch
-          # that `pol` and `%polarity% l` differ, we swap `l`'s polarity before
-          # we continue.
-          %record_seal_tail% sealing_key (%chng_pol% label) acc value,
+          )
+    else
+      # Note: in order to correctly attribute blame, the polarity of `l`
+      # must match the polarity of the `forall` which introduced the
+      # polymorphic contract (i.e. `pol`). Since we know in this branch
+      # that `pol` and `%polarity% l` differ, we swap `l`'s polarity before
+      # we continue.
+      %record_seal_tail% sealing_key (%chng_pol% label) acc value,
 
   "$dyn_tail" = fun acc label value => acc & value,
 
@@ -136,11 +144,12 @@
     else
       let extra_fields = %fields% value in
       let plural = if %length% extra_fields == 1 then "" else "s" in
-      %blame% (
-        %label_with_message%
-          "extra field%{plural} `%{string.join ", " extra_fields}`"
-          label
-      ),
+      %blame%
+        (
+          %label_with_message%
+            "extra field%{plural} `%{string.join ", " extra_fields}`"
+            label
+        ),
 
   # Recursive priorities operators
 

--- a/stdlib/number.ncl
+++ b/stdlib/number.ncl
@@ -1,7 +1,7 @@
 {
   number = {
     Integer
-    | doc m%"
+      | doc m%"
       Contract to enforce a number is an integer.
 
       For example:
@@ -12,17 +12,17 @@
           42
       ```
       "%
-    = fun label value =>
-      if %typeof% value == `Number then
-        if value % 1 == 0 then
-          value
+      = fun label value =>
+        if %typeof% value == `Number then
+          if value % 1 == 0 then
+            value
+          else
+            %blame% (%label_with_message% "not an integer" label)
         else
-          %blame% (%label_with_message% "not an integer" label)
-      else
-        %blame% (%label_with_message% "not a number" label),
+          %blame% (%label_with_message% "not a number" label),
 
     Nat
-    | doc m%"
+      | doc m%"
       Contract to enforce a number is a natural number (including 0).
 
       For example:
@@ -35,17 +35,17 @@
           error
       ```
       "%
-    = fun label value =>
-      if %typeof% value == `Number then
-        if value % 1 == 0 && value >= 0 then
-          value
+      = fun label value =>
+        if %typeof% value == `Number then
+          if value % 1 == 0 && value >= 0 then
+            value
+          else
+            %blame% (%label_with_message% "not a natural" label)
         else
-          %blame% (%label_with_message% "not a natural" label)
-      else
-        %blame% (%label_with_message% "not a number" label),
+          %blame% (%label_with_message% "not a number" label),
 
     PosNat
-    | doc m%"
+      | doc m%"
       Contract to enforce a number is a positive natural number.
 
       For example:
@@ -58,17 +58,17 @@
           error
       ```
       "%
-    = fun label value =>
-      if %typeof% value == `Number then
-        if value % 1 == 0 && value > 0 then
-          value
+      = fun label value =>
+        if %typeof% value == `Number then
+          if value % 1 == 0 && value > 0 then
+            value
+          else
+            %blame% (%label_with_message% "not positive integer" label)
         else
-          %blame% (%label_with_message% "not positive integer" label)
-      else
-        %blame% (%label_with_message% "not a number" label),
+          %blame% (%label_with_message% "not a number" label),
 
     NonZero
-    | doc m%"
+      | doc m%"
       Contract to enforce a number is anything but zero.
 
       For example:
@@ -79,17 +79,18 @@
           error
       ```
       "%
-    = fun label value =>
-      if %typeof% value == `Number then
-        if value != 0 then
-          value
+      = fun label value =>
+        if %typeof% value == `Number then
+          if value != 0 then
+            value
+          else
+            %blame% (%label_with_message% "non-zero" label)
         else
-          %blame% (%label_with_message% "non-zero" label)
-      else
-        %blame% (%label_with_message% "not a number" label),
+          %blame% (%label_with_message% "not a number" label),
 
-    is_integer : Number -> Bool
-    | doc m%"
+    is_integer
+      : Number -> Bool
+      | doc m%"
       Checks if the given number is an integer.
 
       For example:
@@ -100,10 +101,11 @@
           false
       ```
       "%
-    = fun x => x % 1 == 0,
+      = fun x => x % 1 == 0,
 
-    min : Number -> Number -> Number
-    | doc m%"
+    min
+      : Number -> Number -> Number
+      | doc m%"
       Results in the lowest of the given two numbers.
 
       For example:
@@ -112,10 +114,11 @@
           -1337
       ```
       "%
-    = fun x y => if x <= y then x else y,
+      = fun x y => if x <= y then x else y,
 
-    max : Number -> Number -> Number
-    | doc m%"
+    max
+      : Number -> Number -> Number
+      | doc m%"
       Results in the highest of the given two numbers.
 
       For example:
@@ -124,10 +127,11 @@
           42
       ```
       "%
-    = fun x y => if x >= y then x else y,
+      = fun x y => if x >= y then x else y,
 
-    floor : Number -> Number
-    | doc m%"
+    floor
+      : Number -> Number
+      | doc m%"
       Rounds the number down to the next integer.
 
       For example:
@@ -136,13 +140,15 @@
           42
       ```
       "%
-    = fun x =>
-      if x >= 0
-      then x - (x % 1)
-      else x - 1 - (x % 1),
+      = fun x =>
+        if x >= 0 then
+          x - (x % 1)
+        else
+          x - 1 - (x % 1),
 
-    abs : Number -> Number
-    | doc m%"
+    abs
+      : Number -> Number
+      | doc m%"
       Results in the absolute value of the given number.
 
       For example:
@@ -153,10 +159,11 @@
           42
       ```
       "%
-    = fun x => if x < 0 then -x else x,
+      = fun x => if x < 0 then -x else x,
 
-    fract : Number -> Number
-    | doc m%"
+    fract
+      : Number -> Number
+      | doc m%"
       Results in the fractional part of the given number.
 
       For example:
@@ -167,10 +174,11 @@
           0
       ```
       "%
-    = fun x => x % 1,
+      = fun x => x % 1,
 
-    truncate : Number -> Number
-    | doc m%"
+    truncate
+      : Number -> Number
+      | doc m%"
       Truncates the given number.
 
       For example:
@@ -181,10 +189,11 @@
           42
       ```
       "%
-    = fun x => x - (x % 1),
+      = fun x => x - (x % 1),
 
-    pow : Number -> Number -> Number
-    | doc m%"
+    pow
+      : Number -> Number -> Number
+      | doc m%"
       `pow x y` results in `x` to the power of `y`.
 
       For example:
@@ -206,6 +215,6 @@
       case, **be aware that both the conversion from rationals to floats, and
       the power operation, might incur rounding errors**.
       "%
-    = fun x n => %pow% x n,
+      = fun x n => %pow% x n,
   }
 }

--- a/stdlib/record.ncl
+++ b/stdlib/record.ncl
@@ -1,7 +1,8 @@
 {
   record = {
-    map : forall a b. (String -> a -> b) -> {_: a} -> {_: b}
-    | doc m%"
+    map
+      : forall a b. (String -> a -> b) -> { _ : a } -> { _ : b }
+      | doc m%"
       Maps a function on every field of a record. The string argument of the function argument is the name of the
       field.
 
@@ -13,10 +14,11 @@
           { hello = 2, world = 3 }
       ```
       "%
-    = fun f r => %record_map% r f,
+      = fun f r => %record_map% r f,
 
-    fields : forall a. { _: a } -> Array String
-    | doc m%"
+    fields
+      : forall a. { _ : a } -> Array String
+      | doc m%"
       Given a record, results in a array of the string representation of all fields in the record.
 
       ```nickel
@@ -24,10 +26,11 @@
           [ "one", "two" ]
       ```
       "%
-    = fun r => %fields% r,
+      = fun r => %fields% r,
 
-    values : forall a. { _: a } -> Array a
-    | doc m%"
+    values
+      : forall a. { _ : a } -> Array a
+      | doc m%"
       Given a record, results in a array containing all the values in that record.
 
       ```nickel
@@ -35,10 +38,11 @@
           [ 1, "world" ]
       ```
       "%
-    = fun r => %values% r,
+      = fun r => %values% r,
 
-    has_field : forall a. String -> {_ : a} -> Bool
-    | doc m%"
+    has_field
+      : forall a. String -> { _ : a } -> Bool
+      | doc m%"
       Given the name of a field and a record, checks if the record contains the given field.
 
       ```nickel
@@ -48,9 +52,10 @@
           true
       ```
       "%
-    = fun field r => %has_field% field r,
+      = fun field r => %has_field% field r,
 
-    insert : forall a. String -> a -> {_: a} -> {_: a}
+    insert
+      : forall a. String -> a -> { _ : a } -> { _ : a }
       | doc m%%"
         Insert a new field in a record. `insert` doesn't mutate the original
         record but returns a new one instead.
@@ -67,7 +72,8 @@
       "%%
       = fun field content r => %record_insert% field r content,
 
-    remove : forall a. String -> {_: a} -> {_: a}
+    remove
+      : forall a. String -> { _ : a } -> { _ : a }
       | doc m%"
         Remove a field from a record. `remove` doesn't mutate the original
         record but returns a new one instead.
@@ -79,7 +85,8 @@
       "%
       = fun field r => %record_remove% field r,
 
-    update : forall a. String -> a -> {_: a} -> {_: a}
+    update
+      : forall a. String -> a -> { _ : a } -> { _ : a }
       | doc m%"
         Update a field of a record with a new value. `update` doesn't mutate the
         original record but returns a new one instead. If the field to update is absent
@@ -102,14 +109,17 @@
         ```
       "%
       = fun field content r =>
-        let r = if %has_field% field r then
-          %record_remove% field r
-        else
-          r in
+        let r =
+          if %has_field% field r then
+            %record_remove% field r
+          else
+            r
+        in
         %record_insert% field r content,
 
-    map_values : forall a b. (a -> b) -> {_: a} -> {_: b}
-    | doc m%"
+    map_values
+      : forall a b. (a -> b) -> { _ : a } -> { _ : b }
+      | doc m%"
       Maps a function over every field value of a record.
 
       For example:
@@ -120,10 +130,11 @@
           { hello = 2, world = 3 }
       ```
     "%
-    = fun f => map (fun _field value => f value),
+      = fun f => map (fun _field value => f value),
 
-    to_array : forall a. {_: a} -> Array {field: String, value: a}
-    | doc m%"
+    to_array
+      : forall a. { _ : a } -> Array { field : String, value : a }
+      | doc m%"
       Converts a record to an array of key-value pairs.
 
       For example:
@@ -134,13 +145,14 @@
           ]
       ```
     "%
-    = fun record =>
-      record
-      |> fields
-      |> array.map (fun field' => {field = field', value = record."%{field'}"}),
+      = fun record =>
+        record
+        |> fields
+        |> array.map (fun field' => { field = field', value = record."%{field'}" }),
 
-    from_array : forall a. Array { field: String, value: a} -> {_: a}
-    | doc m%"
+    from_array
+      : forall a. Array { field : String, value : a } -> { _ : a }
+      | doc m%"
       Convert an array of key-value pairs into a record.
 
       For example:
@@ -151,13 +163,14 @@
           => { hello = "world", foo = "bar" }
       ```
     "%
-    = fun bindings =>
-      bindings
-      |> array.map (fun binding => { "%{binding.field}" = binding.value })
-      |> merge_all,
+      = fun bindings =>
+        bindings
+        |> array.map (fun binding => { "%{binding.field}" = binding.value })
+        |> merge_all,
 
-    is_empty : forall a. {_: a} -> Bool
-    | doc m%"
+    is_empty
+      : forall a. { _ : a } -> Bool
+      | doc m%"
       Check whether a record is empty.
 
       ```nickel
@@ -165,10 +178,11 @@
       is_empty { foo = 1 } => false
       ```
     "%
-    = (==) {},
+      = (==) {},
 
-    merge_all | forall a. Array {_: a} -> {_: a}
-    | doc m%"
+    merge_all
+      | forall a. Array { _ : a } -> { _ : a }
+      | doc m%"
       Merge an array of records.
 
       For example:
@@ -177,10 +191,11 @@
         => { foo = 1, bar = 2 }
       ```
     "%
-    = array.fold_left (&) {},
+      = array.fold_left (&) {},
 
-    filter : forall a. (String -> a -> Bool) -> {_: a} -> {_: a}
-    | doc m%"
+    filter
+      : forall a. (String -> a -> Bool) -> { _ : a } -> { _ : a }
+      | doc m%"
       Filter a record using the given function, which is passed the name and
       value for each key to make a decision.
 
@@ -190,14 +205,14 @@
         => { even = 2 }
       ```
     "%
-    = fun f record =>
-      record
-      |> to_array
-      |> array.filter (fun { field, value } => f field value)
-      |> from_array,
+      = fun f record =>
+        record
+        |> to_array
+        |> array.filter (fun { field, value } => f field value)
+        |> from_array,
 
     length
-      : forall a. {_: a} -> Number
+      : forall a. { _ : a } -> Number
       | doc m%"
           Returns the number of fields in a record. This count doesn't include
           fields both marked as optional and without a definition.

--- a/stdlib/string.ncl
+++ b/stdlib/string.ncl
@@ -1,7 +1,7 @@
 {
   string = {
     BoolLiteral
-    | doc m%"
+      | doc m%"
       Contract to enforce the value is a string that represents a boolean literal. Additionally casts "True" to "true"
       and "False" to "false".
 
@@ -15,19 +15,19 @@
           error
       ```
       "%
-    = fun l s =>
-      if %typeof% s == `String then
-        if s == "true" || s == "True" then
-          "true"
-        else if s == "false" || s == "False" then
-          "false"
+      = fun l s =>
+        if %typeof% s == `String then
+          if s == "true" || s == "True" then
+            "true"
+          else if s == "false" || s == "False" then
+            "false"
+          else
+            %blame% (%label_with_message% "expected \"true\" or \"false\", got %{s}" l)
         else
-          %blame% (%label_with_message% "expected \"true\" or \"false\", got %{s}" l)
-      else
-        %blame% (%label_with_message% "not a string" l),
+          %blame% (%label_with_message% "not a string" l),
 
     NumLiteral
-    | doc m%"
+      | doc m%"
       Contract to enforce the value is a string that represends a numerical value.
 
       For example:
@@ -40,7 +40,7 @@
           error
       ```
       "%
-    = let pattern = m%"^[+-]?(\d+(\.\d*)?(e[+-]?\d+)?|\.\d+(e[+-]?\d+)?)$"% in
+      = let pattern = m%"^[+-]?(\d+(\.\d*)?(e[+-]?\d+)?|\.\d+(e[+-]?\d+)?)$"% in
       let is_num_literal = %str_is_match% pattern in
       fun l s =>
         if %typeof% s == `String then
@@ -52,7 +52,7 @@
           %blame% (%label_with_message% "not a string" l),
 
     Character
-    | doc m%"
+      | doc m%"
       Contract to enforce the value is a character (i.e. a string of length 1).
 
       For example:
@@ -67,17 +67,17 @@
           error
       ```
       "%
-    = fun l s =>
-      if %typeof% s == `String then
-        if length s == 1 then
-          s
+      = fun l s =>
+        if %typeof% s == `String then
+          if length s == 1 then
+            s
+          else
+            %blame% (%label_with_message% "length different than one" l)
         else
-          %blame% (%label_with_message% "length different than one" l)
-      else
-        %blame% (%label_with_message% "not a string" l),
+          %blame% (%label_with_message% "not a string" l),
 
     Stringable
-    | doc m%"
+      | doc m%"
       Contract to enforce the value is convertible to a string via
       `builtin.to_string` or `string.from`. Accepted values are:
 
@@ -99,16 +99,19 @@
           error
       ```
       "%
-    = contract.from_predicate (fun value =>
-      let type = builtin.typeof value in
-      value == null
-      || type == `Number
-      || type == `Bool
-      || type == `String
-      || type == `Enum),
+      = contract.from_predicate
+        (
+          fun value =>
+            let type = builtin.typeof value in
+            value == null
+            || type == `Number
+            || type == `Bool
+            || type == `String
+            || type == `Enum
+        ),
 
     NonEmpty
-    | doc m%"
+      | doc m%"
       Contract to enforce the value is a non-empty string.
 
       For example:
@@ -121,17 +124,18 @@
           error
       ```
       "%
-    = fun l s =>
-      if %typeof% s == `String then
-        if %str_length% s > 0 then
-          s
+      = fun l s =>
+        if %typeof% s == `String then
+          if %str_length% s > 0 then
+            s
+          else
+            %blame% (%label_with_message% "empty string" l)
         else
-          %blame% (%label_with_message% "empty string" l)
-      else
-        %blame% (%label_with_message% "not a string" l),
+          %blame% (%label_with_message% "not a string" l),
 
-    join : String -> Array String -> String
-    | doc m%"
+    join
+      : String -> Array String -> String
+      | doc m%"
       Joins a array of strings given a separator.
 
       For example:
@@ -140,22 +144,21 @@
           "Hello, World!"
       ```
       "%
-    = fun sep fragments =>
-      let length = %length% fragments in
+      = fun sep fragments =>
+        let length = %length% fragments in
+        if length == 0 then
+          ""
+        else
+          let first = %elem_at% fragments 0 in
+          let rest =
+            %array_slice% 1 length fragments
+            |> array.fold_left (fun acc s => acc ++ sep ++ s) ""
+          in
+          first ++ rest,
 
-      if length == 0 then
-        "" 
-      else
-        let first = %elem_at% fragments 0 in
-        let rest =
-          %array_slice% 1 length fragments
-          |> array.fold_left (fun acc s => acc ++ sep ++ s) ""
-        in
-
-        first ++ rest,
-
-    split : String -> String -> Array String
-    | doc m%"
+    split
+      : String -> String -> Array String
+      | doc m%"
       Splits a string based on a separator string.
 
       For example:
@@ -169,10 +172,11 @@
       Note that this function never splits up Unicode extended grapheme
       clusters, even in cases where the sought value exists within one.
       "%
-    = fun sep s => %str_split% s sep,
+      = fun sep s => %str_split% s sep,
 
-    trim : String -> String
-    | doc m%"
+    trim
+      : String -> String
+      | doc m%"
       Trims whitespace from the start and end of the string.
 
       For example:
@@ -183,10 +187,11 @@
         "1   2   3"
       ```
       "%
-    = fun s => %str_trim% s,
+      = fun s => %str_trim% s,
 
-    characters : String -> Array String
-    | doc m%"
+    characters
+      : String -> Array String
+      | doc m%"
       Separates a string into its individual Unicode extended grapheme clusters.
 
       For example:
@@ -195,10 +200,11 @@
           [ "H", "e", "l", "l", "o" ]
       ```
       "%
-    = fun s => %str_chars% s,
+      = fun s => %str_chars% s,
 
-    uppercase : String -> String
-    | doc m%"
+    uppercase
+      : String -> String
+      | doc m%"
       Results in the uppercase version of the given character (including non-ascii characters) if it exists, the same
       character if not.
 
@@ -212,10 +218,11 @@
           "."
       ```
       "%
-    = fun s => %str_uppercase% s,
+      = fun s => %str_uppercase% s,
 
-    lowercase : String -> String
-    | doc m%"
+    lowercase
+      : String -> String
+      | doc m%"
       Results in the lowercase version of the given character (including non-ascii characters) if it exists, the same
       character if not.
 
@@ -229,10 +236,11 @@
           "."
       ```
       "%
-    = fun s => %str_lowercase% s,
+      = fun s => %str_lowercase% s,
 
-    contains: String -> String -> Bool
-    | doc m%"
+    contains
+      : String -> String -> Bool
+      | doc m%"
       Checks if the first string is part of the second string.
 
       For example:
@@ -248,10 +256,11 @@
       Note that this function returns false if the sought string exists inside
       a Unicode extended grapheme cluster.
       "%
-    = fun subs s => %str_contains% s subs,
+      = fun subs s => %str_contains% s subs,
 
-    replace: String -> String -> String -> String
-    | doc m%"
+    replace
+      : String -> String -> String -> String
+      | doc m%"
       `replace sub repl str` replaces every occurrence of `sub` in `str` with `repl`.
 
       For example:
@@ -265,11 +274,12 @@
       Note that this function will not replace `sub` if it exists within a
       larger unicode extended grapheme cluster.
       "%
-    = fun pattern replace s =>
-       %str_replace% s pattern replace,
+      = fun pattern replace s =>
+        %str_replace% s pattern replace,
 
-    replace_regex: String -> String -> String -> String
-    | doc m%"
+    replace_regex
+      : String -> String -> String -> String
+      | doc m%"
       `replace_regex regex repl str` replaces every match of `regex` in `str` with `repl`.
 
       For example:
@@ -284,11 +294,12 @@
       grapheme clusters if the regex matches a codepoint that exists within
       one. This behaviour is expected to change in a future version.
       "%
-    = fun pattern replace s =>
-       %str_replace_regex% s pattern replace,
+      = fun pattern replace s =>
+        %str_replace_regex% s pattern replace,
 
-    is_match : String -> String -> Bool
-    | doc m%"
+    is_match
+      : String -> String -> Bool
+      | doc m%"
       `is_match regex String` checks if `String` matches `regex`.
 
       For example:
@@ -324,34 +335,36 @@
       regex match overlaps, or happens entirely within, with a Unicode extended
       grapheme cluster. This behaviour is expected to change in a future version.
       "%
-    = fun regex => %str_is_match% regex,
+      = fun regex => %str_is_match% regex,
 
-    find : String -> String -> {matched: String, index: Number, groups: Array String}
-    | doc m%"
-      `find regex str` matches `str` given `regex`. Results in the part of `str` that matched, the index of the
-      first character that was part of the match in `str`, and a arrays of all capture groups if any.
+    find
+      : String -> String -> { matched : String, index : Number, groups : Array String }
+      | doc m%"
+          `find regex str` matches `str` given `regex`. Results in the part of `str` that matched, the index of the
+          first character that was part of the match in `str`, and a arrays of all capture groups if any.
 
-      For example:
-      ```nickel
-        find "^(\\d).*(\\d).*(\\d).*$" "5 apples, 6 pears and 0 grapes" =>
-          { matched = "5 apples, 6 pears and 0 grapes", index = 0, groups = [ "5", "6", "0" ] }
-        find "3" "01234" =>
-          { matched = "3", index = 3, groups = [ ] }
-      ```
+          For example:
+          ```nickel
+            find "^(\\d).*(\\d).*(\\d).*$" "5 apples, 6 pears and 0 grapes" =>
+              { matched = "5 apples, 6 pears and 0 grapes", index = 0, groups = [ "5", "6", "0" ] }
+            find "3" "01234" =>
+              { matched = "3", index = 3, groups = [ ] }
+          ```
 
-      Note that this function may perform better by sharing its partial application between multiple calls,
-      because in this case the underlying regular expression will only be compiled once (See the documentation
-      of `string.is_match` for more details).
+          Note that this function may perform better by sharing its partial application between multiple calls,
+          because in this case the underlying regular expression will only be compiled once (See the documentation
+          of `string.is_match` for more details).
 
-      WARNING: this function will currently return incorrect indices if `str`
-      contains Unicode extended grapheme clusters. The indices returned will
-      be the location of the matching codepoints, rather than the matching
-      grapheme clusters.
-      "%
-    = fun regex => %str_find% regex,
+          **WARNING**: this function will currently return incorrect indices if `str`
+          contains Unicode extended grapheme clusters. The indices returned will
+          be the location of the matching codepoints, rather than the matching
+          grapheme clusters. This behaviour is expected to change in a future version.
+        "%
+      = fun regex => %str_find% regex,
 
-    length : String -> Number
-    | doc m%"
+    length
+      : String -> Number
+      | doc m%"
       Returns the length of the string, as measured by the number of UTF-8
       [extended grapheme clusters](https://unicode.org/glossary/#extended_grapheme_cluster).
 
@@ -369,10 +382,11 @@
           1
       ```
       "%
-    = fun s => %str_length% s,
+      = fun s => %str_length% s,
 
-    substring: Number -> Number -> String -> String
-    | doc m%"
+    substring
+      : Number -> Number -> String -> String
+      | doc m%"
       Takes a slice from the string. Errors if either index is out of range.
 
       The index arguments are the indices of Unicode extended grapheme clusters
@@ -388,10 +402,11 @@
           error
       ```
       "%
-    = fun start end s => %str_substr% s start end,
+      = fun start end s => %str_substr% s start end,
 
-    from | Stringable -> String
-    | doc m%"
+    from
+      | Stringable -> String
+      | doc m%"
       Converts a correct value to a string representation. Same as
       `builtin.to_string`.
 
@@ -404,10 +419,11 @@
       from null =>
         "null"
       "%
-    = fun x => %to_str% x,
+      = fun x => %to_str% x,
 
-    from_number | Number -> String
-    | doc m%"
+    from_number
+      | Number -> String
+      | doc m%"
       Converts a number to its string representation.
 
       For example:
@@ -416,10 +432,11 @@
         "42"
       ```
       "%
-    = from,
+      = from,
 
-    from_enum | enum.Tag -> String
-    | doc m%"
+    from_enum
+      | enum.Tag -> String
+      | doc m%"
       Converts an enum variant to its string representation.
 
       For example:
@@ -428,10 +445,11 @@
         "MyEnum"
       ```
       "%
-    = from,
+      = from,
 
-    from_bool | Bool -> String
-    | doc m%"
+    from_bool
+      | Bool -> String
+      | doc m%"
       Converts a boolean value to its string representation.
 
       For example:
@@ -440,10 +458,11 @@
           "true"
       ```
       "%
-    = from,
+      = from,
 
-    to_number | NumLiteral -> Number
-    | doc m%"
+    to_number
+      | NumLiteral -> Number
+      | doc m%"
       Converts a string that represents an integer to that integer.
 
       For example:
@@ -452,10 +471,11 @@
           123
       ```
       "%
-    = fun s => %num_from_str% s,
+      = fun s => %num_from_str% s,
 
-    to_bool | BoolLiteral -> Bool
-    | doc m%"
+    to_bool
+      | BoolLiteral -> Bool
+      | doc m%"
       Converts a string that represents a boolean to that boolean.
 
       For example:
@@ -468,10 +488,11 @@
           false
       ```
       "%
-    = fun s => s == "true",
+      = fun s => s == "true",
 
-    to_enum | String -> enum.Tag
-    | doc m%"
+    to_enum
+      | String -> enum.Tag
+      | doc m%"
       Converts any string that represents an enum variant to that enum variant.
 
       For example:
@@ -480,6 +501,6 @@
           `Hello
       ```
       "%
-    = fun s => %enum_from_str% s,
+      = fun s => %enum_from_str% s,
   }
 }


### PR DESCRIPTION
This is the result of running Topiary against the Nickel standard library and the Mantis benchmark Nickel files. This PR is mostly to drive discussion, rather than to be merged...although, I guess it ultimately will be. Nonetheless, I've marked it as draft for now.

There are some niggles (see https://github.com/tweag/topiary/issues/389), but I believe everything in https://github.com/tweag/topiary/issues/331 has been addressed. Please have a look through and let me know if there's anything you have strong opinions about.

**Note** Multi-line strings are not affected by formatting, so their indentation may need to be manually changed to correct their alignment.