### PR TITLE
Fix query path parsing

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -405,6 +405,12 @@ pub enum ParseError {
         /// The position of the type annotation.
         annot_span: RawSpan,
     },
+    /// The user provided a field path to run a metadata query, but the parsed field path contains
+    /// string interpolation.
+    InterpolationInQuery {
+        input: String,
+        path_elem_pos: TermPos,
+    },
 }
 
 /// An error occurring during the resolution of an import.
@@ -1603,6 +1609,17 @@ impl IntoDiagnostics<FileId> for ParseError {
                     record type. Please refer to the manual for the defining conditions of a \
                     record type."),
                 ])
+            }
+            ParseError::InterpolationInQuery { input, path_elem_pos } => {
+                Diagnostic::error()
+                    .with_message("string interpolation is forbidden within a query")
+                    .with_labels(vec![
+                        primary_alt(path_elem_pos.into_opt(), input, files),
+                    ])
+                    .with_notes(vec![
+                        "Field paths don't support string interpolation when querying metadata. \
+                        Only identifiers and simple string literals are allowed".into()
+                    ])
             }
         };
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -409,7 +409,7 @@ pub enum ParseError {
     /// string interpolation.
     InterpolationInQuery {
         input: String,
-        path_elem_pos: TermPos,
+        pos_path_elem: TermPos,
     },
 }
 
@@ -1610,7 +1610,7 @@ impl IntoDiagnostics<FileId> for ParseError {
                     record type."),
                 ])
             }
-            ParseError::InterpolationInQuery { input, path_elem_pos } => {
+            ParseError::InterpolationInQuery { input, pos_path_elem: path_elem_pos } => {
                 Diagnostic::error()
                     .with_message("string interpolation is forbidden within a query")
                     .with_labels(vec![

--- a/src/identifier.rs
+++ b/src/identifier.rs
@@ -58,7 +58,7 @@ impl Ident {
     pub fn label_quoted(&self) -> String {
         let reg = Regex::new("^_?[a-zA-Z][_a-zA-Z0-9-]*$").unwrap();
         let label = self.label();
-        if reg.is_match(label) && !KEYWORDS.contains(&&label) {
+        if reg.is_match(label) && !KEYWORDS.contains(&label) {
             String::from(label)
         } else {
             format!("\"{label}\"")

--- a/src/identifier.rs
+++ b/src/identifier.rs
@@ -41,7 +41,7 @@ impl Ident {
     }
 
     /// Create a new fresh identifier. This identifier is unique and is guaranteed not to collide
-    /// with any identifier defined before. Generated identifier starts with a special prefix that
+    /// with any identifier defined before. Generated identifiers start with a special prefix that
     /// can't be used by normal, user-defined identifiers.
     pub fn fresh() -> Self {
         Self::new(format!("{}{}", GEN_PREFIX, GeneratedCounter::next()))

--- a/src/identifier.rs
+++ b/src/identifier.rs
@@ -1,10 +1,11 @@
 //! Define the type of an identifier.
 use once_cell::sync::Lazy;
+use regex::Regex;
 use serde::{Deserialize, Serialize};
 use std::fmt::{self, Debug};
 use std::hash::Hash;
 
-use crate::{position::TermPos, term::string::NickelString};
+use crate::{parser::lexer::KEYWORDS, position::TermPos, term::string::NickelString};
 
 simple_counter::generate_counter!(GeneratedCounter, usize);
 static INTERNER: Lazy<interner::Interner> = Lazy::new(interner::Interner::new);
@@ -39,12 +40,29 @@ impl Ident {
         Self::new_with_pos(label, TermPos::None)
     }
 
+    /// Create a new fresh identifier. This identifier is unique and is guaranteed not to collide
+    /// with any identifier defined before. Generated identifier starts with a special prefix that
+    /// can't be used by normal, user-defined identifiers.
     pub fn fresh() -> Self {
         Self::new(format!("{}{}", GEN_PREFIX, GeneratedCounter::next()))
     }
 
+    /// Return the string representation of this identifier.
     pub fn label(&self) -> &str {
         INTERNER.lookup(self.symbol)
+    }
+
+    /// Return the string representation of this identifier, and add enclosing double quotes if the
+    /// label isn't a valid identifier according to the parser, for example if it contains a
+    /// special character like a space.
+    pub fn label_quoted(&self) -> String {
+        let reg = Regex::new("^_?[a-zA-Z][_a-zA-Z0-9-]*$").unwrap();
+        let label = self.label();
+        if reg.is_match(label) && !KEYWORDS.contains(&&label) {
+            String::from(label)
+        } else {
+            format!("\"{label}\"")
+        }
     }
 
     pub fn into_label(self) -> String {

--- a/src/parser/grammar.lalrpop
+++ b/src/parser/grammar.lalrpop
@@ -443,7 +443,7 @@ RecordLastField: RecordLastField = {
 };
 
 // A field path syntax in a field definition, as in `{foo."bar bar".baz = "value"}`.
-FieldPath: Vec<FieldPathElem> = {
+pub FieldPath: FieldPath = {
     <mut elems: (<FieldPathElem> ".")*> <last: FieldPathElem> => {
         elems.push(last);
         elems

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -89,6 +89,7 @@ macro_rules! generate_lalrpop_parser_impl {
 generate_lalrpop_parser_impl!(grammar::ExtendedTermParser, ExtendedTerm);
 generate_lalrpop_parser_impl!(grammar::TermParser, RichTerm);
 generate_lalrpop_parser_impl!(grammar::FixedTypeParser, Types);
+generate_lalrpop_parser_impl!(grammar::FieldPathParser, utils::FieldPath);
 
 /// Generic interface of the various specialized Nickel parsers.
 ///

--- a/src/program.rs
+++ b/src/program.rs
@@ -94,7 +94,7 @@ impl QueryPath {
                     let as_string = expr.as_ref().try_str_chunk_as_static_str().ok_or(
                         ParseError::InterpolationInQuery {
                             input: s.into(),
-                            path_elem_pos: expr.pos,
+                            pos_path_elem: expr.pos,
                         },
                     )?;
                     Ok(Ident::from(as_string))


### PR DESCRIPTION
Closes #1249.

The parsing of a field path when querying metadata was broken (when using quotes). Instead of duplicating the parsing logic, this commit makes the query path code to piggy back on the actual Nickel parser to parse a field path.