### PR TITLE
Migrate to clap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -55,42 +55,51 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.2.6"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "342258dd14006105c2b75ab1bd7543a03bdf0cfc94383303ac212a04939dff6f"
+checksum = "0ca84f3628370c59db74ee214b3263d58f9aadd9b4fe7e711fd87dc452b7f163"
 dependencies = [
  "anstyle",
  "anstyle-parse",
+ "anstyle-query",
  "anstyle-wincon",
- "concolor-override",
- "concolor-query",
+ "colorchoice",
  "is-terminal",
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle"
-version = "0.3.5"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23ea9e81bd02e310c216d080f6223c179012256e5151c41db88d12c88a1684d2"
+checksum = "41ed9a86bf92ae6580e0a31281f65a1b1d867c0cc68d5346e2ae128dddfa6a7d"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7d1bb534e9efed14f3e5f44e7dd1a4f709384023a4165199a4241e18dff0116"
+checksum = "e765fd216e48e067936442276d1d57399e37bce53c264d6fefbe298080cb57ee"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
-name = "anstyle-wincon"
-version = "0.2.0"
+name = "anstyle-query"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3127af6145b149f3287bb9a0d10ad9c5692dba8c53ad48285e5bec4063834fa"
+checksum = "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b"
+dependencies = [
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180abfa45703aebe0093f79badacc01b8fd4ea2e35118747e5811127f926e188"
 dependencies = [
  "anstyle",
- "windows-sys 0.45.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -294,13 +303,9 @@ version = "2.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
 dependencies = [
- "ansi_term",
- "atty",
  "bitflags",
- "strsim 0.8.0",
  "textwrap 0.11.0",
  "unicode-width",
- "vec_map",
 ]
 
 [[package]]
@@ -317,9 +322,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.2.1"
+version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "046ae530c528f252094e4a77886ee1374437744b2bff1497aa898bbddbbb29b3"
+checksum = "93aae7a4192245f70fe75dd9157fc7b4a5bf53e88d30bd4396f7d8f9284d5acc"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -328,25 +333,25 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.2.1"
+version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "223163f58c9a40c3b0a43e1c4b50a9ce09f007ea2cb1ec258a687945b4b7929f"
+checksum = "4f423e341edefb78c9caba2d9c7f7687d0e72e89df3ce3394554754393ac3990"
 dependencies = [
  "anstream",
  "anstyle",
  "bitflags",
- "clap_lex 0.4.1",
- "strsim 0.10.0",
+ "clap_lex 0.5.0",
+ "strsim",
  "terminal_size",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "4.2.0"
+version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f9644cd56d6b87dbe899ef8b053e331c0637664e9e21a33dfcdc36093f5c5c4"
+checksum = "191d9573962933b4027f932c600cd252ce27a8ad5979418fe78e43c07996f27b"
 dependencies = [
- "heck 0.4.1",
+ "heck",
  "proc-macro2 1.0.56",
  "quote 1.0.26",
  "syn 2.0.13",
@@ -363,9 +368,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a2dd5a6fe8c6e3502f568a6353e5273bbb15193ad9a89e457b9970798efbea1"
+checksum = "2da6da31387c7e4ef160ffab6d5e7f00c42626fe39aea70a7b0f1773f7dd6c1b"
 
 [[package]]
 name = "clipboard-win"
@@ -409,12 +414,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "colorchoice"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
+
+[[package]]
 name = "comrak"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c5a805f31fb098b1611170028501077ceb8c9e78f5345530f4fdefae9b61119"
 dependencies = [
- "clap 4.2.1",
+ "clap 4.3.0",
  "entities",
  "memchr",
  "once_cell",
@@ -425,21 +436,6 @@ dependencies = [
  "typed-arena",
  "unicode_categories",
  "xdg",
-]
-
-[[package]]
-name = "concolor-override"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a855d4a1978dc52fb0536a04d384c2c0c1aa273597f08b77c8c4d3b2eec6037f"
-
-[[package]]
-name = "concolor-query"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88d11d52c3d7ca2e6d0040212be9e4dbbcd78b6447f535b6b561f449427944cf"
-dependencies = [
- "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -1030,15 +1026,6 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "heck"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
-dependencies = [
- "unicode-segmentation",
-]
-
-[[package]]
-name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
@@ -1485,6 +1472,7 @@ version = "1.0.0"
 dependencies = [
  "ansi_term",
  "assert_matches",
+ "clap 4.3.0",
  "codespan",
  "codespan-reporting",
  "comrak",
@@ -1518,7 +1506,6 @@ dependencies = [
  "similar",
  "simple-counter",
  "strip-ansi-escapes",
- "structopt",
  "termimad",
  "test-generator",
  "toml",
@@ -1534,6 +1521,7 @@ version = "1.0.0"
 dependencies = [
  "anyhow",
  "assert_matches",
+ "clap 4.3.0",
  "codespan",
  "codespan-lsp",
  "codespan-reporting",
@@ -1551,7 +1539,6 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "structopt",
 ]
 
 [[package]]
@@ -1835,30 +1822,6 @@ dependencies = [
  "diff",
  "output_vt100",
  "yansi",
-]
-
-[[package]]
-name = "proc-macro-error"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
-dependencies = [
- "proc-macro-error-attr",
- "proc-macro2 1.0.56",
- "quote 1.0.26",
- "syn 1.0.109",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error-attr"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
-dependencies = [
- "proc-macro2 1.0.56",
- "quote 1.0.26",
- "version_check",
 ]
 
 [[package]]
@@ -2450,39 +2413,9 @@ dependencies = [
 
 [[package]]
 name = "strsim"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-
-[[package]]
-name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
-
-[[package]]
-name = "structopt"
-version = "0.3.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c6b5c64445ba8094a6ab0c3cd2ad323e07171012d9c98b0b15651daf1787a10"
-dependencies = [
- "clap 2.34.0",
- "lazy_static",
- "structopt-derive",
-]
-
-[[package]]
-name = "structopt-derive"
-version = "0.4.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
-dependencies = [
- "heck 0.3.3",
- "proc-macro-error",
- "proc-macro2 1.0.56",
- "quote 1.0.26",
- "syn 1.0.109",
-]
 
 [[package]]
 name = "symbolic-common"
@@ -2867,12 +2800,6 @@ name = "uuid"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1674845326ee10d37ca60470760d4288a6f80f304007d92e5c53bab78c9cfd79"
-
-[[package]]
-name = "vec_map"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ lalrpop = "0.19.9"
 lalrpop-util = "0.19.9"
 regex = "1"
 simple-counter = "0.1.0"
+clap = { version = "4.3", features = ["derive"] }
 codespan = "0.11"
 codespan-reporting = "0.11"
 logos = "0.12"
@@ -39,7 +40,6 @@ serde = { version = "1.0.154", features = ["derive"] }
 serde_json = "1.0.94"
 serde_yaml = "0.9.19"
 toml = { version = "0.7.2", features = ["parse"] }
-structopt = "0.3"
 void = "1"
 sha-1 = "0.10.0"
 sha2 = "0.10.6"

--- a/lsp/nls/Cargo.toml
+++ b/lsp/nls/Cargo.toml
@@ -18,12 +18,12 @@ lalrpop = "0.19.6"
 
 [dependencies]
 lalrpop-util = "0.19.6"
+clap = { version = "4.3", features = ["derive"] }
 codespan = "0.11"
 codespan-reporting = "0.11"
 codespan-lsp = "0.11"
 serde = { version = "1.0.154", features = ["derive"] }
 serde_json = "1.0.94"
-structopt = "0.3"
 regex = "1"
 
 lsp-server = "0.6"

--- a/lsp/nls/src/main.rs
+++ b/lsp/nls/src/main.rs
@@ -11,27 +11,26 @@ mod files;
 mod linearization;
 mod requests;
 mod server;
+use clap::Parser;
 use server::Server;
-use structopt::StructOpt;
 
 use crate::trace::Trace;
 
 mod term;
 mod trace;
 
-#[derive(StructOpt, Debug)]
+#[derive(Parser, Debug)]
 /// The LSP server of the Nickel language.
 struct Opt {
     /// The trace output file, disables tracing if not given
-    #[structopt(short = "t", long)]
-    #[structopt(parse(from_os_str))]
+    #[arg(short, long)]
     trace: Option<PathBuf>,
 }
 
 fn main() -> Result<()> {
     env_logger::init();
 
-    let options = Opt::from_args();
+    let options = Opt::parse();
 
     if let Some(file) = options.trace {
         debug!("Writing trace to {:?}", file.canonicalize()?);

--- a/src/bin/nickel.rs
+++ b/src/bin/nickel.rs
@@ -15,69 +15,68 @@ use std::{
     process,
 };
 // use std::ffi::OsStr;
+use clap::{Parser, Subcommand, ValueEnum};
 use directories::BaseDirs;
-use structopt::StructOpt;
 
 /// Command-line options and subcommands.
-#[derive(StructOpt, Debug)]
+#[derive(Parser, Debug)]
 /// The interpreter of the Nickel language.
 struct Opt {
     /// The input file. Standard input by default
-    #[structopt(short = "f", long, global = true, parse(from_os_str))]
+    #[arg(short, long, global = true)]
     file: Option<PathBuf>,
 
     #[cfg(debug_assertions)]
     /// Skips the standard library import. For debugging only. This does not affect REPL
-    #[structopt(long)]
+    #[arg(long)]
     nostdlib: bool,
 
     /// Coloring: auto, always, never.
-    #[structopt(long, global = true, case_insensitive = true, default_value = "auto")]
+    #[arg(long, global = true, value_enum, default_value_t = ColorOpt::Auto)]
     color: ColorOpt,
 
-    #[structopt(subcommand)]
+    #[command(subcommand)]
     command: Option<Command>,
 }
 
 /// Available subcommands.
-#[derive(StructOpt, Debug)]
+#[derive(Subcommand, Debug)]
 enum Command {
     /// Converts the parsed representation (AST) back to Nickel source code and prints it. Used for
     /// debugging purpose
     PprintAst {
         /// Performs code transformations before printing
-        #[structopt(long)]
+        #[arg(long)]
         transform: bool,
     },
     /// Exports the result to a different format
     Export {
-        /// Available formats: `raw, json, yaml, toml`. Default format: `json`.
-        #[structopt(long)]
-        format: Option<ExportFormat>,
+        #[arg(long, default_value_t = ExportFormat::default(), value_enum)]
+        format: ExportFormat,
+
         /// Output file. Standard output by default
-        #[structopt(short = "o", long)]
-        #[structopt(parse(from_os_str))]
+        #[arg(short, long)]
         output: Option<PathBuf>,
     },
     /// Prints the metadata attached to an attribute, given as a path
     Query {
         path: Option<String>,
-        #[structopt(long)]
+        #[arg(long)]
         doc: bool,
-        #[structopt(long)]
+        #[arg(long)]
         contract: bool,
-        #[structopt(long = "type")]
+        #[arg(long = "type")]
         types: bool,
-        #[structopt(long)]
+        #[arg(long)]
         default: bool,
-        #[structopt(long)]
+        #[arg(long)]
         value: bool,
     },
     /// Typechecks the program but do not run it
     Typecheck,
     /// Starts an REPL session
     Repl {
-        #[structopt(long)]
+        #[arg(long)]
         history_file: Option<PathBuf>,
     },
     /// Generates the documentation files for the specified nickel file
@@ -86,19 +85,18 @@ enum Command {
         /// The path of the generated documentation file. Default to
         /// `~/.nickel/doc/<input-file>.md` for input `<input-file>.ncl`, or to
         /// `~/.nickel/doc/out.md` if the input is read from stdin.
-        #[structopt(short = "o", long, parse(from_os_str))]
+        #[arg(short, long)]
         output: Option<PathBuf>,
         /// Write documentation to stdout. Takes precedence over `output`
-        #[structopt(long)]
+        #[arg(long)]
         stdout: bool,
-        /// The output format for the generated documentation. Possible values:
-        /// markdown, json
-        #[structopt(long, default_value = "markdown")]
+        /// The output format for the generated documentation.
+        #[arg(long, value_enum, default_value_t = DocFormat::default())]
         format: DocFormat,
     },
 }
 
-#[derive(Copy, Clone, Eq, PartialEq, Debug, Default)]
+#[derive(Copy, Clone, Eq, PartialEq, Debug, Default, ValueEnum)]
 pub enum DocFormat {
     Json,
     #[default]
@@ -145,7 +143,7 @@ impl std::str::FromStr for DocFormat {
 }
 
 fn main() {
-    let opts = Opt::from_args();
+    let opts = Opt::parse();
 
     if let Some(Command::Repl { history_file }) = opts.command {
         let histfile = if let Some(h) = history_file {
@@ -234,11 +232,10 @@ fn main() {
 
 fn export(
     program: &mut Program<CacheImpl>,
-    format: Option<ExportFormat>,
+    format: ExportFormat,
     output: Option<PathBuf>,
 ) -> Result<(), Error> {
     let rt = program.eval_full_for_export().map(RichTerm::from)?;
-    let format = format.unwrap_or_default();
 
     // We only add a trailing newline for JSON exports. Both YAML and TOML
     // exporters already append a trailing newline by default.

--- a/src/program.rs
+++ b/src/program.rs
@@ -27,13 +27,14 @@ use crate::eval::cache::Cache as EvalCache;
 use crate::eval::VirtualMachine;
 use crate::identifier::Ident;
 use crate::term::{record::Field, RichTerm};
+use clap::ValueEnum;
 use codespan::FileId;
 use codespan_reporting::term::termcolor::{Ansi, ColorChoice, StandardStream};
 use std::ffi::OsString;
 use std::io::{self, Cursor, Read};
 use std::result::Result;
 
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, ValueEnum)]
 pub enum ColorOpt {
     Auto,
     Always,

--- a/src/serialize.rs
+++ b/src/serialize.rs
@@ -10,6 +10,8 @@ use crate::{
     },
 };
 
+use clap::ValueEnum;
+
 use serde::{
     de::{Deserialize, Deserializer},
     ser::{Serialize, SerializeMap, SerializeSeq, Serializer},
@@ -21,7 +23,7 @@ use std::{fmt, io, rc::Rc, str::FromStr};
 
 /// Available export formats.
 // If you add or remove variants, remember to update the CLI docs in `src/bin/nickel.rs'
-#[derive(Copy, Clone, Eq, PartialEq, Debug, Default)]
+#[derive(Copy, Clone, Eq, PartialEq, Debug, Default, ValueEnum)]
 pub enum ExportFormat {
     Raw,
     #[default]


### PR DESCRIPTION
This PR migrates both `nls` and `nickel` from structopt to clap. There should be no semantic changes.

Closes #1162 