### PR TITLE
manual docs: fix mismatch between input command and its echo in the output

### DIFF
--- a/doc/manual/merging.md
+++ b/doc/manual/merging.md
@@ -322,7 +322,7 @@ nickel> {foo = 1, bar | optional} & {bar}
 error: missing definition for `bar`
   ┌─ repl-input-4:1:1
   │
-1 │ {foo = 1, bar | optional} & {bar, baz = bar + 1}
+1 │ {foo = 1, bar | optional} & {bar}
   │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   │ │         │
   │ │         defined here

--- a/doc/manual/merging.md
+++ b/doc/manual/merging.md
@@ -320,12 +320,12 @@ nickel> {foo = 1, bar | optional} & {bar | optional}
 
 nickel> {foo = 1, bar | optional} & {bar}
 error: missing definition for `bar`
-  ┌─ repl-input-4:1:1
+  ┌─ repl-input-0:1:11
   │
 1 │ {foo = 1, bar | optional} & {bar}
-  │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  │ ----------^^^--------------------
   │ │         │
-  │ │         defined here
+  │ │         required here
   │ in this record
 ```
 


### PR DESCRIPTION
Hey, I noticed a little typo while browsing the manual.