### PR TITLE
Add instructions for building ARM64 artifacts to RELEASING.md

### DIFF
--- a/.github/workflows/release-artifacts.yaml
+++ b/.github/workflows/release-artifacts.yaml
@@ -30,7 +30,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           RELEASE_TAG: ${{ github.event_name == 'release' && github.event.release.tag_name || github.event.inputs.release_tag }}
         run: |
-          gh release upload --clobber $RELEASE_TAG nickel-docker-image.tar.gz
+          gh release upload --clobber $RELEASE_TAG nickel-x86_64-docker-image.tar.gz
 
   static-binary:
     name: "Build Nickel release binary"

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -81,12 +81,23 @@ crates and dependent repositories (such as the website) in a consistent state.
 
 ### Release on GitHub
 
-1. Do the [release on
+1. Build a Docker image and a static binary for ARM64 manually, using
+
+   ```console
+   nix build --out-link nickel-arm64-docker-image.tar.gz .#packages.aarch64-linux.dockerImage
+   nix build --out-link nickel-arm64-linux .#packages.aarch64-linux.dockerImage
+   ```
+
+   on an ARM64 Linux machine.
+
+2. Do the [release on
    GitHub](https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository),
    and include the docker image built in 1. Make sure that you set `X.Y.Z-release`
    as the target branch and have GitHub create the `X.Y.Z` tag on release.
+   Upload `nickel-arm64-docker-image.tar.gz` and `nickel-arm64-linux` as release
+   assets from the last step.
 
-2. Verify that the "Upload release artifacts" GitHub action is getting triggered
+3. Verify that the "Upload release artifacts" GitHub action is getting triggered
    and completes successfully, uploading a static Nickel binary for x86_64 Linux
    and a Docker image.
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -88,7 +88,8 @@ crates and dependent repositories (such as the website) in a consistent state.
    nix build --out-link nickel-arm64-linux .#packages.aarch64-linux.dockerImage
    ```
 
-   on an ARM64 Linux machine (x86_64 assets are automatically handled by a workflow, see 3).
+   on an ARM64 Linux machine (x86_64 assets are automatically handled by a
+   workflow, see 3).
 
 2. Do the [release on
    GitHub](https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository),

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -88,7 +88,7 @@ crates and dependent repositories (such as the website) in a consistent state.
    nix build --out-link nickel-arm64-linux .#packages.aarch64-linux.dockerImage
    ```
 
-   on an ARM64 Linux machine.
+   on an ARM64 Linux machine (x86_64 assets are automatically handled by a workflow, see 3).
 
 2. Do the [release on
    GitHub](https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository),


### PR DESCRIPTION
Since we don't have an ARM64 GitHub Actions runner handy, this PR adds some instructions for manually building ARM64 release artifacts to `RELEASING.md`.