### PR TITLE
Make partially applied boolean operators work

### DIFF
--- a/src/parser/utils.rs
+++ b/src/parser/utils.rs
@@ -229,6 +229,9 @@ impl InfixOp {
     pub fn eta_expand(self, pos: TermPos) -> RichTerm {
         let pos = pos.into_inherited();
         match self {
+            // We treat `UnaryOp::BoolAnd` and `UnaryOp::BoolOr` separately.
+            // They should morally be binary operators, but we represent them as unary
+            // operators internally so that their second argument is evaluated lazily.
             InfixOp::Unary(op @ UnaryOp::BoolAnd()) | InfixOp::Unary(op @ UnaryOp::BoolOr()) => {
                 mk_fun!(
                     "x1",


### PR DESCRIPTION
This changes the desugaring of `(&&)` and `(||)`. Even though they are technically unary operators because they need to be lazy in their second arguments, these operator sections are now desugared like binary operators. This means partial applications like `(&&) true` now don't throw errors anymore.

Closes #1281