### PR TITLE
Fix LSP infinite loop on hovering on external imports

### DIFF
--- a/lsp/nls/src/files.rs
+++ b/lsp/nls/src/files.rs
@@ -77,7 +77,7 @@ fn typecheck(server: &mut Server, file_id: FileId) -> Result<CacheOp<()>, Vec<Di
             file_id,
             &server.initial_ctxt,
             &server.initial_env,
-            &mut server.lin_cache,
+            &mut server.lin_registry,
         )
         .map_err(|error| match error {
             CacheError::Error(tc_error) => tc_error

--- a/lsp/nls/src/linearization/completed.rs
+++ b/lsp/nls/src/linearization/completed.rs
@@ -62,7 +62,7 @@ impl Completed {
         id: ItemId,
         lin_registry: &'a LinRegistry,
     ) -> Option<&'a LinearizationItem<Resolved>> {
-        self.get_item(id).or(lin_registry.get_item(id))
+        self.get_item(id).or_else(|| lin_registry.get_item(id))
     }
 
     pub fn get_item_mut(&mut self, id: ItemId) -> Option<&mut LinearizationItem<Resolved>> {

--- a/lsp/nls/src/linearization/completed.rs
+++ b/lsp/nls/src/linearization/completed.rs
@@ -7,7 +7,7 @@ use nickel_lang_lib::{
 
 use super::{
     interface::{Resolved, TermKind, UsageState, ValueState},
-    ItemId, LinearizationItem,
+    ItemId, LinRegistry, LinearizationItem,
 };
 
 #[derive(Debug, Default, Clone)]
@@ -49,34 +49,25 @@ impl Completed {
         (left, right)
     }
 
-    pub fn get_item<'a>(
-        &'a self,
-        id: ItemId,
-        lin_cache: &'a HashMap<FileId, Completed>,
-    ) -> Option<&'a LinearizationItem<Resolved>> {
-        let ItemId { file_id, .. } = id;
+    pub fn get_item(&self, id: ItemId) -> Option<&LinearizationItem<Resolved>> {
         self.id_to_index
             .get(&id)
             .and_then(|index| self.linearization.get(*index))
-            .or_else(|| {
-                let lin = lin_cache.get(&file_id).unwrap();
-                lin.get_item(id, lin_cache)
-            })
+    }
+
+    /// Try to retrieve the item from the current linearization first, and if that fails, look into
+    /// the registry if there is a linearization corresponding to the item's file id.
+    pub fn get_item_with_reg<'a>(
+        &'a self,
+        id: ItemId,
+        lin_registry: &'a LinRegistry,
+    ) -> Option<&'a LinearizationItem<Resolved>> {
+        self.get_item(id).or(lin_registry.get_item(id))
     }
 
     pub fn get_item_mut(&mut self, id: ItemId) -> Option<&mut LinearizationItem<Resolved>> {
         let index = self.id_to_index.get(&id)?;
         self.linearization.get_mut(*index)
-    }
-
-    pub fn get_in_scope<'a>(
-        &'a self,
-        LinearizationItem { env, .. }: &'a LinearizationItem<Resolved>,
-        lin_cache: &'a HashMap<FileId, Completed>,
-    ) -> Vec<&LinearizationItem<Resolved>> {
-        env.iter()
-            .filter_map(|(_, id)| self.get_item(*id, lin_cache))
-            .collect()
     }
 
     /// Finds the index of a linearization item for a given location
@@ -136,17 +127,30 @@ impl Completed {
         item
     }
 
