### PR TITLE
[Fix] Add missing check for unifying equal type vars

### DIFF
--- a/nickel-lang-lib/src/typecheck/mod.rs
+++ b/nickel-lang-lib/src/typecheck/mod.rs
@@ -2263,7 +2263,6 @@ pub fn unify(
                 UnifType::Concrete(ty2),
             )),
         },
-        (UnifType::UnifVar(p1), UnifType::UnifVar(p2)) if p1 == p2 => Ok(()),
         (UnifType::UnifVar(p), uty) | (uty, UnifType::UnifVar(p)) => {
             state.table.assign_type(p, uty);
             Ok(())
@@ -2510,18 +2509,33 @@ impl UnifTable {
 
     /// Assign a type to a type unification variable.
     pub fn assign_type(&mut self, var: VarId, uty: UnifType) {
+        // Unifying a free variable with itself is a no-op.
+        if matches!(uty, UnifType::UnifVar(x) if x == var) {
+            return;
+        }
+
         debug_assert!(self.types[var].is_none());
         self.types[var] = Some(uty);
     }
 
     /// Assign record rows to a record rows unification variable.
     pub fn assign_rrows(&mut self, var: VarId, rrows: UnifRecordRows) {
+        // Unifying a free variable with itself is a no-op.
+        if matches!(rrows, UnifRecordRows::UnifVar(x) if x == var) {
+            return;
+        }
+
         debug_assert!(self.rrows[var].is_none());
         self.rrows[var] = Some(rrows);
     }
 
     /// Assign enum rows to an enum rows unification variable.
     pub fn assign_erows(&mut self, var: VarId, erows: UnifEnumRows) {
+        // Unifying a free variable with itself is a no-op.
+        if matches!(erows, UnifEnumRows::UnifVar(x) if x == var) {
+            return;
+        }
+
         debug_assert!(self.erows[var].is_none());
         self.erows[var] = Some(erows);
     }

--- a/nickel-lang-lib/tests/integration/pass/types/regression-rrows-unification-loops.ncl
+++ b/nickel-lang-lib/tests/integration/pass/types/regression-rrows-unification-loops.ncl
@@ -1,0 +1,5 @@
+# test.type = 'pass'
+let f : forall a b. (a -> b -> b) -> b -> Dyn = fun x b => null in
+let _ign = (f (fun result acc => if result.success then acc else result)) : _ in
+# we only care about typechecking here
+true


### PR DESCRIPTION
Closes #1389

We didn't test if a record rows unification variable was equal to itself upon unification, which led to cycles in the unification table, and thus an infinite loop in the typechecker. This was probably introduced by the refactoring of row types (#875), where the original code - which did check for equality, and is why normal type variables were fine - was split and moved around.

This commit moves the equality check directly at the level of `UnifTable`, so that higher-level functions `unify_xxx` don't have to care anymore if they are unifying a variable with itself and are ensured to never create such simple direct cycles.