### PR TITLE
Give a better error message when trying to query a non-record

### DIFF
--- a/src/eval/mod.rs
+++ b/src/eval/mod.rs
@@ -292,12 +292,11 @@ impl<R: ImportResolver, C: Cache> VirtualMachine<R, C> {
                 }
                 Some(_) => {
                     //unwrap(): if we enter this pattern branch, `field.value` must be `Some(_)`
-                    return Err(EvalError::TypeError(
-                        String::from("Record"),
-                        String::from("query"),
-                        prev_pos,
-                        field.value.unwrap(),
-                    ));
+                    return Err(EvalError::QueryNonRecord {
+                        pos: prev_pos,
+                        id,
+                        value: field.value.unwrap(),
+                    });
                 }
             }
             prev_id = id;

--- a/src/eval/mod.rs
+++ b/src/eval/mod.rs
@@ -222,9 +222,9 @@ impl<R: ImportResolver, C: Cache> VirtualMachine<R, C> {
         path: QueryPath,
         initial_env: &Environment,
     ) -> Result<Field, EvalError> {
+        let mut prev_pos = t.pos;
         let (rt, mut env) = self.eval_closure(Closure::atomic_closure(t), initial_env)?;
 
-        let mut prev_pos = rt.pos;
         let mut field: Field = rt.into();
 
         let mut path = path.0.into_iter().peekable();

--- a/tests/snapshot/inputs/errors/query_non_record.ncl
+++ b/tests/snapshot/inputs/errors/query_non_record.ncl
@@ -1,0 +1,3 @@
+# capture = 'stderr'
+# command = [ 'query', 'value' ]
+1

--- a/tests/snapshot/snapshots/snapshot__query_stderr_query_non_record.ncl.snap
+++ b/tests/snapshot/snapshots/snapshot__query_stderr_query_non_record.ncl.snap
@@ -1,0 +1,11 @@
+---
+source: tests/snapshot/main.rs
+expression: err
+---
+error: tried to query field of a non-record
+  ┌─ [INPUTS_PATH]/errors/query_non_record.ncl:3:1
+  │
+3 │ 1
+  │ ^ tried to query field `value`, but the expression has type Number
+
+


### PR DESCRIPTION
The first commit is a simple bug fix: the error position should point to the un-evaluated term. This is consistent with what happens for later elements in the path.

The second commit adds a special error variant for querying fields of non-records.

Fixes #1292