### PR TITLE
Refactor record type errors, and detect duplicate fields

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -16,7 +16,7 @@ use crate::{
     },
     parser::{
         self,
-        error::{LexicalError, ParseError as InternalParseError},
+        error::{InvalidRecordTypeError, LexicalError, ParseError as InternalParseError},
         lexer::Token,
         utils::mk_span,
     },
@@ -386,25 +386,17 @@ pub enum ParseError {
     ),
     /// Unbound type variable
     UnboundTypeVariables(Vec<Ident>),
-    /// Illegal record literal in the uniterm syntax. In practice, this is a record with a
-    /// polymorphic tail that contains a construct that wasn't permitted inside a record type in
-    /// the original syntax. Typically, a field assignment:
+    /// Illegal record type literal.
     ///
-    /// ```nickel
-    /// forall a. {foo : Number; a} # allowed
-    /// forall a. {foo : Number = 1; a} # InvalidUniRecord error: giving a value to foo is forbidden
-    /// ```
-    ///
+    /// This occurs when failing to convert from the uniterm syntax to a record type literal.
     /// See [RFC002](../../rfcs/002-merge-types-terms-syntax.md) for more details.
-    InvalidUniRecord(
-        RawSpan, /* illegal (in conjunction with a tail) construct position */
-        RawSpan, /* tail position */
-        RawSpan, /* whole record position */
-    ),
-    /// A record type using string interpolation as one of its fields.
-    RecordTypeWithInterpolation {
-        illegal_span: RawSpan,
-        span: RawSpan,
+    InvalidRecordType {
+        /// The position of the invalid record.
+        record_span: RawSpan,
+        /// Position of the tail, if there was one.
+        tail_span: Option<RawSpan>,
+        /// The reason that interpretation as a record type failed.
+        cause: InvalidRecordTypeError,
     },
     /// A recursive let pattern was encountered. They are not currently supported because we
     /// decided it was too involved to implement them.
@@ -605,12 +597,15 @@ impl ParseError {
                 InternalParseError::UnboundTypeVariables(idents) => {
                     ParseError::UnboundTypeVariables(idents)
                 }
-                InternalParseError::InvalidUniRecord(illegal_pos, tail_pos, pos) => {
-                    ParseError::InvalidUniRecord(illegal_pos, tail_pos, pos)
-                }
-                InternalParseError::RecordTypeWithInterpolation { illegal_span, span } => {
-                    ParseError::RecordTypeWithInterpolation { illegal_span, span }
-                }
+                InternalParseError::InvalidRecordType {
+                    record_span,
+                    tail_span,
+                    cause,
+                } => ParseError::InvalidRecordType {
+                    record_span,
+                    tail_span,
+                    cause,
+                },
                 InternalParseError::RecursiveLetPattern(pos) => {
                     ParseError::RecursiveLetPattern(pos)
                 }
@@ -1657,27 +1652,27 @@ impl IntoDiagnostics<FileId> for ParseError {
                 .with_labels(
                     idents.into_iter().filter_map(|id| id.pos.into_opt()).map(|span| primary(&span).with_message("this identifier is unbound")).collect()
                  ),
-            ParseError::InvalidUniRecord(illegal_span, tail_span, span) => Diagnostic::error()
-                .with_message("invalid record literal")
-                .with_labels(vec![
-                    primary(&span),
-                    secondary(&illegal_span).with_message("can't use this record construct"),
-                    secondary(&tail_span).with_message("in presence of a tail"),
-                ])
-                .with_notes(vec![
-                    "Using a polymorphic tail in a record literal `{ ..; a}` requires the rest \
-                    of the literal to be a record type.".into(),
-                    "A record type is a literal composed only of type annotations, of the \
-                    form `<field>: <type>`.".into(),
-                    "Value assignments such as `<field> = <expr>`, and metadata \
-                    annotation (annotation, documentation, etc.) are forbidden.".into(),
-                ]),
-            ParseError::RecordTypeWithInterpolation { illegal_span, span } => Diagnostic::error()
-                .with_message("record type literals cannot have interpolated fields")
-                .with_labels(vec![
-                    primary(&span),
-                    secondary(&illegal_span).with_message("this field uses interpolation")
-                ]),
+            ParseError::InvalidRecordType { record_span, tail_span, cause } => {
+                let mut labels: Vec<_> = std::iter::once(primary(&record_span))
+                    .chain(cause.labels())
+                    .collect();
+                let mut notes: Vec<_> = std::iter::once(
+                        "A record type is a literal composed only of type annotations, of the \
+                        form `<field>: <type>`.".into()
+                    ).chain(cause.notes()).collect();
+
+                if let Some(tail_span) = tail_span {
+                    labels.push(secondary(&tail_span).with_message("tail"));
+                    notes.push(
+                        "This literal was interpreted as a record type because it has a \
+                        polymorphic tail".into()
+                    );
+                };
+                Diagnostic::error()
+                    .with_message("invalid record literal")
+                    .with_labels(labels)
+                    .with_notes(notes)
+            }
             ParseError::RecursiveLetPattern(span) => Diagnostic::error()
                 .with_message("recursive destructuring is not supported")
                 .with_labels(vec![

--- a/src/error.rs
+++ b/src/error.rs
@@ -1665,7 +1665,13 @@ impl IntoDiagnostics<FileId> for ParseError {
                     labels.push(secondary(&tail_span).with_message("tail"));
                     notes.push(
                         "This literal was interpreted as a record type because it has a \
-                        polymorphic tail".into()
+                        polymorphic tail; record values cannot have tails.".into()
+                    );
+                } else {
+                    notes.push(
+                        "This literal was interpreted as a record type because it has \
+                        fields with type annotations but no value definitions; to make \
+                        this a record value, assign values to its fields.".into()
                     );
                 };
                 Diagnostic::error()

--- a/src/parser/error.rs
+++ b/src/parser/error.rs
@@ -18,7 +18,7 @@ pub enum LexicalError {
 /// Error indicating that a construct is not allowed when trying to interpret an `UniRecord` as a
 /// record type in a strict way.
 ///
-/// See [`UniRecord::into_type_strict`].
+/// See [`UniRecord::into_type_strict`](crate::parser::uniterm::UniRecord::into_type_strict).
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum InvalidRecordTypeError {
     /// The record type had an invalid field, for example because it had a contract,

--- a/src/parser/error.rs
+++ b/src/parser/error.rs
@@ -1,3 +1,6 @@
+use codespan::FileId;
+use codespan_reporting::diagnostic::Label;
+
 use crate::{identifier::Ident, position::RawSpan};
 
 #[derive(Clone, PartialEq, Eq, Debug)]
@@ -12,31 +15,79 @@ pub enum LexicalError {
     Generic(usize, usize),
 }
 
+/// Error indicating that a construct is not allowed when trying to interpret an `UniRecord` as a
+/// record type in a strict way.
+///
+/// See [`UniRecord::into_type_strict`].
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum InvalidRecordTypeError {
+    /// The record type had an invalid field, for example because it had a contract,
+    /// an assigned value, or lacked a type annotation.
+    InvalidField(RawSpan),
+    /// The record had an ellipsis.
+    IsOpen(RawSpan),
+    /// The record type had a field whose name used string interpolation.
+    InterpolatedField(RawSpan),
+    /// A field name was repeated.
+    RepeatedField { orig: RawSpan, dup: RawSpan },
+}
+
+impl InvalidRecordTypeError {
+    pub fn labels(&self) -> Vec<Label<FileId>> {
+        let label = |span: &RawSpan| {
+            Label::secondary(span.src_id, span.start.to_usize()..span.end.to_usize())
+        };
+        match self {
+            InvalidRecordTypeError::InvalidField(pos) => {
+                vec![label(pos).with_message("invalid field for a record type literal")]
+            }
+            InvalidRecordTypeError::IsOpen(pos) => {
+                vec![label(pos).with_message("cannot have ellipsis in a record type literal")]
+            }
+            InvalidRecordTypeError::InterpolatedField(pos) => {
+                vec![label(pos).with_message("this field uses interpolation")]
+            }
+            InvalidRecordTypeError::RepeatedField { orig, dup } => {
+                vec![
+                    label(orig).with_message("first occurrence"),
+                    label(dup).with_message("second occurrence"),
+                ]
+            }
+        }
+    }
+
+    pub fn notes(&self) -> Option<String> {
+        match self {
+            InvalidRecordTypeError::InvalidField(_) => Some(
+                "Value assignments such as `<field> = <expr>`, and metadata \
+                    annotation (annotation, documentation, etc.) are forbidden."
+                    .into(),
+            ),
+            InvalidRecordTypeError::InterpolatedField(_) => {
+                Some("String interpolation in field names is forbidden in record types".into())
+            }
+            InvalidRecordTypeError::RepeatedField { .. } => {
+                Some("Repeated field names are forbidden".into())
+            }
+            _ => None,
+        }
+    }
+}
+
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub enum ParseError {
     /// A specific lexical error
     Lexical(LexicalError),
     /// Unbound type variable(s)
     UnboundTypeVariables(Vec<Ident>),
-    /// Illegal record literal in the uniterm syntax. In practice, this is a record with a
-    /// polymorphic tail that contains a construct that wasn't permitted inside a record type in
-    /// the original syntax. Typically, a field assignment:
+    /// Illegal record type literal.
     ///
-    /// ```nickel
-    /// forall a. {foo : Num; a} # allowed
-    /// forall a. {foo : Num = 1; a} # InvalidUniRecord error: giving a value to foo is forbidden
-    /// ```
-    ///
+    /// This occurs when failing to convert from the uniterm syntax to a record type literal.
     /// See [RFC002](../../rfcs/002-merge-types-terms-syntax.md) for more details.
-    InvalidUniRecord(
-        RawSpan, /* illegal (in conjunction with a tail) construct position */
-        RawSpan, /* tail position */
-        RawSpan, /* whole record position */
-    ),
-    /// A record type using string interpolation as one of its fields.
-    RecordTypeWithInterpolation {
-        illegal_span: RawSpan,
-        span: RawSpan,
+    InvalidRecordType {
+        record_span: RawSpan,
+        tail_span: Option<RawSpan>,
+        cause: InvalidRecordTypeError,
     },
     /// A recursive let pattern was encountered. They are not currently supported because we
     /// decided it was too involved to implement them.

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -333,12 +333,12 @@ fn record_terms() {
 fn invalid_record_types() {
     assert_matches!(
         parse("let x | forall r. { n | Num; r } = {} in x"),
-        Err(ParseError::InvalidUniRecord(..))
+        Err(ParseError::InvalidRecordType { .. })
     );
 
     assert_matches!(
         parse("let x : forall r. { n = fun i => i; r } = {} in x"),
-        Err(ParseError::InvalidUniRecord(..))
+        Err(ParseError::InvalidRecordType { .. })
     );
 }
 

--- a/src/parser/uniterm.rs
+++ b/src/parser/uniterm.rs
@@ -501,7 +501,7 @@ impl TryFrom<UniRecord> for Types {
         if let Some((_, tail_pos)) = ur.tail {
             ur.into_type_strict()
                 .map_err(|cause| ParseError::InvalidRecordType {
-                    tail_span: Some(tail_pos.unwrap()),
+                    tail_span: tail_pos.into_opt(),
                     record_span: pos.unwrap(),
                     cause,
                 })

--- a/src/parser/uniterm.rs
+++ b/src/parser/uniterm.rs
@@ -1,5 +1,5 @@
 //! Additional AST nodes for the common UniTerm syntax (see RFC002 for more details).
-use super::*;
+use super::{error::InvalidRecordTypeError, *};
 use error::ParseError;
 use indexmap::{map::Entry, IndexMap};
 use utils::{build_record, FieldDef, FieldPathElem};
@@ -17,7 +17,7 @@ use crate::{
     },
 };
 
-use std::{cell::RefCell, convert::TryFrom};
+use std::{cell::RefCell, collections::HashMap, convert::TryFrom};
 
 /// A node of the uniterm AST. We only define new variants for those constructs that are common to
 /// types and terms. Otherwise, we piggyback on the existing ASTs to avoid duplicating methods and
@@ -165,12 +165,6 @@ pub struct UniRecord {
     /// must be different from `TermPos::None` if and only if `attrs.open` is `true`.
     pub pos_ellipsis: TermPos,
 }
-
-/// Error indicating that a construct is not allowed when trying to interpret an `UniRecord` as a
-/// record type in a strict way. See [`UniRecord::into_type_strict`]. Hold the position of the
-/// illegal construct.
-#[derive(Debug, Copy, Clone)]
-pub struct InvalidRecordTypeError(pub TermPos);
 
 impl UniRecord {
     /// Check if a field definition has a type annotation but no definition. This is currently
@@ -359,9 +353,9 @@ impl UniRecord {
                     // (parsing)
                     let span_id = id.pos.unwrap();
                     let term_pos = field_def.pos.into_opt().unwrap_or(span_id);
-                    Err(InvalidRecordTypeError(TermPos::Original(
+                    Err(InvalidRecordTypeError::InvalidField(
                         RawSpan::fuse(span_id, term_pos).unwrap(),
-                    )))
+                    ))
                 }
             }
         }
@@ -371,8 +365,11 @@ impl UniRecord {
         debug_assert!((self.pos_ellipsis == TermPos::None) != self.attrs.open);
 
         if let Some(raw_span) = self.pos_ellipsis.into_opt() {
-            return Err(InvalidRecordTypeError(TermPos::Original(raw_span)));
+            return Err(InvalidRecordTypeError::IsOpen(raw_span));
         }
+
+        // Track the field names we've seen, to check for duplicates.
+        let mut fields_seen = HashMap::new();
 
         let rrows = self
             .fields
@@ -387,35 +384,42 @@ impl UniRecord {
                     .unwrap_or(RecordRows(RecordRowsF::Empty)),
                 |acc: RecordRows, mut field_def| {
                     // We don't support compound paths for types, yet.
+                    // All positions can be unwrapped because we're still parsing.
                     if field_def.path.len() > 1 {
                         let span = field_def
                             .path
                             .into_iter()
                             .map(|path_elem| match path_elem {
-                                FieldPathElem::Ident(id) => id.pos.into_opt(),
-                                FieldPathElem::Expr(rt) => rt.pos.into_opt(),
+                                FieldPathElem::Ident(id) => id.pos.unwrap(),
+                                FieldPathElem::Expr(rt) => rt.pos.unwrap(),
                             })
-                            .reduce(|acc, pos| {
-                                acc.zip(pos)
-                                    .and_then(|(acc, span)| RawSpan::fuse(acc, span))
-                            })
-                            .flatten();
+                            .reduce(|acc, span| RawSpan::fuse(acc, span).unwrap_or(acc))
+                            // We already checked that the path is non-empty.
+                            .unwrap();
 
-                        Err(InvalidRecordTypeError(
-                            span.map_or(TermPos::None, TermPos::Original),
-                        ))
+                        Err(InvalidRecordTypeError::InvalidField(span))
                     } else {
                         let elem = field_def.path.pop().unwrap();
-                        match elem {
-                            FieldPathElem::Ident(id) => term_to_record_rows(id, field_def, acc),
+                        let id = match elem {
+                            FieldPathElem::Ident(id) => id,
                             FieldPathElem::Expr(expr) => {
-                                let Some(id) = expr.term.as_ref().try_str_chunk_as_static_str() else {
-                                        return Err(InvalidRecordTypeError(field_def.pos))
-                                };
-                                let id = Ident::new_with_pos(id, expr.pos);
-                                term_to_record_rows(id, field_def, acc)
+                                let name = expr.term.as_ref().try_str_chunk_as_static_str().ok_or(
+                                    InvalidRecordTypeError::InterpolatedField(
+                                        field_def.pos.unwrap(),
+                                    ),
+                                )?;
+                                Ident::new_with_pos(name, expr.pos)
                             }
+                        };
+                        if let Some(prev_id) = fields_seen.insert(id, id) {
+                            return Err(InvalidRecordTypeError::RepeatedField {
+                                // Because we're iterating backwards, `id` came first.
+                                orig: id.pos.unwrap(),
+                                dup: prev_id.pos.unwrap(),
+                            });
                         }
+
+                        term_to_record_rows(id, field_def, acc)
                     }
                 },
             )?;
@@ -450,27 +454,15 @@ impl TryFrom<UniRecord> for RichTerm {
 
         // First try to interpret this record as a type.
         let result = if ur.tail.is_some() || (ur.is_record_type() && !ur.fields.is_empty()) {
-            let mut ty = if let Some((_, tail_pos)) = ur.tail {
-                // We unwrap all positions: at this stage of the parsing, they must all be set
-                ur.into_type_strict()
-                    .map_err(|InvalidRecordTypeError(illegal_pos)| {
-                        ParseError::InvalidUniRecord(
-                            illegal_pos.unwrap(),
-                            tail_pos.unwrap(),
-                            pos.unwrap(),
-                        )
-                    })?
-            } else {
-                // If `is_record_type` succeeds, the only possible failure of `into_type_strict`
-                // is a field interpolation.
-                ur.into_type_strict()
-                    .map_err(|InvalidRecordTypeError(illegal_span)| {
-                        ParseError::RecordTypeWithInterpolation {
-                            span: pos.unwrap(),
-                            illegal_span: illegal_span.unwrap(),
-                        }
-                    })?
-            };
+            let tail_span = ur.tail.as_ref().and_then(|t| t.1.into_opt());
+            // We unwrap all positions: at this stage of the parsing, they must all be set
+            let mut ty = ur
+                .into_type_strict()
+                .map_err(|cause| ParseError::InvalidRecordType {
+                    tail_span,
+                    record_span: pos.unwrap(),
+                    cause,
+                })?;
 
             ty.fix_type_vars(pos.unwrap())?;
             ty.contract()
@@ -508,12 +500,10 @@ impl TryFrom<UniRecord> for Types {
 
         if let Some((_, tail_pos)) = ur.tail {
             ur.into_type_strict()
-                .map_err(|InvalidRecordTypeError(illegal_pos)| {
-                    ParseError::InvalidUniRecord(
-                        illegal_pos.unwrap(),
-                        tail_pos.unwrap(),
-                        pos.unwrap(),
-                    )
+                .map_err(|cause| ParseError::InvalidRecordType {
+                    tail_span: Some(tail_pos.unwrap()),
+                    record_span: pos.unwrap(),
+                    cause,
                 })
         } else {
             let pos = ur.pos;

--- a/tests/snapshot/inputs/errors/record_type_repeated_field.ncl
+++ b/tests/snapshot/inputs/errors/record_type_repeated_field.ncl
@@ -1,0 +1,3 @@
+# capture = 'stderr'
+# command = []
+({foo.bar.baz = "a"} : {foo : String, foo : Number})

--- a/tests/snapshot/snapshots/snapshot__error_stderr_interpolate_record_type_field.ncl.snap
+++ b/tests/snapshot/snapshots/snapshot__error_stderr_interpolate_record_type_field.ncl.snap
@@ -2,12 +2,15 @@
 source: tests/snapshot/main.rs
 expression: err
 ---
-error: record type literals cannot have interpolated fields
+error: invalid record literal
   ┌─ [INPUTS_PATH]/errors/interpolate_record_type_field.ncl:4:18
   │
 4 │ let a = "foo" in { "%{a}" : Number }
   │                  ^^^^^^^^^^^^^^^^^^^
   │                    │
   │                    this field uses interpolation
+  │
+  = A record type is a literal composed only of type annotations, of the form `<field>: <type>`.
+  = String interpolation in field names is forbidden in record types
 
 

--- a/tests/snapshot/snapshots/snapshot__error_stderr_interpolate_record_type_field.ncl.snap
+++ b/tests/snapshot/snapshots/snapshot__error_stderr_interpolate_record_type_field.ncl.snap
@@ -12,5 +12,6 @@ error: invalid record literal
   │
   = A record type is a literal composed only of type annotations, of the form `<field>: <type>`.
   = String interpolation in field names is forbidden in record types
+  = This literal was interpreted as a record type because it has fields with type annotations but no value definitions; to make this a record value, assign values to its fields.
 
 

--- a/tests/snapshot/snapshots/snapshot__error_stderr_invalid_record_type.ncl.snap
+++ b/tests/snapshot/snapshots/snapshot__error_stderr_invalid_record_type.ncl.snap
@@ -8,11 +8,11 @@ error: invalid record literal
 4 │ {a: Number, b = 1; r}
   │ ^^^^^^^^^^^^^^^^^^^^^
   │             │    │
-  │             │    in presence of a tail
-  │             can't use this record construct
+  │             │    tail
+  │             invalid field for a record type literal
   │
-  = Using a polymorphic tail in a record literal `{ ..; a}` requires the rest of the literal to be a record type.
   = A record type is a literal composed only of type annotations, of the form `<field>: <type>`.
   = Value assignments such as `<field> = <expr>`, and metadata annotation (annotation, documentation, etc.) are forbidden.
+  = This literal was interpreted as a record type because it has a polymorphic tail
 
 

--- a/tests/snapshot/snapshots/snapshot__error_stderr_invalid_record_type.ncl.snap
+++ b/tests/snapshot/snapshots/snapshot__error_stderr_invalid_record_type.ncl.snap
@@ -13,6 +13,6 @@ error: invalid record literal
   │
   = A record type is a literal composed only of type annotations, of the form `<field>: <type>`.
   = Value assignments such as `<field> = <expr>`, and metadata annotation (annotation, documentation, etc.) are forbidden.
-  = This literal was interpreted as a record type because it has a polymorphic tail
+  = This literal was interpreted as a record type because it has a polymorphic tail; record values cannot have tails.
 
 

--- a/tests/snapshot/snapshots/snapshot__error_stderr_record_type_repeated_field.ncl.snap
+++ b/tests/snapshot/snapshots/snapshot__error_stderr_record_type_repeated_field.ncl.snap
@@ -1,0 +1,17 @@
+---
+source: tests/snapshot/main.rs
+expression: err
+---
+error: invalid record literal
+  ┌─ [INPUTS_PATH]/errors/record_type_repeated_field.ncl:3:24
+  │
+3 │ ({foo.bar.baz = "a"} : {foo : String, foo : Number})
+  │                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  │                         │             │
+  │                         │             second occurrence
+  │                         first occurrence
+  │
+  = A record type is a literal composed only of type annotations, of the form `<field>: <type>`.
+  = Repeated field names are forbidden
+
+

--- a/tests/snapshot/snapshots/snapshot__error_stderr_record_type_repeated_field.ncl.snap
+++ b/tests/snapshot/snapshots/snapshot__error_stderr_record_type_repeated_field.ncl.snap
@@ -13,5 +13,6 @@ error: invalid record literal
   │
   = A record type is a literal composed only of type annotations, of the form `<field>: <type>`.
   = Repeated field names are forbidden
+  = This literal was interpreted as a record type because it has fields with type annotations but no value definitions; to make this a record value, assign values to its fields.
 
 


### PR DESCRIPTION
This refactors record type literal errors to be more structured, and also adds a variant for checking duplicate field names.

 Fixes #1284.