### PR TITLE
Err on the side of too much syntax highlighting in the manual

### DIFF
--- a/doc/manual/contracts.md
+++ b/doc/manual/contracts.md
@@ -41,7 +41,7 @@ are performed:
 2. Check that the result is a number.
 3. If it is, return the expression unchanged. Otherwise, raise an error.
 
-```text
+```nickel
 nickel> 1 + 1 | Number
 2
 
@@ -100,7 +100,7 @@ In `IsFoo`, we first test if the value is a string, and then if it is equal to
 `"foo"`, in which case the contract succeeds. Otherwise, the contract fails with
 appropriate error messages. Let us try:
 
-```text
+```nickel
 nickel> 1 | IsFoo
 error: contract broken by a value [not a string].
 [..]
@@ -353,7 +353,7 @@ In addition to defining the contracts of fields, record contracts can also
 attach metadata (see [merging](./merging.md)) to fields, such as documentation
 or default values:
 
-```text
+```nickel
 nickel>
 let Schema = {
   foo
@@ -370,7 +370,7 @@ nickel> std.serialize 'Json config
   "foo": "foo"
 }"
 
-nickel>:query config foo
+nickel> :query config foo
 * contract: String
 * default: "foo"
 * documentation: This documentation will propagate to the final value!
@@ -380,7 +380,7 @@ nickel>:query config foo
 
 By default, record contracts are closed, meaning that additional fields are forbidden:
 
-```text
+```nickel
 nickel> let Contract = {foo | String}
 nickel> {foo = "a", bar = 1} | Contract
 error: contract broken by a value [extra field `bar`].
@@ -390,7 +390,7 @@ error: contract broken by a value [extra field `bar`].
 If you want to allow additional fields, append `, ..` after the last field
 definition to define an open contract:
 
-```text
+```nickel
 nickel> let Contract = {foo | String, ..}
 nickel> {foo = "a", bar = 1} | Contract
 { bar = 1, foo = "a" }
@@ -404,7 +404,7 @@ contract or a normal value. If a field is defined both in the contract and the
 checked value, the two definitions will be merged in the final result. For
 example:
 
