### PR TITLE
Fix position bug in context completion 

### DIFF
--- a/lsp/nls/src/requests/completion.rs
+++ b/lsp/nls/src/requests/completion.rs
@@ -348,8 +348,8 @@ fn find_fields_from_term(
         Term::Annotated(annot, term) => {
             find_fields_from_term_with_annot(annot, Some(term), path, info)
         }
-        Term::Var(..) | Term::Op1(UnaryOp::StaticAccess(..), _) => {
-            let pos = term.pos;
+        Term::Var(ident) | Term::Op1(UnaryOp::StaticAccess(ident), _) => {
+            let pos = ident.pos;
             let span = pos.unwrap();
             let locator = (span.src_id, span.start);
             // This unwrap is safe because we're getting an expression from


### PR DESCRIPTION
Say we have this program: 
```nickel
let Contract = {
    A = {
        value | String, 
        other | Number,
    }, 

    value1 | String, 
    other1 | Number,
} in 

{ 
   [.]
} | Contract.A
```

and we want we want context completion at the `[.]` point, we get the identifiers `value1` and `other1` instead of `value` and `other`.  The problem is that for some reason `Contract.A` point to `Contract` instead of the field `A`. 

This pull request fixes this (as a side note: this was not the case when context completion was implemented so I don't know how this sneaked it)


Closes #1221 