### PR TITLE
[CI] Avoid segfaults on MacOS

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -53,7 +53,7 @@ jobs:
 
     - name: Run all checks
       run: |
-        nix flake check --print-build-logs
+        export GC_DONT_GC=1; nix flake check --print-build-logs
 
     - name: Typecheck benchmarks
       run: find benches -type f -name "*.ncl" -print0 | xargs -0 -I file nix run . -- -f file typecheck


### PR DESCRIPTION
Various flake-centric Nix commands seem to randomly segfault when evaluating the Nickel flake on the CI, in some situations. It seems to be GC-related (after discussing with more Nix people internally at Tweag), and disabling garbage collection should hopefully get rid of those errors in the meantime.