### PR TITLE
Update documentation to reflect RFC002 and RFC005

### DIFF
--- a/doc/manual/contracts.md
+++ b/doc/manual/contracts.md
@@ -351,7 +351,7 @@ nickel>{foo = "a", bar = 1} | Contract
 #### Giving values for fields
 
 While most record contracts don't have field definitions, they can. In fact,
-records contracts are nothing special: any record literal can be used both as a
+record contracts are nothing special: any record literal can be used both as a
 contract or a normal value. If a field is defined both in the contract and the
 checked value, the two definitions will be merged in the final result. For
 example:

--- a/doc/manual/contracts.md
+++ b/doc/manual/contracts.md
@@ -26,6 +26,11 @@ let x | Number = 1 + 1 in x
 {x | Number = 1 + 1}
 ```
 
+**Important**: contracts attached to a record field, such as `{x | Number = 1}`,
+and a free standing contract annotation such as `{x = (1 | Number)}` behave
+*differently* with respect to record merging. However, as far as runtime checks
+are concerned (which is the focus of this document), they are equivalent.
+
 Here, `x` is bound to a `Number` contract. When evaluating `x`, the following steps
 are performed:
 
@@ -346,7 +351,7 @@ nickel>{foo = "a", bar = 1} | Contract
 #### Giving values for fields
 
 While most record contracts don't have field definitions, they can. In fact,
-records contracts are not special: any record literal can be used both as a
+records contracts are nothing special: any record literal can be used both as a
 contract or a normal value. If a field is defined both in the contract and the
 checked value, the two definitions will be merged in the final result. For
 example:
@@ -385,9 +390,9 @@ At first sight, `=` also fits the bill. However, there are a number of subtle
 but potentially surprising differences.
 
 One concerns open contracts. Merging never requires the presence of specific
-fields: thus, the contract `{bar | String}` attached to `foo` will actually behave
-as an open contract, even if you didn't use `..`. This is usually not what you
-want:
+fields: thus, the contract `{bar | String}` attached to `foo` will actually
+behave as an open contract, even if you didn't use `..`. This might not be what
+you want:
 
 ```text
 nickel>let ContractPipe = {
@@ -538,11 +543,11 @@ needed. For example, record fields are not evaluated until they are accessed,
 printed (in the REPL or as a result of `nickel`), or until the whole record is
 serialized/exported. Thanks to laziness, you can for example query specific
 information on a large configuration without having to actually evaluate
-everything. We will use a dummy failing expression `1 + "a"` to observe where
-evaluation takes place:
+everything. We will use a failing expression `builtin.fail_with "ooch!"` to observe
+where evaluation takes place:
 
 ```text
-nickel>let config = {fail = 1 + "a", data | doc "Some information" = 42}
+nickel>let config = {fail = builtin.fail_with "ooch", data | doc "Some information" = 42}
 nickel>:query config.data
 * value: 42
 * documentation: Some information
@@ -560,8 +565,8 @@ corresponding to its schema. If this contract checked everything eagerly,
 forcing the evaluation of the most part of the configuration, we would lose the
 benefits of laziness. Thus, *we want contracts to be lazy as well*. In
 particular, a subcontract attached to a field should only fire when the field is
-requested. This is the case with record contracts, and in general all native
-contracts combinators are lazy too.
+requested. This is the case with record contracts, and in general with all native
+contracts combinators.
 
 ### Writing lazy contracts
 

--- a/doc/manual/contracts.md
+++ b/doc/manual/contracts.md
@@ -27,8 +27,8 @@ let x | Number = 1 + 1 in x
 ```
 
 **Important**: contracts attached to a record field, such as `{x | Number = 1}`,
-and a free standing contract annotation such as `{x = (1 | Number)}` behave
-*differently* with respect to record merging. However, as far as runtime checks
+and a freestanding contract annotation such as `{x = (1 | Number)}` *behave
+differently with respect to record merging*. However, as far as runtime checks
 are concerned (which is the focus of this document), they are equivalent.
 
 Here, `x` is bound to a `Number` contract. When evaluating `x`, the following steps

--- a/doc/manual/merging.md
+++ b/doc/manual/merging.md
@@ -574,11 +574,11 @@ including being dropped in favor of another value, the final value for `foo` has
 to respect the contract as well or the evaluation will fail accordingly.
 
 This is only true for *contracts attached directly to record fields* (either
-directly, or coming from an enclosing record contract). In particular, `{foo |
-Num = 1} & {foo | force = "bar"}` will fail, but `{foo = (1 | Num)} & {foo |
-force = "bar"}` will succeed. In the latter case, the contract is not considered
-to be field metadata, but a local contract check, which is not propagated by
-merging.
+directly, or coming from an enclosing record contract). In particular,
+`{foo | Number = 1} & {foo | force = "bar"}` will fail, but
+`{foo = (1 | Number)} & {foo | force = "bar"}` will succeed. In the latter case,
+the contract is not considered to be field metadata, but a local contract check,
+which is not propagated by merging.
 
 #### Specification
 

