### PR TITLE
Stop recompiling the quoting regex for printing identifiers

### DIFF
--- a/core/src/identifier.rs
+++ b/core/src/identifier.rs
@@ -9,6 +9,7 @@ use crate::{parser::lexer::KEYWORDS, position::TermPos, term::string::NickelStri
 
 simple_counter::generate_counter!(GeneratedCounter, usize);
 static INTERNER: Lazy<interner::Interner> = Lazy::new(interner::Interner::new);
+static QUOTING_REGEX: Lazy<Regex> = Lazy::new(|| Regex::new("^_?[a-zA-Z][_a-zA-Z0-9-]*$").unwrap());
 
 #[derive(Clone, Copy, Deserialize, Serialize)]
 #[serde(into = "String", from = "String")]
@@ -56,9 +57,8 @@ impl Ident {
     /// label isn't a valid identifier according to the parser, for example if it contains a
     /// special character like a space.
     pub fn label_quoted(&self) -> String {
-        let reg = Regex::new("^_?[a-zA-Z][_a-zA-Z0-9-]*$").unwrap();
         let label = self.label();
-        if reg.is_match(label) && !KEYWORDS.contains(&label) {
+        if QUOTING_REGEX.is_match(label) && !KEYWORDS.contains(&label) {
             String::from(label)
         } else {
             format!("\"{label}\"")


### PR DESCRIPTION
As observed by @jneem we were constantly recompiling the regular expression determining whether quoting an identifier is necessary. This change improves the pretty printer performance on a non-synthetic example by a factor of 3.