-    /// Resolve type and meta information for a given item
-    pub fn resolve_item_type_meta(
+    /// Return all the items in the scope of the given linearization item.
+    pub fn get_in_scope<'a>(
+        &'a self,
+        LinearizationItem { env, .. }: &'a LinearizationItem<Resolved>,
+        lin_registry: &'a LinRegistry,
+    ) -> Vec<&'a LinearizationItem<Resolved>> {
+        env.iter()
+            .filter_map(|(_, id)| self.get_item_with_reg(*id, lin_registry))
+            .collect()
+    }
+
+    /// Retrive the type and the metadata of a linearization item. Requires a registry as this code
+    /// tries to jump to the definitions of objects to find the relevant data, which might lie in a
+    /// different file (and thus in a different linearization within the registry).
+    pub fn get_type_and_metadata(
         &self,
         item: &LinearizationItem<Resolved>,
-        lin_cache: &HashMap<FileId, Completed>,
+        lin_registry: &LinRegistry,
     ) -> (Resolved, Vec<String>) {
         let mut extra = Vec::new();
 
         let item = match item.kind {
             TermKind::Usage(UsageState::Resolved(declaration)) => self
-                .get_item(declaration, lin_cache)
+                .get_item_with_reg(declaration, lin_registry)
                 .and_then(|decl| match decl.kind {
                     TermKind::Declaration {
                         value: ValueState::Known(value),
@@ -155,14 +159,14 @@ impl Completed {
                     | TermKind::RecordField {
                         value: ValueState::Known(value),
                         ..
-                    } => self.get_item(value, lin_cache),
+                    } => self.get_item_with_reg(value, lin_registry),
                     _ => None,
                 })
                 .unwrap_or(item),
             TermKind::Declaration {
                 value: ValueState::Known(value),
                 ..
-            } => self.get_item(value, lin_cache).unwrap_or(item),
+            } => self.get_item_with_reg(value, lin_registry).unwrap_or(item),
             _ => item,
         };
 

--- a/lsp/nls/src/linearization/mod.rs
+++ b/lsp/nls/src/linearization/mod.rs
@@ -51,17 +51,6 @@ impl LinRegistry {
         let lin = self.map.get(&id.file_id).unwrap();
         lin.get_item(id)
     }
-
-    /// Retrieve the type and the metadata of a linearization item, by finding the matching
-    /// linearization from the registry and calling the corresponding method on
-    /// [completed::Completed].
-    pub fn get_type_and_metadata(
-        &self,
-        item: &LinearizationItem<Resolved>,
-    ) -> (Resolved, Vec<String>) {
-        let lin = self.map.get(&item.id.file_id).unwrap();
-        lin.get_type_and_metadata(item, self)
-    }
 }
 
 #[derive(PartialEq, Copy, Debug, Clone, Eq, Hash)]

--- a/lsp/nls/src/requests/completion.rs
+++ b/lsp/nls/src/requests/completion.rs
@@ -1,6 +1,4 @@
-use std::collections::HashMap;
-
-use codespan::{ByteIndex, FileId};
+use codespan::ByteIndex;
 use codespan_lsp::position_to_byte_index;
 use lazy_static::lazy_static;
 use log::debug;
@@ -22,7 +20,7 @@ use crate::{
     linearization::{
         completed::Completed,
         interface::{TermKind, UsageState, ValueState},
-        ItemId, LinearizationItem,
+        ItemId, LinRegistry, LinearizationItem,
     },
     server::{self, Server},
     trace::{Enrich, Trace},
@@ -112,10 +110,11 @@ impl IdentWithType {
     }
 }
 
-/// Completion Context: General data structures required by most completion functions.
+/// Completion context: general data structures required by most completion functions.
+#[derive(Clone, Copy)]
 pub struct ComplCtx<'a> {
     linearization: &'a Completed,
-    lin_cache: &'a HashMap<FileId, Completed>,
+    lin_registry: &'a LinRegistry,
 }
 
 /// Find the record field associated with a particular ID in the linearization
