### PR TITLE
Fix leftover short type names in Term::type_of

### DIFF
--- a/src/deserialize.rs
+++ b/src/deserialize.rs
@@ -676,7 +676,7 @@ mod tests {
             A::deserialize(q),
             Err(RustDeserializationError::InvalidType {
                 expected: "Null".to_string(),
-                occurred: "Fun".to_string()
+                occurred: "Function".to_string()
             })
         )
     }

--- a/src/term/mod.rs
+++ b/src/term/mod.rs
@@ -624,9 +624,9 @@ impl Term {
         match self {
             Term::Null => Some("Null"),
             Term::Bool(_) => Some("Bool"),
-            Term::Num(_) => Some("Num"),
-            Term::Str(_) => Some("Str"),
-            Term::Fun(_, _) | Term::FunPattern(_, _, _) => Some("Fun"),
+            Term::Num(_) => Some("Number"),
+            Term::Str(_) => Some("String"),
+            Term::Fun(_, _) | Term::FunPattern(_, _, _) => Some("Function"),
             Term::Match { .. } => Some("MatchExpression"),
             Term::Lbl(_) => Some("Label"),
             Term::Enum(_) => Some("Enum"),


### PR DESCRIPTION
These affect type error messages by printing the old names of the expected type.