### PR TITLE
Introduce unification variable levels and fix unsound generalization

### DIFF
--- a/core/src/error.rs
+++ b/core/src/error.rs
@@ -307,7 +307,7 @@ pub enum TypecheckError {
     },
     /// Unsound generalization.
     ///
-    /// When typechecking polymorphic expressions, polymoprhic variables introduced by a `forall`
+    /// When typechecking polymorphic expressions, polymorphic variables introduced by a `forall`
     /// are substituted with rigid type variables, which can only unify with a free unification
     /// variable. However, the condition that the unification variable is free isn't enough.
     ///
@@ -317,7 +317,7 @@ pub enum TypecheckError {
     /// (fun x => let y : forall a. a = x in (y : Number)) : _
     /// ```
     ///
-    /// This example must be rejected, as it is an identity function casts any value to something
+    /// This example must be rejected, as it is an identity function that casts any value to something
     /// of type `Number`. It will typically fail with a contract error if applied to a string, for
     /// example.
     ///

--- a/core/src/error.rs
+++ b/core/src/error.rs
@@ -2128,7 +2128,7 @@ impl IntoDiagnostics<FileId> for TypecheckError {
                 }
 
                 vec![Diagnostic::error()
-                    .with_message(format!("invalid polymorphic generalization"))
+                    .with_message("invalid polymorphic generalization".to_string())
                     .with_labels(labels)
                     .with_notes(vec![
                         "While the type of this expression is still undetermined, it appears \

--- a/core/src/error.rs
+++ b/core/src/error.rs
@@ -330,7 +330,7 @@ pub enum TypecheckError {
     /// discipline needed to reject those case is similar to region-based memory management. See
     /// [crate::typecheck] for more details. This error indicates that a case similar to the above
     /// example happened.
-    VariableLevelMismatch {
+    VarLevelMismatch {
         /// The user-defined type variable (the rigid type variable during unification) that
         /// couldn't be unified.
         type_var: Ident,
@@ -2115,15 +2115,13 @@ impl IntoDiagnostics<FileId> for TypecheckError {
                     ),
                 ]
             }
-            TypecheckError::VariableLevelMismatch {
+            TypecheckError::VarLevelMismatch {
                 type_var: constant,
                 pos,
             } => {
                 let mut labels = mk_expr_label(&pos);
 
-                println!("Position of constant: {:?}", constant.pos);
                 if let Some(span) = constant.pos.into_opt() {
-                    println!("Adding to label position");
                     labels.push(secondary(&span).with_message("this polymorphic type"));
                 }
 

--- a/core/src/typecheck/destructuring.rs
+++ b/core/src/typecheck/destructuring.rs
@@ -104,7 +104,6 @@ fn build_pattern_type(
             | FieldPattern::AliasedRecordPattern { pattern: r_pat, .. },
         ) => {
             let row_tys = build_pattern_type(state, ctxt, r_pat, mode)?;
-            //TODO: var_level, is it correct?
             let ty = UnifType::concrete(TypeF::Record(row_tys));
 
             // If there are type annotations within nested record patterns
@@ -171,8 +170,6 @@ pub fn inject_pattern_variables(
             // ```
             //
             // As such, we don't need to add it to the environment.
-
-            //TODO: var_level, is it correct?
             let UnifType::Concrete { types: TypeF::Record(rs), .. } = ty else {
                 unreachable!("since this is a destructured record, \
                               its type was constructed by build_pattern_ty, \
@@ -185,7 +182,6 @@ pub fn inject_pattern_variables(
 
             env.insert(*alias, ty.clone());
 
-            //TODO: var_level, is it correct?
             let UnifType::Concrete{ types: TypeF::Record(rs), .. } = ty else {
                 unreachable!("since this is a destructured record, \
                               its type was constructed by build_pattern_ty, \

--- a/core/src/typecheck/destructuring.rs
+++ b/core/src/typecheck/destructuring.rs
@@ -57,7 +57,7 @@ fn build_pattern_type(
                 if let Some(l_ty) = ty_annot {
                     UnifType::from_type(l_ty.types, &ctxt.term_env)
                 } else {
-                    state.table.fresh_type_uvar()
+                    state.table.fresh_type_uvar(ctxt.var_level)
                 }
             }
         }
@@ -69,7 +69,7 @@ fn build_pattern_type(
             // but if/when we remove dynamic record tails this could
             // likely be made an empty tail with no impact.
             TypecheckMode::Walk => mk_uty_row!(; RecordRowsF::TailDyn),
-            TypecheckMode::Check => state.table.fresh_rrows_uvar(),
+            TypecheckMode::Check => state.table.fresh_rrows_uvar(ctxt.var_level),
         }
     } else {
         UnifRecordRows::Concrete(RecordRowsF::Empty)

--- a/core/src/typecheck/destructuring.rs
+++ b/core/src/typecheck/destructuring.rs
@@ -101,7 +101,8 @@ fn build_pattern_type(
             | FieldPattern::AliasedRecordPattern { pattern: r_pat, .. },
         ) => {
             let row_tys = build_pattern_type(state, ctxt, r_pat, mode)?;
-            let ty = UnifType::Concrete(TypeF::Record(row_tys));
+            //TODO: var_level, is it correct?
+            let ty = UnifType::concrete(TypeF::Record(row_tys));
 
             // If there are type annotations within nested record patterns
             // then we need to unify them with the pattern type we've built
@@ -163,12 +164,13 @@ pub fn inject_pattern_variables(
             // binding like:
             //
             // ```
-            //   let { foo = { bar = baz } } = { foo.bar = 1 } in ...
+            // let { foo = { bar = baz } } = { foo.bar = 1 } in ...
             // ```
             //
             // As such, we don't need to add it to the environment.
 
-            let UnifType::Concrete(TypeF::Record(rs)) = ty else {
+            //TODO: var_level, is it correct?
+            let UnifType::Concrete { types: TypeF::Record(rs), .. } = ty else {
                 unreachable!("since this is a destructured record, \
                               its type was constructed by build_pattern_ty, \
                               which means it must be a concrete record type")
@@ -180,7 +182,8 @@ pub fn inject_pattern_variables(
 
             env.insert(*alias, ty.clone());
 
-            let UnifType::Concrete(TypeF::Record(rs)) = ty else {
+            //TODO: var_level, is it correct?
+            let UnifType::Concrete{ types: TypeF::Record(rs), .. } = ty else {
                 unreachable!("since this is a destructured record, \
                               its type was constructed by build_pattern_ty, \
                               which means it must be a concrete record type")
@@ -261,6 +264,7 @@ impl RecordTypes {
                 tail: Box::new(tail),
             })
         });
-        UnifType::Concrete(TypeF::Record(rrows))
+        // TODO: var_levels, is it correct?
+        UnifType::concrete(TypeF::Record(rrows))
     }
 }

--- a/core/src/typecheck/eq.rs
+++ b/core/src/typecheck/eq.rs
@@ -438,7 +438,10 @@ fn type_eq_bounded<E: TermEnvironment>(
     env2: &E,
 ) -> bool {
     match (ty1, ty2) {
-        (GenericUnifType::Concrete(s1), GenericUnifType::Concrete(s2)) => match (s1, s2) {
+        (
+            GenericUnifType::Concrete { types: s1, .. },
+            GenericUnifType::Concrete { types: s2, .. },
+        ) => match (s1, s2) {
             (TypeF::Wildcard(id1), TypeF::Wildcard(id2)) => id1 == id2,
             (TypeF::Dyn, TypeF::Dyn)
             | (TypeF::Number, TypeF::Number)

--- a/core/src/typecheck/eq.rs
+++ b/core/src/typecheck/eq.rs
@@ -531,12 +531,12 @@ fn type_eq_bounded<E: TermEnvironment>(
             // all type variables should have been substituted at this point, so we bail out.
             _ => false,
         },
-        (GenericUnifType::UnifVar(p1), GenericUnifType::UnifVar(p2)) => {
+        (GenericUnifType::UnifVar { id: id1, ..}, GenericUnifType::UnifVar { id: id2, ..}) => {
             debug_assert!(
                 false,
                 "we shouldn't come across unification variables during type equality computation"
             );
-            p1 == p2
+            id1 == id2
         }
         (GenericUnifType::Constant(i1), GenericUnifType::Constant(i2)) => i1 == i2,
         _ => false,

--- a/core/src/typecheck/eq.rs
+++ b/core/src/typecheck/eq.rs
@@ -531,7 +531,7 @@ fn type_eq_bounded<E: TermEnvironment>(
             // all type variables should have been substituted at this point, so we bail out.
             _ => false,
         },
-        (GenericUnifType::UnifVar { id: id1, ..}, GenericUnifType::UnifVar { id: id2, ..}) => {
+        (GenericUnifType::UnifVar { id: id1, .. }, GenericUnifType::UnifVar { id: id2, .. }) => {
             debug_assert!(
                 false,
                 "we shouldn't come across unification variables during type equality computation"

--- a/core/src/typecheck/eq.rs
+++ b/core/src/typecheck/eq.rs
@@ -512,16 +512,16 @@ fn type_eq_bounded<E: TermEnvironment>(
 
                 let (uty1_subst, uty2_subst) = match var_kind1 {
                     VarKind::Type => (
-                        body1.subst_type(var1, &GenericUnifType::Constant(cst_id)),
-                        body2.subst_type(var2, &GenericUnifType::Constant(cst_id)),
+                        body1.subst(var1, &GenericUnifType::Constant(cst_id)),
+                        body2.subst(var2, &GenericUnifType::Constant(cst_id)),
                     ),
                     VarKind::RecordRows { .. } => (
-                        body1.subst_rrows(var1, &GenericUnifRecordRows::Constant(cst_id)),
-                        body2.subst_rrows(var2, &GenericUnifRecordRows::Constant(cst_id)),
+                        body1.subst(var1, &GenericUnifRecordRows::Constant(cst_id)),
+                        body2.subst(var2, &GenericUnifRecordRows::Constant(cst_id)),
                     ),
                     VarKind::EnumRows => (
-                        body1.subst_erows(var1, &UnifEnumRows::Constant(cst_id)),
-                        body2.subst_erows(var2, &UnifEnumRows::Constant(cst_id)),
+                        body1.subst(var1, &UnifEnumRows::Constant(cst_id)),
+                        body2.subst(var2, &UnifEnumRows::Constant(cst_id)),
                     ),
                 };
 

--- a/core/src/typecheck/error.rs
+++ b/core/src/typecheck/error.rs
@@ -30,6 +30,11 @@ pub enum RowUnifError {
     ConstMismatch(VarKindDiscriminant, usize, usize),
     /// An unbound type variable was referenced.
     UnboundTypeVariable(Ident),
+    /// Tried to unify a constant with a unification variable with a strictly lower level.
+    VariableLevelMismatch {
+        constant_id: VarId,
+        var_kind: VarKindDiscriminant,
+    },
 }
 
 impl RowUnifError {
@@ -53,6 +58,13 @@ impl RowUnifError {
             RowUnifError::WithConst(c, k, uty) => UnifError::WithConst(c, k, uty),
             RowUnifError::ConstMismatch(k, c1, c2) => UnifError::ConstMismatch(k, c1, c2),
             RowUnifError::UnboundTypeVariable(id) => UnifError::UnboundTypeVariable(id),
+            RowUnifError::VariableLevelMismatch {
+                constant_id,
+                var_kind,
+            } => UnifError::VariableLevelMismatch {
+                constant_id,
+                var_kind,
+            },
         }
     }
 }

--- a/core/src/typecheck/error.rs
+++ b/core/src/typecheck/error.rs
@@ -1,5 +1,5 @@
 //! Internal error types for typechecking.
-use super::{reporting, State, UnifType};
+use super::{reporting, State, UnifType, VarId};
 use crate::{
     error::TypecheckError,
     identifier::Ident,
@@ -88,6 +88,11 @@ pub enum UnifError {
     DomainMismatch(UnifType, UnifType, Box<UnifError>),
     /// An error occurred when unifying the codomains of two arrows.
     CodomainMismatch(UnifType, UnifType, Box<UnifError>),
+    /// Tried to unify a constant with a unification variable with a strictly lower level.
+    VariableLevelMismatch {
+        constant_id: VarId,
+        var_kind: VarKindDiscriminant,
+    },
 }
 
 impl UnifError {
@@ -212,6 +217,12 @@ impl UnifError {
                     Box::new(err_final.into_typecheck_err_(state, names, TermPos::None)),
                     pos_opt,
                 )
+            }
+            UnifError::VariableLevelMismatch { constant_id, var_kind } => {
+                TypecheckError::VariableLevelMismatch {
+                    constant: reporting::cst_name(state.names, names, constant_id, var_kind),
+                    pos: pos_opt,
+                }
             }
         }
     }

--- a/core/src/typecheck/error.rs
+++ b/core/src/typecheck/error.rs
@@ -245,8 +245,14 @@ impl UnifError {
         loop {
             match curr {
                 UnifError::DomainMismatch(
-                    uty1 @ UnifType::Concrete(TypeF::Arrow(_, _)),
-                    uty2 @ UnifType::Concrete(TypeF::Arrow(_, _)),
+                    uty1 @ UnifType::Concrete {
+                        types: TypeF::Arrow(_, _),
+                        ..
+                    },
+                    uty2 @ UnifType::Concrete {
+                        types: TypeF::Arrow(_, _),
+                        ..
+                    },
                     err,
                 ) => {
                     utys = utys.or(Some((uty1, uty2)));
@@ -257,8 +263,14 @@ impl UnifError {
                     "typechecking::to_type_path(): domain mismatch error on a non arrow type"
                 ),
                 UnifError::CodomainMismatch(
-                    uty1 @ UnifType::Concrete(TypeF::Arrow(_, _)),
-                    uty2 @ UnifType::Concrete(TypeF::Arrow(_, _)),
+                    uty1 @ UnifType::Concrete {
+                        types: TypeF::Arrow(_, _),
+                        ..
+                    },
+                    uty2 @ UnifType::Concrete {
+                        types: TypeF::Arrow(_, _),
+                        ..
+                    },
                     err,
                 ) => {
                     utys = utys.or(Some((uty1, uty2)));

--- a/core/src/typecheck/error.rs
+++ b/core/src/typecheck/error.rs
@@ -218,12 +218,13 @@ impl UnifError {
                     pos_opt,
                 )
             }
-            UnifError::VariableLevelMismatch { constant_id, var_kind } => {
-                TypecheckError::VariableLevelMismatch {
-                    constant: reporting::cst_name(state.names, names, constant_id, var_kind),
-                    pos: pos_opt,
-                }
-            }
+            UnifError::VariableLevelMismatch {
+                constant_id,
+                var_kind,
+            } => TypecheckError::VariableLevelMismatch {
+                type_var: reporting::cst_name(state.names, names, constant_id, var_kind),
+                pos: pos_opt,
+            },
         }
     }
 

--- a/core/src/typecheck/error.rs
+++ b/core/src/typecheck/error.rs
@@ -31,7 +31,7 @@ pub enum RowUnifError {
     /// An unbound type variable was referenced.
     UnboundTypeVariable(Ident),
     /// Tried to unify a constant with a unification variable with a strictly lower level.
-    VariableLevelMismatch {
+    VarLevelMismatch {
         constant_id: VarId,
         var_kind: VarKindDiscriminant,
     },
@@ -58,10 +58,10 @@ impl RowUnifError {
             RowUnifError::WithConst(c, k, uty) => UnifError::WithConst(c, k, uty),
             RowUnifError::ConstMismatch(k, c1, c2) => UnifError::ConstMismatch(k, c1, c2),
             RowUnifError::UnboundTypeVariable(id) => UnifError::UnboundTypeVariable(id),
-            RowUnifError::VariableLevelMismatch {
+            RowUnifError::VarLevelMismatch {
                 constant_id,
                 var_kind,
-            } => UnifError::VariableLevelMismatch {
+            } => UnifError::VarLevelMismatch {
                 constant_id,
                 var_kind,
             },
@@ -101,7 +101,7 @@ pub enum UnifError {
     /// An error occurred when unifying the codomains of two arrows.
     CodomainMismatch(UnifType, UnifType, Box<UnifError>),
     /// Tried to unify a constant with a unification variable with a strictly lower level.
-    VariableLevelMismatch {
+    VarLevelMismatch {
         constant_id: VarId,
         var_kind: VarKindDiscriminant,
     },
@@ -230,10 +230,10 @@ impl UnifError {
                     pos_opt,
                 )
             }
-            UnifError::VariableLevelMismatch {
+            UnifError::VarLevelMismatch {
                 constant_id,
                 var_kind,
-            } => TypecheckError::VariableLevelMismatch {
+            } => TypecheckError::VarLevelMismatch {
                 type_var: reporting::cst_name(state.names, names, constant_id, var_kind),
                 pos: pos_opt,
             },

--- a/core/src/typecheck/mk_uniftype.rs
+++ b/core/src/typecheck/mk_uniftype.rs
@@ -6,12 +6,13 @@ use crate::types::{DictTypeFlavour, TypeF};
 #[macro_export]
 macro_rules! mk_uty_arrow {
     ($left:expr, $right:expr) => {
-        $crate::typecheck::UnifType::Concrete(
-            $crate::types::TypeF::Arrow(
+        $crate::typecheck::UnifType::Concrete {
+            types: $crate::types::TypeF::Arrow(
                 Box::new($crate::typecheck::UnifType::from($left)),
                 Box::new($crate::typecheck::UnifType::from($right))
-            )
-        )
+                ),
+                var_levels_data: Default::default(),
+        }
     };
     ( $fst:expr, $snd:expr , $( $types:expr ),+ ) => {
         $crate::mk_uty_arrow!($fst, $crate::mk_uty_arrow!($snd, $( $types ),+))
@@ -66,11 +67,12 @@ macro_rules! mk_uty_row {
 #[macro_export]
 macro_rules! mk_uty_enum {
     ($( $ids:expr ),* $(; $tail:expr)?) => {
-        $crate::typecheck::UnifType::Concrete(
-            $crate::types::TypeF::Enum(
+        $crate::typecheck::UnifType::Concrete{
+            types: $crate::types::TypeF::Enum(
                 $crate::mk_uty_enum_row!($( $ids ),* $(; $tail)?)
-            )
-        )
+            ),
+            var_levels_data: Default::default(),
+        }
     };
 }
 
@@ -78,11 +80,12 @@ macro_rules! mk_uty_enum {
 #[macro_export]
 macro_rules! mk_uty_record {
     ($(($ids:expr, $tys:expr)),* $(; $tail:expr)?) => {
-        $crate::typecheck::UnifType::Concrete(
-            $crate::types::TypeF::Record(
+        $crate::typecheck::UnifType::Concrete{
+            types: $crate::types::TypeF::Record(
                 $crate::mk_uty_row!($(($ids, $tys)),* $(; $tail)?)
-            )
-        )
+            ),
+            var_levels_data: Default::default()
+        }
     };
 }
 
@@ -90,7 +93,10 @@ macro_rules! mk_uty_record {
 macro_rules! generate_builder {
     ($fun:ident, $var:ident) => {
         pub fn $fun() -> UnifType {
-            UnifType::Concrete(TypeF::$var)
+            UnifType::Concrete {
+                types: TypeF::$var,
+                var_levels_data: Default::default(),
+            }
         }
     };
 }
@@ -99,17 +105,23 @@ pub fn dict<T>(ty: T) -> UnifType
 where
     T: Into<UnifType>,
 {
-    UnifType::Concrete(TypeF::Dict {
-        type_fields: Box::new(ty.into()),
-        flavour: DictTypeFlavour::Type,
-    })
+    UnifType::Concrete {
+        types: TypeF::Dict {
+            type_fields: Box::new(ty.into()),
+            flavour: DictTypeFlavour::Type,
+        },
+        var_levels_data: Default::default(),
+    }
 }
 
 pub fn array<T>(ty: T) -> UnifType
 where
     T: Into<UnifType>,
 {
-    UnifType::Concrete(TypeF::Array(Box::new(ty.into())))
+    UnifType::Concrete {
+        types: TypeF::Array(Box::new(ty.into())),
+        var_levels_data: Default::default(),
+    }
 }
 
 // dyn is a reserved keyword

--- a/core/src/typecheck/mk_uniftype.rs
+++ b/core/src/typecheck/mk_uniftype.rs
@@ -44,13 +44,16 @@ macro_rules! mk_uty_enum_row {
 #[macro_export]
 macro_rules! mk_uty_row {
     () => {
-        $crate::typecheck::UnifRecordRows::Concrete($crate::types::RecordRowsF::Empty)
+        $crate::typecheck::UnifRecordRows::Concrete {
+            rrows: $crate::types::RecordRowsF::Empty,
+            var_levels_data: $crate::typecheck::VarLevelsData::new_no_uvars()
+        }
     };
     (; $tail:expr) => {
         $crate::typecheck::UnifRecordRows::from($tail)
     };
     (($id:expr, $ty:expr) $(,($ids:expr, $tys:expr))* $(; $tail:expr)?) => {
-        $crate::typecheck::UnifRecordRows::Concrete(
+        $crate::typecheck::UnifRecordRows::concrete(
             $crate::types::RecordRowsF::Extend {
                 row: $crate::types::RecordRowF {
                     id: Ident::from($id),

--- a/core/src/typecheck/mk_uniftype.rs
+++ b/core/src/typecheck/mk_uniftype.rs
@@ -23,13 +23,16 @@ macro_rules! mk_uty_arrow {
 #[macro_export]
 macro_rules! mk_uty_enum_row {
     () => {
-        $crate::typecheck::UnifEnumRows::Concrete($crate::types::EnumRowsF::Empty)
+        $crate::typecheck::UnifEnumRows::Concrete {
+            erows: $crate::types::EnumRowsF::Empty,
+            var_levels_data: $crate::typecheck::VarLevelsData::new_no_uvars(),
+        }
     };
     (; $tail:expr) => {
         $crate::typecheck::UnifEnumRows::from($tail)
     };
     ( $id:expr $(, $ids:expr )* $(; $tail:expr)?) => {
-        $crate::typecheck::UnifEnumRows::Concrete(
+        $crate::typecheck::UnifEnumRows::concrete(
             $crate::types::EnumRowsF::Extend {
                 row: Ident::from($id),
                 tail: Box::new($crate::mk_uty_enum_row!($( $ids ),* $(; $tail)?))

--- a/core/src/typecheck/mk_uniftype.rs
+++ b/core/src/typecheck/mk_uniftype.rs
@@ -2,6 +2,11 @@
 use super::UnifType;
 use crate::types::{DictTypeFlavour, TypeF};
 
+macro_rules! compute_combined_level {
+    ($uty: expr) => ($uty);
+    ($x: expr, $($z: expr),+) => (::std::cmp::min($x, min!($($z),*)));
+}
+
 /// Multi-ary arrow constructor for types implementing `Into<TypeWrapper>`.
 #[macro_export]
 macro_rules! mk_uty_arrow {
@@ -120,6 +125,13 @@ where
 {
     UnifType::Concrete {
         types: TypeF::Array(Box::new(ty.into())),
+        var_levels_data: Default::default(),
+    }
+}
+
+pub fn arrow(domain: impl Into<UnifType>, codomain: impl Into<UnifType>) -> UnifType {
+    UnifType::Concrete {
+        types: TypeF::Arrow(Box::new(domain.into()), Box::new(codomain.into())),
         var_levels_data: Default::default(),
     }
 }

--- a/core/src/typecheck/mod.rs
+++ b/core/src/typecheck/mod.rs
@@ -2848,8 +2848,8 @@ pub fn unify(
                 if state.table.get_level(id) < constant_level {
                     return Err(UnifError::VariableLevelMismatch {
                         constant_id: cst_id,
-                        var_kind: VarKindDiscriminant::Type
-                    })
+                        var_kind: VarKindDiscriminant::Type,
+                    });
                 }
             }
 

--- a/core/src/typecheck/mod.rs
+++ b/core/src/typecheck/mod.rs
@@ -202,7 +202,7 @@ pub enum UnifEnumRows {
 /// run in constant time again, as long as we don't unify with a rigid type variable.
 ///
 /// Variable levels data might correspond to different variable kinds (type, record rows and enum
-/// rows) depending on where they appear (in a [UnifType], [UnifRecordRows] or [EnumRecordRows])
+/// rows) depending on where they appear (in a [UnifType], [UnifRecordRows] or [UnifEnumRows])
 #[derive(Clone, Copy, Eq, PartialEq, Debug)]
 pub struct VarLevelsData {
     /// Upper bound on the variable levels of free unification variables contained in this type.

--- a/core/src/typecheck/mod.rs
+++ b/core/src/typecheck/mod.rs
@@ -1123,7 +1123,6 @@ pub trait ReifyAsUnifType {
 /// The typing context is a structure holding the scoped, environment-like data structures required
 /// to perform typechecking.
 ///
-/// The typing context currently includes , and the term environment.
 #[derive(Debug, PartialEq, Clone)]
 pub struct Context {
     /// The typing environment, counterpart of the eval environment for typechecking

--- a/core/src/typecheck/mod.rs
+++ b/core/src/typecheck/mod.rs
@@ -2835,7 +2835,7 @@ pub fn unify(
                 state.table.force_type_updates(constant_level);
 
                 if state.table.get_level(id) < constant_level {
-                    return Err(UnifError::VariableLevelMismatch {
+                    return Err(UnifError::VarLevelMismatch {
                         constant_id: cst_id,
                         var_kind: VarKindDiscriminant::Type,
                     });
@@ -2949,7 +2949,7 @@ pub fn unify_rrows(
                 state.table.force_rrows_updates(constant_level);
 
                 if state.table.get_rrows_level(id) < constant_level {
-                    return Err(RowUnifError::VariableLevelMismatch {
+                    return Err(RowUnifError::VarLevelMismatch {
                         constant_id: cst_id,
                         var_kind: VarKindDiscriminant::RecordRows,
                     });
@@ -3027,7 +3027,7 @@ pub fn unify_erows(
                 state.table.force_erows_updates(constant_level);
 
                 if state.table.get_erows_level(id) < constant_level {
-                    return Err(RowUnifError::VariableLevelMismatch {
+                    return Err(RowUnifError::VarLevelMismatch {
                         constant_id: cst_id,
                         var_kind: VarKindDiscriminant::EnumRows,
                     });

--- a/core/src/typecheck/mod.rs
+++ b/core/src/typecheck/mod.rs
@@ -2846,15 +2846,10 @@ pub fn unify(
                 state.table.force_type_updates(constant_level);
 
                 if state.table.get_level(id) < constant_level {
-                    println!("Uvar {id} has a lower level than constant {constant_level}");
-                    return Err(UnifError::WithConst(
-                        VarKindDiscriminant::Type,
-                        cst_id,
-                        UnifType::UnifVar {
-                            id,
-                            init_level: VarLevel::default(),
-                        },
-                    ));
+                    return Err(UnifError::VariableLevelMismatch {
+                        constant_id: cst_id,
+                        var_kind: VarKindDiscriminant::Type
+                    })
                 }
             }
 
@@ -3079,7 +3074,6 @@ fn instantiate_foralls(
     // type variables introduced afterwards.
     ctxt.var_level += 1;
 
-    // TODO: variable levels
     while let UnifType::Concrete {
         types: TypeF::Forall {
             var,

--- a/core/src/typecheck/mod.rs
+++ b/core/src/typecheck/mod.rs
@@ -1856,8 +1856,8 @@ fn check<L: Linearizer>(
             subsumption(state, &ctxt, tgt, ty).map_err(|err| err.into_typecheck_err(state, rt.pos))
         }
         Term::Match { cases, default } => {
-            // Currently, if it has a default value, we typecheck the whole thing as
-            // taking ANY enum, since it's more permissive and there's no loss of information.
+            // Currently, if the match has a default value, we typecheck the whole thing as taking
+            // ANY enum, since it's more permissive and there's no loss of information.
 
             // A match expression is a special kind of function. Thus it's typed as `a -> b`, where
             // `a` is a enum type determined by the matched tags and `b` is the type of each match
@@ -2681,7 +2681,7 @@ fn erows_add(
             }
         },
         UnifEnumRows::UnifVar {
-            id: tail_var_id,
+            id: var_id,
             init_level,
         } => {
             let tail_var_id = state.table.fresh_erows_var_id(var_level);
@@ -2694,7 +2694,7 @@ fn erows_add(
                 tail: Box::new(tail_var.clone()),
             });
 
-            state.table.assign_erows(tail_var_id, new_tail);
+            state.table.assign_erows(var_id, new_tail);
 
             Ok(tail_var)
         }

--- a/core/src/typecheck/mod.rs
+++ b/core/src/typecheck/mod.rs
@@ -515,45 +515,44 @@ impl<E: TermEnvironment> GenericUnifRecordRows<E> {
     }
 }
 
-trait SubstType<E: TermEnvironment> {
-    fn subst_type(self, id: &Ident, to: &GenericUnifType<E>) -> Self;
+// A type which contains variables which can be substitued with values of type `T`.
+trait Subst<T: Clone>: Sized {
+    fn subst(self, id: &Ident, to: &T) -> Self {
+        self.subst_levels(id, to).0
+    }
+
+    // Must be filled by implementers. In addition to performing substitution, this method bubbles
+    // up potential new values for variable levels data.
+    fn subst_levels(self, id: &Ident, to: &T) -> (Self, VarLevelsData);
 }
 
-trait SubstRRows<E: TermEnvironment> {
-    fn subst_rrows(self, id: &Ident, to: &GenericUnifRecordRows<E>) -> Self;
-}
-
-trait SubstERows {
-    fn subst_erows(self, id: &Ident, to: &UnifEnumRows) -> Self;
-}
-
-impl<E: TermEnvironment> SubstType<E> for GenericUnifType<E> {
-    fn subst_type(self, id: &Ident, to: &GenericUnifType<E>) -> Self {
+impl<E: TermEnvironment> Subst<GenericUnifType<E>> for GenericUnifType<E> {
+    fn subst_levels(self, id: &Ident, to: &GenericUnifType<E>) -> (Self, VarLevelsData) {
         todo!();
 
-        match self {
-            GenericUnifType::Concrete {
-                types: TypeF::Var(var_id),
-                ..
-            } if var_id == *id => to.clone(),
-            GenericUnifType::Concrete {
-                types,
-                var_levels_data,
-            } => GenericUnifType::Concrete {
-                types: types.map(
-                    |ty| Box::new(ty.subst_type(id, to)),
-                    |rrows| rrows.subst_type(id, to),
-                    |erows| erows,
-                ),
-                var_levels_data,
-            },
-            _ => self,
-        }
+        //        match self {
+        //            GenericUnifType::Concrete {
+        //                types: TypeF::Var(var_id),
+        //                ..
+        //            } if var_id == *id => to.clone(),
+        //            GenericUnifType::Concrete {
+        //                types,
+        //                var_levels_data,
+        //            } => GenericUnifType::Concrete {
+        //                types: types.map(
+        //                    |ty| Box::new(ty.subst_type(id, to)),
+        //                    |rrows| rrows.subst_type(id, to),
+        //                    |erows| erows,
+        //                ),
+        //                var_levels_data,
+        //            },
+        //            _ => self,
+        //        }
     }
 }
 
-impl<E: TermEnvironment> SubstType<E> for GenericUnifRecordRows<E> {
-    fn subst_type(self, id: &Ident, to: &GenericUnifType<E>) -> Self {
+impl<E: TermEnvironment> Subst<GenericUnifType<E>> for GenericUnifRecordRows<E> {
+    fn subst_levels(self, id: &Ident, to: &GenericUnifType<E>) -> (Self, VarLevelsData) {
         todo!();
 
         // match self {
@@ -566,27 +565,29 @@ impl<E: TermEnvironment> SubstType<E> for GenericUnifRecordRows<E> {
     }
 }
 
-impl<E: TermEnvironment> SubstRRows<E> for GenericUnifType<E> {
-    fn subst_rrows(self, id: &Ident, to: &GenericUnifRecordRows<E>) -> Self {
-        match self {
-            GenericUnifType::Concrete {
-                types,
-                var_levels_data,
-            } => GenericUnifType::Concrete {
-                types: types.map(
-                    |ty| Box::new(ty.subst_rrows(id, to)),
-                    |rrows| rrows.subst_rrows(id, to),
-                    |erows| erows,
-                ),
-                var_levels_data,
-            },
-            _ => self,
-        }
+impl<E: TermEnvironment> Subst<GenericUnifRecordRows<E>> for GenericUnifType<E> {
+    fn subst_levels(self, id: &Ident, to: &GenericUnifRecordRows<E>) -> (Self, VarLevelsData) {
+        todo!();
+
+        // match self {
+        //     GenericUnifType::Concrete {
+        //         types,
+        //         var_levels_data,
+        //     } => GenericUnifType::Concrete {
+        //         types: types.map(
+        //             |ty| Box::new(ty.subst_rrows(id, to)),
+        //             |rrows| rrows.subst_rrows(id, to),
+        //             |erows| erows,
+        //         ),
+        //         var_levels_data,
+        //     },
+        //     _ => self,
+        // }
     }
 }
 
-impl<E: TermEnvironment> SubstRRows<E> for GenericUnifRecordRows<E> {
-    fn subst_rrows(self, id: &Ident, to: &GenericUnifRecordRows<E>) -> Self {
+impl<E: TermEnvironment> Subst<GenericUnifRecordRows<E>> for GenericUnifRecordRows<E> {
+    fn subst_levels(self, id: &Ident, to: &GenericUnifRecordRows<E>) -> (Self, VarLevelsData) {
         todo!();
 
         //match self {
@@ -602,27 +603,29 @@ impl<E: TermEnvironment> SubstRRows<E> for GenericUnifRecordRows<E> {
     }
 }
 
-impl<E: TermEnvironment> SubstERows for GenericUnifType<E> {
-    fn subst_erows(self, id: &Ident, to: &UnifEnumRows) -> Self {
-        match self {
-            GenericUnifType::Concrete {
-                types,
-                var_levels_data,
-            } => GenericUnifType::Concrete {
-                types: types.map(
-                    |ty| Box::new(ty.subst_erows(id, to)),
-                    |rrows| rrows.subst_erows(id, to),
-                    |erows| erows.subst_erows(id, to),
-                ),
-                var_levels_data,
-            },
-            _ => self,
-        }
+impl<E: TermEnvironment> Subst<UnifEnumRows> for GenericUnifType<E> {
+    fn subst_levels(self, id: &Ident, to: &UnifEnumRows) -> (Self, VarLevelsData) {
+        todo!();
+
+        // match self {
+        //     GenericUnifType::Concrete {
+        //         types,
+        //         var_levels_data,
+        //     } => GenericUnifType::Concrete {
+        //         types: types.map(
+        //             |ty| Box::new(ty.subst_erows(id, to)),
+        //             |rrows| rrows.subst_erows(id, to),
+        //             |erows| erows.subst_erows(id, to),
+        //         ),
+        //         var_levels_data,
+        //     },
+        //     _ => self,
+        // }
     }
 }
 
-impl<E: TermEnvironment> SubstERows for GenericUnifRecordRows<E> {
-    fn subst_erows(self, id: &Ident, to: &UnifEnumRows) -> Self {
+impl<E: TermEnvironment> Subst<UnifEnumRows> for GenericUnifRecordRows<E> {
+    fn subst_levels(self, id: &Ident, to: &UnifEnumRows) -> (Self, VarLevelsData) {
         todo!()
 
         //match self {
@@ -641,8 +644,8 @@ impl<E: TermEnvironment> SubstERows for GenericUnifRecordRows<E> {
     }
 }
 
-impl SubstERows for UnifEnumRows {
-    fn subst_erows(self, id: &Ident, to: &UnifEnumRows) -> Self {
+impl Subst<UnifEnumRows> for UnifEnumRows {
+    fn subst_levels(self, id: &Ident, to: &UnifEnumRows) -> (Self, VarLevelsData) {
         todo!();
 
         //match self {
@@ -2620,22 +2623,22 @@ pub fn unify(
                     VarKind::Type => {
                         let constant_type = state.table.fresh_type_const(ctxt.var_level);
                         (
-                            body1.subst_type(&var1, &constant_type),
-                            body2.subst_type(&var2, &constant_type),
+                            body1.subst(&var1, &constant_type),
+                            body2.subst(&var2, &constant_type),
                         )
                     }
                     VarKind::RecordRows { .. } => {
                         let constant_type = state.table.fresh_rrows_const(ctxt.var_level);
                         (
-                            body1.subst_rrows(&var1, &constant_type),
-                            body2.subst_rrows(&var2, &constant_type),
+                            body1.subst(&var1, &constant_type),
+                            body2.subst(&var2, &constant_type),
                         )
                     }
                     VarKind::EnumRows => {
                         let constant_type = state.table.fresh_erows_const(ctxt.var_level);
                         (
-                            body1.subst_erows(&var1, &constant_type),
-                            body2.subst_erows(&var2, &constant_type),
+                            body1.subst(&var1, &constant_type),
+                            body2.subst(&var2, &constant_type),
                         )
                     }
                 };
@@ -2894,7 +2897,7 @@ fn instantiate_foralls(
                     },
                 };
                 state.names.insert((fresh_uid, kind), var);
-                ty = body.subst_type(&var, &uvar);
+                ty = body.subst(&var, &uvar);
             }
             VarKind::RecordRows { excluded } => {
                 let fresh_uid = state.table.fresh_rrows_var_id(ctxt.var_level);
@@ -2906,7 +2909,7 @@ fn instantiate_foralls(
                     },
                 };
                 state.names.insert((fresh_uid, kind), var);
-                ty = body.subst_rrows(&var, &uvar);
+                ty = body.subst(&var, &uvar);
 
                 if inst == ForallInst::Ptr {
                     state.constr.insert(fresh_uid, excluded);
@@ -2922,7 +2925,7 @@ fn instantiate_foralls(
                     },
                 };
                 state.names.insert((fresh_uid, kind), var);
-                ty = body.subst_erows(&var, &uvar);
+                ty = body.subst(&var, &uvar);
             }
         };
     }
@@ -3170,8 +3173,6 @@ impl UnifTable {
     /// Used inside [self::eq] to generate temporary rigid type variables that are guaranteed to
     /// not conflict with existing variables.
     pub fn max_uvars_count(&self) -> VarId {
-        use std::cmp::max;
-
         max(self.types.len(), max(self.rrows.len(), self.erows.len()))
     }
 }

--- a/core/src/typecheck/mod.rs
+++ b/core/src/typecheck/mod.rs
@@ -3228,7 +3228,7 @@ impl UnifTable {
             return;
         }
 
-        self.update_rrows_level(var, &rrows, self.types[var].level);
+        self.update_rrows_level(var, &rrows, self.rrows[var].level);
         debug_assert!(self.rrows[var].value.is_none());
         self.rrows[var].value = Some(rrows);
     }
@@ -3240,7 +3240,7 @@ impl UnifTable {
                 id: var_id,
                 init_level: _,
             } => {
-                if new_level < self.types[*var_id].level {
+                if new_level < self.rrows[*var_id].level {
                     self.rrows[*var_id].level = new_level;
                 }
             }
@@ -3265,7 +3265,7 @@ impl UnifTable {
             return;
         }
 
-        self.update_erows_level(var, &erows, self.types[var].level);
+        self.update_erows_level(var, &erows, self.erows[var].level);
         debug_assert!(self.erows[var].value.is_none());
         self.erows[var].value = Some(erows);
     }
@@ -3277,7 +3277,7 @@ impl UnifTable {
                 id: var_id,
                 init_level: _,
             } => {
-                if new_level < self.types[*var_id].level {
+                if new_level < self.erows[*var_id].level {
                     self.erows[*var_id].level = new_level;
                 }
             }

--- a/core/src/typecheck/operation.rs
+++ b/core/src/typecheck/operation.rs
@@ -11,12 +11,13 @@ use crate::{mk_uty_arrow, mk_uty_enum, mk_uty_record};
 /// Type of unary operations.
 pub fn get_uop_type(
     state: &mut State,
+    var_level: VarLevel,
     op: &UnaryOp,
 ) -> Result<(UnifType, UnifType), TypecheckError> {
     Ok(match op {
         // forall a. bool -> a -> a -> a
         UnaryOp::Ite() => {
-            let branches = UnifType::UnifVar(state.table.fresh_type_var_id());
+            let branches = UnifType::UnifVar(state.table.fresh_type_var_id(var_level));
 
             (
                 mk_uniftype::bool(),
@@ -38,7 +39,7 @@ pub fn get_uop_type(
         UnaryOp::BoolNot() => (mk_uniftype::bool(), mk_uniftype::bool()),
         // forall a. Dyn -> a
         UnaryOp::Blame() => {
-            let res = UnifType::UnifVar(state.table.fresh_type_var_id());
+            let res = UnifType::UnifVar(state.table.fresh_type_var_id(var_level));
 
             (mk_uniftype::dynamic(), res)
         }
@@ -46,7 +47,7 @@ pub fn get_uop_type(
         UnaryOp::Pol() => (mk_uniftype::dynamic(), mk_uty_enum!("Positive", "Negative")),
         // forall rows. [| ; rows |] -> [| id ; rows |]
         UnaryOp::Embed(id) => {
-            let row_var_id = state.table.fresh_erows_var_id();
+            let row_var_id = state.table.fresh_erows_var_id(var_level);
             let row = UnifEnumRows::UnifVar(row_var_id);
 
             let domain = mk_uty_enum!(; row.clone());
@@ -65,15 +66,15 @@ pub fn get_uop_type(
         | UnaryOp::GoDict() => (mk_uniftype::dynamic(), mk_uniftype::dynamic()),
         // forall rows a. { id: a | rows} -> a
         UnaryOp::StaticAccess(id) => {
-            let rows = state.table.fresh_rrows_uvar();
-            let res = state.table.fresh_type_uvar();
+            let rows = state.table.fresh_rrows_uvar(var_level);
+            let res = state.table.fresh_type_uvar(var_level);
 
             (mk_uty_record!((*id, res.clone()); rows), res)
         }
         // forall a b. Array a -> (a -> b) -> Array b
         UnaryOp::ArrayMap() => {
-            let a = UnifType::UnifVar(state.table.fresh_type_var_id());
-            let b = UnifType::UnifVar(state.table.fresh_type_var_id());
+            let a = UnifType::UnifVar(state.table.fresh_type_var_id(var_level));
+            let b = UnifType::UnifVar(state.table.fresh_type_var_id(var_level));
 
             let f_type = mk_uty_arrow!(a.clone(), b.clone());
             (
@@ -83,7 +84,7 @@ pub fn get_uop_type(
         }
         // forall a. Num -> (Num -> a) -> Array a
         UnaryOp::ArrayGen() => {
-            let a = UnifType::UnifVar(state.table.fresh_type_var_id());
+            let a = UnifType::UnifVar(state.table.fresh_type_var_id(var_level));
 
             let f_type = mk_uty_arrow!(TypeF::Number, a.clone());
             (
@@ -96,8 +97,8 @@ pub fn get_uop_type(
             // Assuming f has type Str -> a -> b,
             // this has type Dict(a) -> Dict(b)
 
-            let a = UnifType::UnifVar(state.table.fresh_type_var_id());
-            let b = UnifType::UnifVar(state.table.fresh_type_var_id());
+            let a = UnifType::UnifVar(state.table.fresh_type_var_id(var_level));
+            let b = UnifType::UnifVar(state.table.fresh_type_var_id(var_level));
 
             let f_type = mk_uty_arrow!(TypeF::String, a.clone(), b.clone());
             (
@@ -107,21 +108,21 @@ pub fn get_uop_type(
         }
         // forall a b. a -> b -> b
         UnaryOp::Seq() | UnaryOp::DeepSeq() => {
-            let fst = UnifType::UnifVar(state.table.fresh_type_var_id());
-            let snd = UnifType::UnifVar(state.table.fresh_type_var_id());
+            let fst = UnifType::UnifVar(state.table.fresh_type_var_id(var_level));
+            let snd = UnifType::UnifVar(state.table.fresh_type_var_id(var_level));
 
             (fst, mk_uty_arrow!(snd.clone(), snd))
         }
         // forall a. Array a -> Num
         UnaryOp::ArrayLength() => {
-            let ty_elt = UnifType::UnifVar(state.table.fresh_type_var_id());
+            let ty_elt = UnifType::UnifVar(state.table.fresh_type_var_id(var_level));
             (mk_uniftype::array(ty_elt), mk_uniftype::num())
         }
         // This should not happen, as ChunksConcat() is only produced during evaluation.
         UnaryOp::ChunksConcat() => panic!("cannot type ChunksConcat()"),
         // forall a. { _: a } -> Array Str
         UnaryOp::FieldsOf() => {
-            let ty_a = UnifType::UnifVar(state.table.fresh_type_var_id());
+            let ty_a = UnifType::UnifVar(state.table.fresh_type_var_id(var_level));
 
             (
                 mk_uniftype::dict(ty_a),
@@ -130,7 +131,7 @@ pub fn get_uop_type(
         }
         // forall a. { _: a } -> Array a
         UnaryOp::ValuesOf() => {
-            let ty_a = UnifType::UnifVar(state.table.fresh_type_var_id());
+            let ty_a = UnifType::UnifVar(state.table.fresh_type_var_id(var_level));
 
             (mk_uniftype::dict(ty_a.clone()), mk_uniftype::array(ty_a))
         }
@@ -151,7 +152,7 @@ pub fn get_uop_type(
         // Str -> < | a> for a rigid type variable a
         UnaryOp::EnumFromStr() => (
             mk_uniftype::str(),
-            mk_uty_enum!(; state.table.fresh_erows_const()),
+            mk_uty_enum!(; state.table.fresh_erows_const(var_level)),
         ),
         // Str -> Str -> Bool
         UnaryOp::StrIsMatch() => (
@@ -185,19 +186,19 @@ pub fn get_uop_type(
         UnaryOp::Force { .. } => (mk_uniftype::dynamic(), mk_uniftype::dynamic()),
         // forall a. a -> a
         UnaryOp::RecDefault() => {
-            let ty = state.table.fresh_type_uvar();
+            let ty = state.table.fresh_type_uvar(var_level);
             (ty.clone(), ty)
         }
         // forall a. a -> a
         UnaryOp::RecForce() => {
-            let ty = state.table.fresh_type_uvar();
+            let ty = state.table.fresh_type_uvar(var_level);
             (ty.clone(), ty)
         }
         UnaryOp::RecordEmptyWithTail() => (mk_uniftype::dynamic(), mk_uniftype::dynamic()),
 
         // forall a. Str -> a -> a
         UnaryOp::Trace() => {
-            let ty = UnifType::UnifVar(state.table.fresh_type_var_id());
+            let ty = UnifType::UnifVar(state.table.fresh_type_var_id(var_level));
             (mk_uniftype::str(), mk_uty_arrow!(ty.clone(), ty))
         }
         // Morally: Lbl -> Lbl
@@ -212,6 +213,7 @@ pub fn get_uop_type(
 /// Type of a binary operation.
 pub fn get_bop_type(
     state: &mut State,
+    var_level: VarLevel,
     op: &BinaryOp,
 ) -> Result<(UnifType, UnifType, UnifType), TypecheckError> {
     Ok(match op {
@@ -244,8 +246,8 @@ pub fn get_bop_type(
         ),
         // forall a b. a -> b -> Bool
         BinaryOp::Eq() => (
-            UnifType::UnifVar(state.table.fresh_type_var_id()),
-            UnifType::UnifVar(state.table.fresh_type_var_id()),
+            UnifType::UnifVar(state.table.fresh_type_var_id(var_level)),
+            UnifType::UnifVar(state.table.fresh_type_var_id(var_level)),
             mk_uniftype::bool(),
         ),
         // Num -> Num -> Bool
@@ -261,7 +263,7 @@ pub fn get_bop_type(
         ),
         // forall a. Str -> { _ : a} -> a
         BinaryOp::DynAccess() => {
-            let res = UnifType::UnifVar(state.table.fresh_type_var_id());
+            let res = UnifType::UnifVar(state.table.fresh_type_var_id(var_level));
 
             (mk_uniftype::str(), mk_uniftype::dict(res.clone()), res)
         }
@@ -270,7 +272,7 @@ pub fn get_bop_type(
             ext_kind: RecordExtKind::WithValue,
             ..
         } => {
-            let res = UnifType::UnifVar(state.table.fresh_type_var_id());
+            let res = UnifType::UnifVar(state.table.fresh_type_var_id(var_level));
             (
                 mk_uniftype::str(),
                 mk_uniftype::dict(res.clone()),
@@ -282,7 +284,7 @@ pub fn get_bop_type(
             ext_kind: RecordExtKind::WithoutValue,
             ..
         } => {
-            let res = UnifType::UnifVar(state.table.fresh_type_var_id());
+            let res = UnifType::UnifVar(state.table.fresh_type_var_id(var_level));
             (
                 mk_uniftype::str(),
                 mk_uniftype::dict(res.clone()),
@@ -291,7 +293,7 @@ pub fn get_bop_type(
         }
         // forall a. Str -> { _ : a } -> { _ : a}
         BinaryOp::DynRemove() => {
-            let res = UnifType::UnifVar(state.table.fresh_type_var_id());
+            let res = UnifType::UnifVar(state.table.fresh_type_var_id(var_level));
             (
                 mk_uniftype::str(),
                 mk_uniftype::dict(res.clone()),
@@ -300,7 +302,7 @@ pub fn get_bop_type(
         }
         // forall a. Str -> {_: a} -> Bool
         BinaryOp::HasField() => {
-            let ty_elt = UnifType::UnifVar(state.table.fresh_type_var_id());
+            let ty_elt = UnifType::UnifVar(state.table.fresh_type_var_id(var_level));
             (
                 mk_uniftype::str(),
                 mk_uniftype::dict(ty_elt),
@@ -309,13 +311,13 @@ pub fn get_bop_type(
         }
         // forall a. Array a -> Array a -> Array a
         BinaryOp::ArrayConcat() => {
-            let ty_elt = UnifType::UnifVar(state.table.fresh_type_var_id());
+            let ty_elt = UnifType::UnifVar(state.table.fresh_type_var_id(var_level));
             let ty_array = mk_uniftype::array(ty_elt);
             (ty_array.clone(), ty_array.clone(), ty_array)
         }
         // forall a. Array a -> Num -> a
         BinaryOp::ArrayElemAt() => {
-            let ty_elt = UnifType::UnifVar(state.table.fresh_type_var_id());
+            let ty_elt = UnifType::UnifVar(state.table.fresh_type_var_id(var_level));
             (
                 mk_uniftype::array(ty_elt.clone()),
                 mk_uniftype::num(),
@@ -336,7 +338,7 @@ pub fn get_bop_type(
         ),
         // forall a. <Json, Yaml, Toml> -> a -> Str
         BinaryOp::Serialize() => {
-            let ty_input = UnifType::UnifVar(state.table.fresh_type_var_id());
+            let ty_input = UnifType::UnifVar(state.table.fresh_type_var_id(var_level));
             (
                 mk_uty_enum!("Json", "Yaml", "Toml"),
                 ty_input,
@@ -362,7 +364,7 @@ pub fn get_bop_type(
         // The first argument is a contract, the second is a label.
         // forall a. Dyn -> Dyn -> Array a -> Array a
         BinaryOp::ArrayLazyAssume() => {
-            let ty_elt = UnifType::UnifVar(state.table.fresh_type_var_id());
+            let ty_elt = UnifType::UnifVar(state.table.fresh_type_var_id(var_level));
             let ty_array = mk_uniftype::array(ty_elt);
             (
                 mk_uniftype::dynamic(),
@@ -373,7 +375,7 @@ pub fn get_bop_type(
         // The first argument is a label, the third is a contract.
         // forall a. Dyn -> {_: a} -> Dyn -> {_: a}
         BinaryOp::RecordLazyAssume() => {
-            let ty_field = UnifType::UnifVar(state.table.fresh_type_var_id());
+            let ty_field = UnifType::UnifVar(state.table.fresh_type_var_id(var_level));
             let ty_dict = mk_uniftype::dict(ty_field);
             (
                 mk_uniftype::dynamic(),
@@ -414,6 +416,7 @@ pub fn get_bop_type(
 
 pub fn get_nop_type(
     state: &mut State,
+    var_level: VarLevel,
     op: &NAryOp,
 ) -> Result<(Vec<UnifType>, UnifType), TypecheckError> {
     Ok(match op {
@@ -448,7 +451,7 @@ pub fn get_nop_type(
         ),
         // Num -> Num -> Array a -> Array a
         NAryOp::ArraySlice() => {
-            let element_type = state.table.fresh_type_uvar();
+            let element_type = state.table.fresh_type_uvar(var_level);
 
             (
                 vec![

--- a/core/src/typecheck/operation.rs
+++ b/core/src/typecheck/operation.rs
@@ -17,7 +17,7 @@ pub fn get_uop_type(
     Ok(match op {
         // forall a. bool -> a -> a -> a
         UnaryOp::Ite() => {
-            let branches = UnifType::UnifVar(state.table.fresh_type_var_id(var_level));
+            let branches = state.table.fresh_type_uvar(var_level);
 
             (
                 mk_uniftype::bool(),
@@ -39,7 +39,7 @@ pub fn get_uop_type(
         UnaryOp::BoolNot() => (mk_uniftype::bool(), mk_uniftype::bool()),
         // forall a. Dyn -> a
         UnaryOp::Blame() => {
-            let res = UnifType::UnifVar(state.table.fresh_type_var_id(var_level));
+            let res = state.table.fresh_type_uvar(var_level);
 
             (mk_uniftype::dynamic(), res)
         }
@@ -73,8 +73,8 @@ pub fn get_uop_type(
         }
         // forall a b. Array a -> (a -> b) -> Array b
         UnaryOp::ArrayMap() => {
-            let a = UnifType::UnifVar(state.table.fresh_type_var_id(var_level));
-            let b = UnifType::UnifVar(state.table.fresh_type_var_id(var_level));
+            let a = state.table.fresh_type_uvar(var_level);
+            let b = state.table.fresh_type_uvar(var_level);
 
             let f_type = mk_uty_arrow!(a.clone(), b.clone());
             (
@@ -84,7 +84,7 @@ pub fn get_uop_type(
         }
         // forall a. Num -> (Num -> a) -> Array a
         UnaryOp::ArrayGen() => {
-            let a = UnifType::UnifVar(state.table.fresh_type_var_id(var_level));
+            let a = state.table.fresh_type_uvar(var_level);
 
             let f_type = mk_uty_arrow!(TypeF::Number, a.clone());
             (
@@ -97,8 +97,8 @@ pub fn get_uop_type(
             // Assuming f has type Str -> a -> b,
             // this has type Dict(a) -> Dict(b)
 
-            let a = UnifType::UnifVar(state.table.fresh_type_var_id(var_level));
-            let b = UnifType::UnifVar(state.table.fresh_type_var_id(var_level));
+            let a = state.table.fresh_type_uvar(var_level);
+            let b = state.table.fresh_type_uvar(var_level);
 
             let f_type = mk_uty_arrow!(TypeF::String, a.clone(), b.clone());
             (
@@ -108,21 +108,21 @@ pub fn get_uop_type(
         }
         // forall a b. a -> b -> b
         UnaryOp::Seq() | UnaryOp::DeepSeq() => {
-            let fst = UnifType::UnifVar(state.table.fresh_type_var_id(var_level));
-            let snd = UnifType::UnifVar(state.table.fresh_type_var_id(var_level));
+            let fst = state.table.fresh_type_uvar(var_level);
+            let snd = state.table.fresh_type_uvar(var_level);
 
             (fst, mk_uty_arrow!(snd.clone(), snd))
         }
         // forall a. Array a -> Num
         UnaryOp::ArrayLength() => {
-            let ty_elt = UnifType::UnifVar(state.table.fresh_type_var_id(var_level));
+            let ty_elt = state.table.fresh_type_uvar(var_level);
             (mk_uniftype::array(ty_elt), mk_uniftype::num())
         }
         // This should not happen, as ChunksConcat() is only produced during evaluation.
         UnaryOp::ChunksConcat() => panic!("cannot type ChunksConcat()"),
         // forall a. { _: a } -> Array Str
         UnaryOp::FieldsOf() => {
-            let ty_a = UnifType::UnifVar(state.table.fresh_type_var_id(var_level));
+            let ty_a = state.table.fresh_type_uvar(var_level);
 
             (
                 mk_uniftype::dict(ty_a),
@@ -131,7 +131,7 @@ pub fn get_uop_type(
         }
         // forall a. { _: a } -> Array a
         UnaryOp::ValuesOf() => {
-            let ty_a = UnifType::UnifVar(state.table.fresh_type_var_id(var_level));
+            let ty_a = state.table.fresh_type_uvar(var_level);
 
             (mk_uniftype::dict(ty_a.clone()), mk_uniftype::array(ty_a))
         }
@@ -198,7 +198,7 @@ pub fn get_uop_type(
 
         // forall a. Str -> a -> a
         UnaryOp::Trace() => {
-            let ty = UnifType::UnifVar(state.table.fresh_type_var_id(var_level));
+            let ty = state.table.fresh_type_uvar(var_level);
             (mk_uniftype::str(), mk_uty_arrow!(ty.clone(), ty))
         }
         // Morally: Lbl -> Lbl
@@ -246,8 +246,8 @@ pub fn get_bop_type(
         ),
         // forall a b. a -> b -> Bool
         BinaryOp::Eq() => (
-            UnifType::UnifVar(state.table.fresh_type_var_id(var_level)),
-            UnifType::UnifVar(state.table.fresh_type_var_id(var_level)),
+            state.table.fresh_type_uvar(var_level),
+            state.table.fresh_type_uvar(var_level),
             mk_uniftype::bool(),
         ),
         // Num -> Num -> Bool
@@ -263,7 +263,7 @@ pub fn get_bop_type(
         ),
         // forall a. Str -> { _ : a} -> a
         BinaryOp::DynAccess() => {
-            let res = UnifType::UnifVar(state.table.fresh_type_var_id(var_level));
+            let res = state.table.fresh_type_uvar(var_level);
 
             (mk_uniftype::str(), mk_uniftype::dict(res.clone()), res)
         }
@@ -272,7 +272,7 @@ pub fn get_bop_type(
             ext_kind: RecordExtKind::WithValue,
             ..
         } => {
-            let res = UnifType::UnifVar(state.table.fresh_type_var_id(var_level));
+            let res = state.table.fresh_type_uvar(var_level);
             (
                 mk_uniftype::str(),
                 mk_uniftype::dict(res.clone()),
@@ -284,7 +284,7 @@ pub fn get_bop_type(
             ext_kind: RecordExtKind::WithoutValue,
             ..
         } => {
-            let res = UnifType::UnifVar(state.table.fresh_type_var_id(var_level));
+            let res = state.table.fresh_type_uvar(var_level);
             (
                 mk_uniftype::str(),
                 mk_uniftype::dict(res.clone()),
@@ -293,7 +293,7 @@ pub fn get_bop_type(
         }
         // forall a. Str -> { _ : a } -> { _ : a}
         BinaryOp::DynRemove() => {
-            let res = UnifType::UnifVar(state.table.fresh_type_var_id(var_level));
+            let res = state.table.fresh_type_uvar(var_level);
             (
                 mk_uniftype::str(),
                 mk_uniftype::dict(res.clone()),
@@ -302,7 +302,7 @@ pub fn get_bop_type(
         }
         // forall a. Str -> {_: a} -> Bool
         BinaryOp::HasField() => {
-            let ty_elt = UnifType::UnifVar(state.table.fresh_type_var_id(var_level));
+            let ty_elt = state.table.fresh_type_uvar(var_level);
             (
                 mk_uniftype::str(),
                 mk_uniftype::dict(ty_elt),
@@ -311,13 +311,13 @@ pub fn get_bop_type(
         }
         // forall a. Array a -> Array a -> Array a
         BinaryOp::ArrayConcat() => {
-            let ty_elt = UnifType::UnifVar(state.table.fresh_type_var_id(var_level));
+            let ty_elt = state.table.fresh_type_uvar(var_level);
             let ty_array = mk_uniftype::array(ty_elt);
             (ty_array.clone(), ty_array.clone(), ty_array)
         }
         // forall a. Array a -> Num -> a
         BinaryOp::ArrayElemAt() => {
-            let ty_elt = UnifType::UnifVar(state.table.fresh_type_var_id(var_level));
+            let ty_elt = state.table.fresh_type_uvar(var_level);
             (
                 mk_uniftype::array(ty_elt.clone()),
                 mk_uniftype::num(),
@@ -338,7 +338,7 @@ pub fn get_bop_type(
         ),
         // forall a. <Json, Yaml, Toml> -> a -> Str
         BinaryOp::Serialize() => {
-            let ty_input = UnifType::UnifVar(state.table.fresh_type_var_id(var_level));
+            let ty_input = state.table.fresh_type_uvar(var_level);
             (
                 mk_uty_enum!("Json", "Yaml", "Toml"),
                 ty_input,
@@ -364,7 +364,7 @@ pub fn get_bop_type(
         // The first argument is a contract, the second is a label.
         // forall a. Dyn -> Dyn -> Array a -> Array a
         BinaryOp::ArrayLazyAssume() => {
-            let ty_elt = UnifType::UnifVar(state.table.fresh_type_var_id(var_level));
+            let ty_elt = state.table.fresh_type_uvar(var_level);
             let ty_array = mk_uniftype::array(ty_elt);
             (
                 mk_uniftype::dynamic(),
@@ -375,7 +375,7 @@ pub fn get_bop_type(
         // The first argument is a label, the third is a contract.
         // forall a. Dyn -> {_: a} -> Dyn -> {_: a}
         BinaryOp::RecordLazyAssume() => {
-            let ty_field = UnifType::UnifVar(state.table.fresh_type_var_id(var_level));
+            let ty_field = state.table.fresh_type_uvar(var_level);
             let ty_dict = mk_uniftype::dict(ty_field);
             (
                 mk_uniftype::dynamic(),

--- a/core/src/typecheck/operation.rs
+++ b/core/src/typecheck/operation.rs
@@ -48,7 +48,10 @@ pub fn get_uop_type(
         // forall rows. [| ; rows |] -> [| id ; rows |]
         UnaryOp::Embed(id) => {
             let row_var_id = state.table.fresh_erows_var_id(var_level);
-            let row = UnifEnumRows::UnifVar(row_var_id);
+            let row = UnifEnumRows::UnifVar {
+                id: row_var_id,
+                init_level: var_level,
+            };
 
             let domain = mk_uty_enum!(; row.clone());
             let codomain = mk_uty_enum!(*id; row);

--- a/core/src/typecheck/reporting.rs
+++ b/core/src/typecheck/reporting.rs
@@ -193,10 +193,10 @@ pub fn to_type(
     let ty = ty.into_root(table);
 
     match ty {
-        UnifType::UnifVar(p) => Types::from(TypeF::Var(var_name(
+        UnifType::UnifVar{ id, .. } => Types::from(TypeF::Var(var_name(
             reported_names,
             names,
-            p,
+            id,
             VarKindDiscriminant::Type,
         ))),
         UnifType::Constant(c) => Types::from(TypeF::Var(cst_name(

--- a/core/src/typecheck/reporting.rs
+++ b/core/src/typecheck/reporting.rs
@@ -205,8 +205,8 @@ pub fn to_type(
             c,
             VarKindDiscriminant::Type,
         ))),
-        UnifType::Concrete(t) => {
-            let mapped = t.map_state(
+        UnifType::Concrete { types, .. } => {
+            let mapped = types.map_state(
                 |btyp, names| Box::new(to_type(table, reported_names, names, *btyp)),
                 |rrows, names| rrows_to_type(table, reported_names, names, rrows),
                 |erows, names| erows_to_type(table, reported_names, names, erows),

--- a/core/src/typecheck/reporting.rs
+++ b/core/src/typecheck/reporting.rs
@@ -170,10 +170,10 @@ pub fn to_type(
         let erows = erows.into_root(table);
 
         match erows {
-            UnifEnumRows::UnifVar(var_id) => EnumRows(EnumRowsF::TailVar(var_name(
+            UnifEnumRows::UnifVar { id, .. } => EnumRows(EnumRowsF::TailVar(var_name(
                 reported_names,
                 names,
-                var_id,
+                id,
                 VarKindDiscriminant::EnumRows,
             ))),
             UnifEnumRows::Constant(c) => EnumRows(EnumRowsF::TailVar(cst_name(
@@ -182,9 +182,9 @@ pub fn to_type(
                 c,
                 VarKindDiscriminant::EnumRows,
             ))),
-            UnifEnumRows::Concrete(t) => {
-                let mapped =
-                    t.map(|erows| Box::new(erows_to_type(table, reported_names, names, *erows)));
+            UnifEnumRows::Concrete { erows, .. } => {
+                let mapped = erows
+                    .map(|erows| Box::new(erows_to_type(table, reported_names, names, *erows)));
                 EnumRows(mapped)
             }
         }

--- a/core/src/typecheck/reporting.rs
+++ b/core/src/typecheck/reporting.rs
@@ -101,7 +101,7 @@ fn var_name(
 
 /// Either retrieve or generate a new fresh name for a constant for error reporting, and wrap it as
 /// type variable. Constant are named `a`, `b`, .., `a1`, `b1`, .. and so on.
-fn cst_name(
+pub(super) fn cst_name(
     names: &NameTable,
     name_reg: &mut NameReg,
     id: VarId,

--- a/core/src/typecheck/reporting.rs
+++ b/core/src/typecheck/reporting.rs
@@ -138,10 +138,10 @@ pub fn to_type(
         let rrows = rrows.into_root(table);
 
         match rrows {
-            UnifRecordRows::UnifVar(var_id) => RecordRows(RecordRowsF::TailVar(var_name(
+            UnifRecordRows::UnifVar { id, .. } => RecordRows(RecordRowsF::TailVar(var_name(
                 reported_names,
                 names,
-                var_id,
+                id,
                 VarKindDiscriminant::RecordRows,
             ))),
             UnifRecordRows::Constant(c) => RecordRows(RecordRowsF::TailVar(cst_name(
@@ -150,8 +150,8 @@ pub fn to_type(
                 c,
                 VarKindDiscriminant::RecordRows,
             ))),
-            UnifRecordRows::Concrete(t) => {
-                let mapped = t.map_state(
+            UnifRecordRows::Concrete { rrows, .. } => {
+                let mapped = rrows.map_state(
                     |btyp, names| Box::new(to_type(table, reported_names, names, *btyp)),
                     |rrows, names| Box::new(rrows_to_type(table, reported_names, names, *rrows)),
                     names,

--- a/core/src/typecheck/reporting.rs
+++ b/core/src/typecheck/reporting.rs
@@ -193,7 +193,7 @@ pub fn to_type(
     let ty = ty.into_root(table);
 
     match ty {
-        UnifType::UnifVar{ id, .. } => Types::from(TypeF::Var(var_name(
+        UnifType::UnifVar { id, .. } => Types::from(TypeF::Var(var_name(
             reported_names,
             names,
             id,

--- a/core/tests/integration/main.rs
+++ b/core/tests/integration/main.rs
@@ -280,9 +280,8 @@ impl PartialEq<Error> for ErrorExpectation {
             },
             (
                 TypecheckVariableLevelMismatch { type_var: ident },
-                Error::TypecheckError(TypecheckError::VariableLevelMismatch {
-                    type_var: constant,
-                    ..
+                Error::TypecheckError(TypecheckError::VarLevelMismatch {
+                    type_var: constant, ..
                 }),
             ) => ident == constant.label(),
             (_, _) => false,

--- a/core/tests/integration/main.rs
+++ b/core/tests/integration/main.rs
@@ -165,6 +165,8 @@ enum ErrorExpectation {
     TypecheckMissingDynTail,
     #[serde(rename = "TypecheckError::FlatTypeInTermPosition")]
     TypecheckFlatTypeInTermPosition,
+    #[serde(rename = "TypecheckError::VariableLevelMismatch")]
+    TypecheckVariableLevelMismatch { type_var: String },
     #[serde(rename = "ParseError")]
     AnyParseError,
     #[serde(rename = "ParseError::DuplicateIdentInRecordPattern")]
@@ -276,6 +278,13 @@ impl PartialEq<Error> for ErrorExpectation {
                 TypecheckError::RowConflict(ident, ..) => row == ident.label(),
                 _ => false,
             },
+            (
+                TypecheckVariableLevelMismatch { type_var: ident },
+                Error::TypecheckError(TypecheckError::VariableLevelMismatch {
+                    type_var: constant,
+                    ..
+                }),
+            ) => ident == constant.label(),
             (_, _) => false,
         }
     }
@@ -337,6 +346,9 @@ impl std::fmt::Display for ErrorExpectation {
             TypecheckExtraDynTail => "TypecheckError::ExtraDynTail".to_owned(),
             TypecheckMissingDynTail => "TypecheckError::MissingDynTail".to_owned(),
             TypecheckFlatTypeInTermPosition => "TypecheckError::FlatTypeInTermPosition".to_owned(),
+            TypecheckVariableLevelMismatch { type_var: ident } => {
+                format!("TypecheckError::VariableLevelMismatch({ident})")
+            }
         };
         write!(f, "{}", name)
     }

--- a/core/tests/integration/typecheck/fail/unsound_generalization_enum_rows.ncl
+++ b/core/tests/integration/typecheck/fail/unsound_generalization_enum_rows.ncl
@@ -1,0 +1,17 @@
+# test.type = 'error'
+# eval = 'typecheck'
+#
+# [test.metadata]
+# error = 'TypecheckError::VariableLevelMismatch'
+#
+# [test.metadata.expectation]
+# type_var = 'tail'
+(fun tag =>
+  let foo = tag
+    |> match { 
+        _ => null,
+    }
+  in
+  let g : forall tail. [| ; tail |] = tag in
+  g
+) : _

--- a/core/tests/integration/typecheck/fail/unsound_generalization_fun.ncl
+++ b/core/tests/integration/typecheck/fail/unsound_generalization_fun.ncl
@@ -1,0 +1,10 @@
+# test.type = 'error'
+# eval = 'typecheck'
+#
+# [test.metadata]
+# error = 'TypecheckError::TypeMismatch'
+#
+# [test.metadata.expectation]
+# expected = 'c'
+# found = '_a'
+(fun x => let y : forall c d. c -> d = fun z => x z in y) : _

--- a/core/tests/integration/typecheck/fail/unsound_generalization_fun.ncl
+++ b/core/tests/integration/typecheck/fail/unsound_generalization_fun.ncl
@@ -2,9 +2,8 @@
 # eval = 'typecheck'
 #
 # [test.metadata]
-# error = 'TypecheckError::TypeMismatch'
+# error = 'TypecheckError::VariableLevelMismatch'
 #
 # [test.metadata.expectation]
-# expected = 'c'
-# found = '_a'
+# type_var = 'c'
 (fun x => let y : forall c d. c -> d = fun z => x z in y) : _

--- a/core/tests/integration/typecheck/fail/unsound_generalization_record_rows.ncl
+++ b/core/tests/integration/typecheck/fail/unsound_generalization_record_rows.ncl
@@ -1,0 +1,9 @@
+# test.type = 'error'
+# eval = 'typecheck'
+#
+# [test.metadata]
+# error = 'TypecheckError::VariableLevelMismatch'
+#
+# [test.metadata.expectation]
+# type_var = 'tail'
+(fun r => let foo = r.foo in let g : forall tail. {foo : _; tail} = r in g.baz) : _

--- a/core/tests/integration/typecheck/fail/unsound_generalization_simple.ncl
+++ b/core/tests/integration/typecheck/fail/unsound_generalization_simple.ncl
@@ -1,0 +1,10 @@
+# test.type = 'error'
+# eval = 'typecheck'
+#
+# [test.metadata]
+# error = 'TypecheckError::TypeMismatch'
+#
+# [test.metadata.expectation]
+# expected = 'a'
+# found = '_a'
+(fun x => let y : forall a. a = x in y) : _

--- a/core/tests/integration/typecheck/fail/unsound_generalization_simple.ncl
+++ b/core/tests/integration/typecheck/fail/unsound_generalization_simple.ncl
@@ -2,9 +2,8 @@
 # eval = 'typecheck'
 #
 # [test.metadata]
-# error = 'TypecheckError::TypeMismatch'
+# error = 'TypecheckError::VariableLevelMismatch'
 #
 # [test.metadata.expectation]
-# expected = 'a'
-# found = '_a'
+# type_var = 'a'
 (fun x => let y : forall a. a = x in y) : _

--- a/lsp/nls/src/linearization/building.rs
+++ b/lsp/nls/src/linearization/building.rs
@@ -128,7 +128,7 @@ impl<'b> Building<'b> {
                 id,
                 pos: ident.pos,
                 // temporary, the actual type is resolved later and the item retyped
-                ty: UnifType::Concrete(TypeF::Dyn),
+                ty: UnifType::concrete(TypeF::Dyn),
                 kind: TermKind::RecordField {
                     record,
                     ident: *ident,

--- a/lsp/nls/src/linearization/mod.rs
+++ b/lsp/nls/src/linearization/mod.rs
@@ -283,7 +283,7 @@ impl<'a> Linearizer for AnalysisHost<'a> {
                         env: self.env.clone(),
                         id,
                         // TODO: get type from pattern
-                        ty: UnifType::Concrete(TypeF::Dyn),
+                        ty: UnifType::concrete(TypeF::Dyn),
                         pos: new_ident.pos,
                         kind: TermKind::Declaration {
                             id: new_ident.to_owned(),
@@ -367,7 +367,7 @@ impl<'a> Linearizer for AnalysisHost<'a> {
                     env: self.env.clone(),
                     id: root_id,
                     pos: ident.pos,
-                    ty: UnifType::Concrete(TypeF::Dyn),
+                    ty: UnifType::concrete(TypeF::Dyn),
                     kind: TermKind::Usage(UsageState::from(pointed)),
                     metadata: self.meta.take(),
                 });
@@ -389,7 +389,7 @@ impl<'a> Linearizer for AnalysisHost<'a> {
                             env: self.env.clone(),
                             id,
                             pos: accessor.pos,
-                            ty: UnifType::Concrete(TypeF::Dyn),
+                            ty: UnifType::concrete(TypeF::Dyn),
                             kind: TermKind::Usage(UsageState::Deferred {
                                 parent: ItemId {
                                     file_id: self.file,


### PR DESCRIPTION
Closes #1369. Steps toward closing #584. Related to #1027 and #360.

## Motivation

The original issue is typechecking being currently unsound because the tyepchecker allows generalization on types that shouldn't be generalized (because we don't generalize by default, this manifest in practice in Nickel by allowing a rigid type variable to be unified with a unification variable where it shouldn't). See #1369.

Interestingly, this unsound generalization doesn't seem to be usable to write a typed function of type `forall a b. a -> b` or the like, because as soon as we attach an outer type application to the ill-typed term, or if we try to use it without annotations, a rigid type variable ends up being unified with something else and the typechecker complains.

Still, the example from #1369 is a well-typed function that can be blamed at runtime, which breaks blame safety.

This is a preliminary step toward #584, which requires to fix how type instantiation is done, and thus require a proper level discipline.

## Technical solution

Typechecking higher-rank polymorphic types involves an additional discipline on unification variables, to avoid something similar to unsound generalization in ML. Morally, unification variables should keep track of all the rigid type variables introduced before them, and should fail to unify with rigid type variables that are not in this list.

In practice, it's sufficient and more efficient to just keep track of a variable level, which is incremented each time a polymorphic type is instantiated by the check rule with rigid type variables. Each unification variable remembers its level, and can only unify with rigid type variables of level smaller or equals. 

This PR introduces the machinery for tracking and threading those variable levels throughout typechecking. There is some juggling to do to avoid repeated traversal of types when updating variable levels on unification: for example, when unifying `_a` with `Number -> {foo : _b}`, then the level of `_b` must be updated to the max level of `_a` and `_b`. Doing this naively would amount to perform a full traversal of a type `T` each time a type variable is unified with `T`, which is prohibitive.

 This PR follows the general idea of Didier Remy's algorithm for [efficient generalization](http://web.archive.org/web/20230525023637/https://okmij.org/ftp/ML/generalization.html), which the basis to the current OCaml implementation of Hindley-Milner. The general idea is to

1. Store an upper bound of the possible variable levels of unification variables contained in a type, at the level of each type 2. Delay variable level updates, by storing an additional pending level update on unification types. Updates are forced when unifying a rigid type variable with a unification variable, which is where the level check occurs, and thus levels must be up-to-date.

Thanks to this additional discipline, traversals can be combined, and some of them can be avoided totally.

## Follow-up

This change is sizable, we we had to change the definition of all unification types, their constructors and various substitution functions to correctly set and update variable level upper bounds. Some of the code is frustratingly similar (in particular for type unification variables, for record rows variables, and enum rows variables), but not trivially deduplicable either. The size of `typecheck/mod.rs` is also way too high. Finally, I have notes that I would like to add about this aspect of the typechecking algorithm. I plan to do that in a series of follow-up PR:

- split the typechecking module in several files (typically move all unification related machinery to a `unif` submodule)
- find a better naming scheme within `typecheck`. `GenericUnifRecordRowsUnrolling` isn't really nice to type.
- gather free-standing `unify_xxx` functions in a single trait
- look for code deduplication opportunities. It seems at least some type definitions and generic functions could be shared between record rows variables and enum rows variables.
- improve error reporting of a variable level mismatch. Currently the location of the original type variable is lost; I identified why, and just need to fix that in a subsequent.

## Performance

The only typechecking benchmark that we have, the translation of a bunch of functions from the list library of Nixpkgs, shows a small regression which sounds reasonable with respect to the added machinery:

```
nixpkgs lists           time:   [7.1205 ms 7.1432 ms 7.1689 ms]
                        change: [+7.2368% +8.3671% +9.4471%] (p = 0.00 < 0.05)
                        Performance has regressed.
```