### PR TITLE
Add Equal contract to the stdlib

### DIFF
--- a/src/stdlib.rs
+++ b/src/stdlib.rs
@@ -110,8 +110,7 @@ macro_rules! generate_accessor {
     };
 }
 
-/// Accessors to the builtin contracts and other internals operations that aren't accessible from
-/// user code.
+/// Accessors to the builtin contracts and other internals that aren't accessible from user code.
 pub mod internals {
     use super::*;
 
@@ -136,15 +135,8 @@ pub mod internals {
     generate_accessor!(forall_tail);
     generate_accessor!(dyn_tail);
     generate_accessor!(empty_tail);
+    generate_accessor!(contract_equal);
 
     generate_accessor!(rec_default);
     generate_accessor!(rec_force);
-}
-
-pub mod contract {
-    use super::*;
-
-    pub fn equal() -> RichTerm {
-        mk_term::op1(UnaryOp::StaticAccess(Ident::from("contract")), mk_term::var("x")),
-    }
 }

--- a/src/stdlib.rs
+++ b/src/stdlib.rs
@@ -110,8 +110,9 @@ macro_rules! generate_accessor {
     };
 }
 
-/// Accessors to the builtin contracts.
-pub mod contract {
+/// Accessors to the builtin contracts and other internals operations that aren't accessible from
+/// user code.
+pub mod internals {
     use super::*;
 
     // `dyn` is a reserved keyword in rust
@@ -135,11 +136,15 @@ pub mod contract {
     generate_accessor!(forall_tail);
     generate_accessor!(dyn_tail);
     generate_accessor!(empty_tail);
-}
-
-pub mod internals {
-    use super::*;
 
     generate_accessor!(rec_default);
     generate_accessor!(rec_force);
+}
+
+pub mod contract {
+    use super::*;
+
+    pub fn equal() -> RichTerm {
+        mk_term::op1(UnaryOp::StaticAccess(Ident::from("contract")), mk_term::var("x")),
+    }
 }

--- a/stdlib/contract.ncl
+++ b/stdlib/contract.ncl
@@ -1,5 +1,53 @@
 {
   contract = {
+    Equal
+      | doc m%"
+        `Equal` is a contract enforcing equality to a given constant.
+
+        `Equal` is lazy over arrays and records. When checking such values,
+        `Equal` doesn't test for equality of elements right away (it just test
+        that the size is the same for arrays and that fields are the same for
+        records), but return a new value where an equality contract has been
+        pushed down each element.
+
+        # Example
+
+        ```nickel
+        1 + 4 | Equal 5
+         => 5
+        4 | Equal 5
+         => ERROR (contract broken by a value)
+        ```
+      "%
+    = fun constant =>
+      %typeof% constant
+      |> match {
+        `Record =>
+          #TODO: lazy version for records. The difficulty is not to make it lazy
+          #right now, but to make it preserve recursivity as well. We might need
+          #something like a recursivity-preserving map, or a primop for
+          # per-field contract application, like %array_lazy_assume%.
+          from_predicate ((==) constant),
+        `Array =>
+          fun label' value =>
+            if %typeof% value == `Array then
+              let value_length = %length% value in
+              if value_length == %length% constant then
+                %generate% value_length (fun i =>
+                  contract.apply (Equal (%elem_at% constant i)) label' value)
+              else
+                label'
+                |> label.with_message "array length mismatch (expected `%{%length% constant}`, got `%{value_length}`)"
+                |> label.append_note "`Equal constant` requires that the checked value is equal to the array `constant`, but their lengths differ.`"
+                |> blame
+            else
+              blame_with_message
+                "expected array, got %{builtin.typeof value}"
+                label,
+        # Outside of datastructures, we just use (==)
+        _ => from_predicate ((==) constant),
+      },
+
     blame
       | doc m%"
         Raise blame for a given label.

--- a/stdlib/contract.ncl
+++ b/stdlib/contract.ncl
@@ -37,14 +37,15 @@
                   contract.apply (Equal (%elem_at% constant i)) label' value)
               else
                 label'
-                |> label.with_message "array length mismatch (expected `%{%length% constant}`, got `%{value_length}`)"
-                |> label.append_note "`Equal constant` requires that the checked value is equal to the array `constant`, but their lengths differ.`"
+                |> label.with_message "array length mismatch (expected `%{%to_str% (%length% constant)}`, got `%{%to_str% value_length}`)"
+                |> label.append_note "`Equal some_array` requires that the checked value is equal to the array `some_array`, but their lengths differ."
                 |> blame
             else
-              blame_with_message
-                "expected array, got %{builtin.typeof value}"
-                label,
-        # Outside of datastructures, we just use (==)
+              label'
+                |> label.with_message "expected Array, got %{%to_str% (%typeof% value)}"
+                |> label.append_note "`Equal some_array` requires that the checked value is equal to the array `some_array`, but the provided value isn't an array."
+                |> blame,
+        # Outside of lazy data structure, we just use (==)
         _ => from_predicate ((==) constant),
       },
 

--- a/stdlib/contract.ncl
+++ b/stdlib/contract.ncl
@@ -5,9 +5,9 @@
         `Equal` is a contract enforcing equality to a given constant.
 
         `Equal` is lazy over arrays and records. When checking such values,
-        `Equal` doesn't test for equality of elements right away (it just test
+        `Equal` doesn't test for equality of elements right away (it just tests
         that the size is the same for arrays and that fields are the same for
-        records), but return a new value where an equality contract has been
+        records), but returns a new value where an equality contract has been
         pushed down each element.
 
         # Example

