### PR TITLE
ArraySliceFun incorrectly excludes the length of the array as the end index

### DIFF
--- a/nickel-lang-lib/stdlib/std.ncl
+++ b/nickel-lang-lib/stdlib/std.ncl
@@ -1354,7 +1354,7 @@
 
             let ArraySliceArray = fun end_index label value =>
               if %typeof% end_index == 'Number && %typeof% value == 'Array then
-                if end_index >= %length% value then
+                if end_index > %length% value then
                   let index_as_str = %to_str% end_index in
                   let size_as_str = %to_str% (%length% value) in
                   label


### PR DESCRIPTION
The array slicing primop expects the end index to be one greater than the last index included in the slice. The `ArraySliceFun` contract incorrectly excluded the end index being equal to the length of the array.