@@ -125,10 +124,10 @@ fn find_fields_from_term_kind(
     path: &mut Vec<Ident>,
     info @ ComplCtx {
         linearization,
-        lin_cache,
-    }: &'_ ComplCtx<'_>,
+        lin_registry,
+    }: ComplCtx<'_>,
 ) -> Vec<IdentWithType> {
-    let Some(item) = linearization.get_item(id, lin_cache) else {
+    let Some(item) = linearization.get_item_with_reg(id, lin_registry) else {
         return Vec::new()
     };
     let mut path_clone = path.clone();
@@ -142,8 +141,8 @@ fn find_fields_from_term_kind(
                         // This unwrap is safe because, `id` is the field of the record
                         // we're currently analyzing. We're sure that the linearization
                         // phase doesn't produce wrong or invalid ids.
-                        let item = linearization.get_item(id, lin_cache).unwrap();
-                        let (ty, _) = linearization.resolve_item_type_meta(item, lin_cache);
+                        let item = linearization.get_item_with_reg(id, lin_registry).unwrap();
+                        let (ty, _) = lin_registry.get_type_and_metadata(item);
                         IdentWithType {
                             ident,
                             ty,
@@ -157,9 +156,9 @@ fn find_fields_from_term_kind(
                     Some(id) => find_fields_from_term_kind(
                         *id,
                         path,
-                        &ComplCtx {
+                        ComplCtx {
                             linearization,
-                            lin_cache,
+                            lin_registry,
                         },
                     ),
                     None => Vec::new(),
@@ -199,10 +198,10 @@ fn find_fields_from_contract(
     path: &mut Vec<Ident>,
     info @ ComplCtx {
         linearization,
-        lin_cache,
-    }: &'_ ComplCtx<'_>,
+        lin_registry: lin_cache,
+    }: ComplCtx<'_>,
 ) -> Vec<IdentWithType> {
-    let Some(item) = linearization.get_item(id, lin_cache) else {
+    let Some(item) = linearization.get_item_with_reg(id, lin_cache) else {
         return Vec::new()
     };
     match &item.metadata {
@@ -229,7 +228,7 @@ fn find_fields_from_contract(
 fn find_fields_from_contracts(
     annot: &TypeAnnotation,
     path: &[Ident],
-    info @ ComplCtx { .. }: &'_ ComplCtx<'_>,
+    info @ ComplCtx { .. }: ComplCtx<'_>,
 ) -> Vec<IdentWithType> {
     annot
         .iter()
@@ -244,7 +243,7 @@ fn find_fields_from_contracts(
 fn find_fields_from_type(
     ty: &Types,
     path: &mut Vec<Ident>,
-    info @ ComplCtx { .. }: &'_ ComplCtx<'_>,
+    info @ ComplCtx { .. }: ComplCtx<'_>,
 ) -> Vec<IdentWithType> {
     match &ty.types {
         TypeF::Record(row) => find_fields_from_rrows(row, path, info),
@@ -261,7 +260,7 @@ fn find_fields_from_type(
 fn find_fields_from_rrows(
     rrows: &RecordRows,
     path: &mut Vec<Ident>,
-    info @ ComplCtx { .. }: &'_ ComplCtx<'_>,
+    info @ ComplCtx { .. }: ComplCtx<'_>,
 ) -> Vec<IdentWithType> {
     if let Some(current) = path.pop() {
         let type_of_current = rrows.iter().find_map(|item| match item {
@@ -299,7 +298,7 @@ fn find_fields_from_rrows(
 fn find_fields_from_field(
     field: &Field,
     path: &mut Vec<Ident>,
-    info: &'_ ComplCtx<'_>,
+    info: ComplCtx<'_>,
 ) -> Vec<IdentWithType> {
     find_fields_from_term_with_annot(&field.metadata.annotation, field.value.as_ref(), path, info)
 }
@@ -309,7 +308,7 @@ fn find_fields_from_term_with_annot(
     annot: &TypeAnnotation,
     value: Option<&RichTerm>,
     path: &mut Vec<Ident>,
-    info: &'_ ComplCtx<'_>,
+    info: ComplCtx<'_>,
 ) -> Vec<IdentWithType> {
     let mut info_from_metadata = find_fields_from_contracts(annot, path, info);
 
@@ -324,7 +323,7 @@ fn find_fields_from_term_with_annot(
 fn find_fields_from_term(
     term: &RichTerm,
     path: &mut Vec<Ident>,
-    info @ ComplCtx { lin_cache, .. }: &'_ ComplCtx<'_>,
+    info @ ComplCtx { lin_registry, .. }: ComplCtx<'_>,
 ) -> Vec<IdentWithType> {
     match term.as_ref() {
         Term::Record(data) | Term::RecRecord(data, ..) => match path.pop() {
@@ -355,7 +354,7 @@ fn find_fields_from_term(
             // This unwrap is safe because we're getting an expression from
             // a linearized file, so all terms in the file and all terms in its
             // dependencies must have being linearized and stored in the cache.
-            let linearization = lin_cache.get(&span.src_id).unwrap();
+            let linearization = lin_registry.map.get(&span.src_id).unwrap();
             let item = linearization.item_at(&locator).unwrap();
             find_fields_from_term_kind(item.id, path, info)
         }
@@ -443,19 +442,19 @@ fn collect_record_info(
     linearization: &Completed,
     id: ItemId,
     path: &mut Vec<Ident>,
-    lin_cache: &HashMap<FileId, Completed>,
+    lin_registry: &LinRegistry,
 ) -> Vec<IdentWithType> {
     let info = ComplCtx {
         linearization,
-        lin_cache,
+        lin_registry,
     };
     linearization
-        .get_item(id, lin_cache)
+        .get_item_with_reg(id, lin_registry)
         .map(|item| {
-            let (ty, _) = linearization.resolve_item_type_meta(item, lin_cache);
+            let (ty, _) = linearization.get_type_and_metadata(item, lin_registry);
             match (&item.kind, &ty.types) {
                 // Get record fields from static type info
-                (_, TypeF::Record(rrows)) => find_fields_from_rrows(rrows, path, &info),
+                (_, TypeF::Record(rrows)) => find_fields_from_rrows(rrows, path, info),
                 (
                     TermKind::Declaration {
                         value: ValueState::Known(body_id),
@@ -467,7 +466,7 @@ fn collect_record_info(
                     for ident in idents {
                         path.push(*ident)
                     }
-                    find_fields_from_term_kind(*body_id, path, &info)
+                    find_fields_from_term_kind(*body_id, path, info)
                 }
                 (
                     TermKind::Declaration {
@@ -483,16 +482,16 @@ fn collect_record_info(
                     // The path is mutable, so the first case would consume the path
                     // so we have to clone it so that it can be correctly used for the second case.
                     let mut path_copy = path.clone();
-                    find_fields_from_contract(*body_id, path, &info)
+                    find_fields_from_contract(*body_id, path, info)
                         .into_iter()
-                        .chain(find_fields_from_term_kind(*body_id, &mut path_copy, &info))
+                        .chain(find_fields_from_term_kind(*body_id, &mut path_copy, info))
                         .collect()
                 }
                 _ => {
                     // The item might not com from a declaration (let-binding nor a record field),
                     // but is nontheless a record with interesting completion data. This is
                     // typically the case for the `std` entry point of the stdlib.
-                    find_fields_from_term_kind(id, path, &info)
+                    find_fields_from_term_kind(id, path, info)
                 }
             }
         })
@@ -505,13 +504,15 @@ fn accumulate_record_meta_data<'a>(
     record: ItemId,
     info @ ComplCtx {
         linearization,
-        lin_cache,
-    }: &'a ComplCtx<'a>,
+        lin_registry,
+    }: ComplCtx<'a>,
     mut path: Vec<Ident>,
     result: &mut Vec<(&'a LinearizationItem<Types>, Vec<Ident>)>,
 ) {
     // This unwrap is safe: we know a `RecordField` must have a containing `Record`.
-    let parent = linearization.get_item(record, lin_cache).unwrap();
+    let parent = linearization
+        .get_item_with_reg(record, lin_registry)
+        .unwrap();
 
     // The element just before a value should be the record field, because the linearization
     // items are sorted wrt. position
@@ -555,12 +556,12 @@ fn get_completion_identifiers(
             return Vec::new()
         };
         let lin = server.lin_cache_get(&item_id.file_id).unwrap();
-        collect_record_info(lin, *item_id, path, &server.lin_cache)
+        collect_record_info(lin, *item_id, path, &server.lin_registry)
     }
 
     fn context_complete(
         item: &LinearizationItem<Types>,
-        info: &'_ ComplCtx<'_>,
+        info: ComplCtx<'_>,
         path: Vec<Ident>,
     ) -> Vec<IdentWithType> {
         if let (&TermKind::RecordField { record, .. }, _) | (TermKind::Record(..), record) =
@@ -586,7 +587,7 @@ fn get_completion_identifiers(
 
     let info = ComplCtx {
         linearization,
-        lin_cache: &server.lin_cache,
+        lin_registry: &server.lin_registry,
     };
 
     let in_scope: Vec<_> = match trigger {
@@ -598,7 +599,7 @@ fn get_completion_identifiers(
             let mut path: Vec<_> = path.iter().rev().cloned().map(Ident::from).collect();
 
             let context_path = path.clone();
-            let contextual_result = context_complete(item, &info, context_path);
+            let contextual_result = context_complete(item, info, context_path);
 
             // unwrap is safe here because we are guaranteed by `get_identifier_path`
             // that it will return a non-empty vector
@@ -620,7 +621,7 @@ fn get_completion_identifiers(
                 // The item we get is the uncompleted `dat` field name as the item.
                 // What we *really* want as the item is the `config` field name.
                 let context_path = path.clone();
-                let contextual_result = context_complete(item, &info, context_path);
+                let contextual_result = context_complete(item, info, context_path);
 
                 // unwrap is safe here because we are guaranteed by `get_identifiers_before_field`
                 // that it will return a non-empty vector
@@ -630,11 +631,11 @@ fn get_completion_identifiers(
                     .chain(contextual_result)
                     .collect()
             } else {
-                let contextual_result = context_complete(item, &info, Vec::new());
+                let contextual_result = context_complete(item, info, Vec::new());
                 // Global name completion
-                let (ty, _) = linearization.resolve_item_type_meta(item, &server.lin_cache);
+                let (ty, _) = linearization.get_type_and_metadata(item, &server.lin_registry);
                 linearization
-                    .get_in_scope(item, &server.lin_cache)
+                    .get_in_scope(item, &server.lin_registry)
                     .iter()
                     .filter_map(|i| match i.kind {
                         TermKind::Declaration { id: ident, .. }
@@ -838,12 +839,12 @@ mod tests {
         // nor type constants
         let info = ComplCtx {
             linearization: &Default::default(),
-            lin_cache: &HashMap::new(),
+            lin_registry: &LinRegistry::new(),
         };
         let result: Vec<_> = find_fields_from_rrows(
             &Box::new(a_record_type.try_into().unwrap()),
             &mut path,
-            &info,
+            info,
         )
         .iter()
         .map(|iwm| iwm.ident)
@@ -925,9 +926,9 @@ mod tests {
             for id in ids {
                 let info = ComplCtx {
                     linearization: &completed,
-                    lin_cache: &HashMap::new(),
+                    lin_registry: &LinRegistry::new(),
                 };
-                let mut actual: Vec<_> = find_fields_from_term_kind(id, &mut Vec::new(), &info)
+                let mut actual: Vec<_> = find_fields_from_term_kind(id, &mut Vec::new(), info)
                     .iter()
                     .map(|iwm| iwm.ident)
                     .collect();
@@ -1109,7 +1110,7 @@ mod tests {
         );
         let lin = make_completed(vec![a, b, c]);
 
-        let actual = collect_record_info(&lin, id, &mut Vec::new(), &HashMap::new());
+        let actual = collect_record_info(&lin, id, &mut Vec::new(), &LinRegistry::new());
         let mut expected = vec![Ident::from("one"), Ident::from("two")];
         let mut actual = actual.iter().map(|iwm| iwm.ident).collect::<Vec<_>>();
         expected.sort();

--- a/lsp/nls/src/requests/completion.rs
+++ b/lsp/nls/src/requests/completion.rs
@@ -142,7 +142,7 @@ fn find_fields_from_term_kind(
                         // we're currently analyzing. We're sure that the linearization
                         // phase doesn't produce wrong or invalid ids.
                         let item = linearization.get_item_with_reg(id, lin_registry).unwrap();
-                        let (ty, _) = lin_registry.get_type_and_metadata(item);
+                        let (ty, _) = linearization.get_type_and_metadata(item, lin_registry);
                         IdentWithType {
                             ident,
                             ty,

--- a/lsp/nls/src/requests/goto.rs
+++ b/lsp/nls/src/requests/goto.rs
@@ -53,7 +53,9 @@ pub fn handle_to_definition(
 
     let location = match item.kind {
         TermKind::Usage(UsageState::Resolved(usage_id)) => {
-            let definition = linearization.get_item(usage_id, &server.lin_cache).unwrap();
+            let definition = linearization
+                .get_item_with_reg(usage_id, &server.lin_registry)
+                .unwrap();
             if server.cache.is_stdlib_module(definition.id.file_id) {
                 // The standard library files are embedded in the executable,
                 // so we can't possibly go to their definition on disk.
@@ -128,7 +130,7 @@ pub fn handle_to_usages(
                 .iter()
                 .filter_map(|reference_id| {
                     linearization
-                        .get_item(*reference_id, &server.lin_cache)
+                        .get_item_with_reg(*reference_id, &server.lin_registry)
                         .unwrap()
                         .pos
                         .as_opt_ref()

--- a/lsp/nls/src/requests/hover.rs
+++ b/lsp/nls/src/requests/hover.rs
@@ -52,9 +52,9 @@ pub fn handle(
 
     let item = item.unwrap().to_owned();
 
-    debug!("{:?}", item);
+    debug!("Found item {:?}", item);
 
-    let (ty, meta) = linearization.resolve_item_type_meta(&item, &server.lin_cache);
+    let (ty, meta) = linearization.get_type_and_metadata(&item, &server.lin_registry);
 
     if item.pos == TermPos::None {
         server.reply(Response::new_ok(id, Value::Null));

--- a/lsp/nls/src/requests/symbols.rs
+++ b/lsp/nls/src/requests/symbols.rs
@@ -19,7 +19,7 @@ pub fn handle_document_symbols(
         .id_of(params.text_document.uri.to_file_path().unwrap())
         .unwrap();
 
-    if let Some(completed) = server.lin_cache.get(&file_id) {
+    if let Some(completed) = server.lin_registry.map.get(&file_id) {
         Trace::enrich(&id, completed);
         let symbols = completed
             .linearization


### PR DESCRIPTION
Fix a LSP hang when hovering on the field of a value defined as an external import.

## Issue

When hovering on the field accessed from an external import, the LSP crashed with a stack overflow:

```nickel
# file: foo.json
{"foo" : "bar"}
# file: test.ncl
let x = import "foo.json" in
# hover on `foo`: crash
x.foo
```

## Diagnostic

When trying to retrieve information about an item, the LSP uses `Completed::get_item`, which takes an item id and the linearization cache (mapping from file ids to the corresponding linearization). This methods first tries to retrieve the item from the current linearization, but this can fail, because this item might be coming from a different file. When this happens, `get_item` looks into the linearization cache, find the linearization corresponding to the item `FileId`, and call `get_item` on this linearization.

I suspect an item with a definite id is always supposed to be found in the end, but for now it's not the case for item pointing within external import. This might be a bug or on oversight, but in any case, the item is nowhere to be found. The issue is that the `get_item` method explained above enters an infinite loop: the item isn't found in the current linearization, so we look into the cache, found the corresponding linearization... which is just the same linearization. We call `get_item` and start again.

## Solution

Before investigating more in-depth why some items are nowhere found, we can simply break the cycle by having two levels of `get_item`: once that simply tries to look into the current linearization, and return `None` if nothing is found. We added a `get_item_with_reg`, wich takes an additional cache (now named registry), tries to call `get_item`, and if that fails, look into the cache and call `get_item` on the corresponding linearization. However, note that the latter is the new `get_item`, which doesn't loop, so if the item isn't found for the second time, we just return `None`.

## Other changes

Doing so, I took the occasion to do a few other cosmetic changes:

- Rename `LinCache` to `LinRegistry` (it's not really a cache, it's not updated or evicted, it's just a mapping), make it a proper struct to encapsulate the inner data better. 
- Avoid taking completion context by references, because they are copy, removing unneeded `&` sprinkled around the code