### PR TITLE
[Fix] panic on function contract failure (position of arrow functions not set)

### DIFF
--- a/core/tests/integration/fail/contracts/regression_panic_function_contract_fail.ncl
+++ b/core/tests/integration/fail/contracts/regression_panic_function_contract_fail.ncl
@@ -1,0 +1,5 @@
+# test.type = 'error'
+#
+# [test.metadata]
+# error = 'EvalError::BlameError'
+let foo | (Dyn -> Dyn) -> Dyn = fun x y => x y in foo null null


### PR DESCRIPTION
Fixes #1406 

A position mishandling during the convoluted conversions between types, uniterms and terms in the parser resulted in arrow types being assigned the position `None`, which in turn caused contract error reporting code to panic.