### PR TITLE
Fix LSP panic on requesting doc symbols from VSCode

### DIFF
--- a/lsp/nls/src/requests/symbols.rs
+++ b/lsp/nls/src/requests/symbols.rs
@@ -26,8 +26,11 @@ pub fn handle_document_symbols(
             .iter()
             .filter_map(|item| match &item.kind {
                 TermKind::Declaration { id: name, .. } => {
-                    // TODO: can `unwrap` fail here?
-                    let (file_id, span) = item.pos.unwrap().to_range();
+                    // Although the position maybe shouldn't be `None`, opening the std library
+                    // source inside VSCode made the LSP panic on the previous `item.pos.unwrap()`.
+                    // Before investigating further, let's not make the VSCode extension panic in
+                    // the meantime.
+                    let (file_id, span) = item.pos.into_opt()?.to_range();
 
                     let range =
                         codespan_lsp::byte_span_to_range(server.cache.files(), file_id, span)


### PR DESCRIPTION
When working on the VSCode extension, opening the std library from VSCode would trigger a request for document symbols, which made the LSP panic. It seems that, once more, an item that we assumed MUST have a position doesn't. While it's not clear if this is legit or not (for declaration items to be position-less), replacing the `unwrap()` by just ignoring items without a position at least doesn't crash the server in the meantime.

## TODO (after merging)

- [ ] Backport to `1.1.0-release`