### PR TITLE
Use `transform` for the stdlib and `:load` in the REPL

### DIFF
--- a/src/eval/mod.rs
+++ b/src/eval/mod.rs
@@ -870,19 +870,19 @@ pub enum EnvBuildError {
 
 /// Add the bindings of a record to an environment. Ignore the fields defined by interpolation as
 /// well as fields without definition.
-pub fn env_add_term<C: Cache>(
+pub fn env_add_record<C: Cache>(
     cache: &mut C,
     env: &mut Environment,
-    rt: RichTerm,
+    closure: Closure,
 ) -> Result<(), EnvBuildError> {
-    match_sharedterm! {rt.term, with {
+    match_sharedterm! {closure.body.term, with {
             Term::Record(record) | Term::RecRecord(record, ..) => {
                 let ext = record.fields.into_iter().filter_map(|(id, field)| {
                     field.value.map(|value|
                     (
                         id,
                         cache.add(
-                            Closure::atomic_closure(value),
+                            Closure { body: value, env: closure.env.clone() },
                             IdentKind::Record,
                             BindingType::Normal
                         ),
@@ -892,7 +892,7 @@ pub fn env_add_term<C: Cache>(
                 env.extend(ext);
                 Ok(())
             },
-        } else Err(EnvBuildError::NotARecord(rt))
+        } else Err(EnvBuildError::NotARecord(closure.body))
     }
 }
 

--- a/src/repl/mod.rs
+++ b/src/repl/mod.rs
@@ -428,7 +428,7 @@ pub fn print_help(out: &mut impl Write, arg: Option<&str>) -> std::io::Result<()
             Ok(c @ CommandType::Load) => {
                 writeln!(out, ":{c} <file>")?;
                 print_aliases(out, c)?;
-                writeln!(out,"Evaluate the content of <file> to a record and add its fields to the environment.")?;
+                writeln!(out, "Evaluate the content of <file> to a record and add its fields to the environment.")?;
                 writeln!(
                     out,
                     "Fail if the content of <file> doesn't evaluate to a record."


### PR DESCRIPTION
Restrict the use of `transform_inner` to only the internals module in the standard library. This enables recursive references and top-level let bindings in files loaded in the REPL by `:load` and in all other stdlib modules.

Closes #1248.