### PR TITLE
Fixes incorrect variable names in type mismatch errors

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -131,7 +131,7 @@ pub enum EnumRowsF<ERows> {
 /// write e.g. `forall a :: Type` or `forall a :: Rows`. But the kind of a variable is required for
 /// the typechecker. It is thus determined during parsing and stored as `VarKind` where type
 /// variables are introduced, that is, on forall quantifiers.
-#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+#[derive(Copy, Clone, PartialEq, Eq, Debug, Hash)]
 pub enum VarKind {
     Type,
     EnumRows,

--- a/tests/integration/typecheck/fail/mismatch_enum_poly_nested.ncl
+++ b/tests/integration/typecheck/fail/mismatch_enum_poly_nested.ncl
@@ -5,8 +5,8 @@
 # error = 'TypecheckError::TypeMismatch'
 #
 # [test.metadata.expectation]
-# expected = 'p'
-# found = "[| 'blo ; _a |]"
+# expected = 'a'
+# found = "[| 'blo ; _erows_a |]"
 let f : forall r. (forall p. [| 'blo, 'ble ; r |] -> [| 'bla, 'bli; p |]) =
   match { 'blo => 'bla, 'ble => 'bli, _ => 'blo } 
 in f 'bli

--- a/tests/integration/typecheck/fail/mismatch_enum_poly_row_var.ncl
+++ b/tests/integration/typecheck/fail/mismatch_enum_poly_row_var.ncl
@@ -5,7 +5,7 @@
 # error = 'TypecheckError::TypeMismatch'
 #
 # [test.metadata.expectation]
-# expected = 'r'
+# expected = 'a'
 # found = "[| 'bli |]"
 let f : forall r. [| 'blo, 'ble; r |] -> Number =
   match { 'blo => 1, 'ble => 2, 'bli => 3 }

--- a/tests/integration/typecheck/fail/mismatch_record_dyn_field.ncl
+++ b/tests/integration/typecheck/fail/mismatch_record_dyn_field.ncl
@@ -5,8 +5,8 @@
 # error = 'TypecheckError::TypeMismatch'
 #
 # [test.metadata.expectation]
-# expected = '{ bla: _a ; _a }'
-# found = '{ _ : _b }'
+# expected = '{ bla: _a ; _rrows_b }'
+# found = '{ _ : _c }'
 ({
   "%{if true then "foo" else "bar"}" = 2,
   "foo" = true,

--- a/tests/integration/typecheck/fail/mismatch_record_poly_field_misused.ncl
+++ b/tests/integration/typecheck/fail/mismatch_record_poly_field_misused.ncl
@@ -5,7 +5,7 @@
 # error = 'TypecheckError::TypeMismatch'
 #
 # [test.metadata.expectation]
-# expected = 'r'
+# expected = 'a'
 # found = 'Number'
 
 # TODO: the expected/found types above seem wrong here

--- a/tests/snapshot/inputs/errors/unification_variable_aliasing.ncl
+++ b/tests/snapshot/inputs/errors/unification_variable_aliasing.ncl
@@ -1,0 +1,7 @@
+# capture = 'stderr'
+# command = []
+
+# Regression test for #1312
+let f : forall a. (forall r. { bla : Bool, blo : a, ble : a; r } -> a) = fun r => if r.bla then (r.blo + 1) else r.ble
+  in (f { bla = true, blo = 1, ble = 2, blip = 'blip } : Number)
+

--- a/tests/snapshot/snapshots/snapshot__error_stderr_unification_variable_aliasing.ncl.snap
+++ b/tests/snapshot/snapshots/snapshot__error_stderr_unification_variable_aliasing.ncl.snap
@@ -1,0 +1,15 @@
+---
+source: tests/snapshot/main.rs
+expression: err
+---
+error: incompatible types
+  ┌─ [INPUTS_PATH]/errors/unification_variable_aliasing.ncl:5:98
+  │
+5 │ let f : forall a. (forall r. { bla : Bool, blo : a, ble : a; r } -> a) = fun r => if r.bla then (r.blo + 1) else r.ble
+  │                                                                                                  ^^^^^ this expression
+  │
+  = Expected an expression of type `a`
+  = Found an expression of type `Number`
+  = These types are not compatible
+
+


### PR DESCRIPTION
In certain cases, it was possible for a row type variable to alias an existing type variable, causing confusing error messages. This commit fixes that by tracking type variable kinds together with their IDs.

Fixes #1312