### PR TITLE
Add topiary to pre-commit-hooks

### DIFF
--- a/examples/arrays/arrays.ncl
+++ b/examples/arrays/arrays.ncl
@@ -4,23 +4,22 @@
 # stdlib functions `std.array.map` and `std.array.fold_right` instead.
 let my_array_lib = {
   map : forall a b. (a -> b) -> Array a -> Array b = fun f arr =>
-    if arr == [] then
-      []
-    else
-      let head = std.array.first arr in
-      let tail = std.array.drop_first arr in
-      [f head] @ map f tail,
+      if arr == [] then
+        []
+      else
+        let head = std.array.first arr in
+        let tail = std.array.drop_first arr in
+        [f head] @ map f tail,
 
   fold : forall a b. (a -> b -> b) -> Array a -> b -> b = fun f arr first =>
-    if arr == [] then
-      first
-    else
-      let head = std.array.first arr in
-      let tail = std.array.drop_first arr in
-      f head (fold f tail first),
+      if arr == [] then
+        first
+      else
+        let head = std.array.first arr in
+        let tail = std.array.drop_first arr in
+        f head (fold f tail first),
 }
 in
 # Compute `7!`
 let l = my_array_lib.map (fun x => x + 1) [1, 2, 3, 4, 5, 6] in
 my_array_lib.fold (fun x acc => x * acc) l 1
-

--- a/examples/config-gcc/config-gcc.ncl
+++ b/examples/config-gcc/config-gcc.ncl
@@ -80,7 +80,7 @@ let Contract = {
          - *0*: unoptimized
          - *1*: normal
          - *2*: use optimizations
-      "% 
+      "%
     | OptLevel
     | default
     = 1,
@@ -91,4 +91,3 @@ in
   flags = ["Wextra", { flag = "o", arg = "stuff.o" }],
   optimization_level = 2,
 } | Contract
-

--- a/examples/fibonacci/fibonacci.ncl
+++ b/examples/fibonacci/fibonacci.ncl
@@ -11,4 +11,3 @@ let rec fibonacci = fun n =>
     fibonacci (n - 1) + fibonacci (n - 2)
 in
 fibonacci 10
-

--- a/examples/merge-priorities/main.ncl
+++ b/examples/merge-priorities/main.ncl
@@ -11,7 +11,9 @@ server
   # As opposed to the simple merge example, this would now fail
   # firewall.enabled = false
 
-  firewall.open_ports | priority 10 = [80],firewall.type = "superiptables",server.host.ip = "89.22.11.01",
+  firewall.open_ports | priority 10 = [80],
+  firewall.type = "superiptables",
+  server.host.ip = "89.22.11.01",
 
   # this will only be selected if no values with higher priority (or no priority
   # annotation, which is the same as priority 0) is ever defined
@@ -21,4 +23,3 @@ server
 & {
   server.host.name = "hello-world.main.com",
 }
-

--- a/examples/merge-priorities/security.ncl
+++ b/examples/merge-priorities/security.ncl
@@ -1,5 +1,4 @@
 # test = 'ignore'
-
 {
   server.host.options | priority 10 = "TLS",
 
@@ -8,4 +7,3 @@
   firewall.type | default = "iptables",
   firewall.open_ports | priority 5 = [21, 80, 443],
 }
-

--- a/examples/merge-priorities/server.ncl
+++ b/examples/merge-priorities/server.ncl
@@ -1,8 +1,6 @@
 # test = 'ignore'
-
 {
   server.host.ip | default = "182.168.1.1",
   server.host.port | default = 80,
   server.host.name | default = "hello-world.net",
 }
-

--- a/examples/merge/main.ncl
+++ b/examples/merge/main.ncl
@@ -6,4 +6,3 @@ let server = import "server.ncl" in
 let security = import "security.ncl" in
 # Disabling firewall in the final result
 server & security & { firewall.enabled = false }
-

--- a/examples/merge/security.ncl
+++ b/examples/merge/security.ncl
@@ -1,5 +1,4 @@
 # test = 'ignore'
-
 {
   server.host.options = "TLS",
 
@@ -7,4 +6,3 @@
   firewall.type = "iptables",
   firewall.open_ports = [21, 80, 443],
 }
-

--- a/examples/merge/server.ncl
+++ b/examples/merge/server.ncl
@@ -1,8 +1,6 @@
 # test = 'ignore'
