### PR TITLE
Make the pretty printer parenthesise negative numbers

### DIFF
--- a/core/src/pretty.rs
+++ b/core/src/pretty.rs
@@ -695,13 +695,14 @@ where
                     op.pretty(allocator)
                         .append(allocator.space())
                         .append(allocator.atom(rtl))
+                        .append(allocator.line())
                 } else {
                     allocator
                         .atom(rtl)
                         .append(allocator.space())
                         .append(op.pretty(allocator))
+                        .append(allocator.line())
                 }
-                .append(allocator.line())
                 .append(allocator.atom(rtr))
                 .nest(2)
             }

--- a/core/src/term/mod.rs
+++ b/core/src/term/mod.rs
@@ -814,7 +814,6 @@ impl Term {
         match self {
             Term::Null
             | Term::Bool(..)
-            | Term::Num(..)
             | Term::Str(..)
             | Term::StrChunks(..)
             | Term::Lbl(..)
@@ -834,7 +833,9 @@ impl Term {
             // We might want a more robust mechanism for pretty printing such operators.
             | Term::Op1(UnaryOp::BoolAnd(), _)
             | Term::Op1(UnaryOp::BoolOr(), _) => true,
+            Term::Num(n) if *n >= 0 => true,
             Term::Let(..)
+            | Term::Num(..)
             | Term::Match { .. }
             | Term::LetPattern(..)
             | Term::Fun(..)

--- a/core/tests/integration/pretty.rs
+++ b/core/tests/integration/pretty.rs
@@ -1,6 +1,9 @@
-use nickel_lang_core::pretty::*;
-use nickel_lang_core::term::{RichTerm, StrChunk, Term};
-use nickel_lang_utils::{project_root::project_root, test_program::parse};
+use nickel_lang_core::term::{make, RichTerm, StrChunk, Term, UnaryOp};
+use nickel_lang_core::{mk_app, pretty::*};
+use nickel_lang_utils::{
+    project_root::project_root,
+    test_program::{eval, parse},
+};
 
 use pretty::BoxAllocator;
 use std::io::{Cursor, Read};
@@ -69,4 +72,13 @@ fn str_vs_strchunks() {
         pretty(&Term::Str("string".into()).into()),
         pretty(&Term::StrChunks(vec![StrChunk::Literal("string".to_string())]).into())
     );
+}
+
+#[test]
+fn negative_numbers() {
+    eval(pretty(&mk_app!(
+        Term::Op1(UnaryOp::StaticAccess("is_number".into()), make::var("std")),
+        Term::Num((-5).into())
+    )))
+    .unwrap();
 }


### PR DESCRIPTION
Have the pretty printer consider a `Term::Num(n)` an atom only if `n` is positive. This code path is pretty tricky to hit, since a unary minus gets changed into subtraction from `0` during parsing and while evaluation can of course lead to negative numbers appearing in `Term::Num`, the result typically doesn't require parentheses. However, it is very easy to hit this path when trying to use the pretty printer for Nickel code generation.