### PR TITLE
Add `cargo doc` to flake checks

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -30,40 +30,35 @@ crates and dependent repositories (such as the website) in a consistent state.
    Commit and push your changes.
 3. Make sure that everything builds: run `nix flake check` at the root of the
    repository.
-4. The documentation will be pushed to `crates.io` after the release. Make sure
-   that the documentation builds correctly:
-    - run `cargo doc --no-deps --document-private-items`
-    - fix every warning you can (e.g. referencing private items may be fine, but
-        unresolved references must be dealt with).
-5. Add the changelog since the last release in RELEASES.md. GitHub is able to
+4. Add the changelog since the last release in RELEASES.md. GitHub is able to
    automatically generate release notes: refer to [this
    guide](https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes).
    While the output needs to be reworked, it's a useful starting point. Commit
    and push your changes.
-6. Set the `stable` branch to point to your new `X.Y.Z-release`. Because the
+5. Set the `stable` branch to point to your new `X.Y.Z-release`. Because the
    `stable` branch usually contains specific fixes, or cherry-picked commits,
    we'll have to force push. We advise to first save the previous state in a
    local branch:
 
    ```console
-   $git checkout stable
-   $git branch stable-local-save
+   git checkout stable
+   git branch stable-local-save
    ```
 
    If anything goes wrong, you can reset `stable` to its previous state:
 
    ```console
-   $git checkout stable
-   $git reset --hard stable-local-save
-   $git push --force-with-lease
+   git checkout stable
+   git reset --hard stable-local-save
+   git push --force-with-lease
    ```
 
    Update the `stable` branch:
 
    ```console
-   $git checkout stable
-   $git reset --hard X.Y.Z-release`
-   $git push --force-with-lease
+   git checkout stable
+   git reset --hard X.Y.Z-release`
+   git push --force-with-lease
    ```
 
 ### Release on crates.io
@@ -89,8 +84,8 @@ crates and dependent repositories (such as the website) in a consistent state.
 1. Build the docker image and copy the output somewhere:
 
    ```console
-   $nix build .#dockerImage
-   $cp ./result nickel-X.Y.Z-docker-image.tar.gz
+   nix build .#dockerImage
+   cp ./result nickel-X.Y.Z-docker-image.tar.gz
    ```
 
 2. Do the [release on
@@ -105,11 +100,11 @@ crates and dependent repositories (such as the website) in a consistent state.
 2. Branch out from `master` and update the Nickel input:
 
    ```console
-   $git checkout -b release/X.Y.Z
-   $nix flake lock --update-input nickel
-   $git add flake.lock
-   $git commit -m "Update to Nickel vX.Y.Z"
-   $git push -u origin @
+   git checkout -b release/X.Y.Z
+   nix flake lock --update-input nickel
+   git add flake.lock
+   git commit -m "Update to Nickel vX.Y.Z"
+   git push -u origin @
    ```
 
    Open a pull request on the nickel-lang repository. Once the CI is green and

--- a/flake.nix
+++ b/flake.nix
@@ -234,6 +234,20 @@
             doInstallCargoArtifacts = false;
           };
 
+          # Check that documentation builds without warnings or errors
+          checkRustDoc = craneLib.mkCargoDerivation {
+            inherit src cargoArtifacts;
+            inherit (cargoArtifacts) buildInputs;
+
+            pnameSuffix = "-doc";
+
+            buildPhaseCargoCommand = ''
+              RUSTDOCFLAGS='-D warnings' cargo doc --no-deps --workspace --all-features
+            '';
+
+            doInstallCargoArtifacts = false;
+          };
+
           rustfmt = craneLib.cargoFmt {
             # Notice that unlike other Crane derivations, we do not pass `cargoArtifacts` to `cargoFmt`, because it does not need access to dependencies to format the code.
             inherit src;
@@ -439,6 +453,7 @@
         inherit (mkCraneArtifacts { noRunBench = true; })
           benchmarks
           clippy
+          checkRustDoc
           lsp-nls
           nickel
           rustfmt;

--- a/lsp/nls/src/linearization/building.rs
+++ b/lsp/nls/src/linearization/building.rs
@@ -229,8 +229,8 @@ impl<'b> Building<'b> {
         }
     }
 
-    /// [`resolve_record_references`] tries to resolve the references passed to it, and
-    /// returns the ids of the items it couldn't resolve.
+    /// `resolve_record_references` tries to resolve the references passed to it, and returns the
+    /// ids of the items it couldn't resolve.
     pub(super) fn resolve_record_references(
         &mut self,
         current_file: FileId,

--- a/lsp/nls/src/linearization/interface.rs
+++ b/lsp/nls/src/linearization/interface.rs
@@ -5,9 +5,8 @@ use nickel_lang::{identifier::Ident, typecheck::UnifType, types::Types};
 use super::ItemId;
 
 pub trait ResolutionState {}
-/// Types are available as [TypeWrapper] only during recording
-/// They are resolved after typechecking has collected all terms into concrete
-/// [Types]
+/// Types are available as [nickel_lang::typecheck::UnifType] only during recording. They are
+/// resolved after typechecking as [nickel_lang::types::Types]
 pub type Unresolved = UnifType;
 impl ResolutionState for Unresolved {}
 

--- a/lsp/nls/src/linearization/mod.rs
+++ b/lsp/nls/src/linearization/mod.rs
@@ -62,7 +62,7 @@ pub struct AnalysisHost<'a> {
     meta: Option<FieldMetadata>,
     /// Indexing a record will store a reference to the record as
     /// well as its fields.
-    /// [Self::Scope] will produce a host with a single **`pop`ed**
+    /// `Self::scope` will produce a host with a single **`pop`ed**
     /// Ident. As fields are typechecked in the same order, each
     /// in their own scope immediately after the record, which
     /// gives the corresponding record field _term_ to the ident
@@ -70,9 +70,11 @@ pub struct AnalysisHost<'a> {
     record_fields: Option<(ItemId, Vec<(ItemId, Ident)>)>,
     bindings: Option<Vec<ItemId>>,
     /// Accesses to nested records are recorded recursively.
+    ///
     /// ```
     /// outer.middle.inner -> inner(middle(outer))
     /// ```
+    ///
     /// To resolve those inner fields, accessors (`inner`, `middle`)
     /// are recorded first until a variable (`outer`). is found.
     /// Then, access to all nested records are resolved at once.


### PR DESCRIPTION
Instead of doing it manually when releasing, add to the flake checks (and thus the CI) that the crates doc build without warnings. We got rid of the recommendation of documenting/referring to private items to follow the simplest setting for `cargo doc`. Rustdoc comments can simply be turned into normal comments.

This PR fixes the doc build of NLS, which were raising warnings.