### PR TITLE
Add filetype "nickel" to Coc configuration

### DIFF
--- a/lsp/README.md
+++ b/lsp/README.md
@@ -157,7 +157,8 @@ edit `coc-settings.json`) and add:
         ".git"
       ],
       "filetypes": [
-        "ncl"
+        "ncl",
+        "nickel"
       ]
     }
   }


### PR DESCRIPTION
The vim-nickel plugin sets the filetype to "nickel", not "ncl".