--- a/doc/manual/merging.md
+++ b/doc/manual/merging.md
@@ -20,9 +20,9 @@ this means that order doesn't matter, and `left & right` is the same thing as
 default values for example, the idea is to use metadata to do so (annotations),
 rather than relying on the left or right position.
 
-**Warning**: At the time of writing, Nickel's version is 0.3.1. Custom merge
-functions are planned for a future version. They are not detailed here yet. For
-more details, see the associated technical document [RFC001][rfc001].
+**Warning**: At the time of writing, Nickel's version is 1.0. Custom merge
+functions are planned for a future version. They are not detailed here yet. See
+the associated technical document [RFC001][rfc001].
 
 The section describes the behavior and use-cases of merge, by considering the
 following situations:
@@ -266,11 +266,11 @@ documentation. We describe in this section how metadata interacts with merging.
 
 Note that metadata can only be syntactically attached to record fields, at the
 exception of type and contract annotations, which can appear anywhere in a
-free-standing expression such as `(x | Num) + 1`. However, a contract annotation
+freestanding expression such as `(x | Num) + 1`. However, a contract annotation
 outside of a record field isn't considered a metadata (it's a mere contract
 check) and doesn't behave the same with respect to merging. **In particular,
-`{foo | Num = 1}` behave differently from `{foo = (1 | Num)}` when merging it
-with other values**. See [the contracts section](#contracts) for more details.
+`{foo | Num = 1}` can behave differently from `{foo = (1 | Num)}` when merged**.
+See [the contracts section](#contracts) for more details.
 
 ### Optional fields
 
@@ -467,11 +467,11 @@ priority between the recursive priority and the existing one.
 #### Specification
 
 To each field definition `foo = val` is associated a priority `p(val)`. When
-merging two common fields `value_left` and `value_right`, then the results is
-either the one with the highest priority (that overrides the other), or the two
-are tentatively recursively merged if the priorities are the same. Without loss
-of generality, we consider the simple case of two records with only one field,
-which is the same on both side:
+merging two common fields `value_left` and `value_right`, the results is either
+the one with the highest priority (that overrides the other), or the two are
+tentatively recursively merged if the priorities are the same. Without loss of
+generality, we consider the simple case of two records with only one common
+field:
 
 ```text
 {common = left} & {common = right}
@@ -608,10 +608,10 @@ Leftn, Right1, .., Rightk`. Here, we ignore the case of type annotations such as
 `common: LeftType` that can just be considered as an additional contract
 `Left0`.
 
-The accumulated contracts are applied in a lazily: as long as the value isn't
-requested, contracts are stored but not applied. This makes it possible to build
-a value piecewise, while the intermediate values don't necessarily respect the
-contract. For example:
+The accumulated contracts are applied lazily: as long as the field's value isn't
+requested, contracts are accumulated but not applied. This makes it possible to
+build a value piecewise, whereas the intermediate values don't necessarily
+respect the contract. For example:
 
 ```nickel
 let FooContract = {
@@ -624,12 +624,12 @@ let FooContract = {
 ```
 
 Running the above program succeeds, although the intermediate value
-`{foo.required_field1 = "here"}` doesn't respect `FooContract` (it misses
-`required_field2`.
+`{foo.required_field1 = "here"}` doesn't respect `FooContract` (it misses the
+field `required_field2`).
 
-If we try to observe the intermediate result (using `deep_seq` which forces the
-full evaluation of its first argument and proceeds with evaluating the second),
-we do get a contract violation error:
+If we try to observe the intermediate result (`deep_seq` recrusively forces the
+evaluation of its first argument and proceeds with evaluating the second
+argument), we do get a contract violation error:
 
 ```nickel
 let FooContract = {

--- a/doc/manual/merging.md
+++ b/doc/manual/merging.md
@@ -20,10 +20,9 @@ this means that order doesn't matter, and `left & right` is the same thing as
 default values for example, the idea is to use metadata to do so (annotations),
 rather than relying on the left or right position.
 
-**Warning**: At the time of writing, Nickel's version is 0.1. Important
-additions to merging are planned for coming versions, including priorities and
-custom merge functions. They are not detailed here yet. For more details, see
-the associated technical document [RFC001][rfc001].
+**Warning**: At the time of writing, Nickel's version is 0.3.1. Custom merge
+functions are planned for a future version. They are not detailed here yet. For
+more details, see the associated technical document [RFC001][rfc001].
 
 The section describes the behavior and use-cases of merge, by considering the
 following situations:
@@ -50,7 +49,7 @@ to `{foo = 1, bar = "bar", baz = false}`.
 
 ### Specification
 
-Technically, if we write the left operand as:
+Formally, if we write the left operand as:
 
 ```text
 left = {
@@ -163,6 +162,8 @@ unless one of the following condition hold:
 
 - They are both of a primitive data type `Number`, `Bool`, `Enum`, `String` and
   they are equal
+- They are both arrays and they are equal (checked by generating an application
+  of the lazy contract `contract.Equal`)
 - They are both null
 
 ### Specification
@@ -211,9 +212,13 @@ Then the merge `left & right` evaluates to the record:
 For two values `v1` and `v2`, if at least one value is not a record, then
 
 ```text
-v1 & v2 = v1    if (type_of(v1) is Number, Bool, String, Enum or v1 == null)
-                   AND v1 == v2
-          _|_   otherwise (indicates failure)
+v1 & v2 = v1               if (type_of(v1) is Number, Bool, String, Enum or
+                           v1 == null) AND v1 == v2
+
+          v2 | Equal v1    if type_of(v1) is Array and type_of(v2) is Array
+
+
+          _|_              otherwise (indicates failure)
 ```
 
 ### Example
@@ -256,8 +261,16 @@ final record:
 ## Merging records with metadata
 
 Metadata can be attached to values thanks to the `|` operator. Metadata
-currently includes contract annotations, default value, merge priority, and
+currently include contract annotation, default value, merge priority, and
 documentation. We describe in this section how metadata interacts with merging.
+
+Note that metadata can only be syntactically attached to record fields, at the
+exception of type and contract annotations, which can appear anywhere in a
+free-standing expression such as `(x | Num) + 1`. However, a contract annotation
+outside of a record field isn't considered a metadata (it's a mere contract
+check) and doesn't behave the same with respect to merging. **In particular,
+`{foo | Num = 1}` behave differently from `{foo = (1 | Num)}` when merging it
+with other values**. See [the contracts section](#contracts) for more details.
 
 ### Optional fields
 
@@ -453,13 +466,12 @@ priority between the recursive priority and the existing one.
 
 #### Specification
 
-We can consider the merging system to feature priorities. To each field
-definition `foo = val` is associated a priority `p(val)`. When merging two
-common fields `value_left` and `value_right`, then the results is either the one
-with the highest priority (that overrides the other), or the two are tentatively
-recursively merged, if the priorities are the same. Without loss of generality,
-we consider the simple case of two records with only one field, which is the
-same on both side:
+To each field definition `foo = val` is associated a priority `p(val)`. When
+merging two common fields `value_left` and `value_right`, then the results is
+either the one with the highest priority (that overrides the other), or the two
+are tentatively recursively merged if the priorities are the same. Without loss
+of generality, we consider the simple case of two records with only one field,
+which is the same on both side:
 
 ```text
 {common = left} & {common = right}
@@ -561,10 +573,17 @@ to a field `foo`, merging ensures that whatever is this field merged with,
 including being dropped in favor of another value, the final value for `foo` has
 to respect the contract as well or the evaluation will fail accordingly.
 
+This is only true for *contracts attached directly to record fields* (either
+directly, on coming from an enclosing record contract). In particular, `{foo |
+Num = 1} & {foo | force = "bar"}` will fail, but `{foo = (1 | Num)} & {foo |
+force = "bar"}` will succeed. In the later case, the contract is not considered
+to be a field metadata, but a local contract check, which is not propagated by
+merging.
+
 #### Specification
 
-For two operands with one field each, which is the same on both side, with respective
-contracts `Left1, .., Leftn` and `Right1, .., Rightk` attached:
+For two operands with one field each, which is the same on both side, and
+respective contracts `Left1, .., Leftn` and `Right1, .., Rightk` attached:
 
 ```nickel
 left = {
@@ -588,6 +607,64 @@ Then the `common` field of `left & right` will be checked against `Left1, ..,
 Leftn, Right1, .., Rightk`. Here, we ignore the case of type annotations such as
 `common: LeftType` that can just be considered as an additional contract
 `Left0`.
+
+The accumulated contracts are applied in a lazily: as long as the value isn't
+requested, contracts are stored but not applied. This makes it possible to build
+a value piecewise, while the intermediate values don't necessarily respect the
+contract. For example:
+
+```nickel
+let FooContract = {
+  required_field1,
+  required_field2,
+} in
+{ foo | FooContract}
+& { foo.required_field1 = "here" }
+& { foo.required_field2 = "here" }
+```
+
+Running the above program succeeds, although the intermediate value
+`{foo.required_field1 = "here"}` doesn't respect `FooContract` (it misses
+`required_field2`.
+
+If we try to observe the intermediate result (using `deep_seq` which forces the
+full evaluation of its first argument and proceeds with evaluating the second),
+we do get a contract violation error:
+
+```nickel
+let FooContract = {
+  required_field1,
+  required_field2,
+}
+in
+
+let intermediate =
+  { foo | FooContract}
+  & { foo.required_field1 = "here" }
+in
+
+builtin.deep_seq intermediate (intermediate & { foo.required_field2 = "here" })
+```
+
+Result:
+
+```text
+error: missing definition for `required_field2`
+    ┌─ example.ncl:3:3
+    │
+  3 │   required_field2,
+    │   ^^^^^^^^^^^^^^^ defined here
+    ·
+  9 │   & { foo.required_field1 = "here" }
+    │           ^^^^^^^^^^^^^^^^^^^^^^^^ in this record
+    │
+    ┌─ <stdlib/builtin.ncl>:176:20
+    │
+176 │       = fun x y => %deep_seq% x y,
+    │                    ------------ accessed here
+
+
+```
 
 #### Example
 

--- a/doc/manual/merging.md
+++ b/doc/manual/merging.md
@@ -264,10 +264,10 @@ Metadata can be attached to values thanks to the `|` operator. Metadata
 currently include contract annotation, default value, merge priority, and
 documentation. We describe in this section how metadata interacts with merging.
 
-Note that metadata can only be syntactically attached to record fields, at the
+Note that metadata can only be syntactically attached to record fields, with the
 exception of type and contract annotations, which can appear anywhere in a
 freestanding expression such as `(x | Num) + 1`. However, a contract annotation
-outside of a record field isn't considered a metadata (it's a mere contract
+outside of a record field isn't considered metadata (it's a mere contract
 check) and doesn't behave the same with respect to merging. **In particular,
 `{foo | Num = 1}` can behave differently from `{foo = (1 | Num)}` when merged**.
 See [the contracts section](#contracts) for more details.
@@ -466,8 +466,8 @@ priority between the recursive priority and the existing one.
 
 #### Specification
 
-To each field definition `foo = val` is associated a priority `p(val)`. When
-merging two common fields `value_left` and `value_right`, the results is either
+Each field definition `foo = val` is assigned a priority `p(val)`. When
+merging two common fields `value_left` and `value_right`, the result is either
 the one with the highest priority (that overrides the other), or the two are
 tentatively recursively merged if the priorities are the same. Without loss of
 generality, we consider the simple case of two records with only one common
@@ -574,10 +574,10 @@ including being dropped in favor of another value, the final value for `foo` has
 to respect the contract as well or the evaluation will fail accordingly.
 
 This is only true for *contracts attached directly to record fields* (either
-directly, on coming from an enclosing record contract). In particular, `{foo |
+directly, or coming from an enclosing record contract). In particular, `{foo |
 Num = 1} & {foo | force = "bar"}` will fail, but `{foo = (1 | Num)} & {foo |
-force = "bar"}` will succeed. In the later case, the contract is not considered
-to be a field metadata, but a local contract check, which is not propagated by
+force = "bar"}` will succeed. In the latter case, the contract is not considered
+to be field metadata, but a local contract check, which is not propagated by
 merging.
 
 #### Specification
@@ -627,7 +627,7 @@ Running the above program succeeds, although the intermediate value
 `{foo.required_field1 = "here"}` doesn't respect `FooContract` (it misses the
 field `required_field2`).
 
-If we try to observe the intermediate result (`deep_seq` recrusively forces the
+If we try to observe the intermediate result (`deep_seq` recursively forces the
 evaluation of its first argument and proceeds with evaluating the second
 argument), we do get a contract violation error:
 

--- a/doc/manual/syntax.md
+++ b/doc/manual/syntax.md
@@ -657,9 +657,9 @@ value) in ((fun x => x + 1) : value)`. See the
 for a detailed account of this design.
 
 The documentation still makes a distinction between *types* and other
-expressions, the former being constructs which are handled specifically by the
+expressions, the former being constructs which are handled specially by the
 typechecker and are listed below. However, any expression can be considered a
-type (in the generic case, it's considered as an opaque type), and types
+type (in the generic case, it's considered as an opaque type), and type
 constructors can also appear inside an expression (where they are understood as
 their associated contract, which is indeed an expression, most often a
 function).
@@ -676,8 +676,8 @@ represents any value)
 - Dictionary: `{_ : <type>}` is a record whose fields are of type `<type>`.
 - Enum: ``[| `tag1, .., `tagn |]`` is an enumeration comprised of alternatives
   `` `tag1 ``, .., `` `tagn``. Tags have the same syntax as identifiers and must
-  be prefixed with a backtick `` ` ``. As for record fields, they can be however
-  espaced with double quotes if they contain special characters:
+  be prefixed with a backtick `` ` ``. As for record fields, they can however be
+  enclosed in double quotes if they contain special characters:
   `` `"tag with space" ``.
 - Arrow: `<source> -> <target>` is a function taking an argument of type
   `<source>` and returns values of type `<target>`.
@@ -686,7 +686,7 @@ variables `var1`, .., `varn`.
 - Record: see the next section [Record types](#record-types).
 
 Type variables bound by a `forall` are only visible inside types (any of the
-constructor listed above). As soon as a term expression arise under a `forall`
+constructor listed above). As soon as a term expression arises under a `forall`
 binder, the type variables aren't in scope anymore:
 
 ```test
@@ -741,8 +741,8 @@ error: incompatible types
 
 #### Record types
 
-Record types are syntactically a restricted subset of records literal. They are
-handled differently from normal record literals with respect to typechecking.
+Record types are syntactically a restricted subset of record literals. They are
+handled differently than normal record literals with respect to typechecking.
 
 A record literal is a record type if:
 
@@ -797,7 +797,7 @@ let MyDyn = fun label value => value in
 
 Metadata are used to attach type and contract annotations, documentation, a
 merge priority or other decorations to record fields (and record fields only).
-Multiple metadata can be chained. A metadata is introduced with the syntax
+Multiple metadata annotations can be chained. Metadata is introduced with the syntax
 `<field_name> | <metadata1> | .. | <metadatan> [= value]`.
 
 Adding documentation can be done with `| doc <string>`. Examples:


### PR DESCRIPTION
Closes #1171.

Update the syntax and the contracts section of the user manual to reflect the changes made to the syntax by RFC002 (mixing type and term syntax) and RFC005 (restricting general metavalues to appear only at the level of fields as well as the change in semantics).