### PR TITLE
Add support for completion requests to the lsp harness

### DIFF
--- a/lsp/lsp-harness/src/output.rs
+++ b/lsp/lsp-harness/src/output.rs
@@ -85,3 +85,18 @@ impl LspDebug for lsp_types::GotoDefinitionResponse {
         }
     }
 }
+
+impl LspDebug for lsp_types::CompletionItem {
+    fn debug(&self, mut w: impl Write) -> std::io::Result<()> {
+        write!(w, "{}", self.label)
+    }
+}
+
+impl LspDebug for lsp_types::CompletionResponse {
+    fn debug(&self, w: impl Write) -> std::io::Result<()> {
+        match self {
+            lsp_types::CompletionResponse::Array(items) => Iter(items.iter()).debug(w),
+            lsp_types::CompletionResponse::List(list) => Iter(list.items.iter()).debug(w),
+        }
+    }
+}

--- a/lsp/lsp-harness/src/output.rs
+++ b/lsp/lsp-harness/src/output.rs
@@ -95,8 +95,17 @@ impl LspDebug for lsp_types::CompletionItem {
 impl LspDebug for lsp_types::CompletionResponse {
     fn debug(&self, w: impl Write) -> std::io::Result<()> {
         match self {
-            lsp_types::CompletionResponse::Array(items) => Iter(items.iter()).debug(w),
-            lsp_types::CompletionResponse::List(list) => Iter(list.items.iter()).debug(w),
+            lsp_types::CompletionResponse::Array(items) => {
+                // The order of completions is non-deterministic, so sort them.
+                let mut items = items.clone();
+                items.sort_by_key(|i| i.label.clone());
+                Iter(items.iter()).debug(w)
+            }
+            lsp_types::CompletionResponse::List(list) => {
+                let mut items = list.items.clone();
+                items.sort_by_key(|i| i.label.clone());
+                Iter(list.items.iter()).debug(w)
+            }
         }
     }
 }

--- a/lsp/nls/tests/inputs/completion-basic.ncl
+++ b/lsp/nls/tests/inputs/completion-basic.ncl
@@ -1,0 +1,17 @@
+### /completion-basic.ncl
+let config = {
+  version = "1.2",
+  verified = { really = true },
+  foo = "bar",
+}
+in
+{
+    a = config.version,
+    b = config.verified.really,
+}
+### Completion /completion-basic.ncl:7:12
+### Completion /completion-basic.ncl:7:15 .
+### Completion /completion-basic.ncl:8:15 .
+### Completion /completion-basic.ncl:8:23
+### Completion /completion-basic.ncl:8:24 .
+### Completion /completion-basic.ncl:8:27

--- a/lsp/nls/tests/main.rs
+++ b/lsp/nls/tests/main.rs
@@ -1,8 +1,5 @@
 use assert_cmd::cargo::CommandCargoExt;
-use lsp_types::{
-    request::{Completion, GotoDefinition, Request as LspRequest},
-    CompletionList,
-};
+use lsp_types::request::{Completion, GotoDefinition, Request as LspRequest};
 use nickel_lang_utils::project_root::project_root;
 use test_generator::test_resources;
 

--- a/lsp/nls/tests/main.rs
+++ b/lsp/nls/tests/main.rs
@@ -1,5 +1,8 @@
 use assert_cmd::cargo::CommandCargoExt;
-use lsp_types::request::{GotoDefinition, Request as LspRequest};
+use lsp_types::{
+    request::{Completion, GotoDefinition, Request as LspRequest},
+    CompletionList,
+};
 use nickel_lang_utils::project_root::project_root;
 use test_generator::test_resources;
 
@@ -32,6 +35,7 @@ impl TestHarness {
     fn request_dyn(&mut self, req: Request) {
         match req {
             Request::GotoDefinition(d) => self.request::<GotoDefinition>(d),
+            Request::Completion(c) => self.request::<Completion>(c),
         }
     }
 

--- a/lsp/nls/tests/snapshots/main__lsp__nls__tests__inputs__completion-basic.ncl.snap
+++ b/lsp/nls/tests/snapshots/main__lsp__nls__tests__inputs__completion-basic.ncl.snap
@@ -2,10 +2,10 @@
 source: lsp/nls/tests/main.rs
 expression: output
 ---
-[b, a, config]
-[version, verified, foo]
-[version, verified, foo]
-[version, verified, foo]
+[a, b, config]
+[foo, verified, version]
+[foo, verified, version]
+[foo, verified, version]
 [really]
 [really]
 

--- a/lsp/nls/tests/snapshots/main__lsp__nls__tests__inputs__completion-basic.ncl.snap
+++ b/lsp/nls/tests/snapshots/main__lsp__nls__tests__inputs__completion-basic.ncl.snap
@@ -1,0 +1,11 @@
+---
+source: lsp/nls/tests/main.rs
+expression: output
+---
+[b, a, config]
+[version, verified, foo]
+[version, verified, foo]
+[version, verified, foo]
+[really]
+[really]
+


### PR DESCRIPTION
The first iteration of the lsp harness only supported testing goto-definition requests. This adds completion requests to the list.