### PR TITLE
Change the enum tag start delimiter from backtick to single-quote

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -9,8 +9,8 @@ Breaking changes
 - The `Num` builtin type has been renamed to `Number`
 - The `Str` builtin type has been renamed to `String`
 - The `num` stdlib module has been remaned to `number`
-- The `builtin.typeof` function now returns `` `Number ``, `` `String ``,
-  `` `Function `` instead of respectively `` `Num ``, `` `Str ``, and `` `Fun ``
+- The `builtin.typeof` function now returns `'Number`, `'String`, `'Function`
+  instead of respectively `'Num`, `'Str`, and `'Fun`
 - The `builtin.is_num`, `builtin.is_str` and `builtin.to_str` functions hav been
   renamed to `is_number`, `is_string` and `to_string`
 - The `string.to_num` and `string.from_num` functions have been renamed to

--- a/benches/arrays/sort.ncl
+++ b/benches/arrays/sort.ncl
@@ -1,7 +1,7 @@
 let ascending = fun x y => 
-  if x < y then `Lesser 
-  else if x == y then `Equal 
-  else `Greater 
+  if x < y then 'Lesser 
+  else if x == y then 'Equal 
+  else 'Greater 
 in
 
 { run = std.array.sort ascending }

--- a/benches/mantis.rs
+++ b/benches/mantis.rs
@@ -8,13 +8,13 @@ ncl_bench_group! {
     {
         name = "mantis",
         path = "mantis/run",
-        args = (r#"{namespace = "mantis-staging", job="miner", role=`miner}"#),
+        args = (r#"{namespace = "mantis-staging", job="miner", role='miner}"#),
         eval_mode = EvalMode::DeepSeq,
     }, {
         name = "mantis serialize",
         path = "mantis/run",
         subtest = "serialize",
-        args = (r#"{namespace = "mantis-staging", job="miner", role=`miner}"#),
+        args = (r#"{namespace = "mantis-staging", job="miner", role='miner}"#),
     }
 }
 criterion_main!(benches);

--- a/benches/mantis/deploy-example.ncl
+++ b/benches/mantis/deploy-example.ncl
@@ -2,5 +2,5 @@ import "deploy.ncl"
   {
     namespace = "mantis-staging",
     job = "miner",
-    role = `miner,
+    role = 'miner,
   }

--- a/benches/mantis/deploy.ncl
+++ b/benches/mantis/deploy.ncl
@@ -62,7 +62,7 @@ fun vars =>
     logLevel | default = "INFO",
     loggers = defaultLoggers,
     job = vars.job,
-    role | [| `passive, `miner, `backup |] = vars.role,
+    role | [| 'passive, 'miner, 'backup |] = vars.role,
     reschedule = {},
   }
   in
@@ -79,7 +79,7 @@ fun vars =>
   let miner_ =
     jobDefs.Mantis
     & {
-      role = `miner,
+      role = 'miner,
       mantisRev = revisions.mantisRev
     }
   in

--- a/benches/mantis/jobs/mantis.ncl
+++ b/benches/mantis/jobs/mantis.ncl
@@ -10,7 +10,7 @@ let Params = {
     | std.number.Nat
     | default
     = 5,
-  role | [| `passive, `miner, `backup |],
+  role | [| 'passive, 'miner, 'backup |],
   datacenters | Dyn,
   job | Dyn,
   namespace | String,
@@ -54,11 +54,11 @@ fun params =>
   & (
     if params.network == "etc" then
       {
-        type = `batch,
+        type = 'batch,
         periodic = {
           prohibit_overlap = true,
           cron = "@daily",
-          time_zone = `UTC,
+          time_zone = 'UTC,
         }
       }
     else
@@ -67,11 +67,11 @@ fun params =>
   & (
     if params.network != "etc" then
       {
-        type = `service,
+        type = 'service,
 
         update = {
           max_parallel = 1,
-          health_check = `checks,
+          health_check = 'checks,
           min_healthy_time = "1m",
           # Give enough time for the DAG generation
           healthy_deadline = "15m",
@@ -90,7 +90,7 @@ fun params =>
       {
         count = params.count,
         network = {
-          mode = `host,
+          mode = 'host,
           port = {
             discovery = {},
             metrics = {},
@@ -147,11 +147,11 @@ fun params =>
         # #baseTags: [namespace, #role, "mantis-${NOMAD_ALLOC_INDEX}"]
       }
       & (
-        if params.role == `passive then
+        if params.role == 'passive then
           {
             #TODO: dependent if
             service."%{params.namespace}-mantis-%{std.string.from_enum params.role}-rpc" = {
-              address_mode = `host,
+              address_mode = 'host,
               port = "rpc",
               tags =
                 [
@@ -175,11 +175,11 @@ params.role}.rule=Host(`%{params.namespace}-%{std.string.from_enum params.role}.
         service."%{params.namespace}-mantis-%{std.string.from_enum params.role}-rpc" = {
           check.rpc =
             {
-              address_mode = `host,
+              address_mode = 'host,
               interval = "10s",
               port = "rpc",
               timeout = "3s",
-              type = `http,
+              type = 'http,
               path = "/healthcheck",
             }
             & (
@@ -196,11 +196,11 @@ params.role}.rule=Host(`%{params.namespace}-%{std.string.from_enum params.role}.
         }
       }
       & (
-        if params.role == `miner then
+        if params.role == 'miner then
           {
             # TODO: dependent if
             service."%{params.namespace}-mantis-%{std.string.from_enum params.role}-rpc" = {
-              address_mode = `host,
+              address_mode = 'host,
               port = "rpc",
               tags = ["rpc"] @ baseTags,
             }
@@ -211,13 +211,13 @@ params.role}.rule=Host(`%{params.namespace}-%{std.string.from_enum params.role}.
       & {
         service = {
           "%{params.namespace}-mantis-%{std.string.from_enum params.role}-prometheus" = {
-            address_mode = `host,
+            address_mode = 'host,
             port = "metrics",
             tags = ["prometheus"] @ baseTags,
           },
 
           "%{params.namespace}-%{std.string.from_enum params.role}-${NOMAD_ALLOC_INDEX}" = {
-            address_mode = `host,
+            address_mode = 'host,
             port = "rpc",
             tags =
               [
@@ -236,7 +236,7 @@ params.role}.rule=Host(`%{params.namespace}-%{std.string.from_enum params.role}.
               port = "discovery",
             }
             & (
-              if params.role == `miner then
+              if params.role == 'miner then
                 {
                   tags =
                     [
@@ -253,7 +253,7 @@ params.role}.rule=Host(`%{params.namespace}-%{std.string.from_enum params.role}.
                 {}
             )
             & (
-              if params.role == `passive then
+              if params.role == 'passive then
                 {
                   tags = ["discovery"] @ baseTags
                 }
@@ -269,11 +269,11 @@ params.role}.rule=Host(`%{params.namespace}-%{std.string.from_enum params.role}.
 
           "%{params.namespace}-mantis-%{std.string.from_enum params.role}-server-${NOMAD_ALLOC_INDEX}" =
             {
-              address_mode = `host,
+              address_mode = 'host,
               port = "server",
             }
             & (
-              if params.role == `miner then
+              if params.role == 'miner then
                 {
                   tags =
                     [
@@ -289,7 +289,7 @@ params.role}.rule=Host(`%{params.namespace}-%{std.string.from_enum params.role}.
                 {}
             )
             & (
-              if params.role == `passive then
+              if params.role == 'passive then
                 {
                   tags = ["server"] @ baseTags,
                 }
@@ -304,11 +304,11 @@ params.role}.rule=Host(`%{params.namespace}-%{std.string.from_enum params.role}.
 
               check.server =
                 {
-                  address_mode = `host,
+                  address_mode = 'host,
                   interval = "10s",
                   port = "server",
                   timeout = "3s",
-                  type = `tcp,
+                  type = 'tcp,
                 }
                 & (
                   if params.network != "etc" then
@@ -324,7 +324,7 @@ params.role}.rule=Host(`%{params.namespace}-%{std.string.from_enum params.role}.
             },
 
           "%{params.namespace}-mantis-%{std.string.from_enum params.role}-server" = {
-            address_mode = `host,
+            address_mode = 'host,
             port = "server",
             tags = [ "ingress", "server" ] @ baseTags,
             meta = {
@@ -334,7 +334,7 @@ params.role}.rule=Host(`%{params.namespace}-%{std.string.from_enum params.role}.
           },
 
           "%{params.namespace}-mantis-%{std.string.from_enum params.role}" = {
-            address_mode = `host,
+            address_mode = 'host,
             port = "server",
             tags = ["server"] @ baseTags,
             meta = {

--- a/benches/mantis/run.ncl
+++ b/benches/mantis/run.ncl
@@ -2,6 +2,6 @@
   run = import "deploy.ncl",
   serialize.run = fun args =>
     (
-      std.serialize `Json (run args)
+      std.serialize 'Json (run args)
     )
 }

--- a/benches/mantis/schemas/nomad/types.ncl
+++ b/benches/mantis/schemas/nomad/types.ncl
@@ -14,7 +14,7 @@ in
       Namespace | String,
       Id | Name,
       Name | String,
-      Type | [| `service, `system, `batch |],
+      Type | [| 'service, 'system, 'batch |],
       Priority | std.number.Nat,
       Datacenters | std.array.NonEmpty,
       TaskGroups
@@ -221,9 +221,9 @@ in
 
     Migrate = {
       HealthCheck
-        | [| `checks, `task_states |]
+        | [| 'checks, 'task_states |]
         | default
-        = `checks,
+        = 'checks,
       HealthyDeadline
         | std.number.Nat
         | default
@@ -260,9 +260,9 @@ in
       AutoRevert | Bool | default = false,
       Canary | std.number.Nat | default = 0,
       HealthCheck
-        | [| `checks, `task_states, `manual |]
+        | [| 'checks, 'task_states, 'manual |]
         | default
-        = `checks,
+        = 'checks,
       HealthyDeadline | lib.contracts.Nullable std.number.Nat | default = null,
       MaxParallel | std.number.Nat | default = 1,
       MinHealthyTime | lib.contracts.Nullable std.number.Nat | default = null,
@@ -344,7 +344,7 @@ in
     },
 
     Network = {
-      Mode | [| `host, `bridge |] | default = `host,
+      Mode | [| 'host, 'bridge |] | default = 'host,
       Device | String | default = "",
       CIDR | String | default = "",
       IP | String | default = "",
@@ -355,7 +355,7 @@ in
     },
 
     ServiceCheck = {
-      AddressMode | [| `alloc, `driver, `host |],
+      AddressMode | [| 'alloc, 'driver, 'host |],
       Args | lib.contracts.Nullable (Array String) | default = null,
       CheckRestart | json.CheckRestart,
       Command | String | default = "",
@@ -373,7 +373,7 @@ in
       TaskName | String | default = "",
       Timeout | std.number.Nat,
       TLSSkipVerify | Bool | default = false,
-      Type | [| `http, `tcp, `script, `grpc |],
+      Type | [| 'http, 'tcp, 'script, 'grpc |],
       Body | lib.contracts.Nullable String | default = null,
       # TODO  Header  [string]  [...string]
     },
@@ -387,7 +387,7 @@ in
         },
 
     Lifecycle = {
-      Hook | [| `prestart, `poststart, `poststop |],
+      Hook | [| 'prestart, 'poststart, 'poststop |],
       Sidecar | lib.contracts.Nullable Bool | default = null,
     },
 
@@ -414,7 +414,7 @@ in
         | default
         = false,
       PortLabel | String,
-      AddressMode | [| `alloc, `auto, `driver, `host |],
+      AddressMode | [| 'alloc, 'auto, 'driver, 'host |],
       Checks
         | Array ServiceCheck
         | default
@@ -427,7 +427,7 @@ in
 
     Task = {
       Name | String,
-      Driver | [| `exec, `docker, `nspawn |],
+      Driver | [| 'exec, 'docker, 'nspawn |],
       Config
         | stanza.taskConfig
         | { driver | Driver },
@@ -497,7 +497,7 @@ in
       GetterSource | String,
       # TODO GetterOptions: [string]: string
       # TODO GetterHeaders: [string]: string
-      GetterMode | [| `any, `file, `dir |] | default = `any,
+      GetterMode | [| 'any, 'file, 'dir |] | default = 'any,
       RelativeDest | String,
     },
 
@@ -505,7 +505,7 @@ in
       SourcePath | String | default = "",
       DestPath | String,
       EmbeddedTmpl | String,
-      ChangeMode | [| `restart, `noop, `signal |] | default = `restart,
+      ChangeMode | [| 'restart, 'noop, 'signal |] | default = 'restart,
       ChangeSignal | String | default = "",
       Splay | std.number.Nat | default = 5000000000,
       Perms | lib.contracts.MatchRegexp "^[0-7]{4}$" | default = "0644",
@@ -515,7 +515,7 @@ in
     },
 
     Vault = {
-      ChangeMode | [| `noop, `restart, `signal |] | default = `restart,
+      ChangeMode | [| 'noop, 'restart, 'signal |] | default = 'restart,
       ChangeSignal | String | default = "",
       Env | Bool | default = true,
       Namespace | String | default = "",
@@ -1063,14 +1063,14 @@ in
 
   stanza = {
     job =
-      let type_schema = [| `batch, `service, `system |] in
+      let type_schema = [| 'batch, 'service, 'system |] in
       {
         datacenters | std.array.NonEmpty,
         namespace | String,
         type
           | type_schema
           | default
-          = `service,
+          = 'service,
         affinities
           | Array stanza.affinity
           | default
@@ -1087,7 +1087,7 @@ in
           | {
             _ : stanza.group
             & {
-              type | type_schema | default = `service
+              type | type_schema | default = 'service
             }
           },
         update
@@ -1114,9 +1114,9 @@ in
 
     migrate = {
       health_check
-        | [| `checks, `task_states |]
+        | [| 'checks, 'task_states |]
         | default
-        = `checks,
+        = 'checks,
       healthy_deadline
         | std.number.Nat
         | default
@@ -1256,7 +1256,7 @@ in
         },
 
     group = {
-      type | [| `service, `batch, `system |],
+      type | [| 'service, 'batch, 'system |],
       affinities
         | Array stanza.affinity
         | default
@@ -1292,16 +1292,16 @@ in
         = null,
       reschedule
         | stanza.reschedule
-        & { type | [| `service, `batch, `system |] }
+        & { type | [| 'service, 'batch, 'system |] }
         | default
         = {},
     },
 
     reschedule = {
       type
-        | [| `batch, `service, `system |]
+        | [| 'batch, 'service, 'system |]
         | default
-        = `service,
+        = 'service,
 
       # TODO: convert with ifs or sth
       # if #type == "batch" {
@@ -1324,7 +1324,7 @@ in
     },
 
     network = {
-      mode | [| `host, `bridge |],
+      mode | [| 'host, 'bridge |],
       dns
         | lib.contracts.Nullable
           {
@@ -1370,9 +1370,9 @@ in
         = null,
       port | String,
       address_mode
-        | [| `alloc, `driver, `auto, `host |]
+        | [| 'alloc, 'driver, 'auto, 'host |]
         | default
-        = `auto,
+        = 'auto,
       tags
         | Array String
         | default
@@ -1387,10 +1387,10 @@ in
 
     check = {
       address_mode
-        | [| `alloc, `driver, `host |]
+        | [| 'alloc, 'driver, 'host |]
         | default
-        = `driver,
-      type | [| `http, `tcp, `script, `grpc |],
+        = 'driver,
+      type | [| 'http, 'tcp, 'script, 'grpc |],
       port | String,
       interval | Duration,
       timeout | Duration,
@@ -1486,7 +1486,7 @@ in
     },
 
     lifecycle = {
-      hook | [| `prestart, `poststart, `poststop |],
+      hook | [| 'prestart, 'poststart, 'poststop |],
       sidecar
         | lib.contracts.Nullable Bool
         | default
@@ -1517,9 +1517,9 @@ in
             # destination | Destination,
             headers | { _ : String },
             mode
-              | [| `any, `file, `dir |]
+              | [| 'any, 'file, 'dir |]
               | default
-              = `any,
+              = 'any,
             options | { _ : String },
             source | String,
           }
@@ -1539,7 +1539,7 @@ in
       # meantime, allow config field:
       config | { .. },
 
-      driver | [| `exec, `docker, `nspawn |],
+      driver | [| 'exec, 'docker, 'nspawn |],
 
       env
         | { _ : String }
@@ -1601,9 +1601,9 @@ in
               | default
               = false,
             change_mode
-              | [| `restart, `noop, `signal |]
+              | [| 'restart, 'noop, 'signal |]
               | default
-              = `restart,
+              = 'restart,
             change_signal
               | String
               | default
@@ -1652,7 +1652,7 @@ in
       interval | Duration,
       attempts | std.number.PosNat,
       delay | Duration,
-      mode | [| `delay, `fail |],
+      mode | [| 'delay, 'fail |],
     },
 
     update = {
@@ -1669,9 +1669,9 @@ in
         | default
         = 0,
       health_check
-        | [| `checks, `task_states, `manual |]
+        | [| 'checks, 'task_states, 'manual |]
         | default
-        = `checks,
+        = 'checks,
       healthy_deadline
         | Duration
         | default
@@ -1696,9 +1696,9 @@ in
 
     vault = {
       change_mode
-        | [| `noop, `restart, `signal |]
+        | [| 'noop, 'restart, 'signal |]
         | default
-        = `restart,
+        = 'restart,
       change_signal
         | String
         | default
@@ -1718,7 +1718,7 @@ in
     },
 
     volume = {
-      type | [| `host, `csi |],
+      type | [| 'host, 'csi |],
       source | String,
       read_only
         | Bool

--- a/benches/mantis/tasks/promtail.ncl
+++ b/benches/mantis/tasks/promtail.ncl
@@ -1,7 +1,7 @@
 let types = import "../schemas/nomad/types.ncl" in
 types.stanza.task
 & {
-  driver = `exec,
+  driver = 'exec,
 
   resources = {
     cpu = 100,
@@ -16,7 +16,7 @@ types.stanza.task
 
   template."local/config.yaml".data =
     std.serialize
-      `Yaml
+      'Yaml
       {
         server = {
           http_listen_port = 0,

--- a/benches/mantis/tasks/telegraf.ncl
+++ b/benches/mantis/tasks/telegraf.ncl
@@ -6,11 +6,11 @@ let types = import "../schemas/nomad/types.ncl" in
     | default
     = "{{ env \"NOMAD_JOB_NAME\" }}-{{ env \"NOMAD_ALLOC_INDEX\" }}",
 
-  driver = `exec,
+  driver = 'exec,
 
   vault = {
     policies = ["nomad-cluster"],
-    change_mode = `noop,
+    change_mode = 'noop,
   },
 
   resources = {

--- a/benches/serialization/main.ncl
+++ b/benches/serialization/main.ncl
@@ -1,6 +1,6 @@
 
 {
     input.run = (
-        std.serialize `Json (import "input.json")
+        std.serialize 'Json (import "input.json")
     )
 }

--- a/doc/manual/contracts.md
+++ b/doc/manual/contracts.md
@@ -364,7 +364,7 @@ let Schema = {
   bar | Number,
 }
 nickel> let config | Schema = {bar = 2}
-nickel> std.serialize `Json config
+nickel> std.serialize 'Json config
 "{
   "bar": 2,
   "foo": "foo"
@@ -410,7 +410,7 @@ let Secure = {
   must_be_very_secure | Bool = true,
   data | String,
 }
-nickel> std.serialize `Json ({data = ""} | Secure)
+nickel> std.serialize 'Json ({data = ""} | Secure)
 "{
   "data": "",
   "must_be_very_secure": true

--- a/doc/manual/merging.md
+++ b/doc/manual/merging.md
@@ -284,7 +284,7 @@ A field can be marked as optional using the `optional` annotation:
     command
       | String,
     arg_type
-      | [| `String, `Number |],
+      | [| 'String, 'Number |],
     alias
       | String
       | optional,
@@ -301,7 +301,7 @@ field:
 ```nickel
 {
   command = "exit",
-  arg_type = `String,
+  arg_type = 'String,
   alias = "e",
 } | Command
 ```

--- a/doc/manual/syntax.md
+++ b/doc/manual/syntax.md
@@ -283,47 +283,46 @@ The following examples show how symbolic strings are desugared:
 ```text
 > mytag-s%"I'm %{"symbolic"} with %{"fragments"}"%
 {
-  tag = `SymbolicString,
-  prefix = `mytag
+  tag = 'SymbolicString,
+  prefix = 'mytag
   fragments = [ "I'm ", "symbolic", " with ", "fragments" ],
 }
 
 > let terraform_computed_field = {
-    tag = `TfComputed,
+    tag = 'TfComputed,
     resource = "foo",
     field = "id",
   }
 > tf-s%"id: %{terraform_computed_field}, port: %{5}"%
 {
-  tag = `SymbolicString
-  prefix = `tf,
-  fragments = [ "id: ", { resource = "foo", field = "id", tag = `TfComputed }, ", port: ", 5 ],
+  tag = 'SymbolicString
+  prefix = 'tf,
+  fragments = [ "id: ", { resource = "foo", field = "id", tag = 'TfComputed }, ", port: ", 5 ],
 }
 ```
 
 #### Enum tags
 
 Enumeration tags are used to express a choice among finitely many alternatives.
-They are formed by writing a backtick `` ` `` followed by any valid identifier
+They are formed by writing a single quote `'` followed by any valid identifier
 or by a quoted string. For example, `std.serialize` takes an export format as a
-first argument, which is an enum tag among `` `Json ``, `` `Toml `` or `` `Yaml
-``:
+first argument, which is an enum tag among `'Json`, `'Toml` or `'Yaml`:
 
 ```nickel
-> std.serialize `Json {foo = 1}
+> std.serialize 'Json {foo = 1}
 "{
    \"foo\": 1
  }"
 
-> std.serialize `Toml {foo = 1}
+> std.serialize 'Toml {foo = 1}
 "foo = 1
 "
 ```
 
-An enum tag `` `foo `` is serialized as the string `"foo"`:
+An enum tag `'foo` is serialized as the string `"foo"`:
 
 ```nickel
-> std.serialize `Json {foo = `bar}
+> std.serialize 'Json {foo = 'bar}
 "{
   \"foo\": \"bar\"
 }"
@@ -674,11 +673,11 @@ Nickel features the following builtin types and type constructors:
 represents any value)
 - Arrays: `Array <type>` is an array whose elements are of type `<type>`.
 - Dictionaries: `{_ : <type>}` is a record whose fields are of type `<type>`.
-- Enums: ``[| `tag1, .., `tagn |]`` is an enumeration comprised of the alternatives
-  `` `tag1 ``, .., `` `tagn``. Tags have the same syntax as identifiers and must
-  be prefixed with a backtick `` ` ``. Like record fields, they can however be
+- Enums: `[| 'tag1, .., 'tagn |]` is an enumeration comprised of the alternatives
+  `'tag1`, .., `'tagn`. Tags have the same syntax as identifiers and must
+  be prefixed with a single quote `'`. Like record fields, they can however be
   enclosed in double quotes if they contain special characters:
-  `` `"tag with space" ``.
+  `'"tag with space"`.
 - Arrows: `<source> -> <target>` is a function taking an argument of type
   `<source>` and returns values of type `<target>`.
 - Foralls: `forall var1 .. varn. <type>` is a polymorphic type quantifying over type
@@ -711,14 +710,14 @@ Here are some examples of more complicated types in Nickel:
 { foo = [ [ 1 ] ] }
 
 > let select
-    : forall a. {left: a, right: a} -> [| `left, `right |] -> a
+    : forall a. {left: a, right: a} -> [| 'left, 'right |] -> a
     = fun {left, right} =>
        match {
-         `left => left,
-         `right => right,
+         'left => left,
+         'right => right,
        }
   in
-  (select {left = true, right = false} `left) : Bool
+  (select {left = true, right = false} 'left) : Bool
 true
 
 > let add_foo : forall a. {_: a} -> a -> {_: a} = fun dict value =>
@@ -905,7 +904,7 @@ record is serialized. This includes the output of the `nickel export` command:
 > value
 { foo = 1, bar = 2 }
 
-> std.serialize `Json value
+> std.serialize 'Json value
 "{
   "foo": 1
 }"

--- a/doc/manual/typing.md
+++ b/doc/manual/typing.md
@@ -219,7 +219,7 @@ The following type constructors are available:
   std.record.map (fun char count => count + 1) occurrences : {_ : Number}
   ```
 
-- **Enum**: ``[| `tag1, .., `tagn |]``: an enumeration comprised of alternatives
+- **Enum**: ``[| 'tag1, .., 'tagn |]``: an enumeration comprised of alternatives
   `tag1`, .., `tagn`. An enumeration literal is prefixed with a backtick and
   serialized as a string. It is useful to encode finite alternatives. The
   advantage over strings is that the typechecker handles them more finely: it is
@@ -228,11 +228,11 @@ The following type constructors are available:
   Example:
 
   ```nickel
-  let protocol : [| `http, `ftp, `sftp |] = `http in
+  let protocol : [| 'http, 'ftp, 'sftp |] = 'http in
   (protocol |> match {
-    `http => 1,
-    `ftp => 2,
-    `sftp => 3
+    'http => 1,
+    'ftp => 2,
+    'sftp => 3
   }) : Number
   ```
 
@@ -430,9 +430,9 @@ tail that can be substituted for something else. For example:
 
 ```nickel
 {
-  port_of : forall a. [| `http, `ftp; a |] -> Number = match {
-      `http => 80,
-      `ftp => 21,
+  port_of : forall a. [| 'http, 'ftp; a |] -> Number = match {
+      'http => 80,
+      'ftp => 21,
       _ => 8000,
     }
 }

--- a/examples/README.md
+++ b/examples/README.md
@@ -62,7 +62,7 @@ nickel>
   and print the result as JSON:
 
     ```text
-    nickel> builtin.serialize `Json (import "merge-main.ncl")
+    nickel> builtin.serialize 'Json (import "merge-main.ncl")
     "{
         \"firewall\": {
         ...

--- a/examples/README.md
+++ b/examples/README.md
@@ -36,7 +36,7 @@ data!
 
     ```console
     $ nickel -f record-contract.ncl query kind
-      • contract: [|`ReplicationController, `ReplicaSet, `Pod|]
+      • contract: [|'ReplicationController, 'ReplicaSet, 'Pod|]
       • documentation: The kind of the element being configured.
     ```
 
@@ -76,7 +76,7 @@ nickel>
     ```text
     nickel>let config = import "record-contract.ncl"
     nickel>:query config.kind
-    • contract: [| `ReplicationController, `ReplicaSet, `Pod |]
+    • contract: [| 'ReplicationController, 'ReplicaSet, 'Pod |]
     • documentation: The kind of the element being configured.
 
     nickel>

--- a/examples/record-contract/record-contract.ncl
+++ b/examples/record-contract/record-contract.ncl
@@ -26,9 +26,9 @@ let Container = {
 } in
 
 let KubernetesConfig = {
-  kind | [| `ReplicationController, `ReplicaSet, `Pod |]
+  kind | [| 'ReplicationController, 'ReplicaSet, 'Pod |]
        | doc "The kind of the element being configured."
-       | default = `Pod,
+       | default = 'Pod,
 
   apiVersion | String,
 
@@ -58,7 +58,7 @@ let metadata_ = {
   } in
 
 {
-  kind = `ReplicationController,
+  kind = 'ReplicationController,
   apiVersion = "1.1.0",
   metadata = metadata_,
   spec = {

--- a/src/deserialize.rs
+++ b/src/deserialize.rs
@@ -623,7 +623,7 @@ mod tests {
             A::deserialize(
                 TestProgram::new_from_source(
                     Cursor::new(
-                        br#"{ a = 10, b = "test string", c = null, d = true, e = `foo, f = null, g = -10, h = { bar = "some other string" } }"#.to_vec()
+                        br#"{ a = 10, b = "test string", c = null, d = true, e = 'foo, f = null, g = -10, h = { bar = "some other string" } }"#.to_vec()
                     ),
                     "source"
                 )

--- a/src/eval/operation.rs
+++ b/src/eval/operation.rs
@@ -1797,7 +1797,7 @@ impl<R: ImportResolver, C: Cache> VirtualMachine<R, C> {
                 let mk_err_fst = |t1| {
                     Err(mk_type_error!(
                         "hash",
-                        "[| `Md5, `Sha1, `Sha256, `Sha512 |]",
+                        "[| 'Md5, 'Sha1, 'Sha256, 'Sha512 |]",
                         1,
                         t1,
                         pos1
@@ -1845,7 +1845,7 @@ impl<R: ImportResolver, C: Cache> VirtualMachine<R, C> {
                 let mk_err_fst = |t1| {
                     Err(mk_type_error!(
                         "serialize",
-                        "[| `Json, `Yaml, `Toml |]",
+                        "[| 'Json, 'Yaml, 'Toml |]",
                         1,
                         t1,
                         pos1
@@ -1885,7 +1885,7 @@ impl<R: ImportResolver, C: Cache> VirtualMachine<R, C> {
                 let mk_err_fst = |t1| {
                     Err(mk_type_error!(
                         "deserialize",
-                        "[| `Json, `Yaml, `Toml |]",
+                        "[| 'Json, 'Yaml, 'Toml |]",
                         1,
                         t1,
                         pos1

--- a/src/eval/tests.rs
+++ b/src/eval/tests.rs
@@ -331,10 +331,10 @@ fn substitution() {
         parse("let x = 1 in if true then 1 + (if false then 1 else \"Glob2\") else false").unwrap()
     );
 
-    let t = parse("match{`x => [1, glob1], `y => loc2, `z => {id = true, other = glob3}} loc1")
+    let t = parse("match{'x => [1, glob1], 'y => loc2, 'z => {id = true, other = glob3}} loc1")
         .unwrap();
     assert_eq!(
         subst(&eval_cache, t, &initial_env, &env),
-        parse("match {`x => [1, 1], `y => (if false then 1 else \"Glob2\"), `z => {id = true, other = false}} true").unwrap()
+        parse("match {'x => [1, 1], 'y => (if false then 1 else \"Glob2\"), 'z => {id = true, other = false}} true").unwrap()
     );
 }

--- a/src/parser/grammar.lalrpop
+++ b/src/parser/grammar.lalrpop
@@ -624,7 +624,7 @@ StaticString : String = {
     MultilineStaticString,
 }
 
-StringEnumTag = DelimitedStaticString<"`\"", "\"">;
+StringEnumTag = DelimitedStaticString<"'\"", "\"">;
 
 EnumTag: Ident = {
   "raw enum tag" => <>.into(),
@@ -960,7 +960,7 @@ extern {
         "num literal" => Token::Normal(NormalToken::NumLiteral(<Number>)),
 
         "raw enum tag" => Token::Normal(NormalToken::RawEnumTag(<&'input str>)),
-        "`\"" => Token::Normal(NormalToken::StrEnumTagBegin),
+        "'\"" => Token::Normal(NormalToken::StrEnumTagBegin),
 
         "if" => Token::Normal(NormalToken::If),
         "then" => Token::Normal(NormalToken::Then),

--- a/src/parser/lexer.rs
+++ b/src/parser/lexer.rs
@@ -59,7 +59,7 @@ pub enum NormalToken<'input> {
     #[regex("[ \r\t\n]+", logos::skip)]
     // multiline strings cannot be used as enum tags, so we explicitly
     // disallow that pattern.
-    #[regex("`m(%)+\"")]
+    #[regex("'m(%)+\"")]
     #[error]
     Error,
 
@@ -74,9 +74,9 @@ pub enum NormalToken<'input> {
 
     // **IMPORTANT**
     // This regex should be kept in sync with the one for Identifier above.
-    #[regex("`_?[a-zA-Z][_a-zA-Z0-9-']*", |lex| lex.slice().split_at(1).1)]
+    #[regex("'_?[a-zA-Z][_a-zA-Z0-9-']*", |lex| lex.slice().split_at(1).1)]
     RawEnumTag(&'input str),
-    #[token("`\"")]
+    #[token("'\"")]
     StrEnumTagBegin,
 
     #[token("Dyn")]

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -208,28 +208,28 @@ fn enum_terms() {
     let success_cases = [
         (
             "simple raw enum tag",
-            "`foo",
+            "'foo",
             Enum(Ident::from("foo")).into(),
         ),
         (
             "raw enum tag with keyword ident",
-            "`if",
+            "'if",
             Enum(Ident::from("if")).into(),
         ),
-        ("empty string tag", "`\"\"", Enum(Ident::from("")).into()),
+        ("empty string tag", "'\"\"", Enum(Ident::from("")).into()),
         (
             "string tag with non-ident chars",
-            "`\"foo:bar\"",
+            "'\"foo:bar\"",
             Enum(Ident::from("foo:bar")).into(),
         ),
         (
             "string with spaces",
-            "`\"this works!\"",
+            "'\"this works!\"",
             Enum(Ident::from("this works!")).into(),
         ),
         (
             "match with raw tags",
-            "match { `foo => true, `bar => false, _ => 456, } 123",
+            "match { 'foo => true, 'bar => false, _ => 456, } 123",
             mk_app!(
                 mk_match!(("foo", Bool(true)), ("bar", Bool(false)) ; mk_term::integer(456)),
                 mk_term::integer(123)
@@ -237,7 +237,7 @@ fn enum_terms() {
         ),
         (
             "match with string tags",
-            "match { `\"one:two\" => true, `\"three four\" => false, _ => 13 } 1",
+            "match { '\"one:two\" => true, '\"three four\" => false, _ => 13 } 1",
             mk_app!(
                 mk_match!(("one:two", Bool(true)), ("three four", Bool(false)) ; mk_term::integer(13)),
                 mk_term::integer(1)
@@ -251,11 +251,11 @@ fn enum_terms() {
     }
 
     let failure_cases = [
-        ("whitespace between backtick & identifier", "`     test"),
-        ("invalid identifier", "`$s"),
-        ("empty raw identifier", "`"),
-        ("multiline string", "`m%\"words\"%"),
-        ("interpolation", "`\"%{x}\""),
+        ("whitespace between backtick & identifier", "'     test"),
+        ("invalid identifier", "'$s"),
+        ("empty raw identifier", "'"),
+        ("multiline string", "'m%\"words\"%"),
+        ("interpolation", "'\"%{x}\""),
     ];
 
     for (name, input) in failure_cases {
@@ -558,7 +558,7 @@ fn ty_var_kind_mismatch() {
         (
             "row var in both enum and record",
             r#"
-                let f | forall r. { x : r; r } -> [| `a; r |] = fun x => x in
+                let f | forall r. { x : r; r } -> [| 'a; r |] = fun x => x in
                 f { x = 1 }
             "#,
         ),

--- a/src/parser/uniterm.rs
+++ b/src/parser/uniterm.rs
@@ -646,7 +646,7 @@ pub(super) trait FixTypeVars {
     /// forall a. Num -> {foo: Str ; a} -> {bar: Str ; a}
     /// # occurs both in record rows and enum rows position
     /// # this is inconsistent and will raise a parse error
-    /// forall a. [| `foo, `bar; a |] -> {foo : Str, bar: Str; a}
+    /// forall a. [| 'foo, 'bar; a |] -> {foo : Str, bar: Str; a}
     /// ```
     fn fix_type_vars(&mut self, span: RawSpan) -> Result<(), ParseError> {
         self.fix_type_vars_env(BoundVarEnv::new(), span)

--- a/src/pretty.rs
+++ b/src/pretty.rs
@@ -569,7 +569,7 @@ where
             },
             Var(id) => allocator.as_string(id),
             Enum(id) => allocator
-                .text("`")
+                .text("'")
                 .append(allocator.text(id.label_quoted())),
             Record(record) => allocator
                 .line()
@@ -601,7 +601,7 @@ where
                     .intersperse(
                         sorted_map(cases).iter().map(|&(id, t)| {
                             allocator
-                                .text("`")
+                                .text("'")
                                 .append(allocator.text(id.label_quoted()))
                                 .append(allocator.space())
                                 .append(allocator.text("=>"))
@@ -721,7 +721,7 @@ where
                 .append(allocator.as_string(id)),
             EnumRowsF::Extend { row, tail } => {
                 let builder = allocator
-                    .text("`")
+                    .text("'")
                     .append(allocator.text(row.label_quoted()));
                 let builder = if let EnumRowsF::Extend { .. } = tail.0 {
                     builder

--- a/src/serialize.rs
+++ b/src/serialize.rs
@@ -375,7 +375,7 @@ mod tests {
 
         assert_json_eq!("if true then false else true", false);
         assert_json_eq!(r##""Hello, %{"world"}!""##, "Hello, world!");
-        assert_json_eq!("`foo", "foo");
+        assert_json_eq!("'foo", "foo");
     }
 
     #[test]
@@ -383,14 +383,14 @@ mod tests {
         assert_json_eq!("[]", json!([]));
         assert_json_eq!("[null, (1+1), (2+2), (3+3)]", json!([null, 2, 4, 6]));
         assert_json_eq!(
-            r##"[`a, ("b" ++ "c"), "d%{"e"}f", "g"]"##,
+            r##"['a, ("b" ++ "c"), "d%{"e"}f", "g"]"##,
             json!(["a", "bc", "def", "g"])
         );
         assert_json_eq!(
             r#"std.array.fold_right (fun elt acc => [[elt]] @ acc) [] [1, 2, 3, 4]"#,
             json!([[1], [2], [3], [4]])
         );
-        assert_json_eq!("[\"a\", 1, false, `foo]", json!(["a", 1, false, "foo"]));
+        assert_json_eq!("[\"a\", 1, false, 'foo]", json!(["a", 1, false, "foo"]));
     }
 
     #[test]
@@ -401,7 +401,7 @@ mod tests {
         );
 
         assert_json_eq!(
-            "{a = {} & {b = {c = if true then `richtig else `falsche}}}",
+            "{a = {} & {b = {c = if true then 'richtig else 'falsch}}}",
             json!({"a": {"b": {"c": "richtig"}}})
         );
 
@@ -419,7 +419,7 @@ mod tests {
         );
 
         assert_json_eq!(
-            "{a = {b | default = {}} & {b.c | default = (if true then `faux else `vrai)}}",
+            "{a = {b | default = {}} & {b.c | default = (if true then 'faux else 'vrai)}}",
             json!({"a": {"b": {"c": "faux"}}})
         );
 

--- a/src/term/mod.rs
+++ b/src/term/mod.rs
@@ -697,9 +697,9 @@ impl Term {
                 let re = regex::Regex::new("_?[a-zA-Z][_a-zA-Z0-9]*").unwrap();
                 let s = id.to_string();
                 if re.is_match(&s) {
-                    format!("`{s}")
+                    format!("'{s}")
                 } else {
-                    format!("`\"{s}\"")
+                    format!("'\"{s}\"")
                 }
             }
             Term::Record(..) | Term::RecRecord(..) => String::from("{ ... }"),

--- a/src/term/mod.rs
+++ b/src/term/mod.rs
@@ -1830,7 +1830,7 @@ pub mod make {
     /// Switch for types implementing `Into<Ident>` (for patterns) and `Into<RichTerm>` for the
     /// body of each case. Cases are specified as tuple, and the default case (optional) is separated by a `;`:
     /// `mk_switch!(format, ("Json", json_case), ("Yaml", yaml_case) ; def)` corresponds to
-    /// ``switch { `Json => json_case, `Yaml => yaml_case, _ => def} format``.
+    /// ``match { 'Json => json_case, 'Yaml => yaml_case, _ => def} format``.
     #[macro_export]
     macro_rules! mk_match {
         ( $( ($id:expr, $body:expr) ),* ; $default:expr ) => {

--- a/src/typecheck/operation.rs
+++ b/src/typecheck/operation.rs
@@ -23,7 +23,7 @@ pub fn get_uop_type(
                 mk_uty_arrow!(branches.clone(), branches.clone(), branches),
             )
         }
-        // Dyn -> [| `Number, `Bool, `String, `Enum, `Function, `Array, `Record, `Label, `Other |]
+        // Dyn -> [| 'Number, 'Bool, 'String, 'Enum, 'Function, 'Array, 'Record, 'Label, 'Other |]
         UnaryOp::Typeof() => (
             mk_uniftype::dynamic(),
             mk_uty_enum!(

--- a/src/types.rs
+++ b/src/types.rs
@@ -1090,7 +1090,7 @@ impl Display for EnumRows {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self.0 {
             EnumRowsF::Extend { ref row, ref tail } => {
-                write!(f, "`{row}")?;
+                write!(f, "'{row}")?;
 
                 match tail.0 {
                     EnumRowsF::Extend { .. } => write!(f, ", {tail}"),
@@ -1199,8 +1199,8 @@ mod test {
         assert_format_eq("forall r. { x: Bool, y: Bool, z: Bool ; r }");
         assert_format_eq("{ x: Bool, y: Bool, z: Bool }");
 
-        assert_format_eq("[| `a, `b, `c, `d |]");
-        assert_format_eq("forall r. [| `tag1, `tag2, `tag3 ; r |]");
+        assert_format_eq("[| 'a, 'b, 'c, 'd |]");
+        assert_format_eq("forall r. [| 'tag1, 'tag2, 'tag3 ; r |]");
 
         assert_format_eq("Array Number");
         assert_format_eq("Array (Array Number)");

--- a/src/types.rs
+++ b/src/types.rs
@@ -423,8 +423,8 @@ impl<ERows> EnumRowsF<ERows> {
     /// If we put aside the state and the error (see [EnumRowsF::map), this function makes
     /// `EnumRowsF` a functor. As hinted by the type signature, this function just maps on
     /// "one-level" of recursion, so to speak. Take the instantiated version `EnumRows`, and
-    /// enum rows of the form ``[| `foo, `bar, `baz |]``. Then, calling `try_map_state(f_erows,
-    /// state)` on these rows will map `f_erows` onto ``[| `bar, `baz |]``.
+    /// enum rows of the form ``[| 'foo, 'bar, 'baz |]``. Then, calling `try_map_state(f_erows,
+    /// state)` on these rows will map `f_erows` onto ``[| 'bar, 'baz |]``.
     ///
     /// Note that `f_erows` is just mapped once. Map isn't a recursive operation. It's however a
     /// building block to express recursive operations: as an example, see [RecordRows::traverse].
@@ -766,15 +766,15 @@ impl EnumRows {
         // Otherwise, we build a match with all the tags as cases, which just returns the
         // original argument, and a default case that blames.
         //
-        // For example, for an enum type [| `foo, `bar, `baz |], the `case` function looks
+        // For example, for an enum type [| 'foo, 'bar, 'baz |], the `case` function looks
         // like:
         //
         // ```
         // fun l x =>
         //   match {
-        //     `foo => x,
-        //     `bar => x,
-        //     `baz => x,
+        //     'foo => x,
+        //     'bar => x,
+        //     'baz => x,
         //     _ => $enum_fail l
         //   } x
         // ```

--- a/stdlib/internals.ncl
+++ b/stdlib/internals.ncl
@@ -5,22 +5,22 @@
   # Contract implementations
   "$dyn" = fun _label value => value,
 
-  "$num" = fun label value => if %typeof% value == `Number then value else %blame% label,
+  "$num" = fun label value => if %typeof% value == 'Number then value else %blame% label,
 
-  "$bool" = fun label value => if %typeof% value == `Bool then value else %blame% label,
+  "$bool" = fun label value => if %typeof% value == 'Bool then value else %blame% label,
 
-  "$string" = fun label value => if %typeof% value == `String then value else %blame% label,
+  "$string" = fun label value => if %typeof% value == 'String then value else %blame% label,
 
   "$fail" = fun label _value => %blame% label,
 
   "$array" = fun element_contract label value =>
-    if %typeof% value == `Array then
+    if %typeof% value == 'Array then
       %array_lazy_assume% (%go_array% label) value element_contract
     else
       %blame% label,
 
   "$func" = fun domain codomain label value =>
-    if %typeof% value == `Function then
+    if %typeof% value == 'Function then
       (fun x => %assume% codomain (%go_codom% label) (value (%assume% domain (%chng_pol% (%go_dom% label)) x)))
     else
       %blame% label,
@@ -39,8 +39,8 @@
 
   "$forall" =
     let flip = match {
-      `Positive => `Negative,
-      `Negative => `Positive,
+      'Positive => 'Negative,
+      'Negative => 'Positive,
     }
     in
     fun sealing_key polarity contract label value =>
@@ -48,7 +48,7 @@
       contract (%insert_type_variable% sealing_key polarity label) value,
 
   "$enums" = fun case label value =>
-    if %typeof% value == `Enum then
+    if %typeof% value == 'Enum then
       %assume% case label value
     else
       %blame% (%label_with_message% "not an enum tag" label),
@@ -57,7 +57,7 @@
     %blame% (%label_with_message% "tag not included in the enum type" label),
 
   "$record" = fun field_contracts tail_contract label value =>
-    if %typeof% value == `Record then
+    if %typeof% value == 'Record then
       # Returns the sub-record of `left` containing only those fields which are not
       # present in `right`. If `left` has a sealed polymorphic tail then it will be
       # preserved.
@@ -106,14 +106,14 @@
 
   # Lazy dictionary contract for `{_ | T}`
   "$dict_contract" = fun contract label value =>
-    if %typeof% value == `Record then
+    if %typeof% value == 'Record then
       %record_lazy_assume% (%go_dict% label) value (fun _field => contract)
     else
       %blame% (%label_with_message% "not a record" label),
 
   # Eager dictionary contract for `{_ : T}`
   "$dict_type" = fun contract label value =>
-    if %typeof% value == `Record then
+    if %typeof% value == 'Record then
       %record_map%
         value
         (

--- a/stdlib/std.ncl
+++ b/stdlib/std.ncl
@@ -46,7 +46,7 @@
           ```
         "%
       = fun label value =>
-        if %typeof% value == `Array then
+        if %typeof% value == 'Array then
           if %length% value != 0 then
             value
           else
@@ -454,7 +454,7 @@
       = fun f n => %generate% n f,
 
     sort
-      : forall a. (a -> a -> [| `Lesser, `Equal, `Greater |]) -> Array a -> Array a
+      : forall a. (a -> a -> [| 'Lesser, 'Equal, 'Greater |]) -> Array a -> Array a
       | doc m%"
           Sorts an array based on the provided comparison operator.
 
@@ -463,11 +463,11 @@
           ```nickel
           std.array.sort (fun x y =>
             if x < y then
-              `Lesser
+              'Lesser
             else if (x == y) then
-              `Equal
+              'Equal
             else
-              `Greater)
+              'Greater)
             [ 4, 5, 1, 2 ]
           => [ 1, 2, 4, 5 ]
           ```
@@ -477,7 +477,7 @@
         let length = %length% array in
         let first = %elem_at% array 0 in
         let rest = %array_slice% 1 length array in
-        let parts = partition (fun x => (cmp x first == `Lesser)) rest in
+        let parts = partition (fun x => (cmp x first == 'Lesser)) rest in
         if length <= 1 then
           array
         else
@@ -796,7 +796,7 @@
           in
           constant_type
           |> match {
-            `Record =>
+            'Record =>
               # we map the constant from {field1 = val1, .., fieldn = valn} to
               # {field1 = Equal val1, .., fieldn = Equal valn}, building a
               # dictionary of equality contracts
@@ -816,7 +816,7 @@
                       fun field =>
                         contract_map."%{field}"
                     ),
-            `Array =>
+            'Array =>
               fun ctr_label value =>
                 let value = check_typeof_eq ctr_label value in
                 let value_length = %length% value in
@@ -1113,9 +1113,9 @@
         # Examples
 
         ```nickel
-        (`foo | std.enum.Tag) =>
+        ('foo | std.enum.Tag) =>
           `foo
-        (`FooBar | std.enum.Tag) =>
+        ('FooBar | std.enum.Tag) =>
           `FooBar
         ("tag" | std.enum.Tag) =>
           error
@@ -1143,18 +1143,18 @@
         let Schema = {
           protocol
             | std.enum.TagOrString
-            | [| `http, `ftp |],
+            | [| 'http, 'ftp |],
           port
             | Number,
           method
             | std.enum.TagOrString
-            | [| `GET, `POST |]
+            | [| 'GET, 'POST |]
         } in
         let serialized =
           m%"
             {"protocol": "http", "port": 80, "method": "GET"}
           "%
-          |> std.deserialize `Json
+          |> std.deserialize 'Json
         in
 
         serialized | Schema
@@ -1163,8 +1163,8 @@
       = fun label value =>
         %typeof% value
         |> match {
-          `String => %enum_from_str% value,
-          `Enum => value,
+          'String => %enum_from_str% value,
+          'Enum => value,
           _ =>
             std.contract.blame_with_message
               "expected either a string or an enum tag"
@@ -1276,7 +1276,7 @@
         ```nickel
         pipe 2 [ (+) 2, (+) 3 ]
           => 7
-        pipe `World [ std.string.from, fun s => "Hello, %{s}!" ]
+        pipe 'World [ std.string.from, fun s => "Hello, %{s}!" ]
           => "Hello, World!"
         ```
       "%%
@@ -1298,7 +1298,7 @@
         ```
       "%
       = fun label value =>
-        if %typeof% value == `Number then
+        if %typeof% value == 'Number then
           if value % 1 == 0 then
             value
           else
@@ -1322,7 +1322,7 @@
         ```
       "%
       = fun label value =>
-        if %typeof% value == `Number then
+        if %typeof% value == 'Number then
           if value % 1 == 0 && value >= 0 then
             value
           else
@@ -1346,7 +1346,7 @@
         ```
       "%
       = fun label value =>
-        if %typeof% value == `Number then
+        if %typeof% value == 'Number then
           if value % 1 == 0 && value > 0 then
             value
           else
@@ -1368,7 +1368,7 @@
         ```
       "%
       = fun label value =>
-        if %typeof% value == `Number then
+        if %typeof% value == 'Number then
           if value != 0 then
             value
           else
@@ -1803,7 +1803,7 @@
         ```
       "%
       = fun l s =>
-        if %typeof% s == `String then
+        if %typeof% s == 'String then
           if s == "true" then
             "true"
           else if s == "false" then
@@ -1832,7 +1832,7 @@
         let pattern = m%"^[+-]?(\d+(\.\d*)?(e[+-]?\d+)?|\.\d+(e[+-]?\d+)?)$"% in
         let is_num_literal = %str_is_match% pattern in
         fun l s =>
-          if %typeof% s == `String then
+          if %typeof% s == 'String then
             if is_num_literal s then
               s
             else
@@ -1858,7 +1858,7 @@
         ```
       "%
       = fun l s =>
-        if %typeof% s == `String then
+        if %typeof% s == 'String then
           if length s == 1 then
             s
           else
@@ -1882,8 +1882,8 @@
         # Examples
 
         ```nickel
-        (`Foo | std.string.Stringable)
-          => `Foo
+        ('Foo | std.string.Stringable)
+          => 'Foo
         (false | std.string.Stringable)
           => false
         ("bar" ++ "foo" | std.string.Stringable)
@@ -1898,10 +1898,10 @@
             fun value =>
               let type = std.typeof value in
               value == null
-              || type == `Number
-              || type == `Bool
-              || type == `String
-              || type == `Enum
+              || type == 'Number
+              || type == 'Bool
+              || type == 'String
+              || type == 'Enum
           ),
 
     NonEmpty
@@ -1920,7 +1920,7 @@
         ```
       "%
       = fun l s =>
-        if %typeof% s == `String then
+        if %typeof% s == 'String then
           if %str_length% s > 0 then
             s
           else
@@ -2259,7 +2259,7 @@
         ```nickel
         std.string.from 42
           => "42"
-        std.string.from `Foo
+        std.string.from 'Foo
           => "Foo"
         std.string.from null
           => "null"
@@ -2291,7 +2291,7 @@
         # Examples
 
         ```nickel
-        std.string.from_enum `MyEnum
+        std.string.from_enum 'MyEnum
           => "MyEnum"
         ```
       "%
@@ -2352,9 +2352,9 @@
 
         ```nickel
         std.string.to_enum "Hello"
-          => `Hello
+          => 'Hello
         std.string.to_enum "hey,there!"
-          => `"hey,there!"
+          => '"hey,there!"
         ```
       "%
       = fun s => %enum_from_str% s,
@@ -2374,7 +2374,7 @@
         => false
       ```
     "%
-    = fun x => %typeof% x == `Number,
+    = fun x => %typeof% x == 'Number,
 
   is_bool
     : Dyn -> Bool
@@ -2390,7 +2390,7 @@
         => false
       ```
     "%
-    = fun x => %typeof% x == `Bool,
+    = fun x => %typeof% x == 'Bool,
 
   is_string
     : Dyn -> Bool
@@ -2406,7 +2406,7 @@
         => true
       ```
     "%
-    = fun x => %typeof% x == `String,
+    = fun x => %typeof% x == 'String,
 
   is_enum
     : Dyn -> Bool
@@ -2422,7 +2422,7 @@
         => true
       ```
     "%
-    = fun x => %typeof% x == `Enum,
+    = fun x => %typeof% x == 'Enum,
 
   is_function
     : Dyn -> Bool
@@ -2438,7 +2438,7 @@
         => false
       ```
     "%
-    = fun x => %typeof% x == `Function,
+    = fun x => %typeof% x == 'Function,
 
   is_array
     : Dyn -> Bool
@@ -2454,7 +2454,7 @@
         => false
       ```
     "%
-    = fun x => %typeof% x == `Array,
+    = fun x => %typeof% x == 'Array,
 
   is_record
     : Dyn -> Bool
@@ -2470,19 +2470,19 @@
         => true
       ```
     "%
-    = fun x => %typeof% x == `Record,
+    = fun x => %typeof% x == 'Record,
 
   typeof
     : Dyn -> [|
-      `Number,
-      `Bool,
-      `String,
-      `Enum,
-      `Label,
-      `Function,
-      `Array,
-      `Record,
-      `Other
+      'Number,
+      'Bool,
+      'String,
+      'Enum,
+      'Label,
+      'Function,
+      'Array,
+      'Record,
+      'Other
     |]
     | doc m%"
       Returns the type of a value.
@@ -2491,9 +2491,9 @@
 
       ```nickel
       std.typeof [ 1, 2 ]
-        => `Array
+        => 'Array
       std.typeof (fun x => x)
-        => `Function
+        => 'Function
       ```
     "%
     = fun x => %typeof% x,
@@ -2550,28 +2550,28 @@
     = fun x y => %deep_seq% x y,
 
   hash
-    : [| `Md5, `Sha1, `Sha256, `Sha512 |] -> String -> String
+    : [| 'Md5, 'Sha1, 'Sha256, 'Sha512 |] -> String -> String
     | doc m%"
       Hashes the given string with the desired hashing algorithm.
 
       # Examples
 
       ```nickel
-      std.hash `Md5 "hunter2"
+      std.hash 'Md5 "hunter2"
         => "2ab96390c7dbe3439de74d0c9b0b1767"
       ```
     "%
     = fun type s => %hash% type s,
 
   serialize
-    : [| `Json, `Toml, `Yaml |] -> Dyn -> String
+    : [| 'Json, 'Toml, 'Yaml |] -> Dyn -> String
     | doc m%"
       Serializes a value into the desired representation.
 
       # Examples
 
       ```nickel
-      serialize `Json { hello = "Hello", world = "World" } =>
+      serialize 'Json { hello = "Hello", world = "World" } =>
         "{
           \"hello\": \"Hello\",
           \"world\": \"World\"
@@ -2581,14 +2581,14 @@
     = fun format x => %serialize% format (%force% x),
 
   deserialize
-    : [| `Json, `Toml, `Yaml |] -> String -> Dyn
+    : [| 'Json, 'Toml, 'Yaml |] -> String -> Dyn
     | doc m%"
       Deserializes a string into a Nickel value from the given representation.
 
       # Examples
 
       ```nickel
-      deserialize `Json "{ \"hello\": \"Hello\", \"world\": \"World\" }"
+      deserialize 'Json "{ \"hello\": \"Hello\", \"world\": \"World\" }"
         { hello = "Hello", world = "World" }
       ```
     "%
@@ -2605,7 +2605,7 @@
       ```nickel
       std.to_string 42 =>
         "42"
-      std.to_string `Foo =>
+      std.to_string 'Foo =>
         "Foo"
       std.to_string null =>
         "null"

--- a/tests/integration/contracts_fail.rs
+++ b/tests/integration/contracts_fail.rs
@@ -55,9 +55,9 @@ fn id_fail() {
 
 #[test]
 fn enum_simple() {
-    assert_raise_blame!("`far | [|`foo, `bar|]");
-    assert_raise_blame!("123 | [|`foo, `bar|]");
-    assert_raise_blame!("`foo | [| |]");
+    assert_raise_blame!("'far | [|'foo, 'bar|]");
+    assert_raise_blame!("123 | [|'foo, 'bar|]");
+    assert_raise_blame!("'foo | [| |]");
 }
 
 #[test]
@@ -316,8 +316,8 @@ fn dictionary_contracts() {
 #[test]
 fn enum_complex() {
     eval(
-        "let f : [| `foo, `bar |] -> Number = match { `foo => 1, `bar => 2, } in
-         f `boo",
+        "let f : [| 'foo, 'bar |] -> Number = match { 'foo => 1, 'bar => 2, } in
+         f 'boo",
     )
     .unwrap_err();
 }

--- a/tests/integration/imports.rs
+++ b/tests/integration/imports.rs
@@ -98,7 +98,7 @@ fn serialize() {
     let mut prog = TestProgram::new_from_source(
         BufReader::new(
             format!(
-                "(std.serialize `Json ({})) == (std.serialize `Json ({{foo = \"ab\"}}))",
+                "(std.serialize 'Json ({})) == (std.serialize 'Json ({{foo = \"ab\"}}))",
                 mk_import("record.ncl")
             )
             .as_bytes(),

--- a/tests/integration/pass/arrays.ncl
+++ b/tests/integration/pass/arrays.ncl
@@ -12,9 +12,9 @@ let {check, ..} = import "lib/assert.ncl" in
 
   # sort
   let cmp = fun x y =>
-    if x < y then `Lesser
-    else if x == y then `Equal
-    else `Greater
+    if x < y then 'Lesser
+    else if x == y then 'Equal
+    else 'Greater
   in std.array.sort cmp [3, 42, -1, -5] == [-5, -1, 3, 42],
 
   # Test case added after https://github.com/tweag/nickel/issues/154

--- a/tests/integration/pass/basics.ncl
+++ b/tests/integration/pass/basics.ncl
@@ -32,6 +32,6 @@ let {check, ..} = import "lib/assert.ncl" in
   1/4 + 1/4 - 1/4 + 1/4 < 1/2 == false,
 
   # This test checks that the terms of a match are closured
-  let x = 3 in ((3 + 2) |> match { `foo => 1, _ => x}) == 3,
+  let x = 3 in ((3 + 2) |> match { 'foo => 1, _ => x}) == 3,
 ]
 |> check

--- a/tests/integration/pass/builtins.ncl
+++ b/tests/integration/pass/builtins.ncl
@@ -23,8 +23,8 @@ let {check, ..} = import "lib/assert.ncl" in
   [1,2,3]
    |> std.array.map (fun x => x + 1)
    |> std.array.filter (fun x => x > 2)
-   |> std.serialize `Json
-   |> std.deserialize `Json
+   |> std.serialize 'Json
+   |> std.deserialize 'Json
    == [3,4],
 ]
 |> check

--- a/tests/integration/pass/contracts.ncl
+++ b/tests/integration/pass/contracts.ncl
@@ -28,35 +28,35 @@ let {check, Assert, ..} = import "lib/assert.ncl" in
   ("hello" ++ " world" | String) == "hello world",
 
   # enums_simple
-  (`foo | [| `foo, `bar |]) == `foo,
-  (`bar | forall r. [| `foo, `bar ; r|]) == `bar,
+  ('foo | [| 'foo, 'bar |]) == 'foo,
+  ('bar | forall r. [| 'foo, 'bar ; r|]) == 'bar,
 
   # enums_escaped
-  (`"foo:baz" | [| `"foo:baz", `"bar:baz" |]) == `"foo:baz",
-  (`"bar:baz" | forall r. [| `"foo:baz", `"bar:baz" ; r |]) == `"bar:baz",
+  ('"foo:baz" | [| '"foo:baz", '"bar:baz" |]) == '"foo:baz",
+  ('"bar:baz" | forall r. [| '"foo:baz", '"bar:baz" ; r |]) == '"bar:baz",
 
   # enums_complex
-  let f : forall r. [| `foo, `bar ; r |] -> Number =
-    match { `foo => 1, `bar => 2, _ => 3, } in
-  f `bar == 2,
+  let f : forall r. [| 'foo, 'bar ; r |] -> Number =
+    match { 'foo => 1, 'bar => 2, _ => 3, } in
+  f 'bar == 2,
 
-  let f : forall r. [| `foo, `bar ; r |] -> Number =
-    match { `foo => 1, `bar => 2, _ => 3, } in
-  f `boo == 3,
+  let f : forall r. [| 'foo, 'bar ; r |] -> Number =
+    match { 'foo => 1, 'bar => 2, _ => 3, } in
+  f 'boo == 3,
 
-  let f : forall r. [| `foo, `"bar:baz" ; r |] -> Number =
-    fun x => match { `foo => 1, `"bar:baz" => 2, _ => 3, } x in
-  f `"bar:baz" == 2,
+  let f : forall r. [| 'foo, '"bar:baz" ; r |] -> Number =
+    fun x => match { 'foo => 1, '"bar:baz" => 2, _ => 3, } x in
+  f '"bar:baz" == 2,
 
-  let f : forall r. [| `foo, `"bar:baz" ; r |] -> Number =
-    fun x => match { `foo => 1, `"bar:baz" => 2, _ => 3, } x in
-  f `"boo,grr" == 3,
+  let f : forall r. [| 'foo, '"bar:baz" ; r |] -> Number =
+    fun x => match { 'foo => 1, '"bar:baz" => 2, _ => 3, } x in
+  f '"boo,grr" == 3,
 
   # enums_applied
   # Regression test for enum types converted to contracts outside of annotations
   # causing issues wrt typechecking
-  let Wrapper = std.contract.apply [| `Foo, `Bar |] in
-  (`Foo | Wrapper) == `Foo,
+  let Wrapper = std.contract.apply [| 'Foo, 'Bar |] in
+  ('Foo | Wrapper) == 'Foo,
 
   # records_simple
   ({} | {}) == {},

--- a/tests/integration/pass/eq.ncl
+++ b/tests/integration/pass/eq.ncl
@@ -5,8 +5,8 @@ let {check, ..} = import "lib/assert.ncl" in
   0 == 0 + 0 + 0,
   true == (if true then true else false),
   "a" ++ "b" ++ "c" == "%{"a" ++ "b"}" ++ "c",
-  `Less == `Less,
-  `small == `small,
+  'Less == 'Less,
+  'small == 'small,
 
   1 + 1 != 0,
   true != (if true then false else true),
@@ -14,9 +14,9 @@ let {check, ..} = import "lib/assert.ncl" in
   1 != true,
   "1" != 1,
   "true" != true,
-  `Less != `small,
-  `Less != 0,
-  `Greater != false,
+  'Less != 'small,
+  'Less != 0,
+  'Greater != false,
 
   # arrays
   [] == [],

--- a/tests/integration/pass/metavalues.ncl
+++ b/tests/integration/pass/metavalues.ncl
@@ -52,8 +52,8 @@ let {check, Assert, ..} = import "lib/assert.ncl" in
   let value | Contract = {foo = 1} in
   (
     (value == {foo = 1} | Assert) &&
-    (std.serialize `Json value
-      == std.serialize `Json {foo = 1}
+    (std.serialize 'Json value
+      == std.serialize 'Json {foo = 1}
       | Assert) &&
     (std.record.has_field "foo" value | Assert) &&
     (!(std.record.has_field "opt" value) | Assert) &&
@@ -71,8 +71,8 @@ let {check, Assert, ..} = import "lib/assert.ncl" in
   let value | Contract = with_ctr & {foo = 1, baz = false} in
   (
     (value == {foo = 1, baz = false} | Assert) &&
-    (std.serialize `Json value
-      == std.serialize `Json {foo = 1, baz = false}
+    (std.serialize 'Json value
+      == std.serialize 'Json {foo = 1, baz = false}
       | Assert) &&
     (std.record.has_field "foo" value | Assert) &&
     (std.record.has_field "baz" value | Assert) &&
@@ -85,8 +85,8 @@ let {check, Assert, ..} = import "lib/assert.ncl" in
   let value | Contract = {foo = 1 + 0, opt = "a" ++ "b"} in
   (
     (value == {foo = 1, opt = "ab"} | Assert) &&
-    (std.serialize `Json value
-      == std.serialize `Json {foo = 1, opt = "ab"}
+    (std.serialize 'Json value
+      == std.serialize 'Json {foo = 1, opt = "ab"}
       | Assert) &&
     (std.record.has_field "foo" value | Assert) &&
     (std.record.has_field "opt" value | Assert) &&
@@ -100,8 +100,8 @@ let {check, Assert, ..} = import "lib/assert.ncl" in
   let value = with_ctr & {foo = 1, opt = "a" ++ "b"} in
   (
     (value == {foo = 1, opt = "ab"} | Assert) &&
-    (std.serialize `Json value
-      == std.serialize `Json {foo = 1, opt = "ab"}
+    (std.serialize 'Json value
+      == std.serialize 'Json {foo = 1, opt = "ab"}
       | Assert) &&
     (std.record.has_field "foo" value | Assert) &&
     (std.record.has_field "opt" value | Assert) &&
@@ -117,7 +117,7 @@ let {check, Assert, ..} = import "lib/assert.ncl" in
   # fine
   let value = with_ctr & {foo = 1, opt} in
   (
-    # std.record.has_field/std.record.fields have a dictionnary contract `{_ : T}`
+    # std.record.has_field/std.record.fields have a dictionary contract `{_ : T}`
     # attached, which currently uses `std.record.map` under the hood, which will
     # throw an error for `opt` missing a defnition. They
     # probably shouldn't, but for the time being, we bypass them using the

--- a/tests/integration/pass/records.ncl
+++ b/tests/integration/pass/records.ncl
@@ -29,7 +29,7 @@ let {check, ..} = import "lib/assert.ncl" in
     == 2,
 
   let r = std.record.map
-      (fun y x => if %typeof% x == `Number then x + 1 else 0)
+      (fun y x => if %typeof% x == 'Number then x + 1 else 0)
       {foo = 1, bar = "it's lazy"} in
     (r.foo) + (r.bar) == 2,
 
@@ -41,8 +41,8 @@ let {check, ..} = import "lib/assert.ncl" in
   {a = {b = 1}} & {a = {c = true}}
     == {a = {b = 1, c = true}},
 
-  {a = `A, b = `B} & {a = `A, c = `C}
-    == {a = `A, b = `B, c = `C},
+  {a = 'A, b = 'B} & {a = 'A, c = 'C}
+    == {a = 'A, b = 'B, c = 'C},
 
   # merge_complex
   let rec1 = {

--- a/tests/integration/pass/serialize-package.ncl
+++ b/tests/integration/pass/serialize-package.ncl
@@ -56,12 +56,12 @@ let ctr = {
           = "package",
   }
 } in
-std.serialize `Json (
+std.serialize 'Json (
   {
     name = "nickel",
     buildInputs = [{package = "hello"}],
   } | ctr.Shell
-) == std.serialize `Json {
+) == std.serialize 'Json {
   name = "nickel",
   buildInputs = [{input = "nixpkgs", package = "hello", "_type" = "package"}],
 }

--- a/tests/integration/pass/serialize.ncl
+++ b/tests/integration/pass/serialize.ncl
@@ -3,17 +3,17 @@ let {check, ..} = import "lib/assert.ncl" in
 let assertSerInv = fun x =>
     let assertAux = fun format x =>
       %deserialize% format (%serialize% format (%force% x)) == x in
-    assertAux `Json x &&
-    assertAux `Yaml x &&
-    assertAux `Toml x in
+    assertAux 'Json x &&
+    assertAux 'Yaml x &&
+    assertAux 'Toml x in
 
 let assertDeserInv = fun x =>
     let assertAux = fun format x =>
       let s = %serialize% format (%force% x) in
       %serialize% format (%deserialize% format s) == s in
-    assertAux `Json x &&
-    assertAux `Yaml x &&
-    assertAux `Toml x in
+    assertAux 'Json x &&
+    assertAux 'Yaml x &&
+    assertAux 'Toml x in
 
 [
   assertSerInv {val = 1 + 1},

--- a/tests/integration/pass/stdlib_string_contracts.ncl
+++ b/tests/integration/pass/stdlib_string_contracts.ncl
@@ -23,11 +23,11 @@ let {string, ..} = std in
   ("👩🏿‍❤️‍💋‍👩🏼" | string.Character) == "👩🏿‍❤️‍💋‍👩🏼",
 
   # string.EnumTag
-  (`Foo | std.enum.Tag) == `Foo,
-  (`Barr | std.enum.Tag) == `Barr,
+  ('Foo | std.enum.Tag) == 'Foo,
+  ('Barr | std.enum.Tag) == 'Barr,
 
   # string.Stringable
-  (`Foo | string.Stringable) == `Foo,
+  ('Foo | string.Stringable) == 'Foo,
   (true | string.Stringable) == true,
   (1 | string.Stringable) == 1,
   ("" | string.Stringable) == "",

--- a/tests/integration/pass/stdlib_string_conversions.ncl
+++ b/tests/integration/pass/stdlib_string_conversions.ncl
@@ -6,7 +6,7 @@ let {string, ..} = std in
   string.from true == "true",
   string.from 1 == "1",
   string.from "asdf" == "asdf",
-  string.from `Foo == "Foo",
+  string.from 'Foo == "Foo",
 
   # string.from_number
   string.from_number (-1) == "-1",
@@ -16,8 +16,8 @@ let {string, ..} = std in
   string.from_number 1.2 == "1.2",
 
   # string.from_enum
-  string.from_enum `Enum == "Enum",
-  string.from_enum `Magick == "Magick",
+  string.from_enum 'Enum == "Enum",
+  string.from_enum 'Magick == "Magick",
 
   # string.to_number
   string.to_number "1" == 1,
@@ -29,9 +29,9 @@ let {string, ..} = std in
   !(string.to_bool "false"),
 
   # string.to_enum
-  string.to_enum "" == `"",
-  string.to_enum "x" == `x,
-  string.to_enum "X" == `X,
+  string.to_enum "" == '"",
+  string.to_enum "x" == 'x,
+  string.to_enum "X" == 'X,
   string.to_enum "X" == string.to_enum "X",
-  string.to_enum "タグ" == `"タグ",
+  string.to_enum "タグ" == '"タグ",
 ] |> check

--- a/tests/integration/pass/symbolic-strings.ncl
+++ b/tests/integration/pass/symbolic-strings.ncl
@@ -1,24 +1,24 @@
 let {check, ..} = import "lib/assert.ncl" in
-let sym = fun prefix_ fragments_ => { tag = `SymbolicString, prefix = prefix_, fragments = fragments_ } in
+let sym = fun prefix_ fragments_ => { tag = 'SymbolicString, prefix = prefix_, fragments = fragments_ } in
 
 [
   # Static symbolic string
-  foo-s%"hello, world"% == sym `foo ["hello, world"] ,
+  foo-s%"hello, world"% == sym 'foo ["hello, world"] ,
   # Interpolating a string
   let s = "test" in
-  foo-s%"This is a %{s}"% == sym `foo ["This is a ", "test"],
+  foo-s%"This is a %{s}"% == sym 'foo ["This is a ", "test"],
   # Interpolating an interpolated string
   let f = "f" in
-  foo-s%"abc %{"de%{f}"}"% == sym `foo ["abc ", "def"],
+  foo-s%"abc %{"de%{f}"}"% == sym 'foo ["abc ", "def"],
   # Interpolating a number
-  foo-s%"num: %{100}"% == sym `foo ["num: ", 100],
+  foo-s%"num: %{100}"% == sym 'foo ["num: ", 100],
   # Interpolating a bool
-  foo-s%"bool: %{true}"% == sym `foo ["bool: ", true],
+  foo-s%"bool: %{true}"% == sym 'foo ["bool: ", true],
   # Interpolating an array
-  foo-s%"array: %{[true, 1, "yes"]}"% == sym `foo ["array: ", [true, 1, "yes"]],
+  foo-s%"array: %{[true, 1, "yes"]}"% == sym 'foo ["array: ", [true, 1, "yes"]],
   # Interpolating a record
   let r = { a = 1, b = false } in
-  foo-s%"record: %{r}"% == sym `foo ["record: ", r],
+  foo-s%"record: %{r}"% == sym 'foo ["record: ", r],
   # Interpolating multiple values
   let str = "some string" in
   let num = 999.999 in
@@ -32,7 +32,7 @@ let sym = fun prefix_ fragments_ => { tag = `SymbolicString, prefix = prefix_, f
      4. %{array}
      5. %{record}"%
   in
-  let expected = sym `foo [
+  let expected = sym 'foo [
     "1. ", str,
     "\n2. ", num,
     "\n3. ", bool,

--- a/tests/integration/pass/typechecking.ncl
+++ b/tests/integration/pass/typechecking.ncl
@@ -50,30 +50,30 @@ let typecheck = [
     ((if (f true) then (f 2) else 3) : Number),
 
   # enums_simple
-  (`bla : [|`bla |]),
-  (`blo : [|`bla, `blo |]),
-  (`bla : forall r. [|`bla ; r |]),
-  (`bla : forall r. [|`bla, `blo ; r |]),
-  ((`bla |> match {`bla => 3}) : Number),
-  ((`blo |> match {`bla => 3, _ => 2}) : Number),
+  ('bla : [|'bla |]),
+  ('blo : [|'bla, 'blo |]),
+  ('bla : forall r. [|'bla ; r |]),
+  ('bla : forall r. [|'bla, 'blo ; r |]),
+  (('bla |> match {'bla => 3}) : Number),
+  (('blo |> match {'bla => 3, _ => 2}) : Number),
 
   # enums_complex
-  ((fun x => x |> match {`bla => 1, `ble => 2}) : [|`bla, `ble |] -> Number),
-  ((fun x => %embed% bli x |> match {`bla => 1, `ble => 2, `bli => 4})
-    : [|`bla, `ble |] -> Number),
+  ((fun x => x |> match {'bla => 1, 'ble => 2}) : [|'bla, 'ble |] -> Number),
+  ((fun x => %embed% bli x |> match {'bla => 1, 'ble => 2, 'bli => 4})
+    : [|'bla, 'ble |] -> Number),
   ((fun x =>
-      (x |> match {`bla => 3, `bli => 2})
-      + (x |> match {`bli => 6, `bla => 20}))
-    `bla
+      (x |> match {'bla => 3, 'bli => 2})
+      + (x |> match {'bli => 6, 'bla => 20}))
+    'bla
     : Number),
 
-  let f : forall r. [|`blo, `ble ; r |] -> Number =
-    match {`blo => 1, `ble => 2, _ => 3} in
-    (f `bli : Number),
+  let f : forall r. [|'blo, 'ble ; r |] -> Number =
+    match {'blo => 1, 'ble => 2, _ => 3} in
+    (f 'bli : Number),
 
-  let f : forall r. (forall p. [|`blo, `ble ; r |] -> [|`bla, `bli ; p |]) =
-    match {`blo => `bla, `ble => `bli, _ => `bla} in
-    f `bli,
+  let f : forall r. (forall p. [|'blo, 'ble ; r |] -> [|'bla, 'bli ; p |]) =
+    match {'blo => 'bla, 'ble => 'bli, _ => 'bla} in
+    f 'bli,
 
   # recursive let bindings
   let rec f : forall a. a -> Number -> a = fun x n =>
@@ -98,9 +98,9 @@ let typecheck = [
   let f : forall a r. {bla : Bool, blo : a, ble : a ; r} -> a =
       fun r => if r.bla then r.blo else r.ble in
     (if (f {bla = true, blo = false, ble = true, blip = 1, }) then
-      (f {bla = true, blo = 1, ble = 2, blip = `blip, })
+      (f {bla = true, blo = 1, ble = 2, blip = 'blip, })
     else
-      (f {bla = true, blo = 3, ble = 4, bloppo = `bloppop, }) : Number),
+      (f {bla = true, blo = 3, ble = 4, bloppo = 'bloppop, }) : Number),
 
   ({ "%{if true then "foo" else "bar"}" = 2, } : {_ : Number}),
   ({ "%{if true then "foo" else "bar"}" = 2, }."%{"bl" ++ "a"}" : Number),

--- a/tests/integration/typecheck_fail.rs
+++ b/tests/integration/typecheck_fail.rs
@@ -79,32 +79,32 @@ fn simple_forall() {
 
 #[test]
 fn enum_simple() {
-    assert_typecheck_fails!("`foo : [| `bar |]");
-    assert_typecheck_fails!("match { `foo => 3} `bar : Number");
-    assert_typecheck_fails!("match { `foo => 3, `bar => true} `bar : Number");
+    assert_typecheck_fails!("'foo : [| 'bar |]");
+    assert_typecheck_fails!("match { 'foo => 3} 'bar : Number");
+    assert_typecheck_fails!("match { 'foo => 3, 'bar => true} 'bar : Number");
 }
 
 #[test]
 fn enum_complex() {
     assert_typecheck_fails!(
-        "(match {`bla => 1, `ble => 2, `bli => 4}) : [| `bla, `ble |] -> Number"
+        "(match {'bla => 1, 'ble => 2, 'bli => 4}) : [| 'bla, 'ble |] -> Number"
     );
     // TODO typecheck this, I'm not sure how to do it with row variables
     // LATER NOTE: this requires row subtyping, not easy
     assert_typecheck_fails!(
         "(fun x =>
-            (x |> match {`bla => 3, `bli => 2}) +
-            (x |> match {`bla => 6, `blo => 20})) `bla : Number"
+            (x |> match {'bla => 3, 'bli => 2}) +
+            (x |> match {'bla => 6, 'blo => 20})) 'bla : Number"
     );
     assert_typecheck_fails!(
-        "let f : forall r. [| `blo, `ble ; r |] -> Number =
-            match {`blo => 1, `ble => 2, `bli => 3} in
+        "let f : forall r. [| 'blo, 'ble ; r |] -> Number =
+            match {'blo => 1, 'ble => 2, 'bli => 3} in
         f"
     );
     assert_typecheck_fails!(
-        "let f : forall r. (forall p. [| `blo, `ble ; r |] -> [| `bla, `bli ; p |]) =
-            match {`blo => `bla, `ble => `bli, _ => `blo} in
-        f `bli"
+        "let f : forall r. (forall p. [| 'blo, 'ble ; r |] -> [| 'bla, 'bli ; p |]) =
+            match {'blo => 'bla, 'ble => 'bli, _ => 'blo} in
+        f 'bli"
     );
 }
 
@@ -118,12 +118,12 @@ fn static_record_simple() {
     assert_typecheck_fails!(
         "let f : forall a. (forall r. {bla : Bool, blo : a, ble : a ; r} -> a) =
             fun r => if r.bla then r.blo else r.ble in
-         (f {bla = true, blo = 1, ble = true, blip = `blip} : Number)"
+         (f {bla = true, blo = 1, ble = true, blip = 'blip} : Number)"
     );
     assert_typecheck_fails!(
         "let f : forall a. (forall r. {bla : Bool, blo : a, ble : a ; r} -> a) =
             fun r => if r.bla then (r.blo + 1) else r.ble in
-         (f {bla = true, blo = 1, ble = 2, blip = `blip} : Number)"
+         (f {bla = true, blo = 1, ble = 2, blip = 'blip} : Number)"
     );
 }
 


### PR DESCRIPTION
Change the enum tag syntax from `` `Foo`` to `'Foo` as suggested in #671. This is a mostly mechanical change fixing failing tests after changing the syntax. It also changes printing to conform with the new syntax in `Term::shallow_repr` and the pretty printer.