### PR TITLE
Add flake output for static binaries on linux

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -372,10 +372,9 @@
         tag = version;
         contents = [
           nickel
-          pkgs.bashInteractive
         ];
         config = {
-          Cmd = "bash";
+          Cmd = "${nickel}/bin/nickel";
         };
       };
 
@@ -444,7 +443,7 @@
           paths = [ packages.nickel packages.lsp-nls ];
         };
         nickelWasm = buildNickelWasm { };
-        dockerImage = buildDocker packages.nickel; # TODO: docker image should be a passthru
+        dockerImage = buildDocker packages.nickel-static; # TODO: docker image should be a passthru
         inherit vscodeExtension;
         inherit userManual;
         stdlibMarkdown = stdlibDoc "markdown";

--- a/flake.nix
+++ b/flake.nix
@@ -374,7 +374,7 @@
           nickel
         ];
         config = {
-          Cmd = "${nickel}/bin/nickel";
+          Entrypoint = "${nickel}/bin/nickel";
         };
       };
 


### PR DESCRIPTION
This seems to work and produces statically linked Linux binaries. I don't know enough about Darwin to figure out how to build a redistributable executable there, unfortunately.

As a fun side effect, using the static binary in the Docker image and removing `bash` shrinks the image from 18M to 4.3M; just removing `bash` shrinks it to only 15M 😎