### PR TITLE
Replace Term::deep_repr by the pretty printer

### DIFF
--- a/src/bin/nickel.rs
+++ b/src/bin/nickel.rs
@@ -6,7 +6,7 @@ use nickel_lang::program::Program;
 use nickel_lang::repl::query_print;
 #[cfg(feature = "repl")]
 use nickel_lang::repl::rustyline_frontend;
-use nickel_lang::term::{RichTerm, Term};
+use nickel_lang::term::RichTerm;
 use nickel_lang::{serialize, serialize::ExportFormat};
 use std::path::{Path, PathBuf};
 use std::{
@@ -207,9 +207,7 @@ fn main() {
                 stdout,
                 format,
             }) => export_doc(&mut program, opts.file.as_ref(), output, stdout, format),
-            None => program
-                .eval_full()
-                .map(|t| println!("{}", Term::from(t).deep_repr())),
+            None => program.eval_full().map(|t| println!("{t}")),
         };
 
         if let Err(err) = result {

--- a/src/pretty.rs
+++ b/src/pretty.rs
@@ -416,9 +416,20 @@ where
     A: Clone + 'a,
 {
     fn pretty(self, allocator: &'a D) -> DocBuilder<'a, D, A> {
+        self.as_ref().pretty(allocator)
+    }
+}
+
+impl<'a, D, A> Pretty<'a, D, A> for &Term
+where
+    D: NickelAllocatorExt<'a, A>,
+    D::Doc: Clone,
+    A: Clone + 'a,
+{
+    fn pretty(self, allocator: &'a D) -> DocBuilder<'a, D, A> {
         use Term::*;
 
-        match self.as_ref() {
+        match self {
             Null => allocator.text("null"),
             Bool(v) => allocator.as_string(v),
             Num(n) => allocator.as_string(format!("{}", n.to_sci())),
@@ -453,8 +464,8 @@ where
             // TODO Pattern destructuring to implement.
             FunPattern(..) => {
                 let mut params = vec![];
-                let mut rt = &self;
-                while let FunPattern(id, dst, t) = rt.as_ref() {
+                let mut rt = self;
+                while let FunPattern(id, dst, t) = rt {
                     params.push(if let Some(id) = id {
                         allocator
                             .as_string(id)
@@ -462,7 +473,7 @@ where
                     } else {
                         dst.pretty(allocator)
                     });
-                    rt = t;
+                    rt = t.as_ref();
                 }
                 allocator
                     .text("fun")

--- a/src/repl/rustyline_frontend.rs
+++ b/src/repl/rustyline_frontend.rs
@@ -95,7 +95,7 @@ pub fn repl(histfile: PathBuf, color_opt: ColorOpt) -> Result<(), InitError> {
                     }),
                     Ok(Command::Print(exp)) => {
                         match repl.eval_full(&exp) {
-                            Ok(EvalResult::Evaluated(rt)) => println!("{}\n", rt.as_ref().deep_repr()),
+                            Ok(EvalResult::Evaluated(rt)) => println!("{rt}"),
                             Ok(EvalResult::Bound(_)) => (),
                             Err(err) => program::report(repl.cache_mut(), err, color_opt),
                         };
@@ -120,7 +120,7 @@ pub fn repl(histfile: PathBuf, color_opt: ColorOpt) -> Result<(), InitError> {
             }
             Ok(line) => {
                 match repl.eval_full(&line) {
-                    Ok(EvalResult::Evaluated(rt)) => println!("{}\n", rt.as_ref().deep_repr()),
+                    Ok(EvalResult::Evaluated(rt)) => println!("{rt}\n"),
                     Ok(EvalResult::Bound(_)) => (),
                     Err(err) => program::report(repl.cache_mut(), err, color_opt),
                 };

--- a/src/repl/simple_frontend.rs
+++ b/src/repl/simple_frontend.rs
@@ -65,7 +65,7 @@ pub fn input<R: Repl>(repl: &mut R, line: &str) -> Result<InputResult, InputErro
             Ok(Command::Print(exp)) => repl
                 .eval_full(&exp)
                 .map(|res| match res {
-                    EvalResult::Evaluated(rt) => InputResult::Success(rt.as_ref().deep_repr()),
+                    EvalResult::Evaluated(rt) => InputResult::Success(format!("{rt}\n")),
                     EvalResult::Bound(_) => InputResult::Blank,
                 })
                 .map_err(InputError::from),
@@ -82,9 +82,7 @@ pub fn input<R: Repl>(repl: &mut R, line: &str) -> Result<InputResult, InputErro
     } else {
         repl.eval_full(line)
             .map(|eval_res| match eval_res {
-                EvalResult::Evaluated(rt) => {
-                    InputResult::Success(format!("{}\n", rt.as_ref().deep_repr()))
-                }
+                EvalResult::Evaluated(rt) => InputResult::Success(format!("{rt}\n")),
                 EvalResult::Bound(_) => InputResult::Success(String::new()),
             })
             .map_err(InputError::from)

--- a/src/term/mod.rs
+++ b/src/term/mod.rs
@@ -22,7 +22,6 @@ pub mod record;
 pub mod string;
 
 use array::{Array, ArrayAttrs};
-use pretty::BoxAllocator;
 use record::{Field, FieldDeps, FieldMetadata, RecordData, RecordDeps};
 use string::NickelString;
 
@@ -1702,7 +1701,7 @@ impl std::fmt::Display for RichTerm {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         use crate::pretty::*;
 
-        let allocator = BoxAllocator;
+        let allocator = pretty::BoxAllocator;
 
         let doc: DocBuilder<_, ()> = self.clone().pretty(&allocator);
         doc.render_fmt(80, f)

--- a/src/term/mod.rs
+++ b/src/term/mod.rs
@@ -22,6 +22,7 @@ pub mod record;
 pub mod string;
 
 use array::{Array, ArrayAttrs};
+use pretty::BoxAllocator;
 use record::{Field, FieldDeps, FieldMetadata, RecordData, RecordDeps};
 use string::NickelString;
 
@@ -739,40 +740,6 @@ impl Term {
             | Term::OpN(..)
             | Term::Import(_)
             | Term::ResolvedImport(_) => String::from("<unevaluated>"),
-        }
-    }
-
-    /// Return a deep string representation of a term, used for printing in the REPL
-    pub fn deep_repr(&self) -> String {
-        match self {
-            Term::Record(r) | Term::RecRecord(r, ..) => {
-                let fields_str: Vec<String> = r
-                    .fields
-                    .iter()
-                    .map(|(ident, field)| {
-                        if let Some(ref value) = field.value {
-                            format!("{} = {}", ident, value.as_ref().deep_repr())
-                        } else {
-                            format!("{ident}")
-                        }
-                    })
-                    .collect();
-
-                let suffix = match self {
-                    Term::RecRecord(_, dyn_fields, ..) if !dyn_fields.is_empty() => ", ..",
-                    _ => "",
-                };
-
-                format!("{{ {}{} }}", fields_str.join(", "), suffix)
-            }
-            Term::Array(elements, _) => {
-                let elements_str: Vec<String> = elements
-                    .iter()
-                    .map(|term| term.as_ref().deep_repr())
-                    .collect();
-                format!("[ {} ]", elements_str.join(", "))
-            }
-            _ => self.shallow_repr(),
         }
     }
 
@@ -1734,7 +1701,6 @@ impl From<Term> for RichTerm {
 impl std::fmt::Display for RichTerm {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         use crate::pretty::*;
-        use pretty::BoxAllocator;
 
         let allocator = BoxAllocator;
 

--- a/tests/snapshot/inputs/eval/escaping.ncl
+++ b/tests/snapshot/inputs/eval/escaping.ncl
@@ -1,0 +1,3 @@
+# capture = 'stdout'
+# command = []
+"a\"bcd\""

--- a/tests/snapshot/inputs/eval/records.ncl
+++ b/tests/snapshot/inputs/eval/records.ncl
@@ -1,0 +1,3 @@
+# capture = 'stdout'
+# command = []
+{ a = true, b | Number = 6 * 7 }

--- a/tests/snapshot/snapshots/snapshot__error_stdout_escaping.ncl.snap
+++ b/tests/snapshot/snapshots/snapshot__error_stdout_escaping.ncl.snap
@@ -1,0 +1,6 @@
+---
+source: tests/snapshot/main.rs
+expression: out
+---
+"a\"bcd\""
+

--- a/tests/snapshot/snapshots/snapshot__error_stdout_records.ncl.snap
+++ b/tests/snapshot/snapshots/snapshot__error_stdout_records.ncl.snap
@@ -1,0 +1,6 @@
+---
+source: tests/snapshot/main.rs
+expression: out
+---
+{ a = true, b | Number = 42, }
+


### PR DESCRIPTION
This PR gets rid of `Term::deep_repr` and replaces all calls to it by invocations of the pretty printer. Incidentally, it ensures that quotes and newlines in strings are correctly escaped when printing evaluation results.

As a bonus, the pretty printer formats records with many fields on multiple lines in the REPL if they don't fit into 80 columns.

Closes #1257 