--- a/stdlib/internals.ncl
+++ b/stdlib/internals.ncl
@@ -146,4 +146,11 @@
 
   "$rec_force" = fun value => %rec_force% (%force% value),
   "$rec_default" = fun value => %rec_default% (%force% value),
+
+  # Provide an access to contract.Equal within the initial environement. Merging
+  # makes use of `contract.Equal`, but it can't blindly substitute such an
+  # expression, because `contract` might have been redefined locally. Putting it
+  # in an internal value prefixed with `$` makes it accessible from the initial
+  # environment and prevent it from being shadowed.
+  "$stdlib_contract_equal" = contract.Equal,
 }

--- a/stdlib/internals.ncl
+++ b/stdlib/internals.ncl
@@ -147,10 +147,10 @@
   "$rec_force" = fun value => %rec_force% (%force% value),
   "$rec_default" = fun value => %rec_default% (%force% value),
 
-  # Provide an access to contract.Equal within the initial environement. Merging
+  # Provide access to contract.Equal within the initial environement. Merging
   # makes use of `contract.Equal`, but it can't blindly substitute such an
   # expression, because `contract` might have been redefined locally. Putting it
   # in an internal value prefixed with `$` makes it accessible from the initial
-  # environment and prevent it from being shadowed.
+  # environment and prevents it from being shadowed.
   "$stdlib_contract_equal" = contract.Equal,
 }

--- a/stdlib/record.ncl
+++ b/stdlib/record.ncl
@@ -199,7 +199,7 @@
     length
       : forall a. {_: a} -> Number
       | doc m%"
-          Returns the number of fields in a record. This cound doesn't include
+          Returns the number of fields in a record. This count doesn't include
           fields both marked as optional and without a definition.
 
           Because of the need to filter empty optional fields, the cost of

--- a/stdlib/record.ncl
+++ b/stdlib/record.ncl
@@ -195,5 +195,19 @@
       |> to_array
       |> array.filter (fun { field, value } => f field value)
       |> from_array,
+
+    length
+      : forall a. {_: a} -> Number
+      | doc m%"
+          Returns the number of fields in a record. This cound doesn't include
+          fields both marked as optional and without a definition.
+
+          Because of the need to filter empty optional fields, the cost of
+          `length` is linear in the size of the record.
+        "%
+      = fun record =>
+        record
+        |> fields
+        |> array.length,
   }
 }


### PR DESCRIPTION
Following #935, and https://github.com/tweag/nickel/pull/1199#issuecomment-1484696929 (meaning this PR is required before tackling #1187), this PR introduces an `Equal` contract to the stdlib, which simply checks that the tested value equals to some constant provided as a parameter to the contract. The `Equal` contract should preserve laziness over arrays and records.

As per https://github.com/tweag/nickel/pull/1199#issuecomment-1484696929 and the following comment, this is probably required to fix #1187. This PR doesn't deal with records lazily yet, as it might require a new primop to properly preserve recursiveness (if we use record.map, then we're going to kill recursive references, which is not expected from contracts). This is planned as an immediate follow-up, but this chunk is already reviewable and functional.