### PR TITLE
Make the pretty printer correctly escape field names

### DIFF
--- a/cli/tests/snapshot/inputs/pretty/field_escaping.ncl
+++ b/cli/tests/snapshot/inputs/pretty/field_escaping.ncl
@@ -1,0 +1,5 @@
+# capture = 'stdout'
+# command = ['pprint-ast']
+{
+  "this needs \\\"escaping\"\nvery much" = true
+}

--- a/cli/tests/snapshot/snapshots/snapshot__pprint-ast_stdout_field_escaping.ncl.snap
+++ b/cli/tests/snapshot/snapshots/snapshot__pprint-ast_stdout_field_escaping.ncl.snap
@@ -1,0 +1,5 @@
+---
+source: cli/tests/snapshot/main.rs
+expression: out
+---
+{ "this needs \\\"escaping\"\nvery much" = true, }

--- a/core/src/identifier.rs
+++ b/core/src/identifier.rs
@@ -1,17 +1,13 @@
 //! Define the type of an identifier.
 use once_cell::sync::Lazy;
-use regex::Regex;
 use serde::{Deserialize, Serialize};
 use std::fmt::{self, Debug};
 use std::hash::Hash;
 
-use crate::{
-    parser::lexer::KEYWORDS, position::TermPos, pretty::escape, term::string::NickelString,
-};
+use crate::{position::TermPos, term::string::NickelString};
 
 simple_counter::generate_counter!(GeneratedCounter, usize);
 static INTERNER: Lazy<interner::Interner> = Lazy::new(interner::Interner::new);
-static QUOTING_REGEX: Lazy<Regex> = Lazy::new(|| Regex::new("^_?[a-zA-Z][_a-zA-Z0-9-]*$").unwrap());
 
 #[derive(Clone, Copy, Deserialize, Serialize)]
 #[serde(into = "String", from = "String")]
@@ -53,18 +49,6 @@ impl Ident {
     /// Return the string representation of this identifier.
     pub fn label(&self) -> &str {
         INTERNER.lookup(self.symbol)
-    }
-
-    /// Return the string representation of this identifier, and add enclosing double quotes if the
-    /// label isn't a valid identifier according to the parser, for example if it contains a
-    /// special character like a space.
-    pub fn label_quoted(&self) -> String {
-        let label = self.label();
-        if QUOTING_REGEX.is_match(label) && !KEYWORDS.contains(&label) {
-            String::from(label)
-        } else {
-            format!("\"{}\"", escape(label))
-        }
     }
 
     pub fn into_label(self) -> String {

--- a/core/src/identifier.rs
+++ b/core/src/identifier.rs
@@ -5,7 +5,9 @@ use serde::{Deserialize, Serialize};
 use std::fmt::{self, Debug};
 use std::hash::Hash;
 
-use crate::{parser::lexer::KEYWORDS, position::TermPos, term::string::NickelString};
+use crate::{
+    parser::lexer::KEYWORDS, position::TermPos, pretty::escape, term::string::NickelString,
+};
 
 simple_counter::generate_counter!(GeneratedCounter, usize);
 static INTERNER: Lazy<interner::Interner> = Lazy::new(interner::Interner::new);
@@ -61,7 +63,7 @@ impl Ident {
         if QUOTING_REGEX.is_match(label) && !KEYWORDS.contains(&label) {
             String::from(label)
         } else {
-            format!("\"{label}\"")
+            format!("\"{}\"", escape(label))
         }
     }
 

--- a/core/src/pretty.rs
+++ b/core/src/pretty.rs
@@ -42,6 +42,13 @@ fn sorted_map<K: Ord, V>(m: &'_ IndexMap<K, V>) -> Vec<(&'_ K, &'_ V)> {
     ret
 }
 
+pub fn escape(s: &str) -> String {
+    s.replace('\\', "\\\\")
+        .replace("%{", "\\%{")
+        .replace('\"', "\\\"")
+        .replace('\n', "\\n")
+}
+
 impl<'a, A: Clone + 'a> NickelAllocatorExt<'a, A> for pretty::BoxAllocator {}
 
 trait NickelAllocatorExt<'a, A: 'a>: DocAllocator<'a, A> + Sized
@@ -52,12 +59,7 @@ where
     /// Escape the special characters in a string, including the newline character, so that it can
     /// be enclosed by double quotes a be a valid Nickel string.
     fn escaped_string(&'a self, s: &str) -> DocBuilder<'a, Self, A> {
-        let s = s
-            .replace('\\', "\\\\")
-            .replace("%{", "\\%{")
-            .replace('\"', "\\\"")
-            .replace('\n', "\\n");
-        self.text(s)
+        self.text(escape(s))
     }
 
     /// Print string chunks, either in the single line or multiline style.


### PR DESCRIPTION
Previously, the pretty printer relied on `Ident::label_quoted` for printing record field names. This function blindly placed an identifier between quotes if it was deemed necessary. This produces incorrect results if the identifier label itself contains quotes, for example.