### PR TITLE
Raise blame error when trying to access fields in the sealed tail of a polymorphic record

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -143,15 +143,19 @@ pub enum EvalError {
 pub enum IllegalPolymorphicTailAction {
     Map,
     Merge,
+    StaticAccess { field: Ident },
 }
 
 impl IllegalPolymorphicTailAction {
-    fn message(&self) -> &'static str {
+    fn message(&self) -> String {
         use IllegalPolymorphicTailAction::*;
 
         match self {
-            Map => "cannot map over a record sealed by a polymorphic contract",
-            Merge => "cannot merge a record sealed by a polymorphic contract",
+            Map => "cannot map over a record sealed by a polymorphic contract".to_owned(),
+            Merge => "cannot merge a record sealed by a polymorphic contract".to_owned(),
+            StaticAccess { field } => {
+                format!("cannot access field `{field}` sealed by a polymorphic contract")
+            }
         }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -143,6 +143,7 @@ pub enum EvalError {
 pub enum IllegalPolymorphicTailAction {
     Map,
     Merge,
+    RecordRemove { field: String },
     StaticAccess { field: Ident },
 }
 
@@ -153,6 +154,9 @@ impl IllegalPolymorphicTailAction {
         match self {
             Map => "cannot map over a record sealed by a polymorphic contract".to_owned(),
             Merge => "cannot merge a record sealed by a polymorphic contract".to_owned(),
+            RecordRemove { field } => {
+                format!("cannot remove field `{field}` sealed by a polymorphic contract")
+            }
             StaticAccess { field } => {
                 format!("cannot access field `{field}` sealed by a polymorphic contract")
             }

--- a/src/error.rs
+++ b/src/error.rs
@@ -141,10 +141,10 @@ pub enum EvalError {
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum IllegalPolymorphicTailAction {
+    FieldAccess { field: String },
     Map,
     Merge,
     RecordRemove { field: String },
-    StaticAccess { field: Ident },
 }
 
 impl IllegalPolymorphicTailAction {
@@ -152,13 +152,13 @@ impl IllegalPolymorphicTailAction {
         use IllegalPolymorphicTailAction::*;
 
         match self {
+            FieldAccess { field } => {
+                format!("cannot access field `{field}` sealed by a polymorphic contract")
+            }
             Map => "cannot map over a record sealed by a polymorphic contract".to_owned(),
             Merge => "cannot merge a record sealed by a polymorphic contract".to_owned(),
             RecordRemove { field } => {
                 format!("cannot remove field `{field}` sealed by a polymorphic contract")
-            }
-            StaticAccess { field } => {
-                format!("cannot access field `{field}` sealed by a polymorphic contract")
             }
         }
     }

--- a/src/eval/operation.rs
+++ b/src/eval/operation.rs
@@ -2419,7 +2419,7 @@ impl<R: ImportResolver, C: Cache> VirtualMachine<R, C> {
                             &mut env,
                             env4,
                         );
-                        let fields = tail.fields.keys().map(|f| f.to_string()).collect();
+                        let fields = tail.fields.keys().cloned().collect();
                         r.sealed_tail = Some(record::SealedTail::new(
                             *s,
                             label.clone(),

--- a/src/term/record.rs
+++ b/src/term/record.rs
@@ -440,7 +440,7 @@ pub struct SealedTail {
     /// The term which is sealed.
     term: RichTerm,
     /// The field names of the sealed fields.
-    fields: HashSet<Ident>,
+    fields: HashSet<String>,
 }
 
 impl SealedTail {
@@ -448,7 +448,7 @@ impl SealedTail {
         sealing_key: SealingKey,
         label: Label,
         term: RichTerm,
-        fields: HashSet<Ident>,
+        fields: HashSet<String>,
     ) -> Self {
         Self {
             sealing_key,
@@ -468,6 +468,10 @@ impl SealedTail {
     }
 
     pub fn has_field(&self, field: &Ident) -> bool {
+        self.fields.contains(field.label())
+    }
+
+    pub fn has_dyn_field(&self, field: &str) -> bool {
         self.fields.contains(field)
     }
 }

--- a/src/term/record.rs
+++ b/src/term/record.rs
@@ -439,14 +439,22 @@ pub struct SealedTail {
     pub label: Label,
     /// The term which is sealed.
     term: RichTerm,
+    /// The field names of the sealed fields.
+    fields: HashSet<Ident>,
 }
 
 impl SealedTail {
-    pub fn new(sealing_key: SealingKey, label: Label, term: RichTerm) -> Self {
+    pub fn new(
+        sealing_key: SealingKey,
+        label: Label,
+        term: RichTerm,
+        fields: HashSet<Ident>,
+    ) -> Self {
         Self {
             sealing_key,
             label,
             term,
+            fields,
         }
     }
 
@@ -457,5 +465,9 @@ impl SealedTail {
         } else {
             None
         }
+    }
+
+    pub fn has_field(&self, field: &Ident) -> bool {
+        self.fields.contains(field)
     }
 }

--- a/src/term/record.rs
+++ b/src/term/record.rs
@@ -440,16 +440,18 @@ pub struct SealedTail {
     /// The term which is sealed.
     term: RichTerm,
     /// The field names of the sealed fields.
-    fields: HashSet<String>,
+    // You may find yourself wondering why this is a `Vec` rather than a
+    // `HashSet` given we only ever do containment checks against it.
+    // In brief: we'd need to use a `HashSet<String>`, which would mean
+    // allocating `fields.len()` `String`s in a fairly hot codepath.
+    // Since we only ever check whether the tail contains a specific field
+    // when we already know we're going to raise an error, it's not really
+    // an issue to have a linear lookup there, so we do that instead.
+    fields: Vec<Ident>,
 }
 
 impl SealedTail {
-    pub fn new(
-        sealing_key: SealingKey,
-        label: Label,
-        term: RichTerm,
-        fields: HashSet<String>,
-    ) -> Self {
+    pub fn new(sealing_key: SealingKey, label: Label, term: RichTerm, fields: Vec<Ident>) -> Self {
         Self {
             sealing_key,
             label,
@@ -468,10 +470,10 @@ impl SealedTail {
     }
 
     pub fn has_field(&self, field: &Ident) -> bool {
-        self.fields.contains(field.label())
+        self.fields.contains(field)
     }
 
     pub fn has_dyn_field(&self, field: &str) -> bool {
-        self.fields.contains(field)
+        self.fields.iter().any(|i| i.label() == field)
     }
 }

--- a/tests/integration/contracts_fail.rs
+++ b/tests/integration/contracts_fail.rs
@@ -210,6 +210,12 @@ fn records_contracts_poly() {
             f { a | default = 100, b = 1 }
             "#,
         ),
+        (
+            "accessing a sealed field violates parametricity",
+            r#"
+            let f | forall a. { ; a } -> { ; a } = fun x => %seq% x.a x in f { a = 1 }
+            "#,
+        ),
     ] {
         assert_raise_tail_blame!(input, "failed on case: {}", name);
     }
@@ -218,12 +224,6 @@ fn records_contracts_poly() {
     // don't yet inspect the sealed tail to see if the requested field is inside.
     // Once we do, these tests will start failing, and if you're currently here
     // for that reason, you can just move the examples into the array above.
-    let bad_acc = "let f | forall a. { ; a} -> { ; a} = fun x => %seq% x.a x in f";
-    assert_matches!(
-        eval(format!("{bad_acc} {{a=1}}")),
-        Err(Error::EvalError(EvalError::FieldMissing(..)))
-    );
-
     let remove_sealed_field = r#"
         let remove_x | forall r. { ; r } -> { ; r } = fun r => %record_remove% "x" r in
         remove_x { x = 1 }

--- a/tests/integration/contracts_fail.rs
+++ b/tests/integration/contracts_fail.rs
@@ -211,9 +211,15 @@ fn records_contracts_poly() {
             "#,
         ),
         (
-            "accessing a sealed field violates parametricity",
+            "statically accessing a sealed field violates parametricity",
             r#"
             let f | forall a. { ; a } -> { ; a } = fun x => %seq% x.a x in f { a = 1 }
+            "#,
+        ),
+        (
+            "dynamically accessing a sealed field violates parametricity",
+            r#"
+            let f | forall a. { ; a } -> { ; a } = fun x => %seq% x."a" x in f { a = 1 }
             "#,
         ),
         (

--- a/tests/integration/contracts_fail.rs
+++ b/tests/integration/contracts_fail.rs
@@ -216,22 +216,16 @@ fn records_contracts_poly() {
             let f | forall a. { ; a } -> { ; a } = fun x => %seq% x.a x in f { a = 1 }
             "#,
         ),
+        (
+            "removing a sealed field violates parametricity",
+            r#"
+            let remove_x | forall r. { ; r } -> { ; r } = fun r => %record_remove% "x" r in
+            remove_x { x = 1 }
+            "#,
+        ),
     ] {
         assert_raise_tail_blame!(input, "failed on case: {}", name);
     }
-
-    // These are currently FieldMissing errors rather than BlameErrors as we
-    // don't yet inspect the sealed tail to see if the requested field is inside.
-    // Once we do, these tests will start failing, and if you're currently here
-    // for that reason, you can just move the examples into the array above.
-    let remove_sealed_field = r#"
-        let remove_x | forall r. { ; r } -> { ; r } = fun r => %record_remove% "x" r in
-        remove_x { x = 1 }
-    "#;
-    assert_matches!(
-        eval(remove_sealed_field),
-        Err(Error::EvalError(EvalError::FieldMissing(..)))
-    );
 }
 
 #[test]


### PR DESCRIPTION
This updates `SealedTail` to store a `HashSet` of the identifiers which the tail contains. Then, when we hit a point where we'd otherwise raise a `FieldMissing` error, we check whether the field is in the sealed tail. If so, we instead raise a blame error.

This closes #952.