### PR TITLE
Fix LSP hanging under certain conditions involving external imports

### DIFF
--- a/lsp/nls/src/cache.rs
+++ b/lsp/nls/src/cache.rs
@@ -98,8 +98,8 @@ impl CacheExt for Cache {
             .into_iter()
             .map(|id| {
                 let message = "This import could not be resolved because its content has failed to typecheck correctly.";
-                // The unwrap is safe here because (1) we have linearized `file_id` and it must be 
-                // in the `lin_cache` and (2) every resolved import has a corresponding position in 
+                // The unwrap is safe here because (1) we have linearized `file_id` and it must be
+                // in the `lin_cache` and (2) every resolved import has a corresponding position in
                 // the linearization of the file that imports it.
                 let pos = lin_cache.get(&file_id).and_then(|lin| lin.import_locations.get(&id)).unwrap();
                 let name: String = self.name(id).to_str().unwrap().into();

--- a/lsp/nls/src/linearization/mod.rs
+++ b/lsp/nls/src/linearization/mod.rs
@@ -3,7 +3,6 @@ use std::{collections::HashMap, marker::PhantomData};
 use codespan::FileId;
 use log::debug;
 use nickel_lang_lib::{
-    cache::InputFormat,
     identifier::Ident,
     position::TermPos,
     term::{
@@ -463,18 +462,7 @@ impl<'a> Linearizer for AnalysisHost<'a> {
 
                 // This is safe because the import file is resolved before we linearize the
                 // containing file, therefore the cache MUST have the term stored.
-                let (term, input_format) = lin.cache.get_with_input_format(file).unwrap();
-
-                // If the import is an external format (such as JSON or YAML), no position will be
-                // set (except the root position). It seems that it should work, but completion
-                // causes the LSP to crash with a stack overflow, probably because external imports
-                // break some invariant or expectation. For now, we simply bail out. This means we
-                // can't "go to definition" or get completion on an external import for the time
-                // being.
-                if !matches!(input_format, InputFormat::Nickel) {
-                    return;
-                }
-
+                let term = lin.cache.get_owned(*file).unwrap();
                 let position = final_term_pos(&term);
 
                 // unwrap(): this unwrap fails only when position is a `TermPos::None`, which only


### PR DESCRIPTION
Closes #1385.

A previous patch (#1382) tried to avoid performing some code analysis on import expressions of external format (JSON, YAML or TOML) to avoid a panic. However, it turns out this introduced an off-by-one error in the LSP, which expects that each and every node of the AST gives rise to an entry in the linearization. This commits revert the previous patch and get rid of the input format field in the cache, which isn't used anywhere anymore. Still, the part of #1385 which sets the position of the root term for external import is kept, and is sufficient to fix the original bug addressed by #1385.

Unfortunately we encountered more LSP-related bugs with external imports, but they seem to happen on a different codepath, and might not necessarily be related to completion, like this one, so this still seems like a net improvement.