-
 {
   server.host.ip = "182.168.1.1",
   server.host.port = 80,
   server.host.name = "hello-world.net",
 }
-

--- a/examples/polymorphism/polymorphism.ncl
+++ b/examples/polymorphism/polymorphism.ncl
@@ -6,4 +6,3 @@ let fst : forall a b. a -> b -> a = fun x y => x in
 let ev : forall a b. (a -> b) -> a -> b = fun f x => f x in
 let id : forall a. a -> a = fun x => x in
 (ev id (fst 5 10) == 5 : Bool)
-

--- a/examples/record-contract/record-contract.ncl
+++ b/examples/record-contract/record-contract.ncl
@@ -2,33 +2,40 @@
 
 # An illustrative (thus incomplete and maybe incorrect) contract example for a
 # Kubernetes configuration.
-# Schema and example derived from https://github.com/kubernetes/examples/blob/master/guestbook-go/guestbook-controller.json.
+# Schema and example derived from
+# https://github.com/kubernetes/examples/blob/master/guestbook-go/guestbook-controller.json.
+let Port | doc "A contract for a port number"
+  =
+    std.contract.from_predicate
+      (
+        fun value =>
+          std.is_number value
+          && (value % 1 == 0)
+          && (value >= 0)
+          && (value <= 65535)
+      )
+  in
 
-let Port
-  | doc "A contract for a port number"
-  = std.contract.from_predicate (fun value =>
-    std.is_number value &&
-    value % 1 == 0 &&
-    value >= 0 &&
-    value <= 65535) in
-
-let PortElt
-  | doc "A contract for a port element of a Kubernetes configuration"
+let PortElt | doc "A contract for a port element of a Kubernetes configuration"
   = {
     name | String,
     containerPort | Port,
-  } in
+  }
+  in
 
 let Container = {
   name | String,
   image | String,
   ports | Array PortElt,
-} in
+}
+in
 
 let KubernetesConfig = {
-  kind | [| 'ReplicationController, 'ReplicaSet, 'Pod |]
-       | doc "The kind of the element being configured."
-       | default = 'Pod,
+  kind
+    | [| 'ReplicationController, 'ReplicaSet, 'Pod |]
+    | doc "The kind of the element being configured."
+    | default
+    = 'Pod,
 
   apiVersion | String,
 
@@ -38,9 +45,11 @@ let KubernetesConfig = {
   },
 
   spec = {
-    replicas | std.number.PosNat
-             | doc "The number of replicas"
-             | default = 1,
+    replicas
+      | std.number.PosNat
+      | doc "The number of replicas"
+      | default
+      = 1,
 
     selector.matchLabels.app | String,
 
@@ -49,13 +58,15 @@ let KubernetesConfig = {
       spec.containers | Array Container,
     },
   },
-} in
+}
+in
 
 let name_ = "myApp" in
 let metadata_ = {
-    name = name_,
-    labels.app = name_,
-  } in
+  name = name_,
+  labels.app = name_,
+}
+in
 
 {
   kind = 'ReplicationController,
@@ -68,21 +79,21 @@ let metadata_ = {
       matchLabels.app = name_,
     },
     template = {
-       metadata = metadata_,
-       spec = {
-          containers = [
-            {
-              name = name_,
-              image = "k8s.gcr.io/%{name_}:v3",
-              ports = [
-                {
-                  name = "http-server",
-                  containerPort = 80,
-                }
-              ]
-            }
-          ]
-        }
+      metadata = metadata_,
+      spec = {
+        containers = [
+          {
+            name = name_,
+            image = "k8s.gcr.io/%{name_}:v3",
+            ports = [
+              {
+                name = "http-server",
+                containerPort = 80,
+              }
+            ]
+          }
+        ]
+      }
     }
   }
 } | KubernetesConfig

--- a/examples/simple-contracts/simple-contract-bool.ncl
+++ b/examples/simple-contracts/simple-contract-bool.ncl
@@ -19,4 +19,3 @@ let AlwaysFalse = EqualsTo false in
 # by `x`) to see contract errors appear.
 let not | AlwaysTrue -> AlwaysFalse = fun x => !x in
 not true
-

--- a/examples/simple-contracts/simple-contract-div.ncl
+++ b/examples/simple-contracts/simple-contract-div.ncl
@@ -20,4 +20,3 @@ in
     | Even
     | DivBy3
 )
-

