### PR TITLE
Keep track of field names in labels

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -1149,17 +1149,17 @@ mod blame_error {
             // a positive blame
             assert_eq!(l.polarity, Polarity::Positive);
             match l.field_name {
-                Some(ident) => format!("contract broken by the value of {ident}"),
+                Some(ident) => format!("contract broken by the value of `{ident}`"),
                 None => "contract broken by a value".to_owned(),
             }
         } else if l.polarity == Polarity::Positive {
             match l.field_name {
-                Some(ident) => format!("contract broken by the function {ident}"),
+                Some(ident) => format!("contract broken by the function `{ident}`"),
                 None => "contract broken by a function".to_owned(),
             }
         } else {
             match l.field_name {
-                Some(ident) => format!("contract broken by the caller of {ident}"),
+                Some(ident) => format!("contract broken by the caller of `{ident}`"),
                 None => "contract broken by the caller".to_owned(),
             }
         }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1143,16 +1143,25 @@ mod blame_error {
 
     /// Returns a title to be used by blame errors based on the `path` and `polarity`
     /// of the label.
-    pub fn title(l: &label::Label) -> &str {
+    pub fn title(l: &label::Label) -> String {
         if ty_path::has_no_arrow(&l.path) {
             // An empty path or a path that contains only fields necessarily corresponds to
             // a positive blame
             assert_eq!(l.polarity, Polarity::Positive);
-            "contract broken by a value"
+            match l.field_name {
+                Some(ident) => format!("contract broken by the value of {ident}"),
+                None => "contract broken by a value".to_owned(),
+            }
         } else if l.polarity == Polarity::Positive {
-            "contract broken by a function"
+            match l.field_name {
+                Some(ident) => format!("contract broken by the function {ident}"),
+                None => "contract broken by a function".to_owned(),
+            }
         } else {
-            "contract broken by the caller"
+            match l.field_name {
+                Some(ident) => format!("contract broken by the caller of {ident}"),
+                None => "contract broken by the caller".to_owned(),
+            }
         }
     }
 

--- a/src/label.rs
+++ b/src/label.rs
@@ -298,6 +298,10 @@ pub struct Label {
     /// Signal to a polymorphic contract that it should generate the dual
     /// contract. Part of the preliminary fix for [#1161](https://github.com/tweag/nickel/issues/1161).
     pub dualize: bool,
+    /// The name of the record field to report in blame errors. This is set
+    /// while first transforming a record as part of the pending contract generation.
+    /// Contract applications outside of records will have this field set to `None`.
+    pub field_name: Option<Ident>,
 }
 
 /// Data about type variables that is needed for polymorphic contracts to decide which actions to take.
@@ -488,6 +492,10 @@ impl Label {
             self.diagnostics.push(ContractDiagnostic::new());
         }
     }
+
+    pub fn with_field_name(self, field_name: Option<Ident>) -> Self {
+        Label { field_name, ..self }
+    }
 }
 
 impl Default for Label {
@@ -506,6 +514,7 @@ impl Default for Label {
             path: Default::default(),
             type_environment: Default::default(),
             dualize: false,
+            field_name: None,
         }
     }
 }

--- a/src/term/mod.rs
+++ b/src/term/mod.rs
@@ -295,14 +295,6 @@ impl RuntimeContract {
     {
         contracts.fold(rt, |acc, ctr| ctr.apply(acc, pos))
     }
-
-    /// Modify the label's `field_name` field.
-    pub fn with_field_name(self, ident: Option<Ident>) -> Self {
-        RuntimeContract {
-            label: self.label.with_field_name(ident),
-            ..self
-        }
-    }
 }
 
 impl Traverse<RichTerm> for RuntimeContract {
@@ -522,6 +514,17 @@ impl TypeAnnotation {
             .cloned()
             .map(RuntimeContract::try_from)
             .collect::<Result<Vec<_>, _>>()
+    }
+
+    pub fn with_field_name(self, field_name: Option<Ident>) -> Self {
+        TypeAnnotation {
+            types: self.types.map(|t| t.with_field_name(field_name)),
+            contracts: self
+                .contracts
+                .into_iter()
+                .map(|t| t.with_field_name(field_name))
+                .collect(),
+        }
     }
 }
 

