### PR TITLE
Avoid breaking up grapheme clusters in stdlib regex functions

### DIFF
--- a/src/eval/operation.rs
+++ b/src/eval/operation.rs
@@ -1053,7 +1053,7 @@ impl<R: ImportResolver, C: Cache> VirtualMachine<R, C> {
             UnaryOp::StrIsMatchCompiled(regex) => {
                 if let Term::Str(s) = &*t {
                     Ok(Closure::atomic_closure(RichTerm::new(
-                        Term::Bool(regex.is_match(s)),
+                        s.matches_regex(regex),
                         pos_op_inh,
                     )))
                 } else {

--- a/src/eval/operation.rs
+++ b/src/eval/operation.rs
@@ -27,8 +27,8 @@ use crate::{
         make as mk_term,
         record::{self, Field, FieldMetadata, RecordData},
         string::NickelString,
-        BinaryOp, IndexMap, MergePriority, NAryOp, Number, PendingContract, RecordExtKind,
-        RichTerm, SharedTerm, StrChunk, Term, UnaryOp,
+        BinaryOp, CompiledRegex, IndexMap, MergePriority, NAryOp, Number, PendingContract,
+        RecordExtKind, RichTerm, SharedTerm, StrChunk, Term, UnaryOp,
     },
     transform::Closurizable,
 };
@@ -1053,7 +1053,7 @@ impl<R: ImportResolver, C: Cache> VirtualMachine<R, C> {
             UnaryOp::StrIsMatchCompiled(regex) => {
                 if let Term::Str(s) = &*t {
                     Ok(Closure::atomic_closure(RichTerm::new(
-                        s.matches_regex(regex),
+                        s.matches_regex(&regex),
                         pos_op_inh,
                     )))
                 } else {
@@ -2771,7 +2771,7 @@ impl<R: ImportResolver, C: Cache> VirtualMachine<R, C> {
                             let re = regex::Regex::new(from)
                                 .map_err(|err| EvalError::Other(err.to_string(), pos_op))?;
 
-                            re.replace_all(s, to.as_str()).into()
+                            s.replace_regex(&CompiledRegex(re), to)
                         };
 
                         Ok(Closure::atomic_closure(RichTerm::new(

--- a/src/term/mod.rs
+++ b/src/term/mod.rs
@@ -1157,7 +1157,7 @@ pub enum UnaryOp {
 // See: https://github.com/rust-lang/regex/issues/178
 /// [`regex::Regex`] which implements [`PartialEq`].
 #[derive(Debug, Clone)]
-pub struct CompiledRegex(regex::Regex);
+pub struct CompiledRegex(pub regex::Regex);
 
 impl PartialEq for CompiledRegex {
     fn eq(&self, other: &Self) -> bool {

--- a/src/term/string.rs
+++ b/src/term/string.rs
@@ -259,7 +259,7 @@ impl NickelString {
             // Push everything between the last match and this one
             result.push_str(&self[prev_match_end..m.start()]);
             // Push the replacement
-            result.push_str(&replacement);
+            result.push_str(replacement);
             // Skip to the end of the match
             prev_match_end = m.end();
         }

--- a/src/term/string.rs
+++ b/src/term/string.rs
@@ -353,7 +353,7 @@ impl NickelString {
     }
 }
 
-/// Errors returned by `NclString`'s `substring` method.
+/// Errors returned by `NickelString`'s `substring` method.
 pub enum SubstringError {
     /// The start index was not an int
     NonIntStart(Rational),

--- a/stdlib/std.ncl
+++ b/stdlib/std.ncl
@@ -2096,10 +2096,9 @@
         was part of the match in `string`, and an array of all capture groups if
         there were any.
 
-        **WARNING**: this function will currently return incorrect indices if
-        `str` contains Unicode extended grapheme clusters. The indices returned
-        will be the location of the matching codepoints, rather than the
-        matching grapheme clusters.
+        **Note**: this function ignores any matches where either the match
+        itself, or one of its capture groups, begin or end in the middle of a
+        Unicode extended grapheme cluster.
 
         # Examples
 

--- a/stdlib/std.ncl
+++ b/stdlib/std.ncl
@@ -2042,9 +2042,11 @@
       | doc m%"
         `is_match regex string` checks if `string` matches `regex`.
 
-        **WARNING**: this function will currently return `true` even if the
-        regex match overlaps, or happens entirely within, with a Unicode extended
-        grapheme cluster. This behaviour is expected to change in a future version.
+        **Note**: this function only returns `true` when the regex match does
+        not begin or end in the middle of a Unicode extended grapheme cluster.
+        For example, searching for `"❤️"` within the string `"👨‍❤️‍💋‍👨"` will
+        return `false`, as the heart codepoint is contained in the larger
+        extended grapheme cluster.
 
         # Examples
 

--- a/stdlib/std.ncl
+++ b/stdlib/std.ncl
@@ -2021,9 +2021,10 @@
       | doc m%"
         `replace_regex regex repl string` replaces every match of `regex` in `string` with `repl`.
 
-        **WARNING**: this function will currently break up Unicode extended
-        grapheme clusters if the regex matches a codepoint that exists within
-        one. This behaviour is expected to change in a future version.
+        **Note**: this function will only replace matches which start & end
+        on the boundary of Unicode extended grapheme clusters. For example,
+        `replace_regex "❤️" "_" "👨‍❤️‍💋‍👨"` will return `"👨‍❤️‍💋‍👨"`, since the
+        heart codepoint occurs within the larger emoji grapheme cluster.
 
         # Examples
 

--- a/tests/integration/pass/stdlib_string_contains_find_replace.ncl
+++ b/tests/integration/pass/stdlib_string_contains_find_replace.ncl
@@ -25,6 +25,9 @@ let {string, ..} = std in
   string.replace_regex "\\d+" "_" "1,234,1 1" == "_,_,_ _",
   string.replace_regex "\\d" "_" "１２３" == "___",
   string.replace_regex "\\d" "_" "一二三" == "一二三",
+  # we don't want to replace codepoints inside extended grapheme clusters
+  string.replace_regex "❤️" "_" "👨‍❤️‍💋‍👨" == "👨‍❤️‍💋‍👨",
+  string.replace_regex "❤️" "_" "x❤️y❤️z" == "x_y_z",
 
   # string.is_match
   string.is_match "^___$" "___",

--- a/tests/integration/pass/stdlib_string_contains_find_replace.ncl
+++ b/tests/integration/pass/stdlib_string_contains_find_replace.ncl
@@ -30,6 +30,9 @@ let {string, ..} = std in
   string.is_match "^___$" "___",
   string.is_match "___" "___)",
   !(string.is_match "^___$" "___)"),
+  # we don't want matches if they occur as part of an extended grapheme cluster
+  !(string.is_match "👨" "👨‍❤️‍💋‍👨"),
+  !(string.is_match "❤️" "👨‍❤️‍💋‍👨"),
 
   # string.find
   string.find "([0-9]{1,3}\\.){3}([0-9]{1,3})" "1.2.3.4" == { matched = "1.2.3.4", index = 0, groups = ["3.", "4"]},

--- a/tests/integration/pass/stdlib_string_contains_find_replace.ncl
+++ b/tests/integration/pass/stdlib_string_contains_find_replace.ncl
@@ -41,4 +41,6 @@ let {string, ..} = std in
   string.find "([0-9]{1,3}\\.){3}([0-9]{1,3})" "1.2.3.4" == { matched = "1.2.3.4", index = 0, groups = ["3.", "4"]},
   string.find "([0-9]{1,3})\\.([0-9]{1,3})\\.([0-9]{1,3})\\.([0-9]{1,3})" "ip: 192.168.1.4, sorry, what's ipv6?" == { matched = "192.168.1.4", index = 4, groups = ["192", "168", "1", "4"]},
   string.find "\\d" "no numeral" == { matched = "", index = -1, groups = []},
-] |> check
+  string.find "❤️" "👨‍❤️‍💋‍👨" == { matched = "", index = -1, groups = []},
+  string.find "❤️" "👨‍❤️‍💋‍👨❤️" == { matched = "❤️", index = 1, groups = [] },
+  ] |> check


### PR DESCRIPTION
In #1200 I updated the non-regex stdlib string functions to avoid ever breaking up Unicode extended grapheme clusters. This PR does the same for the regex functions.

The method for doing this is relatively simple: we find the regex matches as normal, then we filter out any which don't start or end on a Unicode cluster boundary.

Merging this PR will close #1007.