### PR TITLE
Fix the type of `array.elem` and the mantis benchmark

### DIFF
--- a/benches/arrays/fold.ncl
+++ b/benches/arrays/fold.ncl
@@ -1,6 +1,7 @@
-let letter | Number -> string.CharLiteral = fun n =>
-  string.code "a" + (n % 26)
-  |> string.from_code in
+let letter | Number -> string.Character = fun n =>
+  let letters = string.characters "abcdefghijklmnopqrstuvwxyz" in
+  array.at (n % 26) letters
+in
 
 {
   right = {

--- a/benches/mantis/deploy.ncl
+++ b/benches/mantis/deploy.ncl
@@ -67,6 +67,7 @@ fun vars =>
       loggers = defaultLoggers,
       job = vars.job,
       role | [| `passive, `miner, `backup |] = vars.role,
+      reschedule = {},
     }
   in
   let jobDefs =

--- a/stdlib/array.ncl
+++ b/stdlib/array.ncl
@@ -356,7 +356,7 @@
       = fun pred l => fold_right (fun x acc => if pred x then true else acc) false l,
 
     elem
-      : forall a. a -> Array a -> Bool
+      : Dyn -> Array Dyn -> Bool
       | doc m%"
           Returns true if the given value appears in the array, false otherwise.
 


### PR DESCRIPTION
When trying to run the benchmarks on #1220, they were broken.

Beside updating to the latest stdlib changes, I had to fix the type of `array.elem` which lies, because it's polymorphic but equality isn't actually parametric. This means that sadly, currently some statically typed code can actually fails its contract, because the equality is typed with `_a -> _a -> Bool`. Maybe it shouldn't. In the meantime, let fix `elem`, which currently fails on any reasonable usage with a spurious blame error.