### PR TITLE
Fix LSP panic when importing JSON

### DIFF
--- a/lsp/lsp-harness/tests/inputs/external_import.json
+++ b/lsp/lsp-harness/tests/inputs/external_import.json
@@ -1,0 +1,3 @@
+{
+    "someData": "someValue"
+}

--- a/lsp/lsp-harness/tests/inputs/external_import.yaml
+++ b/lsp/lsp-harness/tests/inputs/external_import.yaml
@@ -1,0 +1,1 @@
+someData: someValue

--- a/lsp/lsp-harness/tests/inputs/import_external_format.ncl
+++ b/lsp/lsp-harness/tests/inputs/import_external_format.ncl
@@ -1,0 +1,8 @@
+### /external_import.ncl
+let foo = import "external_import.json" in
+let bar = import "external_import.yaml" in
+foo & bar
+# This request isn't really useful, this test simply checks that the LSP can
+# linearize this file without crashing. However, the LSP test suite currently
+# requires that we have at least one request, so here it is.
+### GotoDefinition /goto.ncl:3:1


### PR DESCRIPTION
Closes #1378

## Context

Nickel terms imported from a JSON file currently don't have any position set, which is making the LSP panic. Indeed, import expressions are registered as an usage site, to enable go to definition on them (which jumps to the corresponding file). The LSP expects that parsed terms have all their positions set, and in particular the one of the root term (corresponding to the whole file).

This commits stores the original input format alongside cached terms, and makes this information available to the public API of `cache`. The LSP can thus use it and abort any usage analysis when the term comes from an external import.

## Improvement

We might be able to set the position of the root term at least, even when it comes from an external format, which would enable go to definition. I'll try that as well