### PR TITLE
Update roadmap in manual introduction

### DIFF
--- a/doc/manual/introduction.md
+++ b/doc/manual/introduction.md
@@ -74,9 +74,9 @@ website.
 
 ## Current state and roadmap
 
-Nickel is currently released in version `0.3.1`. This version should be
-functional and intended to gather feedback and real-life testing. The next
-planned version is `1.0`. The next steps we plan to work on are:
+Nickel is currently released in version `1.0`. We expect the core design of the
+language to be stable and the language to be useful for real-world applications.
+The next steps we plan to work on are:
 
 - Nix integration: being able to seamlessly use Nickel to write packages and
   shells ([nickel-nix](https://github.com/nickel-lang/nickel-nix))


### PR DESCRIPTION
We forgot to update the version number in the introduction section of the manual. This change should be cherry-picked into `1.0-release` and put on nickel-lang.org.

Closes #1306 