### PR TITLE
Update topiary to latest version

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -411,11 +411,11 @@
         "rust-overlay": "rust-overlay_4"
       },
       "locked": {
-        "lastModified": 1682415064,
-        "narHash": "sha256-uAyg5d+i2YLJrY+nnoFb+w2wlcuwIa9Vs4UtvMEKBVs=",
+        "lastModified": 1682503900,
+        "narHash": "sha256-3Kb9D8S0lkGcPAcpJJGInVyFN79K6gn6TN0ZHWFA19s=",
         "owner": "tweag",
         "repo": "topiary",
-        "rev": "74952c7720ccd7f055f629b5cff61bda7adfab4f",
+        "rev": "773159aa4c819b46c6d51ca9275e7366087eb3a0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Another update of topiary, this time to incorporate the `tree-sitter-nickel` grammar changes for the new enum tag syntax.