### PR TITLE
Get rid of old jargon "enriched"

### DIFF
--- a/RATIONALE.md
+++ b/RATIONALE.md
@@ -135,14 +135,14 @@ the program itself or later in the pipeline ?  Using types, the generating
 language is no more oblivious to these external schemas and can model them
 internally, enabling early and precise error reporting.
 
-In Nickel, such schemas are specified using *enriched values*. Enriched values
-are meta-data about record fields like `id` or `baseURL`: they can provide
-documentation, a default value, or even a type. Types so specified are called
-*contracts*: they are not part of the static type system, but rather offer a
-principled approach to dynamic type checking. They enforce types (or more
-complex, user-defined) assertions at runtime. Equipped with enriched values, one
-can for example ensure that `baseURL` is not only a string but a valid URL, and
-document that it should be the Github homepage of a project.
+In Nickel, such schemas are specified using metadata. Metadata can provide
+documentation, a default value, or even a runtime type. Runtime types so
+specified are called *contracts*: they are not part of the static type system,
+but rather offer a principled approach to dynamic type checking. They enforce
+types (or more complex, user-defined assertions) at runtime. Equipped with
+metadata, one can for example enforce that `baseURL` is not only a string but a
+valid URL, and attach documentation to specify that it should be the Github
+homepage of a project.
 
 ### Turing completeness
 
@@ -323,7 +323,7 @@ This provides:
 - Querying: synthesize values inhabiting a type
 - Trimming: Automatically simplify code
 
-Nickel's merge system and enriched values are inspired by CUE's type lattice,
+Nickel's merge system and metadata are inspired by CUE's type lattice,
 although the flexibility of Nickel necessarily makes the two system behave
 differently.
 
@@ -344,8 +344,8 @@ functionalities to Nickel's merge system.
 ### Jsonnet vs Nickel
 
 The main difference between Jsonnet and Nickel are types. Jsonnet does not
-feature static types, contracts or enriched values, and thus can't type library
-code and has no principled approach to data validation.
+feature static types, contracts or metadata, and thus can't type library code
+and has no principled approach to data validation.
 
 ### Comparison with other configuration languages
 <!-- Intentionally duplicated in `README.md`, please update the other one for

