### PR TITLE
Simplify formatting instructions in LSP

### DIFF
--- a/lsp/nls/README.md
+++ b/lsp/nls/README.md
@@ -12,45 +12,11 @@ it in VSCode, (Neo)Vim and Emacs.
 
 ## Formatting Capabilities
 
-Formatting in `nls` is currently based on [topiary](https://github.com/tweag/topiary).
+Formatting in `nls` is currently based on
+[topiary](https://github.com/tweag/topiary).
 
-To use it successfully, you need ensure you follow these steps:
-
-1. Have the `topiary` binary installed in your `PATH`. See [here](https://github.com/tweag/topiary#installing).
-2. Have the [topiary](https://github.com/tweag/topiary) repo cloned locally.
-3. Set the environment variable `TOPIARY_REPO_DIR` to point to the local copy
-of the repo.
-4. And finally, an environment variable `TOPIARY_LANGUAGE_DIR` to point to `$TOPIARY_REPO_DIR/languages`.
-
-Steps 2-4 are necessary because, for now, `topiary` cannot be used outside its
-repo directory.
-
-## Alternatives
-
-I think making a user fetch the `topiary` and set those environment variables,
-just to have the formatting capability in `nls` is a bit too much. I can think
-of the following alternatives, but I don't know if they are ideal.
-
-### Keep a cache of the topiary repo
-
-Keep a cache of the `topiary` repo. Fetch the repo from GitHub if it is not
-available in the local cache or not up to date.
-
-* Pros
-  * Automatic updates of the repo (and hence the formatting rules for Nickel)
-* Cons
-  * We still have to set environment variables at runtime
-  * `nls` has to download a potentially large repo
-
-### Embedded Nickel formatting rules as a string in the `nls` binary
-
- Since `topiary` just needs a single `nickel.scm` to be able to format nickel
- files we could just point `TOPIARY_LANGUAGE_DIR` to `<temp-directory>/language`
- , and put the embedded file in that directory.
-
-* Pros:
-  * It's just a single file, so it will be small
-  * No need to download/fetch anything
-* Cons:
-  * We still have to set environment variables at runtime
-  * We have to ensure the formatting rules are up to date with `topiary`
+To enable formatting in NLS, you have to make the `topiary` executable available
+in your `PATH`. Please follow [Topiary's setup
+instructions](https://github.com/tweag/topiary#installing) and ensure in
+particular that the environment variable `TOPIARY_LANGUAGE_DIR` is correctly set
+(this is covered in the setup instructions).


### PR DESCRIPTION
The current instructions for formatting in the LSP are a bit confusing to me:

- The first step says to install topiary, and the second says to clone the topiary repository. However cloning the topiary repository is, to my knowledge, required to install topiary in the first place. The steps aren't in the chronological order.
- We are adding specific instructions about `TOPIARY_LANGUAGE_DIR` that made me think that NLS had specific requirements. However, it doesn't: we just need to have a topiary executable available in the path, and able to be run from any location. It turns out the latter requirement isn't trivial for Topiary, but IMHO this is the Topiary README's responsibility (cf https://github.com/tweag/topiary/pull/424). We shouldn't duplicate Topiary installation instructions here, which could get out of sync, etc.
- There is an "Alternatives" section, but this section doesn't speak about currently working alternatives. This section actually enumerates what NLS _could do_ differently, design-wise, to interface with topiary: while this information is valuable, the NLS README is probably not the place where to put it. A Nickel user doesn't really care about what we could do differently in the future, but cares about what they can do as of today, and how. We should probably move this information to an issue though, to avoid losing it.

This PR tries to simplify the setup guide, by removing the "Alternatives" section and by pointing to Topiary's README instead of duplicating (or adding our own variation of) the installation instructions.