-```text
+```nickel
 nickel>
 let Secure = {
   must_be_very_secure | Bool = true,
@@ -447,7 +447,7 @@ fields: thus, the contract `{bar | String}` attached to `foo` will actually
 behave like an open contract, even if you didn't use `..`. This might or might not
 be what you want:
 
-```text
+```nickel
 nickel>
 let ContractPipe = {
   sub_field | {foo | String}
@@ -479,7 +479,7 @@ system](./typing.md) can be used to combine contracts.
 An array contract checks that the value is an array and applies its parameter
 contract to each element:
 
-```text
+```nickel
 nickel>
 let VeryBig =
   std.contract.from_predicate (
@@ -535,13 +535,13 @@ is a bug you have to fix.
 The interpreter automatically performs bookkeeping for function contracts in
 order to make this caller/callee distinction:
 
-```text
-nickel>let add_semi | String -> String = fun x => x ++ ";" in
+```nickel
+nickel> let add_semi | String -> String = fun x => x ++ ";" in
 add_semi 1
 error: contract broken by the caller.
 [..]
 
-nickel>let wrong | String -> String = fun x => 0 in
+nickel> let wrong | String -> String = fun x => 0 in
 wrong "a"
 error: contract broken by a function.
 [..]
@@ -553,7 +553,7 @@ The beauty of function contracts is that they gracefully scale to higher-order
 functions as well. Higher-order functions are functions that take other
 functions as parameters. Here is an example:
 
-```text
+```nickel
 nickel>
 let apply_fun | (Number -> Number) -> Number = fun f => f 0 in
 apply_fun (fun x => "a")
@@ -603,13 +603,13 @@ laziness, you can for example query specific information on a large
 configuration without having to actually evaluate everything. We will use the
 always failing contract `std.FailWith` to observe where evaluation takes place:
 
-```text
+```nickel
 nickel>
 let config = {
   fail | std.FailWith "ooch" = null,
   data | doc "Some information" = 42
 }
-nickel>:query config data
+nickel> :query config data
 * documentation: Some information
 
 nickel> config.fail
@@ -711,7 +711,7 @@ value and continues with the second argument (here, our wrapped `value`).
 
 Let us see if we indeed preserved laziness:
 
-```text
+```nickel
 nickel>
 let config | NumberBoolDict = {
   "1" | std.FailWith "ooch" = null, # same as our previous "fail"
@@ -724,7 +724,7 @@ nickel>:query config "0"
 Yes! Our contract doesn't unduly cause the evaluation of the field `"1"`. Does
 it check anything, though?
 
-```text
+```nickel
 nickel>
 let config | NumberBoolDict = {
   not_a_number = false,

--- a/doc/manual/correctness.md
+++ b/doc/manual/correctness.md
@@ -79,9 +79,7 @@ Types and contracts are enforced similarly, via annotations.
 
 Type annotations are introduced with `:`. For example:
 
-```text
-$ nickel repl
-
+```nickel
 nickel> 1 + 1.5 : Number
 2.5
 
@@ -96,9 +94,7 @@ error: incompatible types
 
 Contract annotations are introduced with `|`. For example:
 
-```text
-$ nickel repl
-
+```nickel
 nickel> let GreaterThan = fun bound =>
   std.contract.from_predicate (fun val => val >= bound) in
 -1 | GreaterThan 10
@@ -123,7 +119,7 @@ practical differences between types and contracts.
 Suppose we need a function to convert an array of key-value pairs into an array
 of keys and an array of values. Let's call it `split`:
 
-```text
+```nickel
 nickel> split [{key = "foo", value = 1}, {key = "bar", value = 2}]
 {keys = ["foo", "bar"], values = [1, 2]}
 

--- a/doc/manual/merging.md
+++ b/doc/manual/merging.md
@@ -51,7 +51,7 @@ evaluates to `{foo = 1, bar = "bar", baz = false}`.
 
 Formally, if we write the left operand as
 
-```text
+```nickel
 left = {
   field_left_1 = value_left_1,
   ..,
@@ -61,7 +61,7 @@ left = {
 
 and the right operand as
 
-```text
+```nickel
 right = {
   field_right_1 = value_right_1,
   ..,
@@ -71,7 +71,7 @@ right = {
 
 then the merge `left & right` evaluates to the record:
 
-```text
+```nickel
 {
   field_left_1 = value_left_1,
   ..,
@@ -367,7 +367,7 @@ values are given the priority `0`. Values with the same priority are recursively
 merged as specified in this document, which can mean failure if the values can't
 be meaningfully combined:
 
-```text
+```nickel
 nickel> {foo = 1} & {foo = 2}
 error: non mergeable terms
   ┌─ repl-input-1:1:8
@@ -383,7 +383,7 @@ error: non mergeable terms
 If the priorities differ, the value with the highest priority simply erases the
 other:
 
-```text
+```nickel
 nickel> {foo | priority 1 = 1} & {foo = 2}
 { foo = 1 }
 

--- a/doc/manual/syntax.md
+++ b/doc/manual/syntax.md
@@ -93,7 +93,7 @@ evaluates to `false`.
 
 Here are some examples of boolean operators in Nickel:
 
-```text
+```nickel
 > true && false
 false
 
@@ -117,13 +117,13 @@ The string interpolation syntax is
 
 Here are some examples of string handling in Nickel:
 
-```text
+```nickel
 > "Hello, World!"
 "Hello, World!"
 
 > m%"Well, if this isn't a multiline string?
 Yes it is, indeed it is"%
-"Well, if this isn't a string?
+"Well, if this isn't a multiline string?
 Yes it is, indeed it is"
 
 > "Hello" ++ "World"
@@ -145,7 +145,7 @@ present on all lines of the string is stripped. This way, multiline strings can
 be indented for nicer code formatting without producing unwanted whitespace in
 the output. For example:
 
-```text
+```nickel
 > m%"
   This line has no indentation.
     This line is indented.
@@ -160,7 +160,7 @@ This line has no more indentation."
 
 The only special sequence in a multiline string is the string interpolation:
 
-```text
+```nickel
 > m%"Multiline\nString?"%
 "Multiline\nString?"
 
@@ -175,7 +175,7 @@ closing delimiter. If you want to use string interpolation, you must use the
 same amount of `%` signs as in the delimiters. This can be useful for escaping
 `"%` or `%{` sequences in a string:
 
-```text
+```nickel
 > m%%"Hello World"%%
 "Hello World"
 
@@ -192,7 +192,7 @@ same amount of `%` signs as in the delimiters. This can be useful for escaping
 Multiline string interpolation is "indentation-aware". This means that you can
 interpolate a string with indentation and the result will be as expected:
 
-```text
+```nickel
 > let log = m%"
   if log:
     print("log:", s)
@@ -280,7 +280,7 @@ which uses symbolic strings, remember that:
 
 The following examples show how symbolic strings are desugared:
 
-```text
+```nickel
 > mytag-s%"I'm %{"symbolic"} with %{"fragments"}"%
 {
   tag = 'SymbolicString,
@@ -343,7 +343,7 @@ types are never equal: that is, `==` doesn't perform implicit conversions.
 
 Here are some examples of equality comparisons in Nickel:
 
-```text
+```nickel
 > 1 == 1
 true
 
@@ -381,7 +381,7 @@ The following are valid Nickel arrays, for example:
 
 Arrays can be concatenated with the operator `@`:
 
-```text
+```nickel
 > [1] @ [2, 3]
 [ 1, 2, 3 ]
 ```
@@ -407,7 +407,7 @@ Here are some valid Nickel records:
 
 Record fields can be accessed using the `.` operator :
 
-```text
+```nickel
 > { a = 1, b = 5 }.a
 1
 
@@ -421,7 +421,7 @@ error: Missing field
 It is possible to write records of records via *piecewise syntax*, where we
 separate fields by dots:
 
-```text
+```nickel
 > { a = { b = 1 } }
 { a = { b = 1 } }
 
@@ -435,7 +435,7 @@ separate fields by dots:
 When fields are enclosed in double quotes (`"`), you can use string
 interpolation to create or access fields:
 
-```text
+```nickel
 > let k = "a" in { "%{k}" = 1 }
 { a = 1 }
 
@@ -452,7 +452,7 @@ This construct allows conditional branching in your code. You can use it like
 
 Here are some valid conditional expressions in Nickel:
 
-```text
+```nickel
 > if true then "TRUE :)" else "false :("
 "TRUE :)"
 
@@ -476,7 +476,7 @@ Currently, only a single variable can be bound per let binding.
 
 Here are some examples of let bindings in Nickel:
 
-```text
+```nickel
 > let r = { a = "a", b = "b" } in r.a
 "a"
 
@@ -508,7 +508,7 @@ arguments, and so on.
 
 Here are some examples of function definitions in Nickel:
 
-```text
+```nickel
 > (fun a b => a + b) 1 2
 3
 
@@ -524,7 +524,7 @@ Here are some examples of function definitions in Nickel:
 All existing infix operators in Nickel can be turned into functions by putting
 them inside parentheses, for example:
 
-```text
+```nickel
 > 1 + 2
 3
 
@@ -548,7 +548,7 @@ Functions may be composed using the *pipe operator*. The pipe operator allows
 for a function application `f x` to be written as `x |> f`. This operator is
 left-associative, so `x |> f |> g` will be interpreted as `g (f x)`. For example:
 
-```text
+```nickel
 > "Hello World" |> std.string.split " "
 ["Hello", "World"]
 
@@ -586,7 +586,7 @@ expression without having to come up with a type.
 
 Here are some examples of type annotations in Nickel:
 
-```text
+```nickel
 > 5 : Number
 5
 
@@ -622,7 +622,7 @@ syntactically all the same and can be arbitrary Nickel expressions in practice.
 
 Here are some examples of contract annotations in Nickel:
 
-```text
+```nickel
 > 5 | Number
 5
 
@@ -688,7 +688,7 @@ Type variables bound by a `forall` are only visible inside types (any of the
 constructor listed above). As soon as a term expression appears under a `forall`
 binder, the type variables aren't in scope anymore:
 
-```test
+```nickel
 > forall a. a -> (a -> a) -> {_ : {foo : a}}
 <func>
 
@@ -702,7 +702,7 @@ error: unbound identifier
 
 Here are some examples of more complicated types in Nickel:
 
-```text
+```nickel
 > let f : forall a. a -> a = fun x => x in (f 5 : Number)
 5
 
@@ -762,7 +762,7 @@ is a parse error.
 
 Here are some examples of record types in Nickel:
 
-```text
+```nickel
 > {foo = 1, bar = "foo" } : {foo : Number, bar: String}
 { bar = "foo", foo = 1 }
 
@@ -774,7 +774,7 @@ Here, the right-hand side is missing a type annotation for `baz`, so it doesn't
 qualify as a record type and is parsed as a record contract. This throws an
 "incompatible types" error:
 
-```text
+```nickel
 > {foo = 1, bar = "foo" } : {foo : Number, bar : String, baz}
 error: incompatible types
   ┌─ repl-input-6:1:1
@@ -791,7 +791,7 @@ If there's a metadata annotation apart from the type, the record cannot be
 parsed as a type. Consequently, it is considered a record contract and converted
 into an opaque type, yielding an error:
 
-```text
+```nickel
 > {foo = 1, bar = "foo" } : {foo : Number, bar : String | optional}
 error: incompatible types
 [..]
@@ -801,7 +801,7 @@ While in the following `MyDyn` isn't a proper type, the record literal `{foo :
 Number, bar : MyDyn}` respects all the requirements for a record type and is
 parsed as such:
 
-```text
+```nickel
 > let MyDyn = fun label value => value in
     {foo = 1, bar | MyDyn = "foo"} : {foo : Number, bar : MyDyn}
 { bar = "foo", foo = 1 }
@@ -817,7 +817,7 @@ is introduced with the syntax `<field_name> | <metadata1> | .. | <metadataN>
 
 Documentation can be attached with `| doc <string>`. For example:
 
-```text
+```nickel
 > let record = {
     value
       | doc "The number five"
@@ -853,7 +853,7 @@ about this in the [dedicated section on merging](./merging.md).
 
 Here are some examples using merge priorities in Nickel:
 
-```text
+```nickel
 > let Ais2ByDefault = { a | default = 2 } in
     {} | Ais2ByDefault
 { a = 2 }
@@ -881,7 +881,7 @@ Here are some examples using merge priorities in Nickel:
 The `optional` annotation indicates that a field is not mandatory. It is usually
 found in record contracts.
 
-```text
+```nickel
 > let Contract = {
     foo | Num,
     bar | Num
@@ -899,7 +899,7 @@ error: missing definition for `foo`
 The `not_exported` annotation indicates that a field should be skipped when a
 record is serialized. This includes the output of the `nickel export` command:
 
-```text
+```nickel
 > let value = { foo = 1, bar | not_exported = 2}
 > value
 { foo = 1, bar = 2 }

--- a/examples/README.md
+++ b/examples/README.md
@@ -51,7 +51,7 @@ nickel>
 
 - Just import a file directly to evaluate it:
 
-    ```text
+    ```nickel
     nickel> import "fibonacci.ncl"
     55
 
@@ -61,7 +61,7 @@ nickel>
 - Use `std.serialize` to have the same behavior as the `export` subcommand
   and print the result as JSON:
 
-    ```text
+    ```nickel
     nickel> builtin.serialize 'Json (import "merge-main.ncl")
     "{
         \"firewall\": {
@@ -73,9 +73,9 @@ nickel>
 
 - Use `:query` to retrieve information and documentation about a field:
 
-    ```text
-    nickel>let config = import "record-contract.ncl"
-    nickel>:query config.kind
+    ```nickel
+    nickel> let config = import "record-contract.ncl"
+    nickel> :query config.kind
     • contract: [| 'ReplicationController, 'ReplicaSet, 'Pod |]
     • documentation: The kind of the element being configured.
 


### PR DESCRIPTION
Convert many of the `text` markdown code blocks into `nickel` code blocks to address https://github.com/tweag/nickel-lang.org/issues/455