### PR TITLE
Implement the record_lazy_assume primop

### DIFF
--- a/src/eval/merge.rs
+++ b/src/eval/merge.rs
@@ -562,7 +562,7 @@ fn fields_merge_closurize<'a, I: DoubleEndedIterator<Item = &'a Ident> + Clone, 
 }
 
 /// Same as [Closurizable], but also revert the element if the term is a variable.
-trait RevertClosurize {
+pub(super) trait RevertClosurize {
     /// Revert the element at the index inside the term (if any), and closurize the result inside `env`.
     fn revert_closurize<C: Cache>(
         self,

--- a/src/identifier.rs
+++ b/src/identifier.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 use std::fmt::{self, Debug};
 use std::hash::Hash;
 
-use crate::position::TermPos;
+use crate::{position::TermPos, term::string::NickelString};
 
 simple_counter::generate_counter!(GeneratedCounter, usize);
 static INTERNER: Lazy<interner::Interner> = Lazy::new(interner::Interner::new);
@@ -106,6 +106,12 @@ where
 impl Into<String> for Ident {
     fn into(self) -> String {
         self.into_label()
+    }
+}
+
+impl From<Ident> for NickelString {
+    fn from(id: Ident) -> Self {
+        id.to_string().into()
     }
 }
 

--- a/src/parser/grammar.lalrpop
+++ b/src/parser/grammar.lalrpop
@@ -840,7 +840,7 @@ InfixExpr: UniTerm = {
 BOpPre: BinaryOp = {
     "assume" => BinaryOp::Assume(),
     "array_lazy_assume" => BinaryOp::ArrayLazyAssume(),
-    "dictionary_assume" => BinaryOp::DictionaryAssume(),
+    "record_lazy_assume" => BinaryOp::RecordLazyAssume(),
     "unseal" => BinaryOp::Unseal(),
     "seal" => BinaryOp::Seal(),
     "go_field" => BinaryOp::GoField(),
@@ -1001,7 +1001,7 @@ extern {
         "typeof" => Token::Normal(NormalToken::Typeof),
         "assume" => Token::Normal(NormalToken::Assume),
         "array_lazy_assume" => Token::Normal(NormalToken::ArrayLazyAssume),
-        "dictionary_assume" => Token::Normal(NormalToken::DictionaryAssume),
+        "record_lazy_assume" => Token::Normal(NormalToken::RecordLazyAssume),
         "op force" => Token::Normal(NormalToken::OpForce),
         "blame" => Token::Normal(NormalToken::Blame),
         "chng_pol" => Token::Normal(NormalToken::ChangePol),

--- a/src/parser/lexer.rs
+++ b/src/parser/lexer.rs
@@ -186,8 +186,8 @@ pub enum NormalToken<'input> {
     Assume,
     #[token("%array_lazy_assume%")]
     ArrayLazyAssume,
-    #[token("%dictionary_assume%")]
-    DictionaryAssume,
+    #[token("%record_lazy_assume%")]
+    RecordLazyAssume,
     #[token("%blame%")]
     Blame,
     #[token("%chng_pol%")]

--- a/src/term/mod.rs
+++ b/src/term/mod.rs
@@ -1284,15 +1284,9 @@ pub enum BinaryOp {
     /// This simply inserts a contract into the array attributes.
     ArrayLazyAssume(),
 
-    /// Apply a dictionary contract to a record. The arguments are a label
-    /// and the contract contained in the dictionary type. Results in a function from
-    /// records to records that applies the dictionary contract to its argument.
-    ///
-    /// When used with a dictionary contract `{_: C}` and a record `R`,
-    /// synthesizes a record contract whose fields are the fields of `R` with the
-    /// contract `C` attached to each of them. Then uses `NAryOp::MergeContract` to
-    /// apply this record contract to `R`.
-    DictionaryAssume(),
+    /// Lazily map contracts over a record. The arguments are a label and a function which takes
+    /// the name of the field as a parameter and returns the corresponding contract.
+    RecordLazyAssume(),
 
     /// Set the message of the current diagnostic of a label.
     LabelWithMessage(),

--- a/src/transform/desugar_destructuring.rs
+++ b/src/transform/desugar_destructuring.rs
@@ -154,7 +154,7 @@ fn bind_open_field(x: Ident, pat: &RecordPattern, body: RichTerm) -> RichTerm {
         var,
         matches.iter().fold(Term::Var(x).into(), |x, m| match m {
             Match::Simple(i, _) | Match::Assign(i, _, _) => {
-                op2(DynRemove(), Term::Str(i.to_string().into()), x)
+                op2(DynRemove(), Term::Str((*i).into()), x)
             }
         }),
         body,

--- a/src/typecheck/operation.rs
+++ b/src/typecheck/operation.rs
@@ -382,7 +382,7 @@ pub fn get_bop_type(
         }
         // The first argument is a label, the third is a contract.
         // forall a. Dyn -> {_: a} -> Dyn -> {_: a}
-        BinaryOp::DictionaryAssume() => {
+        BinaryOp::RecordLazyAssume() => {
             let ty_field = UnifType::UnifVar(state.table.fresh_type_var_id());
             let ty_dict = mk_uniftype::dyn_record(ty_field);
             (

--- a/stdlib/internals.ncl
+++ b/stdlib/internals.ncl
@@ -100,7 +100,7 @@
 
   "$dyn_record" = fun contract label value =>
     if %typeof% value == `Record then
-      %dictionary_assume% (%go_dict% label) value contract
+      %record_lazy_assume% (%go_dict% label) value (fun _field => contract)
     else
       %blame% (%label_with_message% "not a record" label),
 


### PR DESCRIPTION
Follow-up of #1203. Preliminary PR to make the `Equal` contract lazy.

This PR introduces a new primop, akin to the existing `array_lazy_assume`,  which adds a contract to the `pending_contracts` of each field of a record. This primop also reverts recursive records, as this new contract may alter fields (e.g. by adding a default value), and thus triggers a recomputation of the recursive record's fixpoint.

Doing so, we got rid of the `dictionary_assume` contract, which can be subsumed (more easily and more efficiently!) by this new primop.