### PR TITLE
[CI] Continue on MacOS failure (don't kill the Ubuntu job)

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -22,14 +22,13 @@ jobs:
         include:
           - os: ubuntu-latest
             system: x86_64-linux
-            experimental: false
           - os: macos-latest
             system: x86_64-darwin
-            experimental: false
+            continue-on-error: true
 
     runs-on: ${{ matrix.os }}
-    # The `== true` makes it work wether experimental has been defined or not.
-    continue-on-error: ${{ matrix.experimental == true }}
+    # The `== true` makes it work wether continue-on-error has been defined or not.
+    continue-on-error: ${{ matrix.continue-on-error == true }}
 
     steps:
 


### PR DESCRIPTION
We're currently getting consistent segfaults on flake evaluation in the MacOS runner. The current configuration prevents the Ubuntu job from evaluating further. This PR enables `continue-on-error` for the MacOS job, so that it doesn't kill other jobs, and we can still merge PRs while we figure out a way to fix the MacOS CI.