### PR TITLE
Make type annotations to not propagate through merging

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -1590,7 +1590,7 @@ impl IntoDiagnostics<FileId> for ParseError {
                 ]),
             ParseError::TypedFieldWithoutDefinition { field_span, annot_span } => {
                 Diagnostic::error()
-                    .with_message("statically typed field without definition")
+                    .with_message("statically typed field without a definition")
                     .with_labels(vec![
                         primary(&field_span).with_message("this field doesn't have a definition"),
                         secondary(&annot_span).with_message("but it has a type annotation"),

--- a/src/eval/fixpoint.rs
+++ b/src/eval/fixpoint.rs
@@ -85,7 +85,7 @@ pub fn rec_env<'a, I: Iterator<Item = (&'a Ident, &'a Field)>, C: Cache>(
                 let id_value = Ident::fresh();
                 final_env.insert(id_value, idx);
 
-                let with_ctr_applied = PendingContract::apply_all(
+                let with_ctr_applied = RuntimeContract::apply_all(
                     RichTerm::new(Term::Var(id_value), value.pos),
                     field.pending_contracts.iter().cloned().flat_map(|ctr| {
                         // This operation is the heart of our preliminary fix for
@@ -112,7 +112,7 @@ pub fn rec_env<'a, I: Iterator<Item = (&'a Ident, &'a Field)>, C: Cache>(
                         } else {
                             vec![
                                 ctr.clone(),
-                                PendingContract {
+                                RuntimeContract {
                                     contract: ctr.contract,
                                     label: Label {
                                         polarity: ctr.label.polarity.flip(),

--- a/src/eval/merge.rs
+++ b/src/eval/merge.rs
@@ -646,24 +646,24 @@ impl RevertClosurize for Field {
     }
 }
 
-impl RevertClosurize for PendingContract {
+impl RevertClosurize for RuntimeContract {
     fn revert_closurize<C: Cache>(
         self,
         cache: &mut C,
         env: &mut Environment,
         with_env: Environment,
-    ) -> PendingContract {
+    ) -> RuntimeContract {
         self.map_contract(|ctr| ctr.revert_closurize(cache, env, with_env))
     }
 }
 
-impl RevertClosurize for Vec<PendingContract> {
+impl RevertClosurize for Vec<RuntimeContract> {
     fn revert_closurize<C: Cache>(
         self,
         cache: &mut C,
         env: &mut Environment,
         with_env: Environment,
-    ) -> Vec<PendingContract> {
+    ) -> Vec<RuntimeContract> {
         self.into_iter()
             .map(|pending_contract| pending_contract.revert_closurize(cache, env, with_env.clone()))
             .collect()

--- a/src/eval/mod.rs
+++ b/src/eval/mod.rs
@@ -87,7 +87,7 @@ use crate::{
         array::ArrayAttrs,
         make as mk_term,
         record::{Field, RecordData},
-        BinaryOp, BindingType, LetAttrs, PendingContract, RichTerm, StrChunk, Term, UnaryOp,
+        BinaryOp, BindingType, LetAttrs, RichTerm, RuntimeContract, StrChunk, Term, UnaryOp,
     },
     transform::Closurizable,
 };
@@ -253,7 +253,7 @@ impl<R: ImportResolver, C: Cache> VirtualMachine<R, C> {
                         value_next = value_next
                             .map(|value| -> Result<RichTerm, EvalError> {
                                 let pos_value = value.pos;
-                                let value_with_ctr = PendingContract::apply_all(
+                                let value_with_ctr = RuntimeContract::apply_all(
                                     value,
                                     pending_contracts.into_iter(),
                                     pos_value,
@@ -649,7 +649,7 @@ impl<R: ImportResolver, C: Cache> VirtualMachine<R, C> {
                         .pending_contracts
                         .iter()
                         .map(|ctr| {
-                            PendingContract::new(
+                            RuntimeContract::new(
                                 ctr.contract.clone().closurize(
                                     &mut self.cache,
                                     &mut local_env,
@@ -688,10 +688,10 @@ impl<R: ImportResolver, C: Cache> VirtualMachine<R, C> {
                 // avoiding repeated contract application. Annotations could then be a good way of
                 // remembering which contracts have been applied to a value.
                 Term::Annotated(annot, inner) => {
-                    let contracts = annot.as_pending_contracts()?;
+                    let contracts = annot.pending_contracts()?;
                     let pos = inner.pos;
                     let inner_with_ctr =
-                        PendingContract::apply_all(inner.clone(), contracts.into_iter(), pos);
+                        RuntimeContract::apply_all(inner.clone(), contracts.into_iter(), pos);
 
                     Closure {
                         body: inner_with_ctr,

--- a/src/parser/error.rs
+++ b/src/parser/error.rs
@@ -44,4 +44,24 @@ pub enum ParseError {
     /// - a variable is used as both a record and enum row variable, e.g. in the
     ///   signature `forall r. [| ; r |] -> { ; r }`.
     TypeVariableKindMismatch { ty_var: Ident, span: RawSpan },
+    /// A record literal, which isn't a record type, has a field with a type annotation but without
+    /// a definition. While we could technically handle this situation, this is most probably an
+    /// error from the user, because this type annotation is useless and, maybe non-intuitively,
+    /// won't have any effect as part of a larger contract:
+    ///
+    /// ```nickel
+    /// let MixedContract = {foo : String, bar | Number} in
+    /// { foo = 1, bar = 2} | MixedContract
+    /// ```
+    ///
+    /// This example works, because the `foo : String` annotation doesn't propagate, and contract
+    /// application is mostly merging, which is probably not the intent. It might become a warning
+    /// in a future version, but we don't have warnings for now, so we rather forbid such
+    /// constructions.
+    TypedFieldWithoutDefinition {
+        /// The position of the field definition (the identifier only).
+        field_span: RawSpan,
+        /// The position of the type annotation.
+        annot_span: RawSpan,
+    },
 }

--- a/src/parser/uniterm.rs
+++ b/src/parser/uniterm.rs
@@ -1,7 +1,7 @@
 //! Additional AST nodes for the common UniTerm syntax (see RFC002 for more details).
 use super::*;
 use error::ParseError;
-use std::collections::{hash_map::Entry, HashMap};
+use indexmap::{IndexMap, map::Entry};
 use utils::{build_record, FieldDef, FieldPathElem};
 
 use crate::{
@@ -213,7 +213,8 @@ impl UniRecord {
         // ```
         // { foo = { bar = {baz : Num = 1 } } }
         // ```
-        let mut candidate_fields = HashMap::new();
+        // We're using an index map because this map impacts the determinism of error reporting.
+        let mut candidate_fields = IndexMap::new();
 
         let first_without_def = self.fields.iter().find_map(|field_def| {
             let path_as_ident = field_def.path_as_ident();

--- a/src/parser/uniterm.rs
+++ b/src/parser/uniterm.rs
@@ -1,7 +1,7 @@
 //! Additional AST nodes for the common UniTerm syntax (see RFC002 for more details).
 use super::*;
 use error::ParseError;
-use indexmap::{IndexMap, map::Entry};
+use indexmap::{map::Entry, IndexMap};
 use utils::{build_record, FieldDef, FieldPathElem};
 
 use crate::{

--- a/src/parser/utils.rs
+++ b/src/parser/utils.rs
@@ -183,6 +183,18 @@ impl FieldDef {
 
         (fst, content)
     }
+
+    /// Returns the identifier corresponding to this definition if the path is composed of exactly one element which is a static identifier. Returns `None` otherwise.
+    pub fn path_as_ident(&self) -> Option<Ident> {
+        if self.path.len() > 1 {
+            return None;
+        }
+
+        self.path.first().and_then(|path_elem| match path_elem {
+            FieldPathElem::Expr(_) => None,
+            FieldPathElem::Ident(ident) => Some(*ident),
+        })
+    }
 }
 
 /// The last field of a record, that can either be a normal field declaration or an ellipsis.

--- a/src/term/array.rs
+++ b/src/term/array.rs
@@ -12,7 +12,7 @@ pub struct ArrayAttrs {
     pub closurized: bool,
     /// List of lazily-applied contracts.
     /// These are only observed when data enters or leaves the array.
-    pub pending_contracts: Vec<PendingContract>,
+    pub pending_contracts: Vec<RuntimeContract>,
 }
 
 impl ArrayAttrs {
@@ -41,7 +41,7 @@ impl ArrayAttrs {
     /// future
     pub fn with_extra_contracts<I>(mut self, iter: I) -> Self
     where
-        I: IntoIterator<Item = PendingContract>,
+        I: IntoIterator<Item = RuntimeContract>,
     {
         for ctr in iter {
             if !self.pending_contracts.contains(&ctr) {

--- a/src/term/record.rs
+++ b/src/term/record.rs
@@ -146,7 +146,7 @@ pub struct Field {
     pub metadata: FieldMetadata,
     /// List of contracts yet to be applied.
     /// These are only observed when data enter or leave the record.
-    pub pending_contracts: Vec<PendingContract>,
+    pub pending_contracts: Vec<RuntimeContract>,
 }
 
 impl From<RichTerm> for Field {
@@ -348,7 +348,7 @@ impl RecordData {
                     let pos = v.pos;
                     Some(Ok((
                         id,
-                        PendingContract::apply_all(v, field.pending_contracts.into_iter(), pos),
+                        RuntimeContract::apply_all(v, field.pending_contracts.into_iter(), pos),
                     )))
                 }
                 None if !field.metadata.opt => Some(Err(MissingFieldDefError {
@@ -405,7 +405,7 @@ impl RecordData {
                 ..
             }) => {
                 let pos = value.pos;
-                Ok(Some(PendingContract::apply_all(
+                Ok(Some(RuntimeContract::apply_all(
                     value.clone(),
                     pending_contracts.iter().cloned(),
                     pos,

--- a/src/transform/gen_pending_contracts.rs
+++ b/src/transform/gen_pending_contracts.rs
@@ -1,7 +1,7 @@
 //! Generate contract applications from annotations.
 //!
 //! Since RFC005, contracts aren't "pre-applied" during the apply contract transformation, but
-//! lazilyy applied during evaluation. This phase still exists, just to generate the pending
+//! lazily applied during evaluation. This phase still exists, just to generate the pending
 //! contracts (the only ones that the interpreter will care about at runtime) from the static
 //! annotations.
 //!

--- a/src/transform/mod.rs
+++ b/src/transform/mod.rs
@@ -3,7 +3,7 @@ use crate::{
     cache::ImportResolver,
     eval::{cache::Cache, Closure, Environment, IdentKind},
     identifier::Ident,
-    term::{record::Field, BindingType, PendingContract, RichTerm, Term, Traverse, TraverseOrder},
+    term::{record::Field, BindingType, RichTerm, RuntimeContract, Term, Traverse, TraverseOrder},
     typecheck::Wildcards,
     types::UnboundTypeVariableError,
 };
@@ -165,24 +165,24 @@ impl Closurizable for RichTerm {
     }
 }
 
-impl Closurizable for PendingContract {
+impl Closurizable for RuntimeContract {
     fn closurize<C: Cache>(
         self,
         cache: &mut C,
         env: &mut Environment,
         with_env: Environment,
-    ) -> PendingContract {
+    ) -> RuntimeContract {
         self.map_contract(|ctr| ctr.closurize(cache, env, with_env))
     }
 }
 
-impl Closurizable for Vec<PendingContract> {
+impl Closurizable for Vec<RuntimeContract> {
     fn closurize<C: Cache>(
         self,
         cache: &mut C,
         env: &mut Environment,
         with_env: Environment,
-    ) -> Vec<PendingContract> {
+    ) -> Vec<RuntimeContract> {
         self.into_iter()
             .map(|pending_contract| pending_contract.closurize(cache, env, with_env.clone()))
             .collect()

--- a/tests/integration/pass/types_dont_propagate.ncl
+++ b/tests/integration/pass/types_dont_propagate.ncl
@@ -1,0 +1,23 @@
+let {check, ..} = import "lib/assert.ncl" in
+
+[
+  # check that a record type literal is indeed converted to the corresponding
+  # contract, which shouldn't be a record literal
+# std.typeof {foo : String, bar : Number} != `Record,
+
+  # check_types_dont_propagate
+
+  # TODO: restore the test below. The PR which added it is not at fault: the
+  # test is failing on master. The issue is that contracts derived from record
+  # type seem to erase metadata, while they shouldn't.
+  #({foo | default = 5} | {foo : Number}) & {foo = "a"} == {foo = "a"},
+
+  let swap
+    : forall a b. {foo : a, bar : b} -> {foo : b, bar : a }
+    = fun {foo=prev_foo, bar=prev_bar} => {bar = prev_foo, foo = prev_bar}
+  in
+  ((swap {foo = 1, bar = "a"})
+  & {foo | force = false, bar | force = true})
+  == {foo = false, bar = true},
+]
+|> check

--- a/tests/integration/records_fail.rs
+++ b/tests/integration/records_fail.rs
@@ -74,7 +74,7 @@ fn missing_field() {
         Err(Error::EvalError(EvalError::MissingFieldDef { id, ..})) if id.to_string() == "foo"
     );
     assert_matches!(
-        eval("{foo : Number, bar = foo + 1}.foo"),
+        eval("{foo | not_exported, bar = foo + 1}.foo"),
         Err(Error::EvalError(EvalError::MissingFieldDef {id, ..})) if id.to_string() == "foo"
     );
     assert_matches!(

--- a/tests/integration/typecheck_fail.rs
+++ b/tests/integration/typecheck_fail.rs
@@ -12,6 +12,7 @@ fn type_check(rt: &RichTerm) -> Result<(), TypecheckError> {
     typecheck::type_check(rt, Context::new(), &DummyResolver {}).map(|_| ())
 }
 
+#[track_caller]
 fn type_check_expr(s: impl std::string::ToString) -> Result<(), TypecheckError> {
     let s = s.to_string();
     let id = Files::new().add("<test>", s.clone());

--- a/tests/snapshot/inputs/docs/types.ncl
+++ b/tests/snapshot/inputs/docs/types.ncl
@@ -3,4 +3,5 @@
     : Number
     | std.string.Stringable
     | doc "World!"
+    = 5,
 }

--- a/tests/snapshot/inputs/errors/typed_field_without_annotation.ncl
+++ b/tests/snapshot/inputs/errors/typed_field_without_annotation.ncl
@@ -1,0 +1,5 @@
+{
+  foo : Number
+      | doc "foo",
+  bar : String,
+}

--- a/tests/snapshot/snapshots/snapshot__error_typed_field_without_annotation.ncl.snap
+++ b/tests/snapshot/snapshots/snapshot__error_typed_field_without_annotation.ncl.snap
@@ -1,0 +1,17 @@
+---
+source: tests/snapshot/main.rs
+expression: snapshot
+---
+error: statically typed field without definition
+  ┌─ [INPUTS_PATH]/errors/typed_field_without_annotation.ncl:2:3
+  │
+2 │   foo : Number
+  │   ^^^   ------ but it has a type annotation
+  │   │      
+  │   this field doesn't have a definition
+  │
+  = A static type annotation must be attached to an expression but this field doesn't have a definition.
+  = Did you mean to use `|` instead of `:`, for example when defining a record contract?
+  = Typed fields without definitions are only allowed inside record types, but the enclosing record literal doesn't qualify as a record type. Please refer to the manual for the defining conditions of a record type.
+
+

--- a/tests/snapshot/snapshots/snapshot__error_typed_field_without_annotation.ncl.snap
+++ b/tests/snapshot/snapshots/snapshot__error_typed_field_without_annotation.ncl.snap
@@ -2,7 +2,7 @@
 source: tests/snapshot/main.rs
 expression: snapshot
 ---
-error: statically typed field without definition
+error: statically typed field without a definition
   ┌─ [INPUTS_PATH]/errors/typed_field_without_annotation.ncl:2:3
   │
 2 │   foo : Number


### PR DESCRIPTION
First step toward fixing #1228. Make type annotations behave differently from contract annotations, and in particular, make them not propagate through merging.

## Content

This PR makes a distinction between the contracts coming from a type annotation and the one derived from a contract annotation. In particular, the former aren't stored lazily inside the pending contracts of record fields, nor are they propagated through merging anymore. The contract application for a type annotation is generated statically during program transformations once and for all, making such contract checks local.

### Conversion from a record type literal

Doing so, we encountered an interesting issue, which was that the following program was accepted:

```nickel
let C = {foo : Number} in
{foo = "a"} | C
```

Here, `{foo : Number}` was parsed (on current `master`) as a record literal with one field and without a definition. But because record contract application is mostly merging, the type annotation `{foo : Number}` isn't propagated anymore.

But if we write

```nickel
{foo = "a"} | {foo : Number}
```

Then it do report a contract violation, because `{foo : Number}` is now considered first as a record type, then converted to a proper contract (not a record contract, but a builtin special function), and applied correctly. 

It turns out this is a discrepancy already present on master, and `{foo : Number}` qualifies as a record type but is only considered so in _a type position_. It's just that on master, the difference between the interpretation as a record type and as a record literal is much less noticeable (but still here: for example, record type contracts currently kill metadata, it's a bug, but this is nonetheless an observable distinction between the first and the second example already on master).

**This PR makes a record literal qualifying as a record type to be always interpreted as such, even in a term position**. As an illustration:

```nickel
nickel> {foo : Num}
<func>

```

We get an opaque function instead of a record. I think it's mostly fine, because it doesn't make much sense to apply record operations such as merging on such an object anyway. It can be considered the same as `Number -> {_ : String}`, that is some opaque value that can only be applied as a contract.

### The typed field without definition restriction

After the change, something like `{foo : Number, bar | String}` can be misleading. It's not a record type, so we have the same behavior as the initial problematic example, which is that when used as a contract this expression will never enforce that `foo` is a number (but it will enforce that `bar` is a `String`). Because a freestanding type annotation on a field without a definition doesn't make much sense (after the current change, they are useless, and can be removed to exactly the same effect, because they don't apply to any expression), we simply make them illegal at the parsing stage. That is, you must either write a record type, or you can't write a field with a type annotation but no definition.

It might also help people not mixing and confusing type and contract annotations, mostly by forcing them to write contract annotations everywhere inside record contracts, outside record type.

## TODOs

- [x] Fix the issue that right now, doing `{foo = 5} | {foo : String}` fails as expected, but `let Foo = {foo : String} in {foo = 5} | Foo` doesn't. The reason is that the latter isn't inside a type annotation, and is thus parsed as a record literal which is applied through merging, making the type annotation inoperative (which is the point of this PR). I think the solution is to make `{foo : String}` to become the contract associated to the corresponding record type all the time, not only inside type annotations. Additionally, we should forbid a type annotation to be attached to a field without a definition inside a normal record, because it's useless (that is, forbid `{foo : String, bar | Number}` or `{foo : String, bar = 2}` because the type annotation is useless and it might lead to surprising result; it can become a warning later on).