### PR TITLE
Introduce dictionary contracts

### DIFF
--- a/lsp/nls/src/requests/completion.rs
+++ b/lsp/nls/src/requests/completion.rs
@@ -248,8 +248,8 @@ fn find_fields_from_type(
 ) -> Vec<IdentWithType> {
     match &ty.types {
         TypeF::Record(row) => find_fields_from_rrows(row, path, info),
-        TypeF::Dict(ty) => match path.pop() {
-            Some(..) => find_fields_from_type(ty, path, info),
+        TypeF::Dict { type_fields, .. } => match path.pop() {
+            Some(..) => find_fields_from_type(type_fields, path, info),
             _ => Vec::new(),
         },
         TypeF::Flat(term) => find_fields_from_term(term, path, info),

--- a/src/label.rs
+++ b/src/label.rs
@@ -212,8 +212,8 @@ but this field doesn't exist in {}",
                     ..path_span
                 })
             }
-            (TypeF::Dict(ty), next @ Some(Elem::Dict)) => {
-                let path_span = span(path_it, ty)?;
+            (TypeF::Dict { type_fields, .. }, next @ Some(Elem::Dict)) => {
+                let path_span = span(path_it, type_fields)?;
 
                 Some(PathSpan {
                     last: path_span.last.or_else(|| next.copied()),

--- a/src/parser/grammar.lalrpop
+++ b/src/parser/grammar.lalrpop
@@ -62,10 +62,7 @@ use crate::{
         array::Array,
         make as mk_term,
     },
-    types::{
-        Types, TypeF, EnumRows, EnumRowsF, RecordRows, RecordRowsF,
-        VarKind
-    },
+    types::*,
     position::{TermPos, RawSpan},
     label::Label,
 };
@@ -912,7 +909,19 @@ TypeAtom: Types = {
             Types::from(TypeF::Enum(ty))
     },
     "{" "_" ":" <t: WithPos<Types>> "}" => {
-        Types::from(TypeF::Dict(Box::new(t)))
+        Types::from(TypeF::Dict {
+            type_fields: Box::new(t),
+            attrs: DictAttrs::Eager
+        })
+    },
+    // Although dictionary contracts aren't really type, we treat them like
+    // types for the time being, at least syntactically, as they are represented
+    // using a `TypeF::Dict` constructor as well.
+    "{" "_" "|" <t: WithPos<Types>> "}" => {
+        Types::from(TypeF::Dict {
+            type_fields: Box::new(t),
+            attrs: DictAttrs::Lazy
+        })
     },
     "_" => {
         let id = *next_wildcard_id;

--- a/src/parser/grammar.lalrpop
+++ b/src/parser/grammar.lalrpop
@@ -914,10 +914,20 @@ TypeAtom: Types = {
             attrs: DictAttrs::Eager
         })
     },
-    // Although dictionary contracts aren't really type, we treat them like
-    // types for the time being, at least syntactically, as they are represented
-    // using a `TypeF::Dict` constructor as well.
-    "{" "_" "|" <t: WithPos<Types>> "}" => {
+    // Although a dictionary contracts isn't really a type, we treat it like as
+    // a type for now - at least syntactically - as they are represented using a
+    // `TypeF::Dict` constructor in the AST. This just simpler for many reasons
+    // (error reporting of contracts and in particular type paths, LSP, and so
+    // on.)
+    //
+    // However, note that we use a fixed type as an argument. This has the
+    // effect of preventing dictionary contracts from catpuring type variables
+    // that could be in scope. For example, we want `forall a. {_ | a}` to fail
+    // (see https://github.com/tweag/nickel/issues/1228). Fixing type variables
+    // right away inside the dictionary contract (before the enclosing `forall`
+    // is fixed) will indeed turn it into a term variable, and raise an unbound
+    // type variable error.
+    "{" "_" "|" <t: WithPos<FixedType>> "}" => {
         Types::from(TypeF::Dict {
             type_fields: Box::new(t),
             attrs: DictAttrs::Lazy

--- a/src/parser/grammar.lalrpop
+++ b/src/parser/grammar.lalrpop
@@ -911,7 +911,7 @@ TypeAtom: Types = {
     "{" "_" ":" <t: WithPos<Types>> "}" => {
         Types::from(TypeF::Dict {
             type_fields: Box::new(t),
-            attrs: DictAttrs::Eager
+            flavour: DictTypeFlavour::Type
         })
     },
     // Although a dictionary contracts isn't really a type, we treat it like as
@@ -930,7 +930,7 @@ TypeAtom: Types = {
     "{" "_" "|" <t: WithPos<FixedType>> "}" => {
         Types::from(TypeF::Dict {
             type_fields: Box::new(t),
-            attrs: DictAttrs::Lazy
+            flavour: DictTypeFlavour::Contract
         })
     },
     "_" => {

--- a/src/parser/uniterm.rs
+++ b/src/parser/uniterm.rs
@@ -12,7 +12,7 @@ use crate::{
         LabeledType, MergePriority, RichTerm, Term, TypeAnnotation,
     },
     types::{
-        DictAttrs, EnumRows, EnumRowsIteratorItem, RecordRow, RecordRows, RecordRowsF, TypeF,
+        DictTypeFlavour, EnumRows, EnumRowsIteratorItem, RecordRow, RecordRows, RecordRowsF, TypeF,
         Types, UnboundTypeVariableError, VarKind,
     },
 };
@@ -682,7 +682,7 @@ impl FixTypeVars for Types {
             // should not be considered as a static type, but instead work as a contract. In
             // particular mustn't be allowed to capture type variables from the enclosing type: see
             // https://github.com/tweag/nickel/issues/1228.
-            | TypeF::Dict { attrs: DictAttrs::Lazy, ..}
+            | TypeF::Dict { flavour: DictTypeFlavour::Contract, ..}
             | TypeF::Wildcard(_) => Ok(()),
             TypeF::Arrow(ref mut s, ref mut t) => {
                 (*s).fix_type_vars_env(bound_vars.clone(), span)?;
@@ -716,7 +716,7 @@ impl FixTypeVars for Types {
 
                 Ok(())
             }
-            TypeF::Dict { type_fields: ref mut ty, attrs: DictAttrs::Eager} | TypeF::Array(ref mut ty) => {
+            TypeF::Dict { type_fields: ref mut ty, flavour: DictTypeFlavour::Type} | TypeF::Array(ref mut ty) => {
                 (*ty).fix_type_vars_env(bound_vars, span)
             }
             TypeF::Enum(ref mut erows) => erows.fix_type_vars_env(bound_vars, span),

--- a/src/parser/uniterm.rs
+++ b/src/parser/uniterm.rs
@@ -616,7 +616,7 @@ pub(super) trait FixTypeVars {
     ///
     /// Once again because `forall`s only bind variables locally, and don't bind inside contracts, we
     /// don't have to recurse into contracts and this pass will only visit each node of the AST at most
-    /// once in total.
+    /// once in total (and most probably much less so).
     ///
     /// There is one subtlety with unirecords, though. A unirecord can still be in interpreted as a
     /// record type later. Take the following example:
@@ -679,8 +679,9 @@ impl FixTypeVars for Types {
             | TypeF::Symbol
             | TypeF::Flat(_)
             // We don't fix type variables inside a dictionary contract. A dictionary contract
-            // should not be considered as a static type, and in particular mustn't be allowed to
-            // capture type variables: see https://github.com/tweag/nickel/issues/1228.
+            // should not be considered as a static type, but instead work as a contract. In
+            // particular mustn't be allowed to capture type variables from the enclosing type: see
+            // https://github.com/tweag/nickel/issues/1228.
             | TypeF::Dict { attrs: DictAttrs::Lazy, ..}
             | TypeF::Wildcard(_) => Ok(()),
             TypeF::Arrow(ref mut s, ref mut t) => {

--- a/src/pretty.rs
+++ b/src/pretty.rs
@@ -836,7 +836,10 @@ where
             }
             Enum(erows) => erows.pretty(allocator).enclose("[|", "|]"),
             Record(rrows) => rrows.pretty(allocator).braces(),
-            Dict {type_fields: ty, attrs} => allocator
+            Dict {
+                type_fields: ty,
+                attrs,
+            } => allocator
                 .line()
                 .append(allocator.text("_"))
                 .append(allocator.space())

--- a/src/pretty.rs
+++ b/src/pretty.rs
@@ -836,11 +836,14 @@ where
             }
             Enum(erows) => erows.pretty(allocator).enclose("[|", "|]"),
             Record(rrows) => rrows.pretty(allocator).braces(),
-            Dict(ty) => allocator
+            Dict {type_fields: ty, attrs} => allocator
                 .line()
                 .append(allocator.text("_"))
                 .append(allocator.space())
-                .append(allocator.text(":"))
+                .append(match attrs {
+                    DictAttrs::Eager => allocator.text(":"),
+                    DictAttrs::Lazy => allocator.text("|"),
+                })
                 .append(allocator.space())
                 .append(ty.pretty(allocator))
                 .append(allocator.line())

--- a/src/pretty.rs
+++ b/src/pretty.rs
@@ -838,14 +838,14 @@ where
             Record(rrows) => rrows.pretty(allocator).braces(),
             Dict {
                 type_fields: ty,
-                attrs,
+                flavour: attrs,
             } => allocator
                 .line()
                 .append(allocator.text("_"))
                 .append(allocator.space())
                 .append(match attrs {
-                    DictAttrs::Eager => allocator.text(":"),
-                    DictAttrs::Lazy => allocator.text("|"),
+                    DictTypeFlavour::Type => allocator.text(":"),
+                    DictTypeFlavour::Contract => allocator.text("|"),
                 })
                 .append(allocator.space())
                 .append(ty.pretty(allocator))

--- a/src/stdlib.rs
+++ b/src/stdlib.rs
@@ -75,7 +75,8 @@ pub mod internals {
     generate_accessor!(enums);
     generate_accessor!(enum_fail);
     generate_accessor!(record);
-    generate_accessor!(dyn_record);
+    generate_accessor!(dict_type);
+    generate_accessor!(dict_contract);
     generate_accessor!(record_extend);
     generate_accessor!(forall_tail);
     generate_accessor!(dyn_tail);

--- a/src/transform/free_vars.rs
+++ b/src/transform/free_vars.rs
@@ -186,7 +186,7 @@ impl CollectFreeVars for Types {
             | TypeF::Symbol
             | TypeF::Var(_)
             | TypeF::Wildcard(_) => (),
-            TypeF::Forall { body: ty, .. } | TypeF::Dict(ty) | TypeF::Array(ty) => {
+            TypeF::Forall { body: ty, .. } | TypeF::Dict { type_fields: ty, .. } | TypeF::Array(ty) => {
                 ty.as_mut().collect_free_vars(set)
             }
             // No term can appear anywhere in a enum row type, hence we can stop here.

--- a/src/transform/free_vars.rs
+++ b/src/transform/free_vars.rs
@@ -186,9 +186,11 @@ impl CollectFreeVars for Types {
             | TypeF::Symbol
             | TypeF::Var(_)
             | TypeF::Wildcard(_) => (),
-            TypeF::Forall { body: ty, .. } | TypeF::Dict { type_fields: ty, .. } | TypeF::Array(ty) => {
-                ty.as_mut().collect_free_vars(set)
+            TypeF::Forall { body: ty, .. }
+            | TypeF::Dict {
+                type_fields: ty, ..
             }
+            | TypeF::Array(ty) => ty.as_mut().collect_free_vars(set),
             // No term can appear anywhere in a enum row type, hence we can stop here.
             TypeF::Enum(_) => (),
             TypeF::Record(rrows) => rrows.collect_free_vars(set),

--- a/src/typecheck/eq.rs
+++ b/src/typecheck/eq.rs
@@ -445,7 +445,17 @@ fn type_eq_bounded<E: TermEnvironment>(
             | (TypeF::Bool, TypeF::Bool)
             | (TypeF::Symbol, TypeF::Symbol)
             | (TypeF::String, TypeF::String) => true,
-            (TypeF::Dict(uty1), TypeF::Dict(uty2)) | (TypeF::Array(uty1), TypeF::Array(uty2)) => {
+            (
+                TypeF::Dict {
+                    type_fields: uty1,
+                    attrs: attrs1,
+                },
+                TypeF::Dict {
+                    type_fields: uty2,
+                    attrs: attrs2,
+                },
+            ) if attrs1 == attrs2 => type_eq_bounded(state, uty1, env1, uty2, env2),
+            (TypeF::Array(uty1), TypeF::Array(uty2)) => {
                 type_eq_bounded(state, uty1, env1, uty2, env2)
             }
             (TypeF::Arrow(s1, t1), TypeF::Arrow(s2, t2)) => {

--- a/src/typecheck/eq.rs
+++ b/src/typecheck/eq.rs
@@ -448,11 +448,11 @@ fn type_eq_bounded<E: TermEnvironment>(
             (
                 TypeF::Dict {
                     type_fields: uty1,
-                    attrs: attrs1,
+                    flavour: attrs1,
                 },
                 TypeF::Dict {
                     type_fields: uty2,
-                    attrs: attrs2,
+                    flavour: attrs2,
                 },
             ) if attrs1 == attrs2 => type_eq_bounded(state, uty1, env1, uty2, env2),
             (TypeF::Array(uty1), TypeF::Array(uty2)) => {

--- a/src/typecheck/mk_uniftype.rs
+++ b/src/typecheck/mk_uniftype.rs
@@ -1,6 +1,6 @@
 //! Helpers for building `TypeWrapper`s.
 use super::UnifType;
-use crate::types::{DictAttrs, TypeF};
+use crate::types::{DictTypeFlavour, TypeF};
 
 /// Multi-ary arrow constructor for types implementing `Into<TypeWrapper>`.
 #[macro_export]
@@ -101,7 +101,7 @@ where
 {
     UnifType::Concrete(TypeF::Dict {
         type_fields: Box::new(ty.into()),
-        attrs: DictAttrs::Eager,
+        flavour: DictTypeFlavour::Type,
     })
 }
 

--- a/src/typecheck/mk_uniftype.rs
+++ b/src/typecheck/mk_uniftype.rs
@@ -1,6 +1,6 @@
 //! Helpers for building `TypeWrapper`s.
 use super::UnifType;
-use crate::types::{TypeF, DictAttrs};
+use crate::types::{DictAttrs, TypeF};
 
 /// Multi-ary arrow constructor for types implementing `Into<TypeWrapper>`.
 #[macro_export]
@@ -99,7 +99,10 @@ pub fn dict<T>(ty: T) -> UnifType
 where
     T: Into<UnifType>,
 {
-    UnifType::Concrete(TypeF::Dict { type_fields: Box::new(ty.into()), attrs: DictAttrs::Eager})
+    UnifType::Concrete(TypeF::Dict {
+        type_fields: Box::new(ty.into()),
+        attrs: DictAttrs::Eager,
+    })
 }
 
 pub fn array<T>(ty: T) -> UnifType

--- a/src/typecheck/mk_uniftype.rs
+++ b/src/typecheck/mk_uniftype.rs
@@ -1,5 +1,6 @@
 //! Helpers for building `TypeWrapper`s.
-use super::{TypeF, UnifType};
+use super::UnifType;
+use crate::types::{TypeF, DictAttrs};
 
 /// Multi-ary arrow constructor for types implementing `Into<TypeWrapper>`.
 #[macro_export]
@@ -94,11 +95,11 @@ macro_rules! generate_builder {
     };
 }
 
-pub fn dyn_record<T>(ty: T) -> UnifType
+pub fn dict<T>(ty: T) -> UnifType
 where
     T: Into<UnifType>,
 {
-    UnifType::Concrete(TypeF::Dict(Box::new(ty.into())))
+    UnifType::Concrete(TypeF::Dict { type_fields: Box::new(ty.into()), attrs: DictAttrs::Eager})
 }
 
 pub fn array<T>(ty: T) -> UnifType

--- a/src/typecheck/operation.rs
+++ b/src/typecheck/operation.rs
@@ -104,8 +104,8 @@ pub fn get_uop_type(
 
             let f_type = mk_uty_arrow!(TypeF::String, a.clone(), b.clone());
             (
-                mk_uniftype::dyn_record(a),
-                mk_uty_arrow!(f_type, mk_uniftype::dyn_record(b)),
+                mk_uniftype::dict(a),
+                mk_uty_arrow!(f_type, mk_uniftype::dict(b)),
             )
         }
         // forall a b. a -> b -> b
@@ -127,7 +127,7 @@ pub fn get_uop_type(
             let ty_a = UnifType::UnifVar(state.table.fresh_type_var_id());
 
             (
-                mk_uniftype::dyn_record(ty_a),
+                mk_uniftype::dict(ty_a),
                 mk_uniftype::array(mk_uniftype::str()),
             )
         }
@@ -136,7 +136,7 @@ pub fn get_uop_type(
             let ty_a = UnifType::UnifVar(state.table.fresh_type_var_id());
 
             (
-                mk_uniftype::dyn_record(ty_a.clone()),
+                mk_uniftype::dict(ty_a.clone()),
                 mk_uniftype::array(ty_a),
             )
         }
@@ -271,7 +271,7 @@ pub fn get_bop_type(
 
             (
                 mk_uniftype::str(),
-                mk_uniftype::dyn_record(res.clone()),
+                mk_uniftype::dict(res.clone()),
                 res,
             )
         }
@@ -283,8 +283,8 @@ pub fn get_bop_type(
             let res = UnifType::UnifVar(state.table.fresh_type_var_id());
             (
                 mk_uniftype::str(),
-                mk_uniftype::dyn_record(res.clone()),
-                mk_uty_arrow!(res.clone(), mk_uniftype::dyn_record(res)),
+                mk_uniftype::dict(res.clone()),
+                mk_uty_arrow!(res.clone(), mk_uniftype::dict(res)),
             )
         }
         // forall a. Str -> {_ : a} -> {_ : a}
@@ -295,8 +295,8 @@ pub fn get_bop_type(
             let res = UnifType::UnifVar(state.table.fresh_type_var_id());
             (
                 mk_uniftype::str(),
-                mk_uniftype::dyn_record(res.clone()),
-                mk_uty_arrow!(res.clone(), mk_uniftype::dyn_record(res)),
+                mk_uniftype::dict(res.clone()),
+                mk_uty_arrow!(res.clone(), mk_uniftype::dict(res)),
             )
         }
         // forall a. Str -> { _ : a } -> { _ : a}
@@ -304,8 +304,8 @@ pub fn get_bop_type(
             let res = UnifType::UnifVar(state.table.fresh_type_var_id());
             (
                 mk_uniftype::str(),
-                mk_uniftype::dyn_record(res.clone()),
-                mk_uniftype::dyn_record(res),
+                mk_uniftype::dict(res.clone()),
+                mk_uniftype::dict(res),
             )
         }
         // forall a. Str -> {_: a} -> Bool
@@ -313,7 +313,7 @@ pub fn get_bop_type(
             let ty_elt = UnifType::UnifVar(state.table.fresh_type_var_id());
             (
                 mk_uniftype::str(),
-                mk_uniftype::dyn_record(ty_elt),
+                mk_uniftype::dict(ty_elt),
                 mk_uniftype::bool(),
             )
         }
@@ -384,7 +384,7 @@ pub fn get_bop_type(
         // forall a. Dyn -> {_: a} -> Dyn -> {_: a}
         BinaryOp::RecordLazyAssume() => {
             let ty_field = UnifType::UnifVar(state.table.fresh_type_var_id());
-            let ty_dict = mk_uniftype::dyn_record(ty_field);
+            let ty_dict = mk_uniftype::dict(ty_field);
             (
                 mk_uniftype::dynamic(),
                 ty_dict.clone(),
@@ -442,8 +442,8 @@ pub fn get_nop_type(
             vec![
                 mk_uniftype::dynamic(),
                 mk_uniftype::dynamic(),
-                mk_uniftype::dyn_record(mk_uniftype::dynamic()),
-                mk_uniftype::dyn_record(mk_uniftype::dynamic()),
+                mk_uniftype::dict(mk_uniftype::dynamic()),
+                mk_uniftype::dict(mk_uniftype::dynamic()),
             ],
             mk_uniftype::dynamic(),
         ),
@@ -452,7 +452,7 @@ pub fn get_nop_type(
             vec![
                 mk_uniftype::dynamic(),
                 mk_uniftype::dynamic(),
-                mk_uniftype::dyn_record(mk_uniftype::dynamic()),
+                mk_uniftype::dict(mk_uniftype::dynamic()),
             ],
             mk_uniftype::dynamic(),
         ),

--- a/src/typecheck/operation.rs
+++ b/src/typecheck/operation.rs
@@ -135,10 +135,7 @@ pub fn get_uop_type(
         UnaryOp::ValuesOf() => {
             let ty_a = UnifType::UnifVar(state.table.fresh_type_var_id());
 
-            (
-                mk_uniftype::dict(ty_a.clone()),
-                mk_uniftype::array(ty_a),
-            )
+            (mk_uniftype::dict(ty_a.clone()), mk_uniftype::array(ty_a))
         }
         // Str -> Str
         UnaryOp::StrTrim() => (mk_uniftype::str(), mk_uniftype::str()),
@@ -269,11 +266,7 @@ pub fn get_bop_type(
         BinaryOp::DynAccess() => {
             let res = UnifType::UnifVar(state.table.fresh_type_var_id());
 
-            (
-                mk_uniftype::str(),
-                mk_uniftype::dict(res.clone()),
-                res,
-            )
+            (mk_uniftype::str(), mk_uniftype::dict(res.clone()), res)
         }
         // forall a. Str -> {_ : a} -> a -> {_ : a}
         BinaryOp::DynExtend {

--- a/src/types.rs
+++ b/src/types.rs
@@ -161,6 +161,26 @@ impl TryFrom<&Term> for VarKind {
     }
 }
 
+/// Attributes of a dictionary type. There are currently two way of writing a dictionary type: as a
+/// dictionary contract `{_ | T}` or as a dictionary type `{_ : T}`. Ideally, the former wouldn't
+/// actually be a type but mostly syntactic sugar for a builtin contract application.
+///
+/// However, the issue is that the LSP needs to handle dictionary types specifically in order to
+/// provide good completion. As we added dictionary contract just before 1.0 to fix a non trivial
+/// issue with respect to polymorphic contracts ([GitHub
+/// issue](https://github.com/tweag/nickel/issues/1228)), the solution to just tweak dictionary
+/// types to generate a different contract depending on if `{_ | T}` or `{_ : T}` was used seemed
+/// to be the simplest and the one preserving all other features of the LSP, so we went with that.
+///
+/// Dictionary contracts might get a proper AST node later on.
+#[derive(Clone, Debug, Copy, Eq, PartialEq)]
+pub enum DictAttrs {
+    /// Dictionary type (`{_ : T}`)
+    Eager,
+    /// Dictionary contract (`{_ | T}`)
+    Lazy,
+}
+
 /// A Nickel type.
 ///
 /// # Generic representation (functor)
@@ -265,7 +285,7 @@ pub enum TypeF<Ty, RRows, ERows> {
     /// A record type, composed of a sequence of record rows.
     Record(RRows),
     /// A dictionary type.
-    Dict(Ty),
+    Dict { type_fields: Ty, attrs: DictAttrs },
     /// A parametrized array.
     Array(Ty),
     /// A type wildcard, wrapping an ID unique within a given file.
@@ -505,7 +525,10 @@ impl<Ty, RRows, ERows> TypeF<Ty, RRows, ERows> {
             }),
             TypeF::Enum(erows) => Ok(TypeF::Enum(f_erows(erows, state)?)),
             TypeF::Record(rrows) => Ok(TypeF::Record(f_rrows(rrows, state)?)),
-            TypeF::Dict(t) => Ok(TypeF::Dict(f(t, state)?)),
+            TypeF::Dict { type_fields, attrs } => Ok(TypeF::Dict {
+                type_fields: f(type_fields, state)?,
+                attrs,
+            }),
             TypeF::Array(t) => Ok(TypeF::Array(f(t, state)?)),
             TypeF::Wildcard(i) => Ok(TypeF::Wildcard(i)),
         }
@@ -946,8 +969,23 @@ impl Types {
             }
             TypeF::Enum(ref erows) => erows.subcontract()?,
             TypeF::Record(ref rrows) => rrows.subcontract(vars, pol, sy)?,
-            TypeF::Dict(ref ty) => {
-                mk_app!(internals::dyn_record(), ty.subcontract(vars, pol, sy)?)
+            TypeF::Dict {
+                ref type_fields,
+                attrs: DictAttrs::Lazy,
+            } => {
+                mk_app!(
+                    internals::dict_contract(),
+                    type_fields.subcontract(vars, pol, sy)?
+                )
+            }
+            TypeF::Dict {
+                ref type_fields,
+                attrs: DictAttrs::Eager,
+            } => {
+                mk_app!(
+                    internals::dict_type(),
+                    type_fields.subcontract(vars, pol, sy)?
+                )
             }
             TypeF::Wildcard(_) => internals::dynamic(),
         };
@@ -1091,9 +1129,16 @@ impl Display for Types {
                 }
                 write!(f, ". {curr}")
             }
-            TypeF::Enum(row) => write!(f, "[|{row}|]"),
-            TypeF::Record(row) => write!(f, "{{{row}}}"),
-            TypeF::Dict(ty) => write!(f, "{{_: {ty}}}"),
+            TypeF::Enum(row) => write!(f, "[| {row} |]"),
+            TypeF::Record(row) => write!(f, "{{ {row} }}"),
+            TypeF::Dict {
+                type_fields,
+                attrs: DictAttrs::Eager,
+            } => write!(f, "{{ _ : {type_fields}}} "),
+            TypeF::Dict {
+                type_fields,
+                attrs: DictAttrs::Lazy,
+            } => write!(f, "{{ _ | {type_fields}}} "),
             TypeF::Arrow(dom, codom) => match dom.types {
                 TypeF::Arrow(_, _) | TypeF::Forall { .. } => write!(f, "({dom}) -> {codom}"),
                 _ => write!(f, "{dom} -> {codom}"),

--- a/src/types.rs
+++ b/src/types.rs
@@ -1134,11 +1134,11 @@ impl Display for Types {
             TypeF::Dict {
                 type_fields,
                 attrs: DictAttrs::Eager,
-            } => write!(f, "{{ _ : {type_fields}}} "),
+            } => write!(f, "{{ _ : {type_fields} }}"),
             TypeF::Dict {
                 type_fields,
                 attrs: DictAttrs::Lazy,
-            } => write!(f, "{{ _ | {type_fields}}} "),
+            } => write!(f, "{{ _ | {type_fields} }}"),
             TypeF::Arrow(dom, codom) => match dom.types {
                 TypeF::Arrow(_, _) | TypeF::Forall { .. } => write!(f, "({dom}) -> {codom}"),
                 _ => write!(f, "{dom} -> {codom}"),
@@ -1170,6 +1170,7 @@ mod test {
     /// Note that there are infinitely many string representations of the same type since, for
     /// example, spaces are ignored: for the outcome of this function to be meaningful, the
     /// original type must be written in the same way as types are formatted.
+    #[track_caller]
     fn assert_format_eq(s: &str) {
         let ty = parse_type(s);
         assert_eq!(s, &format!("{ty}"));
@@ -1183,15 +1184,17 @@ mod test {
         assert_format_eq("((Number -> Number) -> Number) -> Number");
         assert_format_eq("Number -> (forall a. a -> String) -> String");
 
-        assert_format_eq("{_: String}");
-        assert_format_eq("{_: (String -> String) -> String}");
+        assert_format_eq("{ _ : String }");
+        assert_format_eq("{ _ : (String -> String) -> String }");
+        assert_format_eq("{ _ | String }");
+        assert_format_eq("{ _ | (String -> String) -> String }");
 
-        assert_format_eq("{x: (Bool -> Bool) -> Bool, y: Bool}");
-        assert_format_eq("forall r. {x: Bool, y: Bool, z: Bool ; r}");
-        assert_format_eq("{x: Bool, y: Bool, z: Bool}");
+        assert_format_eq("{ x: (Bool -> Bool) -> Bool, y: Bool }");
+        assert_format_eq("forall r. { x: Bool, y: Bool, z: Bool ; r }");
+        assert_format_eq("{ x: Bool, y: Bool, z: Bool }");
 
-        assert_format_eq("[|`a, `b, `c, `d|]");
-        assert_format_eq("forall r. [|`tag1, `tag2, `tag3 ; r|]");
+        assert_format_eq("[| `a, `b, `c, `d |]");
+        assert_format_eq("forall r. [| `tag1, `tag2, `tag3 ; r |]");
 
         assert_format_eq("Array Number");
         assert_format_eq("Array (Array Number)");
@@ -1201,7 +1204,7 @@ mod test {
 
         assert_format_eq("_");
         assert_format_eq("_ -> _");
-        assert_format_eq("{x: _, y: Bool}");
-        assert_format_eq("{_: _}");
+        assert_format_eq("{ x: _, y: Bool }");
+        assert_format_eq("{ _ : _ }");
     }
 }

--- a/stdlib/internals.ncl
+++ b/stdlib/internals.ncl
@@ -104,7 +104,7 @@
     else
       %blame% (%label_with_message% "not a record" label),
 
-   # Lazy dictionary contract for `{_ | T}`
+  # Lazy dictionary contract for `{_ | T}`
   "$dict_contract" = fun contract label value =>
     if %typeof% value == `Record then
       %record_lazy_assume% (%go_dict% label) value (fun _field => contract)
@@ -114,7 +114,12 @@
   # Eager dictionary contract for `{_ : T}`
   "$dict_type" = fun contract label value =>
     if %typeof% value == `Record then
-      %record_map% value (fun _field field_value => %assume% contract label field_value)
+      %record_map%
+        value
+        (
+          fun _field field_value =>
+            %assume% contract (%go_dict% label) field_value
+        )
     else
       %blame% (%label_with_message% "not a record" label),
 

--- a/stdlib/internals.ncl
+++ b/stdlib/internals.ncl
@@ -104,9 +104,17 @@
     else
       %blame% (%label_with_message% "not a record" label),
 
-  "$dyn_record" = fun contract label value =>
+   # Lazy dictionary contract for `{_ | T}`
+  "$dict_contract" = fun contract label value =>
     if %typeof% value == `Record then
       %record_lazy_assume% (%go_dict% label) value (fun _field => contract)
+    else
+      %blame% (%label_with_message% "not a record" label),
+
+  # Eager dictionary contract for `{_ : T}`
+  "$dict_type" = fun contract label value =>
+    if %typeof% value == `Record then
+      %record_map% value (fun _field field_value => %assume% contract label field_value)
     else
       %blame% (%label_with_message% "not a record" label),
 
@@ -152,8 +160,7 @@
 
   # Recursive priorities operators
 
-  "$rec_force" = fun value => %rec_force% (%force% value),
-  "$rec_default" = fun value => %rec_default% (%force% value),
+  "$rec_force" = fun value => %rec_force% (%force% value),"$rec_default" = fun value => %rec_default% (%force% value),
 
   # Provide access to std.contract.Equal within the initial environement. Merging
   # makes use of `std.contract.Equal`, but it can't blindly substitute such an
@@ -162,3 +169,4 @@
   # environment and prevents it from being shadowed.
   "$stdlib_contract_equal" = std.contract.Equal,
 }
+

--- a/tests/integration/contracts_fail.rs
+++ b/tests/integration/contracts_fail.rs
@@ -296,9 +296,11 @@ fn records_contracts_closed() {
 fn dictionary_contracts() {
     use nickel_lang::label::ty_path::Elem;
 
-    assert_raise_blame!("%force% (({foo} | {_: Number}) & {foo = \"string\"}) true");
+    // dictionary contracts propagate through merging, as opposed to contracts derived from
+    // dictionary types
+    assert_raise_blame!("%force% (({foo} | {_ | Number}) & {foo = \"string\"}) true");
 
-    let res = eval("%force% ({foo = 1} | {_: String}) false");
+    let res = eval("%force% ({foo = 1} | {_ | String}) false");
     match &res {
         Err(Error::EvalError(EvalError::BlameError {
             evaluated_arg: _,

--- a/tests/integration/pass/records.ncl
+++ b/tests/integration/pass/records.ncl
@@ -118,12 +118,12 @@ let {check, ..} = import "lib/assert.ncl" in
 
   # recursive overriding with dictionaries
   # regression tests for [#892](https://github.com/tweag/nickel/issues/892)
-  (({a = 1, b = a} | {_: Number}) & { a | force = 2}).b == 2,
+  (({a = 1, b = a} | {_ | Number}) & { a | force = 2}).b == 2,
 
   ({
      b = { foo = c.foo },
      c = {}
-   } | {_: {
+   } | {_ | {
      foo | default = 0
    } }).b.foo == 0,
 

--- a/tests/integration/pass/records.ncl
+++ b/tests/integration/pass/records.ncl
@@ -132,5 +132,9 @@ let {check, ..} = import "lib/assert.ncl" in
 
   # regression test for [#1224](https://github.com/tweag/nickel/issues/1224)
   std.record.fields ({} | { field | optional = "value" }) == [ "field" ],
+
+  # check that record type don't propagate through merging
+  ({foo = "a"} | {_ : String}) & {foo | force = 1} & {bar = false}
+  == {foo = 1, bar = false},
 ]
 |> check

--- a/tests/integration/typecheck_fail.rs
+++ b/tests/integration/typecheck_fail.rs
@@ -325,11 +325,3 @@ fn locally_different_flat_types() {
         ))
     );
 }
-
-#[test]
-fn dict_contracts_dont_capture_typevar() {
-    assert_matches!(
-        type_check_expr("forall a b. b -> Array b -> {_ | a}"),
-        Err(TypecheckError::UnboundIdentifier(ident, _)) if ident.label() == "a"
-    );
-}

--- a/tests/integration/typecheck_fail.rs
+++ b/tests/integration/typecheck_fail.rs
@@ -325,3 +325,11 @@ fn locally_different_flat_types() {
         ))
     );
 }
+
+#[test]
+fn dict_contracts_dont_capture_typevar() {
+    assert_matches!(
+        type_check_expr("forall a b. b -> Array b -> {_ | a}"),
+        Err(TypecheckError::UnboundIdentifier(ident, _)) if ident.label() == "a"
+    );
+}

--- a/tests/snapshot/snapshots/snapshot__error_dictionary_contract_fail.ncl.snap
+++ b/tests/snapshot/snapshots/snapshot__error_dictionary_contract_fail.ncl.snap
@@ -6,8 +6,8 @@ error: contract broken by a value
   ┌─ [INPUTS_PATH]/errors/dictionary_contract_fail.ncl:1:9
   │
 1 │ { foo = 1, bar = "bar" } | {_: String}
-  │         ^                      ------ expected dictionary field type
+  │         -                      ------ expected dictionary field type
   │         │                       
-  │         applied to this expression
+  │         evaluated to this expression
 
 


### PR DESCRIPTION
Depends on #1271
Closes #1228

Follow-up of #1271. Second part of #1228. Introduce a new construct `{_ | T}` for dictionary contracts, which act like record contracts and propagate. Restore the previous implementation for the contract of `{_ : T}`, which amounts to simply map the contract once over the elements the record. The contract for `{_ | T}` is implemented as the previous (before this PR) contract of `{_ : T}`, the one which is lazy and propagates.

## AST

How to represent the `{_ | T}` node in the AST? I initially thought it should simply be syntactic sugar for a builtin contract, that is `{_ | T}` could be desugared at parsing time to `$dict_contract contract_of_T`. However, that would mean `{_ | T}` would not be understood by the LSP for completion, and wouldn't benefit from the type path calculation inside contract error reporting which helps underline the precise sub contract that fails. Even without thinking about a deadline for 1.0, restoring those capacities is non trivial, because matching on specific primop operation is a bit fragile, and `contract_of_T` would also obfuscate what `T` initially was.

A second solution would be to have a proper AST node for `{_ | T}`, which could be then treated as required by the LSP and the contract error reporting error, and could be evaluated away to the `$dict_contract` application. However, this incurs a non trivial amount of changes, and until now we refrained until from having too many parsing-specific AST nodes (this node is irrelevant and evaluated away at runtime, or could even be at transformation time). This might be the right solution in the long term, but I think we would be better off first splitting the AST in two types, and properly redesign them, with proper nodes for types embedded inside terms, etc.

In the end, the LSP and the error reporting code should treat dictionary contracts the same as a dictionary type: the simplest change was just to use `TypeF::Dict` for both, just with an additional parameter that only impacts contract generation. This means that `{_ | T}` is currently considered a static type equivalent to `{_ : T}`, but I don't think that's a problem. It still can't capture type variables anymore, and its contract should still be enough for type/blame safety (its contract used to be the one of `{ _ : T}` before this PR, anyway).

## TODO

- [x] fix `forall a. {_ | a}` being accepted. Hint: something to do with fixing type variables.