### PR TITLE
Pass on error messages

### DIFF
--- a/benches/mantis/deploy-example.ncl
+++ b/benches/mantis/deploy-example.ncl
@@ -1,1 +1,6 @@
-import "deploy.ncl" { namespace = "mantis-staging", job = "miner", role = `miner }
+import "deploy.ncl"
+  {
+    namespace = "mantis-staging",
+    job = "miner",
+    role = `miner,
+  }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1003,7 +1003,7 @@ impl IntoDiagnostics<FileId> for EvalError {
                         "Primitive values (Number, String, and Bool) or arrays can be merged \
                         only if they are equal."
                             .into(),
-                        "Functions can never be merged together.".into(),
+                        "Functions can never be merged.".into(),
                     ])]
             }
             EvalError::UnboundIdentifier(ident, span_opt) => vec![Diagnostic::error()
@@ -1737,7 +1737,7 @@ impl IntoDiagnostics<FileId> for TypecheckError {
                 )
                 .with_message("this type variable is unbound")])
                 .with_notes(vec![format!(
-                    "Did you forget to put a `forall {ident}.` somewhere in the enclosing type ?"
+                    "Did you forget to put a `forall {ident}.` somewhere in the enclosing type?"
                 )])],
             TypecheckError::TypeMismatch(expd, actual, span_opt) => {
                 fn addendum(ty: &Types) -> &str {
@@ -1875,7 +1875,7 @@ impl IntoDiagnostics<FileId> for TypecheckError {
                         diags.extend(err.into_diagnostics(files, stdlib_ids).into_iter().map(
                             |mut diag| {
                                 diag.message =
-                                    format!("While matching function types: {}", diag.message);
+                                    format!("while matching function types: {}", diag.message);
                                 diag
                             },
                         ));
@@ -1962,7 +1962,7 @@ impl IntoDiagnostics<FileId> for ExportError {
                 .with_message("non serializable term")
                 .with_labels(vec![primary_term(&rt, files)])
                 .with_notes(vec![
-                    "Nickel only support serlializing to and from strings, booleans, numbers, \
+                    "Nickel only supports serlializing to and from strings, booleans, numbers, \
                     enum tags, `null` (depending on the format), as well as records and arrays \
                     of serializable values."
                         .into(),

--- a/src/error.rs
+++ b/src/error.rs
@@ -200,13 +200,6 @@ pub enum TypecheckError {
         TermPos,
     ),
     /// Two incompatible kind (enum vs record) have been deduced for the same identifier of a row type.
-    RowKindMismatch(
-        Ident,
-        /* the expected type */ Option<Types>,
-        /* the actual type */ Option<Types>,
-        TermPos,
-    ),
-    /// Two incompatible types have been deduced for the same identifier in a row type.
     RowMismatch(
         Ident,
         /* the expected row type (whole) */ Types,
@@ -1767,22 +1760,6 @@ impl IntoDiagnostics<FileId> for TypecheckError {
                         format!("{}{}", mk_expected_msg(&expd), addendum(&expd),),
                         format!("{}{}", mk_actual_msg(&actual), addendum(&actual),),
                         String::from(last_note),
-                    ])]
-            }
-            TypecheckError::RowKindMismatch(ident, expd, actual, span_opt) => {
-                let (expd_str, actual_str) = match (expd, actual) {
-                    (Some(_), None) => ("an enum type", "a record type"),
-                    (None, Some(_)) => ("a record type", "an enum type"),
-                    _ => panic!("error::to_diagnostic()::RowKindMismatch: unexpected configuration for `expd` and `actual`"),
-                };
-
-                vec![Diagnostic::error()
-                    .with_message("incompatible row kinds")
-                    .with_labels(mk_expr_label(&span_opt))
-                    .with_notes(vec![
-                        format!("The row type of `{ident}` was expected to be `{expd_str}`"),
-                        format!("The row type of `{ident}` was inferred to be `{actual_str}`"),
-                        String::from("Enum row types and record row types are not compatible"),
                     ])]
             }
             TypecheckError::RowMismatch(ident, expd, actual, mut err, span_opt) => {

--- a/src/parser/error.rs
+++ b/src/parser/error.rs
@@ -17,7 +17,7 @@ pub enum ParseError {
     /// A specific lexical error
     Lexical(LexicalError),
     /// Unbound type variable(s)
-    UnboundTypeVariables(Vec<Ident>, RawSpan),
+    UnboundTypeVariables(Vec<Ident>),
     /// Illegal record literal in the uniterm syntax. In practice, this is a record with a
     /// polymorphic tail that contains a construct that wasn't permitted inside a record type in
     /// the original syntax. Typically, a field assignment:

--- a/src/parser/uniterm.rs
+++ b/src/parser/uniterm.rs
@@ -105,9 +105,7 @@ impl TryFrom<UniTerm> for RichTerm {
             UniTermNode::Types(mut ty) => {
                 ty.fix_type_vars(pos.unwrap())?;
                 ty.contract().map_err(|UnboundTypeVariableError(id)| {
-                    // We unwrap the position of the identifier, which must be set at this stage of parsing
-                    let pos = id.pos;
-                    ParseError::UnboundTypeVariables(vec![id], pos.unwrap())
+                    ParseError::UnboundTypeVariables(vec![id])
                 })?
             }
             UniTermNode::Term(rt) => rt,
@@ -462,9 +460,8 @@ impl TryFrom<UniRecord> for RichTerm {
             };
 
             ty.fix_type_vars(pos.unwrap())?;
-            ty.contract().map_err(|UnboundTypeVariableError(id)| {
-                ParseError::UnboundTypeVariables(vec![id], pos.unwrap())
-            })
+            ty.contract()
+                .map_err(|UnboundTypeVariableError(id)| ParseError::UnboundTypeVariables(vec![id]))
         } else {
             ur.check_typed_field_without_def()?;
 

--- a/src/typecheck/error.rs
+++ b/src/typecheck/error.rs
@@ -18,8 +18,6 @@ pub enum RowUnifError {
     ExtraDynTail(),
     /// There were two incompatible definitions for the same row.
     RowMismatch(Ident, Box<UnifError>),
-    /// Tried to unify an enum row and a record row.
-    RowKindMismatch(Ident, Option<UnifType>, Option<UnifType>),
     /// A [row constraint][super::RowConstr] was violated.
     UnsatConstr(Ident, Option<UnifType>),
     /// Tried to unify a type constant with another different type.
@@ -46,9 +44,6 @@ impl RowUnifError {
             RowUnifError::MissingDynTail() => UnifError::MissingDynTail(left, right),
             RowUnifError::ExtraRow(id) => UnifError::ExtraRow(id, left, right),
             RowUnifError::ExtraDynTail() => UnifError::ExtraDynTail(left, right),
-            RowUnifError::RowKindMismatch(id, uty1, uty2) => {
-                UnifError::RowKindMismatch(id, uty1, uty2)
-            }
             RowUnifError::RowMismatch(id, err) => UnifError::RowMismatch(id, left, right, err),
             RowUnifError::UnsatConstr(id, uty) => UnifError::RowConflict(id, uty, left, right),
             RowUnifError::WithConst(c, uty) => UnifError::WithConst(c, uty),
@@ -65,8 +60,6 @@ pub enum UnifError {
     TypeMismatch(UnifType, UnifType),
     /// There are two incompatible definitions for the same row.
     RowMismatch(Ident, UnifType, UnifType, Box<UnifError>),
-    /// Tried to unify an enum row and a record row.
-    RowKindMismatch(Ident, Option<UnifType>, Option<UnifType>),
     /// Tried to unify two distinct type constants.
     ConstMismatch(usize, usize),
     /// Tried to unify two rows, but an identifier of the LHS was absent from the RHS.
@@ -136,12 +129,6 @@ impl UnifError {
                 reporting::to_type(state.table, state.names, names, uty1),
                 reporting::to_type(state.table, state.names, names, uty2),
                 Box::new((*err).into_typecheck_err_(state, names, TermPos::None)),
-                pos_opt,
-            ),
-            UnifError::RowKindMismatch(id, ty1, ty2) => TypecheckError::RowKindMismatch(
-                id,
-                ty1.map(|tw| reporting::to_type(state.table, state.names, names, tw)),
-                ty2.map(|tw| reporting::to_type(state.table, state.names, names, tw)),
                 pos_opt,
             ),
             // TODO: for now, failure to unify with a type constant causes the same error as a

--- a/src/typecheck/error.rs
+++ b/src/typecheck/error.rs
@@ -189,9 +189,7 @@ impl UnifError {
                 reporting::to_type(state.table, state.names, names, right),
                 pos_opt,
             ),
-            UnifError::UnboundTypeVariable(ident) => {
-                TypecheckError::UnboundTypeVariable(ident, pos_opt)
-            }
+            UnifError::UnboundTypeVariable(ident) => TypecheckError::UnboundTypeVariable(ident),
             err @ UnifError::CodomainMismatch(_, _, _)
             | err @ UnifError::DomainMismatch(_, _, _) => {
                 let (expd, actual, path, err_final) = err.into_type_path().unwrap();

--- a/src/types.rs
+++ b/src/types.rs
@@ -643,15 +643,13 @@ impl From<UnboundTypeVariableError> for EvalError {
 
 impl From<UnboundTypeVariableError> for TypecheckError {
     fn from(err: UnboundTypeVariableError) -> Self {
-        let pos = err.0.pos;
-        TypecheckError::UnboundTypeVariable(err.0, pos)
+        TypecheckError::UnboundTypeVariable(err.0)
     }
 }
 
 impl From<UnboundTypeVariableError> for ParseError {
     fn from(err: UnboundTypeVariableError) -> Self {
-        let pos = err.0.pos;
-        ParseError::UnboundTypeVariables(vec![err.0], pos.unwrap())
+        ParseError::UnboundTypeVariables(vec![err.0])
     }
 }
 

--- a/tests/integration/unbound_type_variables.rs
+++ b/tests/integration/unbound_type_variables.rs
@@ -20,7 +20,7 @@ macro_rules! assert_unbound {
         match res {
             Err(Error::ParseErrors(ParseErrors {errors})) =>
                 assert_matches!(errors.as_slice(),
-                    [ParseError::UnboundTypeVariables(vars, _)]
+                    [ParseError::UnboundTypeVariables(vars)]
                     if vars.contains(&Ident::from($var)) && vars.len() == 1),
             Err(Error::TypecheckError(err)) =>
                 assert_matches!(err,

--- a/tests/snapshot/snapshots/snapshot__doc_stderr_function.ncl.snap
+++ b/tests/snapshot/snapshots/snapshot__doc_stderr_function.ncl.snap
@@ -8,6 +8,6 @@ error: no documentation found
 1 │ fun x => x
   │ ^^^^^^^^^^
   │
-  = documentation can only be collected from records
+  = documentation can only be collected from a record.
 
 

--- a/tests/snapshot/snapshots/snapshot__error_annotated_record_pattern_typecheck_fail.ncl.snap
+++ b/tests/snapshot/snapshots/snapshot__error_annotated_record_pattern_typecheck_fail.ncl.snap
@@ -8,8 +8,8 @@ error: incompatible types
 2 │   let { x : Bool } = { x = 5 } in
   │                            ^ this expression
   │
-  = The type of the expression was expected to be `Bool`
-  = The type of the expression was inferred to be `Number`
+  = Expected an expression of type `Bool`
+  = Found an expression of type `Number`
   = These types are not compatible
 
 

--- a/tests/snapshot/snapshots/snapshot__error_mismatched_row_record_pattern_fail.ncl.snap
+++ b/tests/snapshot/snapshots/snapshot__error_mismatched_row_record_pattern_fail.ncl.snap
@@ -8,13 +8,13 @@ error: incompatible rows declaration
 2 │   let { x : { a : Number } = { a : String } } = { x = { a = true } } 
   │             ^^^^^^^^^^^^^^ this expression
   │
-  = The type of the expression was expected to have the row `a: String`
-  = The type of the expression was inferred to have the row `a: Number`
-  = Could not match the two declaration of `a`
+  = Expected an expression of a record type with the row `a: String`
+  = Found an expression of a record type with the row `a: Number`
+  = Could not match the two declarations of `a`
 
-error: While typing field `a`: incompatible types
- = The type of the expression was expected to be `String`
- = The type of the expression was inferred to be `Number`
+error: while typing field `a`: incompatible types
+ = Expected an expression of type `String`
+ = Found an expression of type `Number`
  = These types are not compatible
 
 

--- a/tests/snapshot/snapshots/snapshot__error_nested_annotated_record_pattern_typecheck_fail.ncl.snap
+++ b/tests/snapshot/snapshots/snapshot__error_nested_annotated_record_pattern_typecheck_fail.ncl.snap
@@ -8,8 +8,8 @@ error: incompatible types
 2 │   let { x = { a : Number }} = { x = { a = "" }} in
   │                                           ^^ this expression
   │
-  = The type of the expression was expected to be `Number`
-  = The type of the expression was inferred to be `String`
+  = Expected an expression of type `Number`
+  = Found an expression of type `String`
   = These types are not compatible
 
 


### PR DESCRIPTION
Pass on error messages. This PR attempts to:

- add missing information from error messages when required, or make important information to appear as high as possible (for example, repeating the name of the unbound identifier in the very first tagline `error: unbound identifier`, so that it is immediately visible without having to read the rest of the error message)
- removing useless/confusing information
- make error messages lighter (avoid heavy, passive formulations)
- use consistent jargon and formatting

This PR also gets rid of an error variant that wasn't used anymore since the the row types refactoring, and factor some error messages into small helpers to avoid repeating the same string literals over and over again.