--- a/flake.nix
+++ b/flake.nix
@@ -162,6 +162,13 @@
             ];
           };
 
+          # we could use pre-commit-hook's built-in topiary, be for now, Topiary
+          # is evolving quickly and we prefer to have the latest version.
+          # This might change once the Nickel support is stabilized.
+          topiary-latest = topiary.lib.${system}.pre-commit-hook // {
+            enable = true;
+            files = "\\.ncl$";
+          };
         };
       };
 

--- a/flake.nix
+++ b/flake.nix
@@ -167,7 +167,14 @@
           # This might change once the Nickel support is stabilized.
           topiary-latest = topiary.lib.${system}.pre-commit-hook // {
             enable = true;
+            # Some tests and benches are currently failing the idempotency
+            # check, and formatting is less important there. We at least want
+            # the examples as well as the stdlib to be properly formatted.
             files = "\\.ncl$";
+            excludes = [
+              "/tests/(.+)\\.ncl$"
+              "/benches/(.+)\\.ncl$"
+            ];
           };
         };
       };

--- a/nickel-lang-lib/stdlib/internals.ncl
+++ b/nickel-lang-lib/stdlib/internals.ncl
@@ -177,7 +177,8 @@
 
   # Recursive priorities operators
 
-  "$rec_force" = fun value => %rec_force% (%force% value),"$rec_default" = fun value => %rec_default% (%force% value),
+  "$rec_force" = fun value => %rec_force% (%force% value),
+  "$rec_default" = fun value => %rec_default% (%force% value),
 
   # Provide access to std.contract.Equal within the initial environement. Merging
   # makes use of `std.contract.Equal`, but it can't blindly substitute such an

--- a/nickel-lang-lib/stdlib/internals.ncl
+++ b/nickel-lang-lib/stdlib/internals.ncl
@@ -141,24 +141,25 @@
               label
           )
     else
-      let conflicts = std.array.filter
-        (fun field => std.array.elem field constr)
-        (%fields% value)
+      let conflicts =
+        std.array.filter
+          (fun field => std.array.elem field constr)
+          (%fields% value)
       in
       if conflicts != [] then
         %blame%
           (
             %label_with_message%
-            "field%{plural conflicts} not allowed in tail: `%{std.string.join ", " conflicts}`"
-            label
+              "field%{plural conflicts} not allowed in tail: `%{std.string.join ", " conflicts}`"
+              label
           )
       else
-      # Note: in order to correctly attribute blame, the polarity of `l`
-      # must match the polarity of the `forall` which introduced the
-      # polymorphic contract (i.e. `pol`). Since we know in this branch
-      # that `pol` and `%polarity% l` differ, we swap `l`'s polarity before
-      # we continue.
-      %record_seal_tail% sealing_key (%chng_pol% label) acc value,
+        # Note: in order to correctly attribute blame, the polarity of `l`
+        # must match the polarity of the `forall` which introduced the
+        # polymorphic contract (i.e. `pol`). Since we know in this branch
+        # that `pol` and `%polarity% l` differ, we swap `l`'s polarity before
+        # we continue.
+        %record_seal_tail% sealing_key (%chng_pol% label) acc value,
 
   "$dyn_tail" = fun acc label value => acc & value,
 

--- a/nickel-lang-lib/stdlib/std.ncl
+++ b/nickel-lang-lib/stdlib/std.ncl
@@ -1282,10 +1282,11 @@
                 if min_size >= %length% value then
                   let index_as_str = %to_str% min_size in
                   let max_as_str = %to_str% (%length% value - 1) in
-                  let note = if %length% value == 0 then
-                    "Can't index into an empty array"
-                  else
-                    "Expected an array index between 0 and %{max_as_str} (included), got %{index_as_str}"
+                  let note =
+                    if %length% value == 0 then
+                      "Can't index into an empty array"
+                    else
+                      "Expected an array index between 0 and %{max_as_str} (included), got %{index_as_str}"
                   in
                   label
                   |> attach_message
@@ -2935,4 +2936,3 @@
     "%
     = fun msg => null | FailWith msg,
 }
-


### PR DESCRIPTION
This PR adds a pre-commit-hook to run Topiary and check that Nickel files are properly formatted. This check automatically fires on the CI as well, as we use pre-commit-hooks in the flake checks too.

I excluded any path containing `/tests` or `/benches`, as those were failing the idempotency check - or some would simply not parse at all (failing tests for the parser).