### PR TITLE
Add a GitHub action for automatically uploading release artifacts

### DIFF
--- a/.github/workflows/release-artifacts.yaml
+++ b/.github/workflows/release-artifacts.yaml
@@ -1,4 +1,4 @@
-name: Uplaod release artifacts
+name: Upload release artifacts
 on:
   release:
     types: [published]
@@ -42,7 +42,7 @@ jobs:
         with:
           extra_nix_config: "experimental-features = nix-command flakes"
           nix_path: "nixpkgs=channel:nixos-unstable"
-      - name: "Build docker image"
+      - name: "Build x86_64 static binary"
         run: |
           nix build --print-build-logs .#nickel-static
           cp ./result nickel-x86_64-linux

--- a/.github/workflows/release-artifacts.yaml
+++ b/.github/workflows/release-artifacts.yaml
@@ -1,0 +1,54 @@
+name: Uplaod release artifacts
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: "The release tag to target"
+
+permissions:
+  contents: write
+
+jobs:
+  docker-image:
+    name: "Build docker image"
+    runs-on: "ubuntu-latest"
+    steps:
+      - uses: actions/checkout@v3
+      - uses: cachix/install-nix-action@v21
+        name: "Installing Nix"
+        with:
+          extra_nix_config: "experimental-features = nix-command flakes"
+          nix_path: "nixpkgs=channel:nixos-unstable"
+      - name: "Build docker image"
+        run: |
+          nix build --print-build-logs .#dockerImage
+          cp ./result nickel-docker-image.tar.gz
+      - name: "Upload docker image as release asset"
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ github.event_name == 'release' && github.event.release.tag_name || github.event.inputs.release_tag }}
+        run: |
+          gh release upload --clobber $RELEASE_TAG nickel-docker-image.tar.gz
+
+  static-binary:
+    name: "Build Nickel release binary"
+    runs-on: "ubuntu-latest"
+    steps:
+      - uses: actions/checkout@v3
+      - uses: cachix/install-nix-action@v21
+        name: "Installing Nix"
+        with:
+          extra_nix_config: "experimental-features = nix-command flakes"
+          nix_path: "nixpkgs=channel:nixos-unstable"
+      - name: "Build docker image"
+        run: |
+          nix build --print-build-logs .#nickel-static
+          cp ./result nickel-x86_64-linux
+      - name: "Upload docker image as release asset"
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ github.event_name == 'release' && github.event.release.tag_name || github.event.inputs.release_tag }}
+        run: |
+          gh release upload --clobber $RELEASE_TAG nickel-x86_64-linux

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -81,17 +81,14 @@ crates and dependent repositories (such as the website) in a consistent state.
 
 ### Release on GitHub
 
-1. Build the docker image and copy the output somewhere:
-
-   ```console
-   nix build .#dockerImage
-   cp ./result nickel-X.Y.Z-docker-image.tar.gz
-   ```
-
-2. Do the [release on
+1. Do the [release on
    GitHub](https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository),
    and include the docker image built in 1. Please look at previous releases
    for the naming convention of git tags.
+
+2. Verify that the "Upload release artifacts" GitHub action is getting triggered
+   and completes successfully, uploading a static Nickel binary for x86_64 Linux
+   and a Docker image.
 
 ### Redeploy nickel-lang.org with the new release
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -83,8 +83,8 @@ crates and dependent repositories (such as the website) in a consistent state.
 
 1. Do the [release on
    GitHub](https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository),
-   and include the docker image built in 1. Please look at previous releases
-   for the naming convention of git tags.
+   and include the docker image built in 1. Make sure that you set `X.Y.Z-release`
+   as the target branch and have GitHub create the `X.Y.Z` tag on release.
 
 2. Verify that the "Upload release artifacts" GitHub action is getting triggered
    and completes successfully, uploading a static Nickel binary for x86_64 Linux


### PR DESCRIPTION
The action is triggered on publishing a GitHub release and automaticlly builds the `dockerImage` and `nickel-static` flake outputs for x86_64 Linux. It then uploads the results as release artifacts on GitHub.