### PR TITLE
Fix CI (markdownlint on typing section)

### DIFF
--- a/doc/manual/typing.md
+++ b/doc/manual/typing.md
@@ -272,8 +272,8 @@ type. Here is our polymorphic type annotation for `filter`:
 }
 ```
 
-Now, filter can be used not only on numbers as in the initial example, but on strings as
-well:
+Now, filter can be used not only on numbers as in the initial example, but on
+strings as well:
 
 ```nickel
 {


### PR DESCRIPTION
I accidentally pushed to master (branch protection was by-passable for admins, I fixed that since). It was a pass on a section of the manual, so no big deal, but it didn't pass the markdown linter, so this makes the CI fail. This PR fixes the error.