### PR TITLE
Implement array merging, part I

### DIFF
--- a/tests/integration/pass/arrays.ncl
+++ b/tests/integration/pass/arrays.ncl
@@ -41,5 +41,28 @@ let {check, ..} = import "lib/assert.ncl" in
     let all = fun pred array => foldr and true (%map% array pred) in
     let isZ = fun x => x == 0 in
     all isZ [0, 0, 0, 1] == false,
+
+  # array pointwise merging
+  let x = array.generate (fun x => 2*x + 1) 10 in x & x == x,
+  [1 / 1, 2*1, 1/3*9] & [0 + 1, 1 + 1, 1 + 2] == [1, 2, 3],
+  # test that double application of a contract with a non-empty array as a
+  # default value doesn't fail (regression test for
+  # https://github.com/tweag/nickel/issues/1187)
+  let CustomNumber =
+  # the _ign is just there to enforce CustomNumber isn't a value
+    let _ign = null in
+    fun _label value => (value | Number)
+  in
+  let Contract = { foo | Array CustomNumber | default = [1,2,3,4]} in
+  let data | Contract
+           | Contract = {}
+  in 
+  data == data,
+  # ensure lazy contracts are applied on both side
+  let DivideByTwo = fun label value => value / 2 in
+  let AddOne = fun label value => value + 1 in
+  ([1 + 1, 2 + 2, 3 + 3] | Array DivideByTwo)
+  & ([0 + 0, 1 + 0, 2 + 0] | Array AddOne)
+  == [1, 2, 3],
 ]
 |> check


### PR DESCRIPTION
In order to make merge idempotent, we've decided to implement a very restricted form of merging on arrays as well (see #1187). This PR makes a first step toward closing #1187, implementing point-wise merging for arrays (and requiring their length to be the same).

In a second time, we plan to be even more restrictive, and refuse to merge array elements that aren't the equal (in particular, records should have exactly the same set of fields). The logic and error reporting for this second step are delayed to a follow-up PR.