### PR TITLE
Fix escaping of contracts' custom error message

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1517,6 +1517,7 @@ dependencies = [
  "sha2",
  "similar",
  "simple-counter",
+ "strip-ansi-escapes",
  "structopt",
  "termimad",
  "test-generator",
@@ -2437,6 +2438,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "strip-ansi-escapes"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "011cbb39cf7c1f62871aea3cc46e5817b0937b49e9447370c93cacbe93a766d8"
+dependencies = [
+ "vte",
+]
+
+[[package]]
 name = "strsim"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2873,6 +2883,27 @@ name = "void"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
+
+[[package]]
+name = "vte"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cbce692ab4ca2f1f3047fcf732430249c0e971bfdd2b234cf2c47ad93af5983"
+dependencies = [
+ "arrayvec 0.5.2",
+ "utf8parse",
+ "vte_generate_state_changes",
+]
+
+[[package]]
+name = "vte_generate_state_changes"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d257817081c7dffcdbab24b9e62d2def62e2ff7d00b1c20062551e6cccc145ff"
+dependencies = [
+ "proc-macro2 1.0.56",
+ "quote 1.0.26",
+]
 
 [[package]]
 name = "walkdir"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,6 +68,7 @@ typed-arena = "2.0.2"
 malachite = {version = "0.3.2", features = ["enable_serde"] }
 malachite-q = "0.3.2"
 indexmap = {version = "1.9.3", features = ["serde"] }
+strip-ansi-escapes = "0.1.1"
 
 [dev-dependencies]
 pretty_assertions = "1.3.0"

--- a/src/error.rs
+++ b/src/error.rs
@@ -513,9 +513,8 @@ impl From<ExportError> for EvalError {
 /// could alter Nickel's error messages.
 pub fn escape(s: &str) -> String {
     String::from_utf8(
-        s.bytes()
-            .flat_map(std::ascii::escape_default)
-            .collect::<Vec<u8>>(),
+        strip_ansi_escapes::strip(&s)
+            .expect("escape(): unexpected IO error when writing inside a in-memory buffer"),
     )
     .expect("escape(): converting from a string should give back a valid UTF8 string")
 }

--- a/tests/snapshot/inputs/errors/blame_custom_message_ansi_escaping.ncl
+++ b/tests/snapshot/inputs/errors/blame_custom_message_ansi_escaping.ncl
@@ -1,0 +1,1 @@
+null | std.FailWith "\x1B[9;33;47m strike through with background \"and\" \"quotes\""

--- a/tests/snapshot/snapshots/snapshot__error_blame_custom_message_ansi_escaping.ncl.snap
+++ b/tests/snapshot/snapshots/snapshot__error_blame_custom_message_ansi_escaping.ncl.snap
@@ -1,0 +1,13 @@
+---
+source: tests/snapshot/main.rs
+expression: snapshot
+---
+error: contract broken by a value:  strike through with background "and" "quotes"
+  ┌─ [INPUTS_PATH]/errors/blame_custom_message_ansi_escaping.ncl:1:1
+  │
+1 │ null | std.FailWith "\x1B[9;33;47m strike through with background \"and\" \"quotes\""
+  │ ^^^^   ------------------------------------------------------------------------------ expected type
+  │ │       
+  │ applied to this expression
+
+

--- a/tests/snapshot/snapshots/snapshot__error_subcontract_nested_custom_diagnostics.ncl.snap
+++ b/tests/snapshot/snapshots/snapshot__error_subcontract_nested_custom_diagnostics.ncl.snap
@@ -2,7 +2,7 @@
 source: tests/snapshot/main.rs
 expression: snapshot
 ---
-error: contract broken by a value: child\'s message
+error: contract broken by a value: child's message
    ┌─ [INPUTS_PATH]/errors/subcontract_nested_custom_diagnostics.ncl:17:8
    │
 17 │ null | ParentContract
@@ -15,7 +15,7 @@ error: contract broken by a value: child\'s message
    │
    = child's note
 
-note: from a parent contract violation: parent\'s message
+note: from a parent contract violation: parent's message
  = parent's note
 
 


### PR DESCRIPTION
Closes #1251.

Custom contract errors were escaped too aggressively (such as turning `"` into `\"`), while we only want to remove ANSI escape sequences to avoid messing up Nickel's error reporting. This PR uses a specialized crate to do so, instead of Rust's std `escape`.