### PR TITLE
Update the roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,16 +209,18 @@ You can find examples in the [`./examples`](./examples) directory.
 
 ## Current state and roadmap
 
-Nickel has been released in version `0.3`. This version should be functional, it
-is intended to gather feedback and real-life testing. Nickel `0.3` isn't intended
-to be used in production yet. The next steps we plan to work on are:
+Nickel is currently released in version `0.3.1`. This version should be
+functional and is intended to gather feedback and real-life testing. The next
+planned version is `1.0`. The next steps we plan to work on are:
 
 - Nix integration: being able to seamlessly use Nickel to write packages and
   shells ([nickel-nix](https://github.com/nickel-lang/nickel-nix))
 - Custom merge functions (second part of the
-  [overriding proposal](https://github.com/tweag/nickel/blob/9fd6e436c0db8f101d4eb26cf97c4993357a7c38/rfcs/001-overriding.md))
-- Rework the merging semantics and implementation ([RFC005](https://github.com/tweag/nickel/blob/6110c7f61e46f39e57503889b8f699de8ef3d41e/rfcs/005-metadata-rework.md))
-- Cached incremental evaluation
+  [overriding
+  proposal](https://github.com/tweag/nickel/blob/9fd6e436c0db8f101d4eb26cf97c4993357a7c38/rfcs/001-overriding.md))
+- Incremental evaluation: design an incremental evaluation model and a caching
+  mechanism in order to perform fast re-evaluation upon small changes to a
+  configuration.
 - Performance improvements
 
 ## Comparison
@@ -242,7 +244,7 @@ to be used in production yet. The next steps we plan to work on are:
     However, this forces the programmer to annotate all of their code with types.
 - [Jsonnet](https://jsonnet.org/) is another language which could be dubbed as
     "JSON with functions" (and others things as well). It is a lazy functional
-    language with object oriented features, among which inheritance is similar
+    language with object-oriented features, among which inheritance is similar
     to Nickel's merge system. One big difference with Nickel is the absence of
     typing.
 - [Pulumi](https://www.pulumi.com/) is not a language in itself, but a cloud

--- a/doc/manual/introduction.md
+++ b/doc/manual/introduction.md
@@ -75,16 +75,18 @@ website.
 
 ## Current state and roadmap
 
-Nickel has been released in version `0.3`. This version should be functional, it
-is intended to gather feedback and real-life testing. Nickel `0.3` isn't intended
-to be used in production yet. The next steps we plan to work on are:
+Nickel is currently released in version `0.3.1`. This version should be
+functional and is intended to gather feedback and real-life testing. The next
+planned version is `1.0`. The next steps we plan to work on are:
 
 - Nix integration: being able to seamlessly use Nickel to write packages and
   shells ([nickel-nix](https://github.com/nickel-lang/nickel-nix))
 - Custom merge functions (second part of the
-  [overriding proposal](https://github.com/tweag/nickel/blob/9fd6e436c0db8f101d4eb26cf97c4993357a7c38/rfcs/001-overriding.md))
-- Rework the merging semantics and implementation ([RFC005](https://github.com/tweag/nickel/blob/6110c7f61e46f39e57503889b8f699de8ef3d41e/rfcs/005-metadata-rework.md))
-- Cached incremental evaluation
+  [overriding
+  proposal](https://github.com/tweag/nickel/blob/9fd6e436c0db8f101d4eb26cf97c4993357a7c38/rfcs/001-overriding.md))
+- Incremental evaluation: design an incremental evaluation model and a caching
+  mechanism in order to perform fast re-evaluation upon small changes to a
+  configuration.
 - Performance improvements
 
 ## Content


### PR DESCRIPTION
What started as a pass in the introduction of the manual became an update of the roadmap, as the intro is mainly a copy of a section of the README, so the two must stay in sync. And the roadmap seemed the only thing which needed an update.