### PR TITLE
Use deterministic hashtables

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1091,6 +1091,7 @@ checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
  "hashbrown",
+ "serde",
 ]
 
 [[package]]
@@ -1489,6 +1490,7 @@ dependencies = [
  "comrak",
  "criterion 0.4.0",
  "directories",
+ "indexmap",
  "indoc 2.0.1",
  "insta",
  "js-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ default = ["markdown", "repl", "doc"]
 markdown = ["termimad"]
 repl = ["rustyline", "rustyline-derive", "ansi_term"]
 repl-wasm = ["wasm-bindgen", "js-sys", "serde_repr"]
-doc = [ "comrak" ]
+doc = ["comrak"]
 
 [build-dependencies]
 lalrpop = "0.19.9"
@@ -67,6 +67,7 @@ once_cell = "1.17.1"
 typed-arena = "2.0.2"
 malachite = {version = "0.3.2", features = ["enable_serde"] }
 malachite-q = "0.3.2"
+indexmap = {version = "1.9.3", features = ["serde"] }
 
 [dev-dependencies]
 pretty_assertions = "1.3.0"

--- a/lsp/nls/src/linearization/building.rs
+++ b/lsp/nls/src/linearization/building.rs
@@ -5,7 +5,7 @@ use log::debug;
 use nickel_lang::{
     cache::Cache,
     identifier::Ident,
-    term::record::Field,
+    term::{record::Field, IndexMap},
     typecheck::{linearization::LinearizationState, UnifType},
     types::TypeF,
 };
@@ -105,7 +105,7 @@ impl<'b> Building<'b> {
     pub(super) fn register_fields(
         &mut self,
         current_file: FileId,
-        record_fields: &HashMap<Ident, Field>,
+        record_fields: &IndexMap<Ident, Field>,
         record: ItemId,
         env: &mut Environment,
     ) {

--- a/src/deserialize.rs
+++ b/src/deserialize.rs
@@ -1,7 +1,6 @@
 //! Deserialization of an evaluated program to plain Rust types.
 
 use malachite::{num::conversion::traits::RoundingFrom, rounding_modes::RoundingMode};
-use std::collections::HashMap;
 use std::iter::ExactSizeIterator;
 
 use serde::de::{
@@ -12,7 +11,7 @@ use serde::de::{
 use crate::identifier::Ident;
 use crate::term::array::{self, Array};
 use crate::term::record::Field;
-use crate::term::{RichTerm, Term};
+use crate::term::{IndexMap, RichTerm, Term};
 
 macro_rules! deserialize_number {
     ($method:ident, $type:tt, $visit:ident) => {
@@ -387,12 +386,12 @@ where
 }
 
 struct RecordDeserializer {
-    iter: <HashMap<Ident, Field> as IntoIterator>::IntoIter,
+    iter: <IndexMap<Ident, Field> as IntoIterator>::IntoIter,
     field: Option<Field>,
 }
 
 impl RecordDeserializer {
-    fn new(map: HashMap<Ident, Field>) -> Self {
+    fn new(map: IndexMap<Ident, Field>) -> Self {
         RecordDeserializer {
             iter: map.into_iter(),
             field: None,
@@ -444,7 +443,7 @@ impl<'de> MapAccess<'de> for RecordDeserializer {
 }
 
 fn visit_record<'de, V>(
-    record: HashMap<Ident, Field>,
+    record: IndexMap<Ident, Field>,
     visitor: V,
 ) -> Result<V::Value, RustDeserializationError>
 where

--- a/src/eval/operation.rs
+++ b/src/eval/operation.rs
@@ -27,8 +27,8 @@ use crate::{
         make as mk_term,
         record::{self, Field, FieldMetadata, RecordData},
         string::NickelString,
-        BinaryOp, MergePriority, NAryOp, Number, PendingContract, RecordExtKind, RichTerm,
-        SharedTerm, StrChunk, Term, UnaryOp,
+        BinaryOp, IndexMap, MergePriority, NAryOp, Number, PendingContract, RecordExtKind,
+        RichTerm, SharedTerm, StrChunk, Term, UnaryOp,
     },
     transform::Closurizable,
 };
@@ -47,7 +47,7 @@ use md5::digest::Digest;
 use simple_counter::*;
 use unicode_segmentation::UnicodeSegmentation;
 
-use std::{collections::HashMap, convert::TryFrom, iter::Extend, rc::Rc};
+use std::{convert::TryFrom, iter::Extend, rc::Rc};
 
 generate_counter!(FreshVariableCounter, usize);
 
@@ -3484,11 +3484,11 @@ fn eq<C: Cache>(
         (Term::SealingKey(s1), Term::SealingKey(s2)) => Ok(EqResult::Bool(s1 == s2)),
         (Term::Enum(id1), Term::Enum(id2)) => Ok(EqResult::Bool(id1 == id2)),
         (Term::Record(r1), Term::Record(r2)) => {
-            let merge::hashmap::SplitResult {
+            let merge::split::SplitResult {
                 left,
                 center,
                 right,
-            } = merge::hashmap::split(r1.fields, r2.fields);
+            } = merge::split::split(r1.fields, r2.fields);
 
             // As for other record operations, we ignore optional fields without a definition.
             if !left.values().all(Field::is_empty_optional)
@@ -3662,7 +3662,7 @@ impl RecordDataExt for RecordData {
     where
         F: FnMut(Ident, RichTerm) -> RichTerm,
     {
-        let fields: Result<HashMap<_, _>, _> = self
+        let fields: Result<IndexMap<_, _>, _> = self
             .fields
             .into_iter()
             .filter_map(|(id, field)| {

--- a/src/parser/grammar.lalrpop
+++ b/src/parser/grammar.lalrpop
@@ -35,7 +35,6 @@
 //! corresponding more precise return type. Other rules that produce or just
 //! propagate general uniterms have to return a `UniTerm`.
 use std::{
-    collections::HashMap,
     ffi::OsString,
     convert::TryFrom,
 };
@@ -290,7 +289,7 @@ Applicative: UniTerm = {
     NOpPre<AsTerm<RecordOperand>>,
     RecordOperand,
     "match" "{" <cases: (MatchCase ",")*> <last: MatchCase?> "}" => {
-        let mut acc = HashMap::with_capacity(cases.len());
+        let mut acc = IndexMap::with_capacity(cases.len());
         let mut default = None;
 
         for case in cases.into_iter().map(|x| x.0).chain(last.into_iter()) {

--- a/src/parser/utils.rs
+++ b/src/parser/utils.rs
@@ -1,7 +1,6 @@
 //! Various helpers and companion code for the parser are put here to keep the grammar definition
 //! uncluttered.
-use std::collections::hash_map::Entry;
-use std::collections::HashMap;
+use indexmap::map::Entry;
 use std::fmt::Debug;
 use std::rc::Rc;
 
@@ -19,8 +18,7 @@ use crate::{
     term::{
         make as mk_term,
         record::{Field, FieldMetadata, RecordAttrs, RecordData},
-        BinaryOp, LabeledType, LetMetadata, Rational, RichTerm, StrChunk, Term, TypeAnnotation,
-        UnaryOp,
+        *,
     },
     types::{TypeF, Types},
 };
@@ -146,7 +144,7 @@ impl FieldDef {
 
             match path_elem {
                 FieldPathElem::Ident(id) => {
-                    let mut fields = HashMap::new();
+                    let mut fields = IndexMap::new();
                     fields.insert(id, acc);
                     Field::from(RichTerm::new(
                         Term::Record(RecordData {
@@ -161,7 +159,7 @@ impl FieldDef {
 
                     if let Some(static_access) = static_access {
                         let id = Ident::new_with_pos(static_access, exp.pos);
-                        let mut fields = HashMap::new();
+                        let mut fields = IndexMap::new();
                         fields.insert(id, acc);
                         Field::from(RichTerm::new(
                             Term::Record(RecordData {
@@ -446,10 +444,10 @@ pub fn build_record<I>(fields: I, attrs: RecordAttrs) -> Term
 where
     I: IntoIterator<Item = (FieldPathElem, Field)> + Debug,
 {
-    let mut static_fields = HashMap::new();
+    let mut static_fields = IndexMap::new();
     let mut dynamic_fields = Vec::new();
 
-    fn insert_static_field(static_fields: &mut HashMap<Ident, Field>, id: Ident, field: Field) {
+    fn insert_static_field(static_fields: &mut IndexMap<Ident, Field>, id: Ident, field: Field) {
         match static_fields.entry(id) {
             Entry::Occupied(mut occpd) => {
                 // temporarily putting an empty field in the entry to take the previous value.

--- a/src/pretty.rs
+++ b/src/pretty.rs
@@ -4,15 +4,13 @@ use crate::parser::lexer::KEYWORDS;
 
 use crate::term::{
     record::{Field, FieldMetadata},
-    BinaryOp, MergePriority, Number, RichTerm, StrChunk, Term, TypeAnnotation, UnaryOp,
+    *,
 };
-use crate::types::{EnumRows, EnumRowsF, RecordRowF, RecordRows, RecordRowsF, TypeF, Types};
+use crate::types::*;
 
 use malachite::num::{basic::traits::Zero, conversion::traits::ToSci};
 pub use pretty::{DocAllocator, DocBuilder, Pretty};
 use regex::Regex;
-
-use std::collections::HashMap;
 
 #[derive(Clone, Copy, Eq, PartialEq)]
 enum StringRenderStyle {
@@ -39,7 +37,7 @@ fn min_interpolate_sign(text: &str) -> usize {
         .unwrap_or(1)
 }
 
-fn sorted_map<K: Ord, V>(m: &'_ HashMap<K, V>) -> Vec<(&'_ K, &'_ V)> {
+fn sorted_map<K: Ord, V>(m: &'_ IndexMap<K, V>) -> Vec<(&'_ K, &'_ V)> {
     let mut ret: Vec<(&K, &V)> = m.iter().collect();
     ret.sort_by_key(|(k, _)| *k);
     ret
@@ -229,7 +227,11 @@ where
             .append(self.text(","))
     }
 
-    fn fields(&'a self, fields: &HashMap<Ident, Field>, with_doc: bool) -> DocBuilder<'a, Self, A> {
+    fn fields(
+        &'a self,
+        fields: &IndexMap<Ident, Field>,
+        with_doc: bool,
+    ) -> DocBuilder<'a, Self, A> {
         self.intersperse(
             sorted_map(fields)
                 .iter()

--- a/src/serialize.rs
+++ b/src/serialize.rs
@@ -6,7 +6,7 @@ use crate::{
     term::{
         array::{Array, ArrayAttrs},
         record::RecordData,
-        Number, RichTerm, Term, TypeAnnotation,
+        IndexMap, Number, RichTerm, Term, TypeAnnotation,
     },
 };
 
@@ -17,7 +17,7 @@ use serde::{
 
 use malachite::num::conversion::traits::IsInteger;
 
-use std::{collections::HashMap, fmt, io, rc::Rc, str::FromStr};
+use std::{fmt, io, rc::Rc, str::FromStr};
 
 /// Available export formats.
 // If you add or remove variants, remember to update the CLI docs in `src/bin/nickel.rs'
@@ -117,7 +117,6 @@ where
 }
 
 /// Serializer for a record. Serialize fields in alphabetical order to get a deterministic output
-/// (by default, `HashMap`'s randomness implies a randomized order of fields in the output).
 pub fn serialize_record<S>(record: &RecordData, serializer: S) -> Result<S::Ok, S::Error>
 where
     S: Serializer,
@@ -147,7 +146,7 @@ pub fn deserialize_record<'de, D>(deserializer: D) -> Result<RecordData, D::Erro
 where
     D: Deserializer<'de>,
 {
-    let fields = HashMap::deserialize(deserializer)?;
+    let fields = IndexMap::deserialize(deserializer)?;
     Ok(RecordData::with_field_values(fields))
 }
 

--- a/src/term/mod.rs
+++ b/src/term/mod.rs
@@ -36,6 +36,7 @@ use crate::{
 };
 
 use codespan::FileId;
+
 pub use malachite::{
     num::{
         basic::traits::Zero,
@@ -47,9 +48,12 @@ pub use malachite::{
 
 use serde::{Deserialize, Serialize};
 
+// Because we use `IndexMap` for recors, consumer of Nickel (as a library) might have to
+// manipulate values of this type, so we re-export this type.
+pub use indexmap::IndexMap;
+
 use std::{
     cmp::{Ordering, PartialOrd},
-    collections::HashMap,
     ffi::OsString,
     fmt,
     ops::Deref,
@@ -127,7 +131,7 @@ pub enum Term {
     /// able to handle yet unapplied match expressions.
     #[serde(skip)]
     Match {
-        cases: HashMap<Ident, RichTerm>,
+        cases: IndexMap<Ident, RichTerm>,
         default: Option<RichTerm>,
     },
 
@@ -1530,7 +1534,7 @@ impl Traverse<RichTerm> for RichTerm {
             Term::Match { cases, default } => {
                 // The annotation on `map_res` use Result's corresponding trait to convert from
                 // Iterator<Result> to a Result<Iterator>
-                let cases_result : Result<HashMap<Ident, RichTerm>, E> = cases
+                let cases_result : Result<IndexMap<Ident, RichTerm>, E> = cases
                     .into_iter()
                     // For the conversion to work, note that we need a Result<(Ident,RichTerm), E>
                     .map(|(id, t)| t.traverse(f, state, order).map(|t_ok| (id, t_ok)))
@@ -1577,7 +1581,7 @@ impl Traverse<RichTerm> for RichTerm {
             Term::Record(record) => {
                 // The annotation on `fields_res` uses Result's corresponding trait to convert from
                 // Iterator<Result> to a Result<Iterator>
-                let fields_res: Result<HashMap<Ident, Field>, E> = record.fields
+                let fields_res: Result<IndexMap<Ident, Field>, E> = record.fields
                     .into_iter()
                     // For the conversion to work, note that we need a Result<(Ident,RichTerm), E>
                     .map(|(id, field)| {
@@ -1590,7 +1594,7 @@ impl Traverse<RichTerm> for RichTerm {
             Term::RecRecord(record, dyn_fields, deps) => {
                 // The annotation on `map_res` uses Result's corresponding trait to convert from
                 // Iterator<Result> to a Result<Iterator>
-                let static_fields_res: Result<HashMap<Ident, Field>, E> = record.fields
+                let static_fields_res: Result<IndexMap<Ident, Field>, E> = record.fields
                     .into_iter()
                     // For the conversion to work, note that we need a Result<(Ident,Field), E>
                     .map(|(id, field)| {
@@ -1785,7 +1789,7 @@ pub mod make {
     macro_rules! mk_record {
         ( $( ($id:expr, $body:expr) ),* ) => {
             {
-                let mut fields = std::collections::HashMap::new();
+                let mut fields = indexmap::IndexMap::new();
                 $(
                     fields.insert($id.into(), $body.into());
                 )*
@@ -1802,7 +1806,7 @@ pub mod make {
     macro_rules! mk_match {
         ( $( ($id:expr, $body:expr) ),* ; $default:expr ) => {
             {
-                let mut cases = std::collections::HashMap::new();
+                let mut cases = indexmap::IndexMap::new();
                 $(
                     cases.insert($id.into(), $body.into());
                 )*
@@ -1810,7 +1814,7 @@ pub mod make {
             }
         };
         ( $( ($id:expr, $body:expr) ),*) => {
-                let mut cases = std::collections::HashMap::new();
+                let mut cases = indexmap::IndexMap::new();
                 $(
                     cases.insert($id.into(), $body.into());
                 )*

--- a/src/term/record.rs
+++ b/src/term/record.rs
@@ -1,9 +1,6 @@
 use super::*;
 use crate::{error::EvalError, identifier::Ident, label::Label};
-use std::{
-    collections::{HashMap, HashSet},
-    rc::Rc,
-};
+use std::{collections::HashSet, rc::Rc};
 
 /// Additional attributes for record.
 #[derive(Debug, Default, Eq, PartialEq, Copy, Clone)]
@@ -71,7 +68,7 @@ impl From<HashSet<Ident>> for FieldDeps {
 #[derive(Debug, Default, Eq, PartialEq, Clone)]
 pub struct RecordDeps {
     /// Must have exactly the same keys as the static fields map of the recursive record.
-    pub stat_fields: HashMap<Ident, FieldDeps>,
+    pub stat_fields: IndexMap<Ident, FieldDeps>,
     /// Must have exactly the same length as the dynamic fields list of the recursive record.
     pub dyn_fields: Vec<FieldDeps>,
 }
@@ -235,7 +232,7 @@ impl Traverse<RichTerm> for Field {
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct RecordData {
     /// Fields whose names are known statically.
-    pub fields: HashMap<Ident, Field>,
+    pub fields: IndexMap<Ident, Field>,
     /// Attributes which may be applied to a record.
     pub attrs: RecordAttrs,
     /// The hidden part of a record under a polymorphic contract.
@@ -263,7 +260,7 @@ impl MissingFieldDefError {
 
 impl RecordData {
     pub fn new(
-        fields: HashMap<Ident, Field>,
+        fields: IndexMap<Ident, Field>,
         attrs: RecordAttrs,
         sealed_tail: Option<SealedTail>,
     ) -> Self {
@@ -280,7 +277,7 @@ impl RecordData {
     }
 
     /// A record with the provided fields and the default set of attributes.
-    pub fn with_field_values(field_values: HashMap<Ident, RichTerm>) -> Self {
+    pub fn with_field_values(field_values: IndexMap<Ident, RichTerm>) -> Self {
         let fields = field_values
             .into_iter()
             .map(|(id, value)| {

--- a/src/transform/free_vars.rs
+++ b/src/transform/free_vars.rs
@@ -8,12 +8,12 @@ use crate::{
     identifier::Ident,
     term::{
         record::{Field, FieldDeps, RecordDeps},
-        RichTerm, SharedTerm, StrChunk, Term,
+        IndexMap, RichTerm, SharedTerm, StrChunk, Term,
     },
     types::{RecordRowF, RecordRows, RecordRowsF, TypeF, Types},
 };
 
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 
 /// Apply the full free var transformation on a term.
 pub fn transform(rt: &mut RichTerm) {
@@ -117,7 +117,7 @@ impl CollectFreeVars for RichTerm {
                 let rec_fields: HashSet<Ident> = record.fields.keys().cloned().collect();
                 let mut fresh = HashSet::new();
                 let mut new_deps = RecordDeps {
-                    stat_fields: HashMap::with_capacity(record.fields.len()),
+                    stat_fields: IndexMap::with_capacity(record.fields.len()),
                     dyn_fields: Vec::with_capacity(dyn_fields.len()),
                 };
 

--- a/src/transform/gen_pending_contracts.rs
+++ b/src/transform/gen_pending_contracts.rs
@@ -11,12 +11,10 @@ use crate::{
     match_sharedterm,
     term::{
         record::{Field, RecordData},
-        RichTerm, Term,
+        IndexMap, RichTerm, Term,
     },
     types::UnboundTypeVariableError,
 };
-
-use std::collections::HashMap;
 
 pub fn transform_one(rt: RichTerm) -> Result<RichTerm, UnboundTypeVariableError> {
     fn attach_to_field(field: Field) -> Result<Field, UnboundTypeVariableError> {
@@ -29,8 +27,8 @@ pub fn transform_one(rt: RichTerm) -> Result<RichTerm, UnboundTypeVariableError>
     }
 
     fn attach_to_fields(
-        fields: HashMap<Ident, Field>,
-    ) -> Result<HashMap<Ident, Field>, UnboundTypeVariableError> {
+        fields: IndexMap<Ident, Field>,
+    ) -> Result<IndexMap<Ident, Field>, UnboundTypeVariableError> {
         fields
             .into_iter()
             .map(|(id, field)| Ok((id, attach_to_field(field)?)))

--- a/src/typecheck/destructuring.rs
+++ b/src/typecheck/destructuring.rs
@@ -1,11 +1,9 @@
-use std::collections::HashMap;
-
 use crate::{
     destructuring::{FieldPattern, Match, RecordPattern},
     error::TypecheckError,
     identifier::Ident,
     mk_uty_row,
-    term::LabeledType,
+    term::{IndexMap, LabeledType},
     typecheck::{unify, UnifRecordRow},
     types::{RecordRowF, RecordRowsF, TypeF},
 };
@@ -204,7 +202,7 @@ pub fn inject_pattern_variables(
 /// have already been "used" in the pattern, to ensure that we can
 /// correctly construct the type of a `..rest` match, if it exists.
 struct RecordTypes {
-    known_types: HashMap<Ident, UnifType>,
+    known_types: IndexMap<Ident, UnifType>,
     tail: UnifRecordRows,
 }
 
@@ -212,7 +210,7 @@ impl From<&UnifRecordRows> for RecordTypes {
     fn from(u: &UnifRecordRows) -> Self {
         let (known_types, tail) =
             u.iter()
-                .fold((HashMap::new(), None), |(mut m, _), ty| match ty {
+                .fold((IndexMap::new(), None), |(mut m, _), ty| match ty {
                     GenericUnifRecordRowsIteratorItem::Row(rt) => {
                         m.insert(rt.id, rt.types.clone());
                         (m, None)

--- a/src/typecheck/eq.rs
+++ b/src/typecheck/eq.rs
@@ -45,7 +45,7 @@
 use super::*;
 use crate::{
     eval::{self, cache::Cache},
-    term::{self, record::Field, UnaryOp},
+    term::{self, record::Field, IndexMap, UnaryOp},
 };
 
 /// The maximal number of variable links we want to unfold before abandoning the check. It should
@@ -351,9 +351,9 @@ fn contract_eq_bounded<E: TermEnvironment>(
 fn map_eq<V, F, E>(
     mut f: F,
     state: &mut State,
-    map1: &HashMap<Ident, V>,
+    map1: &IndexMap<Ident, V>,
     env1: &E,
-    map2: &HashMap<Ident, V>,
+    map2: &IndexMap<Ident, V>,
     env2: &E,
 ) -> bool
 where
@@ -373,8 +373,8 @@ where
 /// returned. `None` is returned as well if a type encountered is not row, or if it is a enum row.
 fn rows_as_map<E: TermEnvironment>(
     erows: &GenericUnifRecordRows<E>,
-) -> Option<HashMap<Ident, &GenericUnifType<E>>> {
-    let map: Option<HashMap<Ident, _>> = erows
+) -> Option<IndexMap<Ident, &GenericUnifType<E>>> {
+    let map: Option<IndexMap<Ident, _>> = erows
         .iter()
         .map(|item| match item {
             GenericUnifRecordRowsIteratorItem::Row(RecordRowF { id, types }) => Some((id, types)),

--- a/src/types.rs
+++ b/src/types.rs
@@ -55,8 +55,9 @@ use crate::{
     label::Polarity,
     mk_app, mk_fun,
     position::TermPos,
-    term::make as mk_term,
-    term::{record::RecordData, RichTerm, Term, Traverse, TraverseOrder},
+    term::{
+        make as mk_term, record::RecordData, IndexMap, RichTerm, Term, Traverse, TraverseOrder,
+    },
 };
 
 use std::{
@@ -711,7 +712,7 @@ impl EnumRows {
     fn subcontract(&self) -> Result<RichTerm, UnboundTypeVariableError> {
         use crate::stdlib::internals;
 
-        let mut cases = HashMap::new();
+        let mut cases = IndexMap::new();
         let mut has_tail = false;
         let value_arg = Ident::from("x");
         let label_arg = Ident::from("l");
@@ -780,7 +781,7 @@ impl RecordRows {
         // We begin by building a record whose arguments are contracts
         // derived from the types of the statically known fields.
         let mut rrows = self;
-        let mut fcs = HashMap::new();
+        let mut fcs = IndexMap::new();
 
         while let RecordRowsF::Extend {
             row: RecordRowF { id, types: ty },


### PR DESCRIPTION
## The issue

Nickel uses the builtin Rust hashtable everywhere. This hashtable is randomized, and in particular the iteration order is random (across evaluations). For some hashtables used solely as maps, this doesn't matter (say the tables of the cache, mapping UID to file content or parsed term).

However, this makes for a quite bad experience with respect to typechecking: because typechecking fails on the first error, when typechecking a record, the error depends on the order of iteration (if there are several typechecking errors, but this include unbound identifiers, so it's far from uncommon). So, you see an error, try to fix it, re-run Nickel. You get a different error somewhere else - yay, one error less! Then, at the next run, the initial error comes again, because you didn't really fix it.

Beside typechecking, exporting also forces records, and the order of iteration is relevant again if several fields fail to evaluate - the same issue as with typechecking.

## Introducing IndexMap

This PR introduces `indexmap::IndexMap`, an external hashmap which is a drop-in replacement for Rust's hashmaps, use the same algorithm under the hood, is advertised as being on par with the builtin hashmap (tested on rustc) but guarantees that the order if iteration is the order of insertion (which corresponds, for record fields, to the actual order of the original source code).

We still sort fields for exports and other products of Nickel: for example, if records are merged, trying to guarantee a consistent order for the result is harder (and what could be this order, anyway?). Thus, the order guaranteed by `IndexMap` is mostly here to impose determinism (and it's a nice plus that it usually corresponds to the intuitive order the things were originally defined in), but isn't a replacement for sorting fields in some cases.

Because the type `indexmap::IndexMap` now appears in several places of the API, the module `term` re-export it, so that consumers (e.g. the LSP) can reuse it without having to manually depend on `indexmap`.

The hashtables not related to a term or to something user-facing (the one of the caches, typically) still use `std::collections::HashMap`.

## Does this work?

Here is a simple test:

```nickel
{
  foo : Number = "a",
  bar : String = 5,
}
```

Run this example 20 times on master, and you'll most likely see an even distribution of errors pointing to either `foo` or `bar`. With this PR, we always get an error on `foo`.