--- a/src/term/mod.rs
+++ b/src/term/mod.rs
@@ -295,6 +295,14 @@ impl RuntimeContract {
     {
         contracts.fold(rt, |acc, ctr| ctr.apply(acc, pos))
     }
+
+    /// Modify the label's `field_name` field.
+    pub fn with_field_name(self, ident: Option<Ident>) -> Self {
+        RuntimeContract {
+            label: self.label.with_field_name(ident),
+            ..self
+        }
+    }
 }
 
 impl Traverse<RichTerm> for RuntimeContract {
@@ -428,6 +436,16 @@ impl fmt::Display for MergePriority {
 pub struct LabeledType {
     pub types: Types,
     pub label: Label,
+}
+
+impl LabeledType {
+    /// Modify the label's `field_name` field.
+    pub fn with_field_name(self, ident: Option<Ident>) -> Self {
+        LabeledType {
+            label: self.label.with_field_name(ident),
+            ..self
+        }
+    }
 }
 
 impl Traverse<RichTerm> for LabeledType {

--- a/src/term/record.rs
+++ b/src/term/record.rs
@@ -193,6 +193,16 @@ impl Field {
             RecordExtKind::WithoutValue
         }
     }
+
+    pub fn with_name(self, field_name: Option<Ident>) -> Self {
+        Field {
+            metadata: FieldMetadata {
+                annotation: self.metadata.annotation.with_field_name(field_name),
+                ..self.metadata
+            },
+            ..self
+        }
+    }
 }
 
 impl Traverse<RichTerm> for Field {

--- a/src/transform/gen_pending_contracts.rs
+++ b/src/transform/gen_pending_contracts.rs
@@ -22,9 +22,15 @@ use crate::{
 };
 
 pub fn transform_one(rt: RichTerm) -> Result<RichTerm, UnboundTypeVariableError> {
-    fn attach_to_field(field: Field) -> Result<Field, UnboundTypeVariableError> {
+    fn attach_to_field(id: Option<Ident>, field: Field) -> Result<Field, UnboundTypeVariableError> {
         // We simply add the contracts to the pending contract fields
-        let pending_contracts = field.metadata.annotation.pending_contracts()?;
+        let pending_contracts = field
+            .metadata
+            .annotation
+            .pending_contracts()?
+            .into_iter()
+            .map(|ctr| ctr.with_field_name(id))
+            .collect();
         // Type annotations are different: the contract is generated statically, because as opposed
         // to contract annotations, type anntotations don't propagate.
         let value = field
@@ -32,7 +38,8 @@ pub fn transform_one(rt: RichTerm) -> Result<RichTerm, UnboundTypeVariableError>
             .map(|v| -> Result<RichTerm, UnboundTypeVariableError> {
                 if let Some(labeled_ty) = &field.metadata.annotation.types {
                     let pos = v.pos;
-                    let contract = RuntimeContract::try_from(labeled_ty.clone())?;
+                    let contract =
+                        RuntimeContract::try_from(labeled_ty.clone().with_field_name(id))?;
                     Ok(contract.apply(v, pos))
                 } else {
                     Ok(v)
@@ -52,7 +59,7 @@ pub fn transform_one(rt: RichTerm) -> Result<RichTerm, UnboundTypeVariableError>
     ) -> Result<IndexMap<Ident, Field>, UnboundTypeVariableError> {
         fields
             .into_iter()
-            .map(|(id, field)| Ok((id, attach_to_field(field)?)))
+            .map(|(id, field)| Ok((id, attach_to_field(Some(id), field)?)))
             .collect()
     }
 
@@ -64,7 +71,7 @@ pub fn transform_one(rt: RichTerm) -> Result<RichTerm, UnboundTypeVariableError>
 
                 let fields = attach_to_fields(fields)?;
                 let dyn_fields = dyn_fields.into_iter().map(|(id_term, field)| {
-                     Ok((id_term, attach_to_field(field)?))
+                     Ok((id_term, attach_to_field(None, field)?))
                 }).collect::<Result<_, _>>()?;
 
                 RichTerm::new(Term::RecRecord(RecordData {fields, attrs, sealed_tail}, dyn_fields, deps), pos)

--- a/tests/snapshot/inputs/errors/caller_contract_violation.ncl
+++ b/tests/snapshot/inputs/errors/caller_contract_violation.ncl
@@ -1,0 +1,2 @@
+std.array.map std.function.id 'not-an-array
+

--- a/tests/snapshot/inputs/errors/function_contract_violation.ncl
+++ b/tests/snapshot/inputs/errors/function_contract_violation.ncl
@@ -1,0 +1,1 @@
+let r = { f | Number -> Number = fun x => 'not-a-number } in r.f 7

--- a/tests/snapshot/inputs/errors/value_contract_violation.ncl
+++ b/tests/snapshot/inputs/errors/value_contract_violation.ncl
@@ -1,0 +1,2 @@
+{ foo | std.FailWith "no reason" = 1 }.foo
+

--- a/tests/snapshot/snapshots/snapshot__error_caller_contract_violation.ncl.snap
+++ b/tests/snapshot/snapshots/snapshot__error_caller_contract_violation.ncl.snap
@@ -1,0 +1,28 @@
+---
+source: tests/snapshot/main.rs
+expression: snapshot
+---
+error: contract broken by the caller of map
+    ┌─ <stdlib/std.ncl>:128:33
+    │
+128 │       : forall a b. (a -> b) -> Array a -> Array b
+    │                                 ------- expected type of the argument provided by the caller
+    │
+    ┌─ [INPUTS_PATH]/errors/caller_contract_violation.ncl:1:31
+    │
+  1 │ std.array.map std.function.id 'not-an-array
+    │                               ------------- evaluated to this expression
+    │
+    = This error may happen in the following situation:
+          1. A function `f` is bound by a contract: e.g. `Number -> Number`.
+          2. `f` is called with an argument of the wrong type: e.g. `f false`.
+    = Either change the contract accordingly, or call `f` with an argument of the right type.
+    = Note: this is an illustrative example. The actual error may involve deeper nested functions calls.
+
+note: 
+  ┌─ [INPUTS_PATH]/errors/caller_contract_violation.ncl:1:1
+  │
+1 │ std.array.map std.function.id 'not-an-array
+  │ ------------------------------------------- (1) calling map
+
+

--- a/tests/snapshot/snapshots/snapshot__error_caller_contract_violation.ncl.snap
+++ b/tests/snapshot/snapshots/snapshot__error_caller_contract_violation.ncl.snap
@@ -2,7 +2,7 @@
 source: tests/snapshot/main.rs
 expression: snapshot
 ---
-error: contract broken by the caller of map
+error: contract broken by the caller of `map`
     ┌─ <stdlib/std.ncl>:128:33
     │
 128 │       : forall a b. (a -> b) -> Array a -> Array b

--- a/tests/snapshot/snapshots/snapshot__error_function_contract_violation.ncl.snap
+++ b/tests/snapshot/snapshots/snapshot__error_function_contract_violation.ncl.snap
@@ -1,0 +1,18 @@
+---
+source: tests/snapshot/main.rs
+expression: snapshot
+---
+error: contract broken by the function f
+  ┌─ [INPUTS_PATH]/errors/function_contract_violation.ncl:1:25
+  │
+1 │ let r = { f | Number -> Number = fun x => 'not-a-number } in r.f 7
+  │                         ------            ------------- evaluated to this expression
+  │                         │                  
+  │                         expected return type
+  │
+  = This error may happen in the following situation:
+        1. A function `f` is bound by a contract: e.g. `Bool -> Number`.
+        2. `f` returns a value of the wrong type: e.g. `f = fun c => "string"` while `Number` is expected.
+  = Either change the contract accordingly, or change the return value of `f`
+
+

--- a/tests/snapshot/snapshots/snapshot__error_function_contract_violation.ncl.snap
+++ b/tests/snapshot/snapshots/snapshot__error_function_contract_violation.ncl.snap
@@ -2,7 +2,7 @@
 source: tests/snapshot/main.rs
 expression: snapshot
 ---
-error: contract broken by the function f
+error: contract broken by the function `f`
   ┌─ [INPUTS_PATH]/errors/function_contract_violation.ncl:1:25
   │
 1 │ let r = { f | Number -> Number = fun x => 'not-a-number } in r.f 7

--- a/tests/snapshot/snapshots/snapshot__error_value_contract_violation.ncl.snap
+++ b/tests/snapshot/snapshots/snapshot__error_value_contract_violation.ncl.snap
@@ -2,7 +2,7 @@
 source: tests/snapshot/main.rs
 expression: snapshot
 ---
-error: contract broken by the value of foo: no reason
+error: contract broken by the value of `foo`: no reason
   ┌─ [INPUTS_PATH]/errors/value_contract_violation.ncl:1:36
   │
 1 │ { foo | std.FailWith "no reason" = 1 }.foo

--- a/tests/snapshot/snapshots/snapshot__error_value_contract_violation.ncl.snap
+++ b/tests/snapshot/snapshots/snapshot__error_value_contract_violation.ncl.snap
@@ -1,0 +1,13 @@
+---
+source: tests/snapshot/main.rs
+expression: snapshot
+---
+error: contract broken by the value of foo: no reason
+  ┌─ [INPUTS_PATH]/errors/value_contract_violation.ncl:1:36
+  │
+1 │ { foo | std.FailWith "no reason" = 1 }.foo
+  │         ------------------------   ^ applied to this expression
+  │         │                           
+  │         expected type
+
+


### PR DESCRIPTION
Add a way of tracking field names for contracts that are attached to specific record fields. For example, this enables some blame errors to give the user a hint for which field was involved when a contract definition is too far away to see this in the codespan diagnostics.