### PR TITLE
Format benches as well using Topiary

### DIFF
--- a/core/benches/arrays/fold.ncl
+++ b/core/benches/arrays/fold.ncl
@@ -1,7 +1,7 @@
 let letter | Number -> std.string.Character = fun n =>
-  let letters = std.string.characters "abcdefghijklmnopqrstuvwxyz" in
-  std.array.at (n % 26) letters
-in
+    let letters = std.string.characters "abcdefghijklmnopqrstuvwxyz" in
+    std.array.at (n % 26) letters
+  in
 
 {
   right = {
@@ -11,7 +11,7 @@ in
     },
     nums = {
       run = fun n =>
-        std.array.fold_right (fun x acc => x*acc + (x - acc)) 0 (std.array.generate (fun n => n/2) n)
+        std.array.fold_right (fun x acc => x * acc + (x - acc)) 0 (std.array.generate (fun n => n / 2) n)
     },
     arrays = {
       run = fun n =>
@@ -25,7 +25,7 @@ in
     },
     nums = {
       run = fun n =>
-        std.array.fold_left (fun acc x => x*acc + (x - acc)) 0 (std.array.generate (fun n => n/2) n)
+        std.array.fold_left (fun acc x => x * acc + (x - acc)) 0 (std.array.generate (fun n => n / 2) n)
     },
     arrays = {
       run = fun n =>

--- a/core/benches/arrays/generate.ncl
+++ b/core/benches/arrays/generate.ncl
@@ -1,16 +1,20 @@
-let g = fun n => n*2 + 5 in
+let g = fun n => n * 2 + 5 in
 {
   unchecked = {
     generate = fun n g =>
-      if n == 0 then []
-      else generate (n - 1) g @ [g n],
+      if n == 0 then
+        []
+      else
+        generate (n - 1) g @ [g n],
 
     run = fun n => generate n g,
   },
   checked = {
     generate_with_contract | forall a. Number -> (Number -> a) -> Array a = fun n g =>
-      if n == 0 then []
-      else generate_with_contract (n - 1) g @ [g n],
+        if n == 0 then
+          []
+        else
+          generate_with_contract (n - 1) g @ [g n],
 
     run = fun n =>
       generate_with_contract n g,

--- a/core/benches/arrays/pipe.ncl
+++ b/core/benches/arrays/pipe.ncl
@@ -1,8 +1,8 @@
 {
   run = fun n =>
-    std.array.generate (fun n => n*n) n
+    std.array.generate (fun n => n * n) n
     |> std.array.filter (fun n => n % 2 == 0)
-    |> std.array.map (fun n => [n, n+1])
+    |> std.array.map (fun n => [n, n + 1])
     |> std.array.flatten
     |> std.array.partition (fun n => n % 2 == 0)
 }

--- a/core/benches/arrays/primes.ncl
+++ b/core/benches/arrays/primes.ncl
@@ -2,35 +2,39 @@ let range
   | doc "Generate an array of integers in the range [`start`, `end`)."
   | Number -> Number -> Array Number
   = fun start end =>
-    if end <= start then 
+    if end <= start then
       []
     else
-      std.array.generate (fun x => x + start) (end - start) 
-in
+      std.array.generate (fun x => x + start) (end - start)
+  in
 
-let is_prime 
-  | doc "Returns true if the argument is a prime number."
+let is_prime | doc "Returns true if the argument is a prime number."
   = fun x => x > 1 && std.array.all (fun d => x % d != 0) (range 2 (x - 1))
-in
+  in
 
 let Prime = std.contract.from_predicate is_prime in
 
-let primes 
+let primes
   | doc "Generate `max` primes using Sieve of Eratosthenes."
   | Number -> Array Prime
   = fun max =>
     let limit = std.number.pow max (1 / 2) in # sqrt(max)
-    let drop_multiples = fun x xs => 
-      let to_drop = max
+    let drop_multiples = fun x xs =>
+      let to_drop =
+        max
         |> std.array.generate (fun y => (y + 2) * x)
-        |> std.array.filter (fun y => y <= max) in
-      std.array.filter (fun y => std.array.all ((!=) y) to_drop) xs in
+        |> std.array.filter (fun y => y <= max)
+      in
+      std.array.filter (fun y => std.array.all ((!=) y) to_drop) xs
+    in
     let rec loop = fun x xs =>
       if x > limit then
         xs
       else
-        loop (x + 1) (drop_multiples x xs) in
-    loop 2 (range 2 max) in
+        loop (x + 1) (drop_multiples x xs)
+    in
+    loop 2 (range 2 max)
+  in
 
 {
   run = primes

--- a/core/benches/arrays/random.ncl
+++ b/core/benches/arrays/random.ncl
@@ -1,6 +1,6 @@
-let mgc 
-  | doc "A multiplicative congruential pseudorandom number generator (MCG)."
-  = fun params x => (params.a * x + params.c) % params.m in
+let mgc | doc "A multiplicative congruential pseudorandom number generator (MCG)."
+  = fun params x => (params.a * x + params.c) % params.m
+  in
 
 # NOTE: These parameters are from "Table 7: Good multipliers for MCGs with m = 2^32"
 # of the 2021 paper "Computationally Easy, Spectrally Good Multipliers for
@@ -12,11 +12,11 @@ let mgc
 let params = { m = std.number.pow 2 32, a = 1664525, c = 1013904223 } in
 
 let rec array_random = fun init n =>
-  if n == 0 then [init]
-  else 
+  if n == 0 then
+    [init]
+  else
     let next = mgc params init in
     [next] @ array_random next (n - 1)
 in
 
 { run = array_random 42 }
-

--- a/core/benches/arrays/sort.ncl
+++ b/core/benches/arrays/sort.ncl
@@ -1,7 +1,10 @@
-let ascending = fun x y => 
-  if x < y then 'Lesser 
-  else if x == y then 'Equal 
-  else 'Greater 
+let ascending = fun x y =>
+  if x < y then
+    'Lesser
+  else if x == y then
+    'Equal
+  else
+    'Greater
 in
 
 { run = std.array.sort ascending }

--- a/core/benches/arrays/sum.ncl
+++ b/core/benches/arrays/sum.ncl
@@ -1,8 +1,10 @@
-let rec sum
-  | Array Number -> Number 
+let rec sum | Array Number -> Number
   = fun xs =>
-    if std.array.length xs == 0 then 0
-    else std.array.first xs + sum (std.array.drop_first xs)
-in {
+    if std.array.length xs == 0 then
+      0
+    else
+      std.array.first xs + sum (std.array.drop_first xs)
+  in
+{
   run = fun n => std.array.generate (fun x => x + 1) n |> sum
 }

--- a/core/benches/functions/church.ncl
+++ b/core/benches/functions/church.ncl
@@ -19,14 +19,19 @@
     let encoded =
       base
       |> std.array.map encode
-      |> std.array.map (fun nChurch =>
-        add (mult (encode 3) nChurch) (encode 5))
-      |> std.array.fold_right add (encode 0) in
+      |> std.array.map
+        (
+          fun nChurch =>
+            add (mult (encode 3) nChurch) (encode 5)
+        )
+      |> std.array.fold_right add (encode 0)
+    in
 
     let decoded =
       base
-      |> std.array.map (fun n => 3*n + 5)
-      |> std.array.fold_left (fun acc n => acc + n) 0 in
+      |> std.array.map (fun n => 3 * n + 5)
+      |> std.array.fold_left (fun acc n => acc + n) 0
+    in
 
     decode encoded == decoded,
 }

--- a/core/benches/mantis/deploy.ncl
+++ b/core/benches/mantis/deploy.ncl
@@ -49,7 +49,7 @@ fun vars =>
           ]
       )
       | default
-      = [ "eu-central-1", "us-east-2" ],
+      = ["eu-central-1", "us-east-2"],
     fqdn = "mantis.ws",
     networkConfig
       | String

--- a/core/benches/mantis/jobs/mantis.ncl
+++ b/core/benches/mantis/jobs/mantis.ncl
@@ -19,7 +19,7 @@ let Params = {
   fqdn | String,
   loggers | { _ : String },
   network
-    | lib.contracts.OneOf [ "testnet-internal-nomad", "etc" ]
+    | lib.contracts.OneOf ["testnet-internal-nomad", "etc"]
     | default
     = "testnet-internal-nomad",
   networkConfig | String,
@@ -326,7 +326,7 @@ params.role}.rule=Host(`%{params.namespace}-%{std.string.from_enum params.role}.
           "%{params.namespace}-mantis-%{std.string.from_enum params.role}-server" = {
             address_mode = 'host,
             port = "server",
-            tags = [ "ingress", "server" ] @ baseTags,
+            tags = ["ingress", "server"] @ baseTags,
             meta = {
               Name = "mantis-${NOMAD_ALLOC_INDEX}",
               PublicIp = "${attr.unique.platform.aws.public-ipv4}",

--- a/core/benches/mantis/schemas/nomad/types.ncl
+++ b/core/benches/mantis/schemas/nomad/types.ncl
@@ -150,12 +150,12 @@ in
       Attempts | std.number.Nat,
       Interval | std.number.Nat,
       Delay | std.number.Nat,
-      Mode | (lib.contracts.OneOf [ "delay", "fail" ]),
+      Mode | (lib.contracts.OneOf ["delay", "fail"]),
     },
 
     Volume = {
       Name | String,
-      Type | (lib.contracts.OneOf [ null, "host", "csi" ]),
+      Type | (lib.contracts.OneOf [ null, "host", "csi"]),
       Source | String,
       ReadOnly
         | Bool
@@ -781,11 +781,13 @@ in
                     }
                   in
                   {
-                    Networks = [{
-                      Mode = tg.network.mode,
-                      ReservedPorts = std.array.map mkPort ports.right,
-                      DynamicPorts = std.array.map mkPort ports.wrong,
-                    }]
+                    Networks = [
+                      {
+                        Mode = tg.network.mode,
+                        ReservedPorts = std.array.map mkPort ports.right,
+                        DynamicPorts = std.array.map mkPort ports.wrong,
+                      }
+                    ]
                   }
                 else
                   {}
@@ -1404,7 +1406,7 @@ in
         | default
         = null,
       initial_status
-        | (lib.contracts.OneOf [ "passing", "warning", "critical", "" ])
+        | (lib.contracts.OneOf ["passing", "warning", "critical", ""])
         | default
         = "",
       success_before_passing

--- a/core/benches/mantis/tasks/promtail.ncl
+++ b/core/benches/mantis/tasks/promtail.ncl
@@ -11,7 +11,7 @@ types.stanza.task
   config = {
     flake = "github:input-output-hk/mantis-ops/cue#grafana-loki",
     command = "/bin/promtail",
-    args = [ "-config.file", "local/config.yaml" ],
+    args = ["-config.file", "local/config.yaml"],
   },
 
   template."local/config.yaml".data =
@@ -24,27 +24,31 @@ types.stanza.task
         },
         positions.filename = "/local/positions.yaml",
         client.url = "http://172.16.0.20:3100/loki/api/v1/push",
-        scrape_configs = [{
-          job_name = "{{ env \"NOMAD_JOB_NAME\" }}-{{ env \"NOMAD_ALLOC_INDEX\"
+        scrape_configs = [
+          {
+            job_name = "{{ env \"NOMAD_JOB_NAME\" }}-{{ env \"NOMAD_ALLOC_INDEX\"
 }}",
-          pipeline_stages = null,
-          static_configs = [{
-            labels = {
-              nomad_alloc_id = "{{ env \"NOMAD_ALLOC_ID\" }}",
-              nomad_alloc_index = "{{ env \"NOMAD_ALLOC_INDEX\" }}",
-              nomad_alloc_name = "{{ env \"NOMAD_ALLOC_NAME\" }}",
-              nomad_dc = "{{ env \"NOMAD_DC\" }}",
-              nomad_group_name = "{{ env \"NOMAD_GROUP_NAME\" }}",
-              nomad_job_id = "{{ env \"NOMAD_JOB_ID\" }}",
-              nomad_job_name = "{{ env \"NOMAD_JOB_NAME\" }}",
-              nomad_job_parent_id = "{{ env \"NOMAD_JOB_PARENT_ID\" }}",
-              nomad_namespace = "{{ env \"NOMAD_NAMESPACE\" }}",
-              nomad_region = "{{ env \"NOMAD_REGION\" }}",
-              # This is currently always "promtail", so this label wouldn't be of any use
-              # nomad_task_name:     "{{ env \"NOMAD_TASK_NAME\" }}"
-              "__path__" = "/alloc/logs/*.std*.[0-9]*",
-            }
-          }]
-        }]
+            pipeline_stages = null,
+            static_configs = [
+              {
+                labels = {
+                  nomad_alloc_id = "{{ env \"NOMAD_ALLOC_ID\" }}",
+                  nomad_alloc_index = "{{ env \"NOMAD_ALLOC_INDEX\" }}",
+                  nomad_alloc_name = "{{ env \"NOMAD_ALLOC_NAME\" }}",
+                  nomad_dc = "{{ env \"NOMAD_DC\" }}",
+                  nomad_group_name = "{{ env \"NOMAD_GROUP_NAME\" }}",
+                  nomad_job_id = "{{ env \"NOMAD_JOB_ID\" }}",
+                  nomad_job_name = "{{ env \"NOMAD_JOB_NAME\" }}",
+                  nomad_job_parent_id = "{{ env \"NOMAD_JOB_PARENT_ID\" }}",
+                  nomad_namespace = "{{ env \"NOMAD_NAMESPACE\" }}",
+                  nomad_region = "{{ env \"NOMAD_REGION\" }}",
+                  # This is currently always "promtail", so this label wouldn't be of any use
+                  # nomad_task_name:     "{{ env \"NOMAD_TASK_NAME\" }}"
+                  "__path__" = "/alloc/logs/*.std*.[0-9]*",
+                }
+              }
+            ]
+          }
+        ]
       }
 }

--- a/core/benches/mantis/tasks/telegraf.ncl
+++ b/core/benches/mantis/tasks/telegraf.ncl
@@ -21,7 +21,7 @@ let types = import "../schemas/nomad/types.ncl" in
   config = {
     flake = "github:NixOS/nixpkgs/nixos-21.05#telegraf",
     command = "/bin/telegraf",
-    args = [ "-config", "/local/telegraf.config" ],
+    args = ["-config", "/local/telegraf.config"],
   },
 
   template."local/telegraf.config" = {

--- a/core/benches/nixpkgs/lists.ncl
+++ b/core/benches/nixpkgs/lists.ncl
@@ -1,8 +1,8 @@
 # General list operations.
-
 {
-  singleton: forall a. a -> (Array a)
-  | doc m%"
+  singleton
+    : forall a. a -> (Array a)
+    | doc m%"
       Create a list consisting of a single element.  `singleton x` is
       sometimes more convenient with respect to indentation than `[x]`
       when x spans multiple lines.
@@ -13,8 +13,9 @@
     "%
     = fun x => [x],
 
-  forEach: forall a b. (Array a) -> (a -> b) -> (Array b)
-  | doc m%"
+  forEach
+    : forall a b. (Array a) -> (a -> b) -> (Array b)
+    | doc m%"
       Apply the function to each element in the list. Same as `map`, but arguments
       flipped.
 
@@ -24,10 +25,11 @@
         )
         >> [ "1" "2" ]
     "%
-  = fun xs f => std.array.map f xs,
+    = fun xs f => std.array.map f xs,
 
-  foldr: forall a b. (a -> b -> b) -> b -> (Array a) -> b
-  | doc m%"
+  foldr
+    : forall a b. (a -> b -> b) -> b -> (Array a) -> b
+    | doc m%"
       “right fold” a binary function `op` between successive elements of
      `list` with `nul' as the starting value, i.e.,
      `foldr op nul [x_1 x_2 ... x_n] == op x_1 (op x_2 ... (op x_n nul))`.
@@ -41,23 +43,25 @@
        strange [ 1 2 3 4 ]
        => "2345a"
   "%
-  = fun op nul list =>
-    let len = std.array.length list in
-    let rec fold_ = fun n =>
-        if n == len
-        then nul
-        else op (std.array.at n list) (fold_ (n + 1))
-    in fold_ 0,
+    = fun op nul list =>
+      let len = std.array.length list in
+      let rec fold_ = fun n =>
+        if n == len then
+          nul
+        else
+          op (std.array.at n list) (fold_ (n + 1))
+      in fold_ 0,
 
-  fold: forall a b. (a -> b -> b) -> b -> (Array a) -> b
-  | doc m%"
+  fold
+    : forall a b. (a -> b -> b) -> b -> (Array a) -> b
+    | doc m%"
       `fold` is an alias of `foldr` for historic reasons "%
-  # FIXME(Profpatsch): deprecate?
-  = foldr,
+    # FIXME(Profpatsch): deprecate?
+    = foldr,
 
-
-  foldl: forall a b. (b -> a -> b) -> b -> (Array a) -> b
-  | doc m%"
+  foldl
+    : forall a b. (b -> a -> b) -> b -> (Array a) -> b
+    | doc m%"
       “left fold”, like `foldr`, but from the left:
      `foldl op nul [x_1 x_2 ... x_n] == op (... (op (op nul x_1) x_2) ... x_n)`.
 
@@ -70,55 +74,61 @@
        lstrange [ 1 2 3 4 ]
        => "a2345"
   "%
-  = fun op nul list =>
-    let rec foldl_ = fun n =>
-        if n == -1
-        then nul
-        else op (foldl_ (n - 1)) (std.array.at n list)
-    in foldl_ (std.array.length list - 1),
+    = fun op nul list =>
+      let rec foldl_ = fun n =>
+        if n == -1 then
+          nul
+        else
+          op (foldl_ (n - 1)) (std.array.at n list)
+      in foldl_ (std.array.length list - 1),
 
-  foldl_: forall a b. (b -> a -> b) -> b -> (Array a) -> b
-  | doc m%"
+  foldl_
+    : forall a b. (b -> a -> b) -> b -> (Array a) -> b
+    | doc m%"
       Strict version of `foldl`.
 
      The difference is that evaluation is forced upon access. Usually used
      with small whole results (in contrast with lazily-generated list or large
      lists where only a part is consumed.)
   "%
-  = fun op nul list => std.array.fold_left op nul list,
+    = fun op nul list => std.array.fold_left op nul list,
 
-  imap0: forall a b. (Number -> a -> b) -> (Array a) -> (Array b)
-  | doc m%%"
+  imap0
+    : forall a b. (Number -> a -> b) -> (Array a) -> (Array b)
+    | doc m%%"
       Map with index starting from 0
 
      Example:
        imap0 (fun i v => "%{v}-%{%to_string% i}") ["a", "b"]
        >> [ "a-0", "b-1" ]
   "%%
-  = fun f list => std.array.generate (fun n => f n (std.array.at n list)) (std.array.length list),
+    = fun f list => std.array.generate (fun n => f n (std.array.at n list)) (std.array.length list),
 
-  imap1: forall a b. (Number -> a -> b) -> (Array a) -> (Array b)
-  | doc m%%"
+  imap1
+    : forall a b. (Number -> a -> b) -> (Array a) -> (Array b)
+    | doc m%%"
       Map with index starting from 1
 
      Example:
        imap1 (fun i v => "%{v}-%{toString i}") ["a", "b"]
        >> [ "a-1", "b-2" ]
   "%%
-  = fun f list => std.array.generate (fun n => f (n + 1) (std.array.at n list)) (std.array.length list),
+    = fun f list => std.array.generate (fun n => f (n + 1) (std.array.at n list)) (std.array.length list),
 
-  concatMap: forall a b. (a -> (Array b)) -> (Array a) -> (Array b)
-  | doc m%"
+  concatMap
+    : forall a b. (a -> (Array b)) -> (Array a) -> (Array b)
+    | doc m%"
       Map and concatenate the result.
 
      Example:
        concatMap (fun x => [x] @ ["z"]) ["a", "b"]
        >> [ "a", "z", "b", "z" ]
   "%
-  = (fun f list => std.array.flatten (std.array.map f list)),
+    = (fun f list => std.array.flatten (std.array.map f list)),
 
-  flatten: Dyn -> Array Dyn
-  | doc m%"
+  flatten
+    : Dyn -> Array Dyn
+    | doc m%"
       Flatten the argument into a single list, that is, nested lists are
      spliced into the top-level lists.
 
@@ -128,24 +138,27 @@
        flatten 1
        >> [1]
   "%
-  = fun x =>
-    if std.is_array x
-    then concatMap (fun y => flatten y) (x | Array Dyn)
-    else [x],
+    = fun x =>
+      if std.is_array x then
+        concatMap (fun y => flatten y) (x | Array Dyn)
+      else
+        [x],
 
-  remove: forall a. a -> Array a -> Array a
-  | doc m%"
+  remove
+    : forall a. a -> Array a -> Array a
+    | doc m%"
       Remove elements equal to 'e' from a list.  Useful for buildInputs.
 
      Example:
        remove 3 [ 1, 3, 4, 3 ]
        >> [ 1, 4 ]
   "%
-  = # Element to remove from the list
-    fun e => std.array.filter ((!=) e),
+    = # Element to remove from the list
+      fun e => std.array.filter ((!=) e),
 
-  findSingle: forall a. (a -> Bool) -> a -> a -> Array a -> a
-  | doc m%"
+  findSingle
+    : forall a. (a -> Bool) -> a -> a -> Array a -> a
+    | doc m%"
       Find the sole element in the list matching the specified
      predicate, returns `default` if no such element exists, or
      `multiple` if there are multiple matching elements.
@@ -158,7 +171,7 @@
        findSingle (fun x => x == 3) "none" "multiple" [ 1, 9 ]
        >> "none"
   "%
-  = fun
+    = fun
     # Predicate
     pred
     # Default value to return if element was not found.
@@ -166,15 +179,19 @@
     # Default value to return if more than one element was found
     multiple
     # Input list
-    list
-    => let found = std.array.filter pred list in
-       let len = std.array.length found in
-       if len == 0 then def
-       else if len != 1 then multiple
-       else std.array.first found,
+    list =>
+      let found = std.array.filter pred list in
+      let len = std.array.length found in
+      if len == 0 then
+        def
+      else if len != 1 then
+        multiple
+      else
+        std.array.first found,
 
-  findFirst: forall a. (a -> Bool) -> a -> Array a -> a
-  | doc m%"
+  findFirst
+    : forall a. (a -> Bool) -> a -> Array a -> a
+    | doc m%"
       Find the first element in the list matching the specified
      predicate or return `default` if no such element exists.
 
@@ -184,18 +201,19 @@
        findFirst (fun x => x > 9) 7 [ 1, 6, 4 ]
        >> 7
   "%
-  = fun
+    = fun
     # Predicate
     pred
     # Default value to return
     def
     # Input list
-    list
-    => let found = std.array.filter pred list in
-       if found == [] then def else std.array.first found,
+    list =>
+      let found = std.array.filter pred list in
+      if found == [] then def else std.array.first found,
 
-  any: forall a. (a -> Bool) -> Array a -> Bool
-  | doc m%"
+  any
+    : forall a. (a -> Bool) -> Array a -> Bool
+    | doc m%"
       Return true if function `pred` returns true for at least one
      element of `list`.
 
@@ -205,10 +223,11 @@
        any builtin.is_string [ 1, { } ]
        >> false
   "%
-  = fun pred => foldr (fun x y => if pred x then true else y) false,
+    = fun pred => foldr (fun x y => if pred x then true else y) false,
 
-  all: forall a. (a -> Bool) -> Array a -> Bool
-  | doc m%"
+  all
+    : forall a. (a -> Bool) -> Array a -> Bool
+    | doc m%"
       Return true if function `pred` returns true for all elements of
      `list`.
 
@@ -218,10 +237,11 @@
        all (fun x => x < 3) [ 1, 2, 3 ]
        >> false
   "%
-  = fun pred => foldr (fun x y => if pred x then y else false) true,
+    = fun pred => foldr (fun x y => if pred x then y else false) true,
 
-  count: forall a. (a -> Bool) -> Array a -> Number
-  | doc m%"
+  count
+    : forall a. (a -> Bool) -> Array a -> Number
+    | doc m%"
       Count how many elements of `list` match the supplied predicate
      function.
 
@@ -229,12 +249,13 @@
        count (fun x => x == 3) [ 3, 2, 3, 4, 6 ]
        >> 2
   "%
-  = fun
+    = fun
     # Predicate
     pred => foldl_ (fun c x => if pred x then c + 1 else c) 0,
 
-  optional': forall a. Bool -> a -> Array a
-  | doc m%"
+  optional'
+    : forall a. Bool -> a -> Array a
+    | doc m%"
       Return a singleton list or an empty list, depending on a boolean
      value.  Useful when building lists with optional elements
      (e.g. `++ optional' (system == "i686-linux") firefox').
@@ -245,10 +266,11 @@
        optional' false "foo"
        >> [ ]
   "%
-  = fun cond elem => if cond then [elem] else [],
+    = fun cond elem => if cond then [elem] else [],
 
-  optionals: forall a. Bool -> Array a -> Array a
-  | doc m%"
+  optionals
+    : forall a. Bool -> Array a -> Array a
+    | doc m%"
       Return a list or an empty list, depending on a boolean value.
 
      Example:
@@ -257,16 +279,15 @@
        optionals false [ 2, 3 ]
        >> [ ]
   "%
-  = fun
+    = fun
     # Condition
     cond
     # List to return if condition is true
-    elems
-    => if cond then elems else [],
+    elems => if cond then elems else [],
 
-
-  toList: Dyn -> Array Dyn
-  | doc m%"
+  toList
+    : Dyn -> Array Dyn
+    | doc m%"
       If argument is a list, return it, else, wrap it in a singleton
      list.  If you're using this, you should almost certainly
      reconsider if there isn't a more "well-typed" approach.
@@ -277,10 +298,11 @@
        toList "hi"
        >> [ "hi "]
   "%
-  = fun x => if std.is_array x then (x | Array Dyn) else [x],
+    = fun x => if std.is_array x then (x | Array Dyn) else [x],
 
-  range: Number -> Number -> Array Number
-  | doc m%"
+  range
+    : Number -> Number -> Array Number
+    | doc m%"
       Return a list of integers from `first' up to and including `last'.
 
      Example:
@@ -289,18 +311,19 @@
        range 3 2
        >> [ ]
   "%
-  = fun
+    = fun
     # First integer in the range
     first
     # Last integer in the range
-    last
-    => if first > last then
-      []
-    else
-      std.array.generate (fun n => first + n) (last - first + 1),
+    last =>
+      if first > last then
+        []
+      else
+        std.array.generate (fun n => first + n) (last - first + 1),
 
-  partition: forall a. (a -> Bool) -> Array a -> { right : Array a, wrong : Array a }
-  | doc m%"
+  partition
+    : forall a. (a -> Bool) -> Array a -> { right : Array a, wrong : Array a }
+    | doc m%"
       Splits the elements of a list in two lists, `right` and
      `wrong`, depending on the evaluation of a predicate.
 
@@ -308,16 +331,21 @@
        partition (fun x => x > 2) [ 5, 1, 2, 3, 4 ]
        >> { right = [ 5, 3, 4 ], wrong = [ 1, 2 ] }
   "%
-  = fun pred =>
-    foldr (fun h t =>
-      if pred h
-      then { right = [h] @ t.right, wrong = t.wrong }
-      else { right = t.right, wrong = [h] @ t.wrong }
-    ) { right = [], wrong = [] },
+    = fun pred =>
+      foldr
+        (
+          fun h t =>
+            if pred h then
+              { right = [h] @ t.right, wrong = t.wrong }
+            else
+              { right = t.right, wrong = [h] @ t.wrong }
+        )
+        { right = [], wrong = [] },
 
   # can not be staticaly checked (see issue #423)
-  groupBy | forall a. (a -> String) -> Array a -> { _: Array a}
-  | doc m%"
+  groupBy
+    | forall a. (a -> String) -> Array a -> { _ : Array a }
+    | doc m%"
      Splits the elements of a list into many lists, using the return value of a predicate.
      Predicate should return a string which becomes keys of attrset `groupBy' returns.
 
@@ -335,23 +363,29 @@
             xfce  = [ { name = "xfce",  script = "xfce4-session &" } ],
           }
   "%
-  = fun pred => foldl_ (fun r e =>
-       let key = pred e in
-         { "%{key}" = (r."%{key}" @ [e]) } & (std.record.remove key r)
-    ) {},
+    = fun pred =>
+      foldl_
+        (
+          fun r e =>
+            let key = pred e in
+            { "%{key}" = (r."%{key}" @ [e]) } & (std.record.remove key r)
+        )
+        {},
 
-  groupBy_ : forall a b. (b -> a -> b) ->  b -> (a -> String) -> Array a -> { _: b}
-  | doc m%"
+  groupBy_
+    : forall a b. (b -> a -> b) -> b -> (a -> String) -> Array a -> { _ : b }
+    | doc m%"
      as `groupBy` and allows to customise the combining function and initial value
 
      Example:
        groupBy_ builtins.add 0 (fun x => boolToString (x > 2)) [ 5, 1, 2, 3, 4 ]
        >> { true = 12, false = 3 }
   "%
-  = fun op nul pred lst => std.record.map (fun name value => foldl op nul value) (groupBy pred lst),
+    = fun op nul pred lst => std.record.map (fun name value => foldl op nul value) (groupBy pred lst),
 
-  zipListsWith: forall a b c. (a -> b -> c) -> Array a -> Array b -> Array c
-  | doc m%"
+  zipListsWith
+    : forall a b c. (a -> b -> c) -> Array a -> Array b -> Array c
+    | doc m%"
       Merges two lists of the same size together. If the sizes aren't the same
      the merging stops at the shortest. How both lists are merged is defined
      by the first argument.
@@ -360,17 +394,17 @@
        zipListsWith (fun a b => a @@ b) ["h", "l"] ["e", "o"]
        >> ["he", "lo"]
   "%
-  = fun
+    = fun
     # Function to zip elements of both lists
     f
     # First list
     fst
     # Second list
-    snd
-    => std.array.generate (fun n => f (std.array.at n fst) (std.array.at n snd)) (std.number.min (std.array.length fst) (std.array.length snd)),
+    snd => std.array.generate (fun n => f (std.array.at n fst) (std.array.at n snd)) (std.number.min (std.array.length fst) (std.array.length snd)),
 
-  zipLists: forall a b. Array a -> Array b -> Array { fst: a, snd: b}
-  | doc m%"
+  zipLists
+    : forall a b. Array a -> Array b -> Array { fst : a, snd : b }
+    | doc m%"
       Merges two lists of the same size together. If the sizes aren't the same
      the merging stops at the shortest.
 
@@ -378,23 +412,25 @@
        zipLists [ 1, 2 ] [ "a", "b" ]
        >> [ { fst = 1, snd = "a" }, { fst = 2, snd = "b" } ]
   "%
-  = zipListsWith (fun fst snd => { fst = fst, snd = snd }),
+    = zipListsWith (fun fst snd => { fst = fst, snd = snd }),
 
-  reverseList: forall a. Array a -> Array a
-  | doc m%"
+  reverseList
+    : forall a. Array a -> Array a
+    | doc m%"
       Reverse the order of the elements of a list.
 
      Example:
        reverseList [ "b", "o", "j" ]
        >> [ "j", "o", "b" ]
   "%
-  = fun xs =>
-    let l = std.array.length xs in
-    std.array.generate (fun n => std.array.at (l - n - 1) xs) l,
+    = fun xs =>
+      let l = std.array.length xs in
+      std.array.generate (fun n => std.array.at (l - n - 1) xs) l,
 
   #TODO: is there a way to type statically?
-  listDfs |  forall a. Bool -> (a -> a -> Bool) -> Array a -> {visited: Array a, rest: Array a ; Dyn}
-  | doc m%"
+  listDfs
+    | forall a. Bool -> (a -> a -> Bool) -> Array a -> { visited : Array a, rest : Array a; Dyn }
+    | doc m%"
       Depth-First Search (DFS) for lists `list != []`.
 
      `before a b == true` means that `b` depends on `a` (there's an
@@ -414,24 +450,29 @@
                 rest    = [ "/home" "other" ],  # everything else
 
    "%
-  = fun stopOnCycles before list =>
-    let rec dfs_ = fun us visited_ rest_ =>
+    = fun stopOnCycles before list =>
+      let rec dfs_ = fun us visited_ rest_ =>
         let c = std.array.filter (fun x => before x us) visited_ in
         let b = partition (fun x => before x us) rest_ in
-        if stopOnCycles && (std.array.length c > 0)
-        then { cycle = us, loops = c, visited = visited_, rest = rest_ }
-        else if std.array.length b.right == 0
-        then # nothing is before us
+        if stopOnCycles && (std.array.length c > 0) then
+          { cycle = us, loops = c, visited = visited_, rest = rest_ }
+        else if std.array.length b.right == 0 then
+          # nothing is before us
           { minimal = us, visited = visited_, rest = rest_ }
-        else # grab the first one before us and continue
-          (dfs_ (std.array.first b.right)
-                ([ us ] @ visited_)
-                (std.array.drop_first b.right @ b.wrong)
-    ) in
-    dfs_ (std.array.first list) [] (std.array.drop_first list),
+        else
+          # grab the first one before us and continue
+          (
+            dfs_
+              (std.array.first b.right)
+              ([us] @ visited_)
+              (std.array.drop_first b.right @ b.wrong)
+          )
+      in
+      dfs_ (std.array.first list) [] (std.array.drop_first list),
 
-  toposort: forall a. (a -> a -> Bool) -> Array a -> {_: Array Dyn}
-  | doc m%"
+  toposort
+    : forall a. (a -> a -> Bool) -> Array a -> { _ : Array Dyn }
+    | doc m%"
       Sort a list based on a partial ordering using DFS. This
      implementation is O(N^2), if your ordering is linear, use `sort`
      instead.
@@ -453,36 +494,41 @@
 
          toposort (a: b: a < b) [ 3, 2, 1 ] == { result = [ 1, 2, 3 ], }
   "%
-  = fun before list =>
-    let dfsthis = listDfs true before list in
-    let toporest = toposort before (dfsthis.visited @ dfsthis.rest) in
+    = fun before list =>
+      let dfsthis = listDfs true before list in
+      let toporest = toposort before (dfsthis.visited @ dfsthis.rest) in
 
-    # The repeated `{_ : Array Dyn}` annotations are verbose, and due to
-    # the handling of dictionary types being cumbersome with the current
-    # typechecker.
-    #
-    # RFC004 is supposed to fix those kind of use-cases by introducing a limited
-    # form of subtyping.
-    if std.array.length list < 2
-      then # finish
-        { result| Array Dyn =  list, } : {_ : Array Dyn}
-    else if std.record.has_field "cycle" (dfsthis | {_: Dyn})
-      then # there's a cycle, starting from the current vertex, return it
-        { cycle = reverseList ([ (dfsthis | {cycle: Dyn}).cycle ] @ dfsthis.visited | Array Dyn),
-          loops = (dfsthis | {loops: Array Dyn}).loops, } : {_ : Array Dyn}
-    else if std.record.has_field "cycle" toporest
-      then # there's a cycle somewhere else in the graph, return it
-        toporest
-      # Slow, but short. Can be made a bit faster with an explicit stack.
-    else # there are no cycles
+      # The repeated `{_ : Array Dyn}` annotations are verbose, and due to
+      # the handling of dictionary types being cumbersome with the current
+      # typechecker.
+      #
+      # RFC004 is supposed to fix those kind of use-cases by introducing a limited
+      # form of subtyping.
+      if std.array.length list < 2 then
+        # finish
+        { result | Array Dyn = list, } : { _ : Array Dyn }
+      else if std.record.has_field "cycle" (dfsthis | { _ : Dyn }) then
+        # there's a cycle, starting from the current vertex, return it
         {
-          result = [ (dfsthis| {minimal:Dyn}).minimal ]
-                   @ (toporest | {result: Array Dyn}).result
-        } : {_: Array Dyn},
+          cycle = reverseList ([(dfsthis | { cycle : Dyn }).cycle] @ dfsthis.visited | Array Dyn),
+          loops = (dfsthis | { loops : Array Dyn }).loops,
+        } : { _ : Array Dyn }
+      else if std.record.has_field "cycle" toporest then
+        # there's a cycle somewhere else in the graph, return it
+        toporest
+        # Slow, but short. Can be made a bit faster with an explicit stack.
+      else
+        # there are no cycles
+        {
+          result =
+            [(dfsthis | { minimal : Dyn }).minimal]
+            @ (toporest | { result : Array Dyn }).result
+        } : { _ : Array Dyn },
 
   #TODO: can it be statically typed?
-  sort | forall a. (a -> a -> Bool) -> Array a -> Array a
-  | doc m%"
+  sort
+    | forall a. (a -> a -> Bool) -> Array a -> Array a
+    | doc m%"
       Sort a list based on a comparator function which compares two
      elements and returns true if the first argument is strictly below
      the second argument.  The returned list is sorted in an increasing
@@ -492,24 +538,30 @@
        sort (a: b: a < b) [ 5, 3, 7 ]
        >> [ 3, 5, 7 ]
   "%
-  = fun strictLess list =>
-    let len = std.array.length list in
-    let first = std.array.first list in
-    let rec pivot_ = (fun n acc@{ left=left_, right=right_ } =>
-      let el = std.array.at n list in
-      let next = pivot_ (n + 1) in
-      if n == len
-      then acc
-      else if strictLess first el
-      then next { left = left_, right = [ el ] @ right_ }
-      else next { left = [ el ] @ left_, right = right_ }
-    ) in
-    let pivot = pivot_ 1 { left = [], right = [] } in
-    if len < 2 then list
-    else (sort strictLess pivot.left) @ [ first ] @ (sort strictLess pivot.right),
+    = fun strictLess list =>
+      let len = std.array.length list in
+      let first = std.array.first list in
+      let rec pivot_ = (
+        fun n acc @ { left = left_, right = right_ } =>
+          let el = std.array.at n list in
+          let next = pivot_ (n + 1) in
+          if n == len then
+            acc
+          else if strictLess first el then
+            next { left = left_, right = [el] @ right_ }
+          else
+            next { left = [el] @ left_, right = right_ }
+      )
+      in
+      let pivot = pivot_ 1 { left = [], right = [] } in
+      if len < 2 then
+        list
+      else
+        (sort strictLess pivot.left) @ [first] @ (sort strictLess pivot.right),
 
-  compareLists: forall a. (a -> a -> Number) -> Array a -> Array a -> Number
-  | doc m%"
+  compareLists
+    : forall a. (a -> a -> Number) -> Array a -> Array a -> Number
+    | doc m%"
       Compare two lists element-by-element.
 
      Example:
@@ -522,41 +574,45 @@
        compareLists compare [ "a", "b" ] [ "a", "c" ]
        >> 1
   "%
-  = fun cmp a b =>
-    if a == []
-    then if b == []
-         then 0
-         else -1
-    else if b == []
-         then 1
-         else let rel = cmp (std.array.first a) (std.array.first b) in
-              if rel == 0
-              then compareLists cmp (std.array.drop_first a) (std.array.drop_first b)
-              else rel,
+    = fun cmp a b =>
+      if a == [] then
+        if b == [] then
+          0
+        else
+          -1
+      else if b == [] then
+        1
+      else
+        let rel = cmp (std.array.first a) (std.array.first b) in
+        if rel == 0 then
+          compareLists cmp (std.array.drop_first a) (std.array.drop_first b)
+        else
+          rel,
 
-# naturalSort: Array String -> Array String
-# | doc m%"
-#     Sort list using "Natural sorting".
-#    Numeric portions of strings are sorted in numeric order.
+  # naturalSort: Array String -> Array String
+  # | doc m%"
+  #     Sort list using "Natural sorting".
+  #    Numeric portions of strings are sorted in numeric order.
 
-#    Example:
-#      naturalSort ["disk11", "disk8", "disk100", "disk9"]
-#      >> ["disk8", "disk9", "disk11", "disk100"]
-#      naturalSort ["10.46.133.149", "10.5.16.62", "10.54.16.25"]
-#      >> ["10.5.16.62" "10.46.133.149" "10.54.16.25"]
-#      naturalSort ["v0.2", "v0.15", "v0.0.9"]
-#      >> [ "v0.0.9", "v0.2", "v0.15" ]
-# "%
-# # TODO: broken. how to implement it in nickel?
-# = fun lst =>
-#   let vectorise = fun s => std.array.map (fun x => if builtin.is_array x then (std.array.first x) | Number else x | Number) (std.string.split "(0|[1-9][0-9]*)" s) | Array Dyn
-#   in
-#     let prepared = std.array.map (fun x => [ (vectorise x), x ]) lst in # remember vectorised version for O(n) regex splits
-#     let less = fun a b => (compareLists compare (std.array.first a) (std.array.first b)) < 0 in
-#     std.array.map (fun x => std.array.at 1 x) (sort less prepared),
+  #    Example:
+  #      naturalSort ["disk11", "disk8", "disk100", "disk9"]
+  #      >> ["disk8", "disk9", "disk11", "disk100"]
+  #      naturalSort ["10.46.133.149", "10.5.16.62", "10.54.16.25"]
+  #      >> ["10.5.16.62" "10.46.133.149" "10.54.16.25"]
+  #      naturalSort ["v0.2", "v0.15", "v0.0.9"]
+  #      >> [ "v0.0.9", "v0.2", "v0.15" ]
+  # "%
+  # # TODO: broken. how to implement it in nickel?
+  # = fun lst =>
+  #   let vectorise = fun s => std.array.map (fun x => if builtin.is_array x then (std.array.first x) | Number else x | Number) (std.string.split "(0|[1-9][0-9]*)" s) | Array Dyn
+  #   in
+  #     let prepared = std.array.map (fun x => [ (vectorise x), x ]) lst in # remember vectorised version for O(n) regex splits
+  #     let less = fun a b => (compareLists compare (std.array.first a) (std.array.first b)) < 0 in
+  #     std.array.map (fun x => std.array.at 1 x) (sort less prepared),
 
-  take: forall a. Number -> Array a -> Array a
-  | doc m%"
+  take
+    : forall a. Number -> Array a -> Array a
+    | doc m%"
       Return the first (at most) N elements of a list.
 
 
@@ -566,12 +622,13 @@
        take 2 [ ]
        >> [ ]
   "%
-  = fun
+    = fun
     # Number of elements to take
     count => sublist 0 count,
 
-  drop: forall a. Number -> Array a -> Array a
-  | doc m%"
+  drop
+    : forall a. Number -> Array a -> Array a
+    | doc m%"
       Remove the first (at most) N elements of a list.
 
 
@@ -581,14 +638,15 @@
        drop 2 [ ]
        >> [ ]
   "%
-  = fun
+    = fun
     # Number of elements to drop
     count
     # Input list
     lst => sublist count (std.array.length lst) lst,
 
-  sublist: forall a. Number -> Number -> Array a -> Array a
-  | doc m%"
+  sublist
+    : forall a. Number -> Number -> Array a -> Array a
+    | doc m%"
       Return a list consisting of at most `count` elements of `list`,
      starting at index `start`.
 
@@ -599,22 +657,28 @@
        sublist 1 3 [ ]
        >> [ ]
   "%
-  = fun
+    = fun
     # Index at which to start the sublist
     start
     # Number of elements to take
     count
     # Input list
     lst =>
-    let len = std.array.length lst in
-    std.array.generate
-      (fun n => std.array.at (n + start) lst)
-      (if start >= len then 0
-       else if start + count > len then len - start
-       else count),
+      let len = std.array.length lst in
+      std.array.generate
+        (fun n => std.array.at (n + start) lst)
+        (
+          if start >= len then
+            0
+          else if start + count > len then
+            len - start
+          else
+            count
+        ),
 
-  last: forall a. Array a -> a
-  | doc m%"
+  last
+    : forall a. Array a -> a
+    | doc m%"
       Return the last element of a list.
 
      This function throws an error if the list is empty.
@@ -624,12 +688,13 @@
        last [ 1, 2, 3 ]
        >> 3
   "%
-  = fun lst =>
-    #assert lib.assertMsg (lst != []) "lists.last: list must not be empty!",
-    std.array.at (std.array.length lst - 1) lst,
+    = fun lst =>
+      #assert lib.assertMsg (lst != []) "lists.last: list must not be empty!",
+      std.array.at (std.array.length lst - 1) lst,
 
-  init: forall a. Array a -> Array a
-  | doc m%"
+  init
+    : forall a. Array a -> Array a
+    | doc m%"
       Return all elements but the last.
 
      This function throws an error if the list is empty.
@@ -638,45 +703,48 @@
        init [ 1, 2, 3 ]
        >> [ 1, 2 ]
   "%
-  = fun lst =>
-    #assert lib.assertMsg (lst != []) "lists.init: list must not be empty!",
-    take (std.array.length lst - 1) lst,
+    = fun lst =>
+      #assert lib.assertMsg (lst != []) "lists.init: list must not be empty!",
+      take (std.array.length lst - 1) lst,
 
-  unique: Array Dyn -> Array Dyn
-  | doc m%"
+  unique
+    : Array Dyn -> Array Dyn
+    | doc m%"
       Remove duplicate elements from the list. O(n^2) complexity.
 
      Example:
        unique [ 3, 2, 3, 4 ]
        >> [ 3, 2, 4 ]
    "%
-  = foldl_ (fun acc e => if std.array.elem e acc then acc else acc @ [ e ]) [],
+    = foldl_ (fun acc e => if std.array.elem e acc then acc else acc @ [e]) [],
 
-  intersectLists: Array Dyn -> Array Dyn -> Array Dyn
-  | doc m%"
+  intersectLists
+    : Array Dyn -> Array Dyn -> Array Dyn
+    | doc m%"
       Intersects list 'e' and another list. O(nm) complexity.
 
      Example:
        intersectLists [ 1, 2, 3 ] [ 6, 3, 2 ]
        >> [ 3, 2 ]
   "%
-  = fun e => std.array.filter (fun x => std.array.elem x e),
+    = fun e => std.array.filter (fun x => std.array.elem x e),
 
-  subtractLists: Array Dyn -> Array Dyn -> Array Dyn
-  | doc m%"
+  subtractLists
+    : Array Dyn -> Array Dyn -> Array Dyn
+    | doc m%"
       Subtracts list 'e' from another list. O(nm) complexity.
 
      Example:
        subtractLists [ 3, 2 ] [ 1, 2, 3, 4, 5, 3 ]
        >> [ 1, 4, 5 ]
   "%
-  = fun e => std.array.filter (fun x => !(std.array.elem x e)),
+    = fun e => std.array.filter (fun x => !(std.array.elem x e)),
 
-  mutuallyExclusive: Array Dyn -> Array Dyn -> Bool
-  | doc m%"
+  mutuallyExclusive
+    : Array Dyn -> Array Dyn -> Bool
+    | doc m%"
       Test if two lists have no common element.
      It should be slightly more efficient than (intersectLists a b == [])
   "%
-  = fun a b => std.array.length a == 0 || !(any (fun x => std.array.elem x a) b),
-
+    = fun a b => std.array.length a == 0 || !(any (fun x => std.array.elem x a) b),
 }

--- a/core/benches/numeric/pidigits.ncl
+++ b/core/benches/numeric/pidigits.ncl
@@ -3,20 +3,20 @@
     if n == 0 then
       x
     else
-      let i = 2*n + 1 in
-      let sign = if n % 2 == 1 then - 1 else 1 in
+      let i = 2 * n + 1 in
+      let sign = if n % 2 == 1 then -1 else 1 in
       sign * (%pow% x i) / i,
 
   sum = fun x total n iterCount =>
     if n == iterCount - 1 then
       total
     else
-      sum x (total + (nth_term x n)) (n+1) iterCount,
+      sum x (total + (nth_term x n)) (n + 1) iterCount,
 
   atan = fun x iterCount => sum x 0 0 iterCount,
 
   pi = fun iterCount =>
-    16 * (atan (1/5) iterCount) - 4 * (atan (1/239) iterCount),
+    16 * (atan (1 / 5) iterCount) - 4 * (atan (1 / 239) iterCount),
 
   run = pi,
 }

--- a/core/benches/numeric/scalar.ncl
+++ b/core/benches/numeric/scalar.ncl
@@ -8,7 +8,7 @@
 
   run = fun n =>
     let left = std.array.generate std.function.id n in
-    let right = std.array.generate (fun n => n*n/2) n in
+    let right = std.array.generate (fun n => n * n / 2) n in
     let prod = map2 (fun x y => x * y) left right in
     std.array.fold_left (fun x y => x + y) 0 prod
 }

--- a/core/benches/records/countLetters.ncl
+++ b/core/benches/records/countLetters.ncl
@@ -4,6 +4,7 @@
       if std.record.has_field char dict then
         std.record.update char (dict."%{char}" + 1) dict
       else
-        std.record.insert "%{char}" 1 dict in
+        std.record.insert "%{char}" 1 dict
+    in
     std.array.fold_left update_dict {} (std.string.chars s)
 }

--- a/core/benches/records/merge.ncl
+++ b/core/benches/records/merge.ncl
@@ -2,18 +2,21 @@
   run = fun n m =>
     let prefix = fun n =>
       std.array.generate (fun _n => "a") n
-      |> std.array.fold_left (fun x y => x ++ y) "" in
+      |> std.array.fold_left (fun x y => x ++ y) ""
+    in
     let make_rec_step = fun state k =>
       let name = state.prev_name ++ (std.string.from_number k) in
       {
-        value = state.value & {"%{name}" = {}},
+        value = state.value & { "%{name}" = {} },
         prev_name = name,
-      } in
+      }
+    in
     let top_array = std.array.generate std.function.id m in
     let make_rec = fun m =>
       let l = std.array.generate std.function.id n in
-      let result = std.array.fold_left make_rec_step {value = {}, prev_name = prefix m} l in
-      result.value in
+      let result = std.array.fold_left make_rec_step { value = {}, prev_name = prefix m } l in
+      result.value
+    in
     std.array.map make_rec top_array
     |> std.array.fold_left (fun r1 r2 => r1 & r2) {}
 }

--- a/core/benches/serialization/main.ncl
+++ b/core/benches/serialization/main.ncl
@@ -1,6 +1,5 @@
-
 {
-    input.run = (
-        std.serialize 'Json (import "input.json")
-    )
+  input.run = (
+    std.serialize 'Json (import "input.json")
+  )
 }

--- a/core/benches/strings/interpolation.ncl
+++ b/core/benches/strings/interpolation.ncl
@@ -1,7 +1,9 @@
 {
-  run = fun n => if n < 1 then
-    ""
-      else m%"
+  run = fun n =>
+    if n < 1 then
+      ""
+    else
+      m%"
         5bSVkTosPNAmX5yhmsDM
         Vdj4osv58320QrJPzBao
         NvTwB4CCW7vSDWPc7fe8

--- a/flake.nix
+++ b/flake.nix
@@ -167,13 +167,12 @@
           # This might change once the Nickel support is stabilized.
           topiary-latest = topiary.lib.${system}.pre-commit-hook // {
             enable = true;
-            # Some tests and benches are currently failing the idempotency
-            # check, and formatting is less important there. We at least want
-            # the examples as well as the stdlib to be properly formatted.
+            # Some tests are currently failing the idempotency check, and
+            # formatting is less important there. We at least want the examples
+            # as well as the stdlib to be properly formatted.
             files = "\\.ncl$";
             excludes = [
               "/tests/(.+)\\.ncl$"
-              "/benches/(.+)\\.ncl$"
             ];
           };
         };


### PR DESCRIPTION
tests and benches were excluded from auto-formatting because they were causing non-idempotency errors from Topiary, but in fact only tests do so. While it's not criticial, it's still nicer to have the benchmarks properly formatted, if we can.

This PR runs Topiary on `core/benches/**/*.ncl` and remove the exclusion of benches from the pre-commit-hooks.