--- a/src/eval/cache/lazy.rs
+++ b/src/eval/cache/lazy.rs
@@ -547,8 +547,8 @@ impl Thunk {
 
     /// Determine if a thunk is worth being put on the stack for future update.
     ///
-    /// Typically, WHNFs and enriched values will not be evaluated to a simpler expression and are not
-    /// worth updating.
+    /// Typically, WHNFs and annotated values will not be evaluated to a simpler expression and are
+    /// not worth updating.
     pub fn should_update(&self) -> bool {
         let term = &self.borrow().body.term;
         !term.is_whnf() && !term.is_annotated()

--- a/src/eval/merge.rs
+++ b/src/eval/merge.rs
@@ -1,7 +1,7 @@
 //! Evaluation of the merge operator.
 //!
 //! Merge is a primitive operation of Nickel, which recursively combines records. Together with
-//! enriched values, it allows to write and mix contracts with standard records.
+//! field metadata, it allows to write and mix contracts with standard records.
 //!
 //! # Operational semantics
 //!
@@ -13,44 +13,17 @@
 //! - Fields that are both in `r1` and `r2` are recursively merged: for a field `f`, the result
 //! contains the binding `f = r1.f & r2.f`
 //!
-//! As fields are recursively merged, merge needs to operate on any value, not only on records.
+//! As fields are recursively merged, merge needs to operate on any value, not only on records:
 //!
-//! ## On simple values
+//! - *function*: merging a function with anything else fails
+//! - *values*: merging any other values succeeds if and only if these two values are equals, in
+//! which case it evaluates to this common value.
 //!
-//! Simple values are terms which are not enriched values.
+//! ## Metadata
 //!
-//! - *Function*: merging a function with anything else fails
-//! - *Values*: merging any other values succeeds if and only if these two values are equals, in which case it evaluates to
-//! this common value.
-//!
-//! Note that merging of arrays is not yet implemented.
-//!
-//! ## On enriched values
-//!
-//! Enriched values (currently `Contract`, `Default`, `ContractDefault` or `Docstring`) get their
-//! special powers from their interaction with the merge operator.
-//!
-//! ### Enriched/Enriched
-//!
-//! - *Contract/contract*: merging two contracts evaluates to a contract which is the composition
-//! of the two
-//! - *Default/default*: merging two default values evaluates to a default which value is the merge
-//! of the two
-//! - *Contract/default*: merging a `Default` with a `Contract` evaluates to a `ContractDefault`
-//! - *ContractDefault/_*: Merging `ContractDefault` is done component-wise: with another
-//! `ContractDefault`, it evaluates to a `ContractDefault` where the two contracts as well as the
-//! two default values are respectively merged together. With either just a `Contract` or a
-//! `Default`, it simply merges the corresponding component and let the other unchanged.
-//!
-//! ### Enriched/Simple
-//!
-//! - *Docstring*: merging a docstring (with inner term `inner`) with another term `t` recursively merges
-//! `inner` and `t`, and evaluates to this result wrapped in the original docstring (`t` may be a simple value or an
-//! enriched one here)
-//! - *Default erasure*: merging a `Default` with a simple value drops the default value and
-//! evaluates to the simple value
-//! - *Contract check*: merging a `Contract` or a `ContractDefault` with a simple value `t`
-//! evaluates to a contract check, that is an `Assume(..., t)`
+//! One can think of merge to be defined on metadata as well. When merging two fields, the
+//! resulting metadata is the result of merging the two original field's metadata. The semantics
+//! depend on each metadata.
 use super::*;
 use crate::error::{EvalError, IllegalPolymorphicTailAction};
 use crate::label::{Label, MergeLabel};

--- a/src/label.rs
+++ b/src/label.rs
@@ -235,8 +235,9 @@ but this field doesn't exist in {}",
 
 /// A blame label.
 ///
-/// A label is associated to a contract check (an assume, a promise or a contract as an enriched
-/// value) and contains information to report to the user when a contract fails and a blame occurs.
+/// A label is associated to a contract check (introduced by an explicit contract annotation, or
+/// implicitly by a merge expression) and contains information to report to the user when a
+/// contract fails and a blame occurs.
 /// It includes in particular a [type path][ty_path::Path] and a **polarity**.
 ///
 /// # Polarity

--- a/src/term/mod.rs
+++ b/src/term/mod.rs
@@ -7,16 +7,8 @@
 //! - Data structures: arrays and records
 //! - Binders: functions and let bindings
 //!
-//! It also features type annotations (promise and assume), and other typechecking related
+//! It also features types and type annotations, and other typechecking or contracts-related
 //! constructs (label, symbols, etc.).
-//!
-//! # Enriched values
-//!
-//! Enriched values are special terms used to represent metadata about record fields: types or
-//! contracts, default values, documentation, etc. They bring such usually external object down to
-//! the term level, and together with [crate::eval::merge], they allow for flexible and modular
-//! definitions of contracts, record and metadata all together.
-
 pub mod array;
 pub mod record;
 pub mod string;

--- a/src/transform/share_normal_form.rs
+++ b/src/transform/share_normal_form.rs
@@ -48,8 +48,8 @@ struct Binding {
 /// This function is not recursive: it just tries to apply one step of the transformation to
 /// the top-level node of the AST. For example, it transforms `[1 + 1, [1 + 2]]` to `let %0 = 1
 /// + 1 in [%0, [1 + 2]]`: the nested subterm `[1 + 2]` is left as it was. If the term is
-/// neither a record, an array nor an enriched value, it is returned the same.  In other words,
-/// the transformation is implemented as rewrite rules, and must be used in conjunction a
+/// neither a record, an array nor an annotated value, it is returned the same.  In other words,
+/// the transformation is implemented as rewrite rules, and must be used in conjunction with a
 /// traversal to obtain a full transformation.
 pub fn transform_one(rt: RichTerm) -> RichTerm {
     let pos = rt.pos;

--- a/src/types.rs
+++ b/src/types.rs
@@ -46,9 +46,8 @@
 //!
 //! To each type corresponds a contract, which is a Nickel function which checks at runtime that
 //! its argument is of the given type and either returns it if it passes or raise a blame
-//! otherwise.  Contract checks are introduced by `Promise` and `Assume` blocks or alternatively by
-//! enriched values `Contract` or `ContractDefault`. They ensure sane interaction between typed and
-//! untyped parts.
+//! otherwise.  Contract checks are introduced by a contract annotation or propagated via merging.
+//! They ensure sane interaction between typed and untyped parts.
 use crate::{
     error::{EvalError, ParseError, ParseErrors, TypecheckError},
     identifier::Ident,


### PR DESCRIPTION
Values with metadata attached were initially called "enriched values" (which was a very bad name). Rereading the rationale document, I realized they were still traces of them lying around. This PR get rid of obsolete mentions and documentation.