### PR TITLE
Trigger deploy preview on merge queue

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -1,6 +1,7 @@
 name: Deploy preview
 on:
   pull_request:
+  merge_group:
 
 jobs:
   deploy:


### PR DESCRIPTION
This change triggers the deploy preview workflow when PRs are added to the merge queue. Otherwise the merge queue is stuck waiting unsuccessfully on a workflow status that never appears.