### PR TITLE
Fix panic on duplicated top-level idents in record destructuring

### DIFF
--- a/src/parser/error.rs
+++ b/src/parser/error.rs
@@ -36,6 +36,13 @@ pub enum ParseError {
     /// A recursive let pattern was encountered. They are not currently supported because we
     /// decided it was too involved to implement them.
     RecursiveLetPattern(RawSpan),
+    /// A duplicate binding was encountered in a record destructuring pattern.
+    DuplicateIdentInRecordPattern {
+        /// The duplicate identifier.
+        ident: Ident,
+        /// The previous instance of the duplicated identifier.
+        prev_ident: Ident,
+    },
     /// A type variable is used in ways that imply it has muiltiple different kinds.
     ///
     /// This can happen in several situations, for example:

--- a/src/parser/grammar.lalrpop
+++ b/src/parser/grammar.lalrpop
@@ -476,7 +476,7 @@ Pattern: FieldPattern = {
 
 // A full pattern at the left-hand side of a destructuring let.
 RecordPattern: RecordPattern = {
-    <start: @L> "{" <mut matches: (<Match> ",")*> <last:LastMatch?> "}" <end: @R> => {
+    <start: @L> "{" <mut matches: (<Match> ",")*> <last:LastMatch?> "}" <end: @R> =>? {
         let (open, rest) = match last {
             Some(LastMatch::Match(m)) => {
                 matches.push(*m);
@@ -487,7 +487,9 @@ RecordPattern: RecordPattern = {
         };
 
         let span = mk_span(src_id, start, end);
-        RecordPattern{ matches, open, rest, span }
+        let pattern = RecordPattern{ matches, open, rest, span };
+        pattern.check_matches()?;
+        Ok(pattern)
     },
 };
 

--- a/tests/integration/destructuring/pass/nested_duplicated_ident.ncl
+++ b/tests/integration/destructuring/pass/nested_duplicated_ident.ncl
@@ -1,0 +1,4 @@
+# test.type = 'pass'
+let f = fun { x = { y }, z = { y } } => y in
+let result = f { x = { y = 1 }, z = { y = 2 } } in
+result == 1

--- a/tests/integration/destructuring/repeated_ident_typed.ncl
+++ b/tests/integration/destructuring/repeated_ident_typed.ncl
@@ -4,6 +4,8 @@
 # error = 'ParseError::DuplicateIdentInRecordPattern'
 #
 # [test.metadata.expectation]
-# ident = 'duped'
-let f = fun { duped, duped, .. } => duped
-in f { duped = 1, other = "x" }
+# ident = 'a'
+(
+  let { a, a, .. } = { a = 1, b = 2 } in
+  a : Number
+): _

--- a/tests/snapshot/inputs/errors/record_destructuring_duplicate_ident.ncl
+++ b/tests/snapshot/inputs/errors/record_destructuring_duplicate_ident.ncl
@@ -1,0 +1,4 @@
+# capture = 'stderr'
+# command = []
+let f = fun { one, two, one } => { one, two }
+in f { one = 1, two = "2" }

--- a/tests/snapshot/snapshots/snapshot__error_stderr_record_destructuring_duplicate_ident.ncl.snap
+++ b/tests/snapshot/snapshots/snapshot__error_stderr_record_destructuring_duplicate_ident.ncl.snap
@@ -1,0 +1,13 @@
+---
+source: tests/snapshot/main.rs
+expression: err
+---
+error: duplicated binding `one` in record pattern
+  ┌─ [INPUTS_PATH]/errors/record_destructuring_duplicate_ident.ncl:3:25
+  │
+3 │ let f = fun { one, two, one } => { one, two }
+  │               ---       ^^^ duplicated binding here
+  │               │          
+  │               previous binding here
+
+


### PR DESCRIPTION
Previously Nickel would panic when encountering code like this:

```
let f = fun { x, x } = x in f { x = 1 }
```

This commit fixes that by checking each destructured record pattern for duplciated identifiers at parsing time, and returning an error if any are encountered.

Note, however, that in order to preserve backwards compatibility with Nickel 1.0, the following code is still valid (and returns `1`):

```
let f = fun { x = { y }, z = { y } } => y
in f { x = { y = 1 }, z = {  y = 2 } }
```

Fixes #1318.