### PR TITLE
Adds a configurable tracing output instead of hardcoding stderr

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -459,7 +459,7 @@
 
       devShells = (forEachRustChannel (channel: {
         name = channel;
-        value = makeDevShell { rust = mkRust { inherit channel; rustProfile = "default"; }; };
+        value = makeDevShell { rust = mkRust { inherit channel; rustProfile = "default"; targets = [ "wasm32-unknown-unknown" ]; }; };
       })) // {
         default = devShells.stable;
       };

--- a/pyckel/src/lib.rs
+++ b/pyckel/src/lib.rs
@@ -19,7 +19,8 @@ fn error_to_exception<E: Into<Error>, EC: Cache>(error: E, program: &mut Program
 /// Evaluate from a Python str of a Nickel expression to a Python str of the resulting JSON.
 #[pyfunction]
 pub fn run(s: String) -> PyResult<String> {
-    let mut program: Program<CacheImpl> = Program::new_from_source(Cursor::new(s), "python")?;
+    let mut program: Program<CacheImpl> =
+        Program::new_from_source(Cursor::new(s), "python", std::io::stderr())?;
 
     let term = program
         .eval_full()

--- a/pyckel/src/lib.rs
+++ b/pyckel/src/lib.rs
@@ -20,7 +20,7 @@ fn error_to_exception<E: Into<Error>, EC: Cache>(error: E, program: &mut Program
 #[pyfunction]
 pub fn run(s: String) -> PyResult<String> {
     let mut program: Program<CacheImpl> =
-        Program::new_from_source(Cursor::new(s), "python", std::io::stderr())?;
+        Program::new_from_source(Cursor::new(s), "python", std::io::sink())?;
 
     let term = program
         .eval_full()

--- a/src/bin/nickel.rs
+++ b/src/bin/nickel.rs
@@ -154,8 +154,8 @@ fn main() {
         let mut program = opts
             .file
             .clone()
-            .map(Program::new_from_file)
-            .unwrap_or_else(Program::new_from_stdin)
+            .map(|f| Program::new_from_file(f, std::io::stderr()))
+            .unwrap_or_else(|| Program::new_from_stdin(std::io::stderr()))
             .unwrap_or_else(|err| {
                 eprintln!("Error when reading input: {err}");
                 process::exit(1)

--- a/src/eval/mod.rs
+++ b/src/eval/mod.rs
@@ -92,6 +92,8 @@ use crate::{
     transform::Closurizable,
 };
 
+use std::io::Write;
+
 pub mod cache;
 pub mod callstack;
 pub mod fixpoint;
@@ -122,24 +124,28 @@ pub struct VirtualMachine<R: ImportResolver, C: Cache> {
     import_resolver: R,
     // The evaluation cache.
     pub cache: C,
+    // The stream for writing trace output.
+    trace: Box<dyn Write>,
 }
 
 impl<R: ImportResolver, C: Cache> VirtualMachine<R, C> {
-    pub fn new(import_resolver: R) -> Self {
+    pub fn new(import_resolver: R, trace: impl Write + 'static) -> Self {
         VirtualMachine {
             import_resolver,
             call_stack: Default::default(),
             stack: Stack::new(),
             cache: Cache::new(),
+            trace: Box::new(trace),
         }
     }
 
-    pub fn new_with_cache(import_resolver: R, cache: C) -> Self {
+    pub fn new_with_cache(import_resolver: R, cache: C, trace: impl Write + 'static) -> Self {
         VirtualMachine {
             import_resolver,
             call_stack: Default::default(),
             stack: Stack::new(),
             cache,
+            trace: Box::new(trace),
         }
     }
 

--- a/src/eval/operation.rs
+++ b/src/eval/operation.rs
@@ -1104,7 +1104,7 @@ impl<R: ImportResolver, C: Cache> VirtualMachine<R, C> {
             },
             UnaryOp::Trace() => {
                 if let Term::Str(s) = &*t {
-                    eprintln!("std.trace: {s}");
+                    let _ = writeln!(self.trace, "std.trace: {s}");
                     Ok(())
                 } else {
                     Err(mk_type_error!("trace", "String"))
@@ -3207,7 +3207,7 @@ mod tests {
     fn ite_operation() {
         let cont: OperationCont = OperationCont::Op1(UnaryOp::Ite(), TermPos::None);
         let mut vm: VirtualMachine<DummyResolver, CacheImpl> =
-            VirtualMachine::new(DummyResolver {});
+            VirtualMachine::new(DummyResolver {}, std::io::sink());
 
         vm.stack
             .push_arg(Closure::atomic_closure(mk_term::integer(5)), TermPos::None);
@@ -3248,7 +3248,7 @@ mod tests {
             body: mk_term::integer(7),
             env: Environment::new(),
         };
-        let mut vm = VirtualMachine::new(DummyResolver {});
+        let mut vm = VirtualMachine::new(DummyResolver {}, std::io::sink());
         vm.stack.push_op_cont(cont, 0, TermPos::None);
 
         clos = vm.continuate_operation(clos).unwrap();
@@ -3293,7 +3293,7 @@ mod tests {
         );
 
         let mut vm: VirtualMachine<DummyResolver, CacheImpl> =
-            VirtualMachine::new(DummyResolver {});
+            VirtualMachine::new(DummyResolver {}, std::io::sink());
         let mut clos = Closure {
             body: mk_term::integer(6),
             env: Environment::new(),

--- a/src/eval/tests.rs
+++ b/src/eval/tests.rs
@@ -13,7 +13,7 @@ use codespan::Files;
 
 /// Evaluate a term without import support.
 fn eval_no_import(t: RichTerm) -> Result<Term, EvalError> {
-    VirtualMachine::<_, CacheImpl>::new(DummyResolver {})
+    VirtualMachine::<_, CacheImpl>::new(DummyResolver {}, std::io::sink())
         .eval(t, &Environment::new())
         .map(Term::from)
 }
@@ -117,7 +117,7 @@ fn asking_for_various_types() {
 
 #[test]
 fn imports() {
-    let mut vm = VirtualMachine::new(SimpleResolver::new());
+    let mut vm = VirtualMachine::new(SimpleResolver::new(), std::io::sink());
     vm.import_resolver_mut()
         .add_source(String::from("two"), String::from("1 + 1"));
     vm.import_resolver_mut()
@@ -266,7 +266,7 @@ fn initial_env() {
 
     let t = mk_term::let_in("x", mk_term::integer(2), mk_term::var("x"));
     assert_eq!(
-        VirtualMachine::new_with_cache(DummyResolver {}, eval_cache.clone())
+        VirtualMachine::new_with_cache(DummyResolver {}, eval_cache.clone(), std::io::sink())
             .eval(t, &initial_env)
             .map(RichTerm::without_pos),
         Ok(mk_term::integer(2))
@@ -274,7 +274,7 @@ fn initial_env() {
 
     let t = mk_term::let_in("x", mk_term::integer(2), mk_term::var("g"));
     assert_eq!(
-        VirtualMachine::new_with_cache(DummyResolver {}, eval_cache.clone())
+        VirtualMachine::new_with_cache(DummyResolver {}, eval_cache.clone(), std::io::sink())
             .eval(t, &initial_env)
             .map(RichTerm::without_pos),
         Ok(mk_term::integer(1))
@@ -283,7 +283,7 @@ fn initial_env() {
     // Shadowing of the initial environment
     let t = mk_term::let_in("g", mk_term::integer(2), mk_term::var("g"));
     assert_eq!(
-        VirtualMachine::new_with_cache(DummyResolver {}, eval_cache.clone())
+        VirtualMachine::new_with_cache(DummyResolver {}, eval_cache.clone(), std::io::sink())
             .eval(t, &initial_env)
             .map(RichTerm::without_pos),
         Ok(mk_term::integer(2))

--- a/src/repl/mod.rs
+++ b/src/repl/mod.rs
@@ -84,12 +84,12 @@ pub struct ReplImpl<EC: EvalCache> {
 
 impl<EC: EvalCache> ReplImpl<EC> {
     /// Create a new empty REPL.
-    pub fn new() -> Self {
+    pub fn new(trace: impl Write + 'static) -> Self {
         ReplImpl {
             parser: grammar::ExtendedTermParser::new(),
             env: Envs::new(),
             initial_type_ctxt: typecheck::Context::new(),
-            vm: VirtualMachine::new(Cache::new(ErrorTolerance::Strict), std::io::stderr()),
+            vm: VirtualMachine::new(Cache::new(ErrorTolerance::Strict), trace),
         }
     }
 

--- a/src/repl/mod.rs
+++ b/src/repl/mod.rs
@@ -89,7 +89,7 @@ impl<EC: EvalCache> ReplImpl<EC> {
             parser: grammar::ExtendedTermParser::new(),
             env: Envs::new(),
             initial_type_ctxt: typecheck::Context::new(),
-            vm: VirtualMachine::new(Cache::new(ErrorTolerance::Strict)),
+            vm: VirtualMachine::new(Cache::new(ErrorTolerance::Strict), std::io::stderr()),
         }
     }
 

--- a/src/repl/rustyline_frontend.rs
+++ b/src/repl/rustyline_frontend.rs
@@ -33,7 +33,7 @@ impl From<ColorOpt> for rustyline::config::ColorMode {
 
 /// Main loop of the REPL.
 pub fn repl(histfile: PathBuf, color_opt: ColorOpt) -> Result<(), InitError> {
-    let mut repl = ReplImpl::<CacheImpl>::new();
+    let mut repl = ReplImpl::<CacheImpl>::new(std::io::stderr());
 
     match repl.load_stdlib() {
         Ok(()) => (),

--- a/src/repl/simple_frontend.rs
+++ b/src/repl/simple_frontend.rs
@@ -29,8 +29,8 @@ impl From<Error> for InputError {
 }
 
 /// Return a new instance of an REPL with the standard library loaded.
-pub fn init<EC: EvalCache>() -> Result<ReplImpl<EC>, Error> {
-    let mut repl = ReplImpl::new();
+pub fn init<EC: EvalCache>(trace: impl Write + 'static) -> Result<ReplImpl<EC>, Error> {
+    let mut repl = ReplImpl::new(trace);
     repl.load_stdlib()?;
     Ok(repl)
 }

--- a/src/repl/wasm_frontend.rs
+++ b/src/repl/wasm_frontend.rs
@@ -274,20 +274,35 @@ impl TryInto<ExportFormat> for WasmExportFormat {
 /// A `Write` implementor that calls a callback whenever it gets written to.
 struct CallbackWriter {
     callback: Option<js_sys::Function>,
+    buf: Vec<u8>,
+}
+
+impl CallbackWriter {
+    fn new(callback: Option<js_sys::Function>) -> Self {
+        Self {
+            callback,
+            buf: Vec::new(),
+        }
+    }
 }
 
 impl std::io::Write for CallbackWriter {
     fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
-        if let Some(callback) = &self.callback {
-            let js_string = JsValue::from_str(&String::from_utf8_lossy(buf));
-            callback
-                .call1(&JsValue::NULL, &js_string)
-                .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, format!("{e:?}")))?;
+        self.buf.extend_from_slice(buf);
+        if buf.contains(&b'\n') {
+            self.flush()?;
         }
         Ok(buf.len())
     }
 
     fn flush(&mut self) -> std::io::Result<()> {
+        if let Some(callback) = &self.callback {
+            let js_string = JsValue::from_str(&String::from_utf8_lossy(&self.buf).trim());
+            callback
+                .call1(&JsValue::NULL, &js_string)
+                .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, format!("{e:?}")))?;
+        }
+        self.buf.clear();
         Ok(())
     }
 }
@@ -322,9 +337,7 @@ pub fn err_to_string(cache: &mut Cache, error: InputError) -> String {
 /// Return a new instance of the WASM REPL, with the standard library loaded.
 #[wasm_bindgen]
 pub fn repl_init(trace_callback: Option<js_sys::Function>) -> WasmInitResult {
-    let trace = CallbackWriter {
-        callback: trace_callback,
-    };
+    let trace = CallbackWriter::new(trace_callback);
     let mut repl = ReplImpl::new(trace);
     match repl.load_stdlib() {
         Ok(()) => WasmInitResult {

--- a/src/repl/wasm_frontend.rs
+++ b/src/repl/wasm_frontend.rs
@@ -271,6 +271,27 @@ impl TryInto<ExportFormat> for WasmExportFormat {
     }
 }
 
+/// A `Write` implementor that calls a callback whenever it gets written to.
+struct CallbackWriter {
+    callback: Option<js_sys::Function>,
+}
+
+impl std::io::Write for CallbackWriter {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        if let Some(callback) = &self.callback {
+            let js_string = JsValue::from_str(&String::from_utf8_lossy(buf));
+            callback
+                .call1(&JsValue::NULL, &js_string)
+                .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, format!("{e:?}")))?;
+        }
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
 /// Render error diagnostics as a string.
 pub fn diags_to_string(cache: &mut Cache, diags: &[Diagnostic<FileId>]) -> String {
     let mut buffer = Ansi::new(Cursor::new(Vec::new()));
@@ -300,8 +321,11 @@ pub fn err_to_string(cache: &mut Cache, error: InputError) -> String {
 
 /// Return a new instance of the WASM REPL, with the standard library loaded.
 #[wasm_bindgen]
-pub fn repl_init() -> WasmInitResult {
-    let mut repl = ReplImpl::new();
+pub fn repl_init(trace_callback: Option<js_sys::Function>) -> WasmInitResult {
+    let trace = CallbackWriter {
+        callback: trace_callback,
+    };
+    let mut repl = ReplImpl::new(trace);
     match repl.load_stdlib() {
         Ok(()) => WasmInitResult {
             msg: String::new(),

--- a/src/repl/wasm_frontend.rs
+++ b/src/repl/wasm_frontend.rs
@@ -297,7 +297,7 @@ impl std::io::Write for CallbackWriter {
 
     fn flush(&mut self) -> std::io::Result<()> {
         if let Some(callback) = &self.callback {
-            let js_string = JsValue::from_str(&String::from_utf8_lossy(&self.buf).trim());
+            let js_string = JsValue::from_str(String::from_utf8_lossy(&self.buf).trim());
             callback
                 .call1(&JsValue::NULL, &js_string)
                 .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, format!("{e:?}")))?;

--- a/tests/examples/main.rs
+++ b/tests/examples/main.rs
@@ -12,7 +12,8 @@ fn check_example_file(path: &str) {
     let test: TestCase<Expectation> =
         read_annotated_test_case(path).expect("Failed to parse annotated program");
 
-    let mut p = TestProgram::new_from_file(path).expect("Failed to load program from file");
+    let mut p = TestProgram::new_from_file(path, std::io::stderr())
+        .expect("Failed to load program from file");
 
     match test.annotation {
         Expectation::Pass => {

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -43,8 +43,12 @@ fn run_test(test_case: TestCase<Test>, path: String) {
     let test = test_case.annotation.test;
 
     for _ in 0..repeat {
-        let p =
-            TestProgram::new_from_source(Cursor::new(program.clone()), path.as_str()).expect("");
+        let p = TestProgram::new_from_source(
+            Cursor::new(program.clone()),
+            path.as_str(),
+            std::io::stderr(),
+        )
+        .expect("");
         match test.clone() {
             Expectation::Error(expected_err) => {
                 let err = eval_strategy.eval_program_to_err(p);

--- a/tests/integration/query.rs
+++ b/tests/integration/query.rs
@@ -10,6 +10,7 @@ pub fn test_query_metadata_basic() {
     let mut program = TestProgram::new_from_source(
         "{val | doc \"Test basic\" = (1 + 1)}".as_bytes(),
         "regr_tests",
+        std::io::stderr(),
     )
     .unwrap();
     let result = program.query(Some(String::from("val"))).unwrap();
@@ -25,11 +26,11 @@ pub fn test_query_with_wildcard() {
     /// Checks whether `lhs` and `rhs` both evaluate to terms with the same static type
     #[track_caller]
     fn assert_types_eq(lhs: &str, rhs: &str, path: Option<String>) {
-        let term1 = TestProgram::new_from_source(lhs.as_bytes(), "regr_tests")
+        let term1 = TestProgram::new_from_source(lhs.as_bytes(), "regr_tests", std::io::stderr())
             .unwrap()
             .query(path.clone())
             .unwrap();
-        let term2 = TestProgram::new_from_source(rhs.as_bytes(), "regr_tests")
+        let term2 = TestProgram::new_from_source(rhs.as_bytes(), "regr_tests", std::io::stderr())
             .unwrap()
             .query(path)
             .unwrap();
@@ -75,7 +76,8 @@ pub fn test_query_with_wildcard() {
 
     // Without wildcard, the result has no type annotation
     let mut program =
-        TestProgram::new_from_source("{value = 10}".as_bytes(), "regr_tests").unwrap();
+        TestProgram::new_from_source("{value = 10}".as_bytes(), "regr_tests", std::io::stderr())
+            .unwrap();
     let result = program.query(path.clone()).unwrap();
     assert!(matches!(
         result,

--- a/utilities/src/bench.rs
+++ b/utilities/src/bench.rs
@@ -121,9 +121,13 @@ pub fn bench_terms<'r>(rts: Vec<Bench<'r>>) -> Box<dyn Fn(&mut Criterion) + 'r> 
                             c_local.typecheck(id, &type_ctxt).unwrap();
                         } else {
                             c_local.prepare(id, &type_ctxt).unwrap();
-                            VirtualMachine::new_with_cache(c_local, eval_cache.clone())
-                                .eval(t, &eval_env)
-                                .unwrap();
+                            VirtualMachine::new_with_cache(
+                                c_local,
+                                eval_cache.clone(),
+                                std::io::sink(),
+                            )
+                            .eval(t, &eval_env)
+                            .unwrap();
                         }
                     },
                     criterion::BatchSize::LargeInput,
@@ -197,7 +201,7 @@ macro_rules! ncl_bench_group {
                                 c_local.typecheck(id, &type_ctxt).unwrap();
                             } else {
                                 c_local.prepare(id, &type_ctxt).unwrap();
-                                VirtualMachine::new_with_cache(c_local, eval_cache.clone()).eval(t, &eval_env).unwrap();
+                                VirtualMachine::new_with_cache(c_local, eval_cache.clone(), std::io::sink()).eval(t, &eval_env).unwrap();
                             }
                         },
                         criterion::BatchSize::LargeInput,

--- a/utilities/src/lib.rs
+++ b/utilities/src/lib.rs
@@ -1,3 +1,5 @@
 pub mod annotated_test;
 pub mod bench;
 pub mod test_program;
+
+pub use nickel_lang;

--- a/utilities/src/test_program.rs
+++ b/utilities/src/test_program.rs
@@ -14,7 +14,8 @@ pub type TestProgram = Program<CacheImpl>;
 
 /// Create a program from a Nickel expression provided as a string.
 pub fn program_from_expr(s: impl std::string::ToString) -> Program<CacheImpl> {
-    Program::<CacheImpl>::new_from_source(Cursor::new(s.to_string()), "test").unwrap()
+    Program::<CacheImpl>::new_from_source(Cursor::new(s.to_string()), "test", std::io::stderr())
+        .unwrap()
 }
 
 pub fn eval(s: impl std::string::ToString) -> Result<Term, Error> {
@@ -41,6 +42,6 @@ pub fn typecheck_fixture(f: &str) -> Result<(), Error> {
 
 fn program_from_test_fixture(f: &str) -> Program<CacheImpl> {
     let path = format!("{}/../tests/integration/{}", env!("CARGO_MANIFEST_DIR"), f);
-    Program::new_from_file(&path)
+    Program::new_from_file(&path, std::io::stderr())
         .unwrap_or_else(|e| panic!("Could not create program from `{}`\n {}", path, e))
 }


### PR DESCRIPTION
I'm not super sure about the API; it's a little painful to have to thread the tracing writer everywhere. Also, what's the story/plan with the crate's API stability?

I've checked that the wasm tracing works on the website, if you init the repl with `repl_init(console.log)`