### PR TITLE
flake: Explicitly set wasm-pack cache dir

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -348,7 +348,7 @@
           inherit cargoArtifacts src;
 
           buildPhaseCargoCommand = ''
-            wasm-pack build nickel-wasm-repl ${wasmPackExtraArgs}
+            WASM_PACK_CACHE=.wasm-pack-cache wasm-pack build nickel-wasm-repl ${wasmPackExtraArgs}
           '';
 
           # nickel-lang.org expects an interface `nickel-repl.wasm`, hence the


### PR DESCRIPTION
It tries to create it in home directory that doesn't exist in sandbox and build fails with this:

```
nickel-lang> ++ command cargo --version
nickel-lang> cargo 1.70.0 (ec8a8a0ca 2023-04-25)
nickel-lang> Error: Permission denied (os error 13)
nickel-lang> Caused by: Permission denied (os error 13)
```

Fix failure in #1201.