### PR TITLE
Convert `import` to statement instead of pseudo-fun

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -40,6 +40,7 @@ Breaking changes
 - Stdlib `string.Stringingable` -> `string.Stringable` by @vkleen in https://github.com/tweag/nickel/pull/1180
 - Fix the type of `array.elem` by @yannham in https://github.com/tweag/nickel/pull/1223
 - Change the enum tag start delimiter from backtick to single-quote by @vkleen in https://github.com/tweag/nickel/pull/1279
+- `import` is now a statement, `import "foo.ncl" arg1 arg2` requires parenthesis now: `(import "foo.ncl") arg1 arg2`, see https://github.com/tweag/nickel/pull/1293
 
 Language features
 -----------------

--- a/benches/mantis/deploy-example.ncl
+++ b/benches/mantis/deploy-example.ncl
@@ -1,4 +1,4 @@
-import "deploy.ncl"
+(import "deploy.ncl")
   {
     namespace = "mantis-staging",
     job = "miner",

--- a/benches/mantis/deploy.ncl
+++ b/benches/mantis/deploy.ncl
@@ -67,7 +67,7 @@ fun vars =>
   }
   in
   let jobDefs = {
-    Mantis = import "jobs/mantis.ncl" params,
+    Mantis = (import "jobs/mantis.ncl") params,
   }
   in
   let revisions = {

--- a/doc/manual/merging.md
+++ b/doc/manual/merging.md
@@ -695,7 +695,7 @@ configuration, from which other fields are derived:
 `greeter` can then be customized without interfering with the final output:
 
 ```console
-$ nickel export <<< 'import "hello-service.ncl" & {greeter = "country"}'
+$ nickel export <<< '(import "hello-service.ncl") & {greeter = "country"}'
 {
   "systemd": {
     "services": {

--- a/src/parser/grammar.lalrpop
+++ b/src/parser/grammar.lalrpop
@@ -244,6 +244,7 @@ UniTerm: UniTerm = {
     <err: Error> => {
         UniTerm::from(err)
     },
+    "import" <s: StandardStaticString> => UniTerm::from(Term::Import(OsString::from(s))),
 };
 
 AnnotatedInfixExpr: UniTerm = {
@@ -276,7 +277,6 @@ Forall: Types =
 // A n-ary application-like expression (n may be 0, in the sense that this rule
 // also includes previous levels).
 Applicative: UniTerm = {
-    "import" <s: StandardStaticString> => UniTerm::from(Term::Import(OsString::from(s))),
     AsUniTerm<WithPos<TypeArray>>,
     <t1: AsTerm<Applicative>> <t2: AsTerm<RecordOperand>> =>
         UniTerm::from(mk_app!(t1, t2)),

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -571,3 +571,23 @@ fn ty_var_kind_mismatch() {
         )
     }
 }
+
+#[test]
+fn import() {
+    assert_eq!(
+        parse_without_pos("import \"file.ncl\""),
+        mk_term::import("file.ncl")
+    );
+    assert_matches!(
+        parse("import \"file.ncl\" some args"),
+        Err(ParseError::UnexpectedToken(_, _))
+    );
+    assert_eq!(
+        parse_without_pos("(import \"file.ncl\") some args"),
+        mk_app!(
+            mk_term::import("file.ncl"),
+            mk_term::var("some"),
+            mk_term::var("args")
+        )
+    );
+}

--- a/tests/integration/pass/import.ncl
+++ b/tests/integration/pass/import.ncl
@@ -1,3 +1,2 @@
-let {Assert, ..} = import "lib/assert.ncl" in
-
-(import "lib/imported.ncl" 3 == 3 | Assert)
+let { Assert, .. } = import "lib/assert.ncl" in
+((import "lib/imported.ncl") 3 == 3 | Assert)

--- a/tests/integration/pass/typechecking.ncl
+++ b/tests/integration/pass/typechecking.ncl
@@ -177,7 +177,7 @@ let typecheck = [
   (let x = {val : Number | doc "some" | default = 1}.val in x + 1) : Number,
 
   # Typed import
-  import "lib/typed-import.ncl" : Number,
+  (import "lib/typed-import.ncl") : Number,
 
   # Regression test for #430 (https://github.com/tweag/nickel/issues/430)
   let x = import "lib/typed-import.ncl"


### PR DESCRIPTION
Currently `import` is treated as a very special function that only accepts literal string as its first argument. It has following downsides:

* Special handling of `import` is hidden. User can assume that its just a function while it's a special keyword. User might expect to be able to pass variables to it while it is only handled before typechecking and evaluation.
* We can't extend `import` functionality without introducing new keywords which is not backward-compatible.

This change makes `import` into another statement like `let` or `fun`, which means it cannot be confused with a function anymore. It also means that expressions like `import "foo.ncl" bar` and `import "foo.ncl" & {..}` are invalid, and `import` statement need to be put in parethesis: `(import "foo.ncl") bar`.

For more context, see discussion in https://github.com/tweag/nickel/issues/329#issuecomment-1531333491