### PR TITLE
Format type and contract information in documentation output

### DIFF
--- a/tests/snapshot/inputs/docs/types.ncl
+++ b/tests/snapshot/inputs/docs/types.ncl
@@ -1,0 +1,6 @@
+{
+  Hello
+    : Number
+    | string.Stringable
+    | doc "World!"
+}

--- a/tests/snapshot/snapshots/snapshot__doc_stderr_types.ncl.snap
+++ b/tests/snapshot/snapshots/snapshot__doc_stderr_types.ncl.snap
@@ -1,0 +1,5 @@
+---
+source: tests/snapshot/main.rs
+expression: snapshot
+---
+

--- a/tests/snapshot/snapshots/snapshot__doc_stdout_types.ncl.snap
+++ b/tests/snapshot/snapshots/snapshot__doc_stdout_types.ncl.snap
@@ -1,0 +1,9 @@
+---
+source: tests/snapshot/main.rs
+expression: snapshot
+---
+# `Hello`
+
+- `Hello: Number`
+World\!
+

--- a/tests/snapshot/snapshots/snapshot__doc_stdout_types.ncl.snap
+++ b/tests/snapshot/snapshots/snapshot__doc_stdout_types.ncl.snap
@@ -4,6 +4,7 @@ expression: snapshot
 ---
 # `Hello`
 
-- `Hello: Number`
+- `Hello : Number`
+- `Hello | string.Stringable`
 World\!
 


### PR DESCRIPTION
Type and contract information is rendered as a list of the form
```
# ident
- `ident : forall a. a`
- `ident | Contract`
```
before the documentation for `ident`.