### PR TITLE
Specify the test harness requests as toml instead of a custom format

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1310,6 +1310,7 @@ dependencies = [
  "serde",
  "serde_json",
  "test-generator",
+ "toml",
 ]
 
 [[package]]

--- a/lsp/lsp-harness/Cargo.toml
+++ b/lsp/lsp-harness/Cargo.toml
@@ -11,6 +11,7 @@ lsp-types.workspace = true
 lsp-server.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
+toml.workspace = true
 
 [dev-dependencies]
 assert_cmd.workspace = true

--- a/lsp/lsp-harness/README.md
+++ b/lsp/lsp-harness/README.md
@@ -12,10 +12,9 @@ Each chunk between these lines consists of the contents of a file to be loaded i
 the language server, and the line before the chunk specifies the name of that file
 (which must be an absolute path).
 
-The input file must also contain at least one trailing line starting with `###`,
-and each such trailing line denotes a request to send to the language server.
-The format of these requests is ad-hoc and will be expanded as more requests are
-supported. See the implementation of `Parse` for `lsp_harness::Request`.
+The input file may end with a block of lines starting with `###`. If it does,
+these lines specify a list of requests to send to the language server.
+These requests are written as LSP requests translated to toml.
 
 For example, a test file might look like:
 
@@ -24,5 +23,8 @@ For example, a test file might look like:
 <contents of /absolute/path.ncl>
 ### /another/absolute/path.ncl
 <contents of /another/absolute/path.ncl>
-### GotoDefinition /absolute/path.ncl:0:0
+### [[request]]
+### type = "GotoDefinition"
+### textDocument.uri = "file:///absolute/path.ncl"
+### position = { line = 3, character = 8 }
 ```

--- a/lsp/lsp-harness/src/lib.rs
+++ b/lsp/lsp-harness/src/lib.rs
@@ -3,11 +3,9 @@ mod output;
 
 pub use jsonrpc::Server;
 use log::error;
-use lsp_types::{
-    CompletionContext, CompletionParams, GotoDefinitionParams, Location, Position, Range,
-    TextDocumentIdentifier, TextDocumentPositionParams, Url,
-};
+use lsp_types::{CompletionParams, GotoDefinitionParams, Url};
 pub use output::LspDebug;
+use serde::Deserialize;
 
 /// A text fixture consists of multiple files (each labelled with a filename)
 /// and multiple requests to run on those files.
@@ -20,125 +18,47 @@ pub struct TestFixture {
     pub reqs: Vec<Request>,
 }
 
-impl TestFixture {
-    pub fn parse(s: &str) -> Option<Self> {
-        <Self as Parse>::parse(s)
-    }
-}
-
 pub struct TestFile {
     pub uri: Url,
     pub contents: String,
 }
 
 /// A subset of LSP requests that our harness supports.
+#[derive(Deserialize, Debug)]
+#[serde(tag = "type")]
 pub enum Request {
     GotoDefinition(GotoDefinitionParams),
     Completion(CompletionParams),
 }
 
-/// A private FromStr, with simpler error handling and (because it's
-/// private) the ability to impl it for external types.
-trait Parse: Sized {
-    fn parse(s: &str) -> Option<Self>;
+#[derive(Deserialize, Debug, Default)]
+pub struct Requests {
+    request: Vec<Request>,
 }
 
-impl Parse for Position {
-    fn parse(s: &str) -> Option<Self> {
-        let (line, char) = s.split_once(':')?;
-        Some(Position {
-            line: line.parse().ok()?,
-            character: char.parse().ok()?,
-        })
-    }
-}
-
-impl Parse for Range {
-    fn parse(s: &str) -> Option<Self> {
-        let (start, end) = s.split_once('-')?;
-        Some(Range {
-            start: Position::parse(start)?,
-            end: Position::parse(end)?,
-        })
-    }
-}
-
-impl Parse for Location {
-    fn parse(s: &str) -> Option<Self> {
-        let (path, range) = s.split_once(':')?;
-        let uri = Url::from_file_path(path).ok()?;
-        let range = Range::parse(range)?;
-        Some(Location { uri, range })
-    }
-}
-
-impl Parse for TextDocumentPositionParams {
-    fn parse(s: &str) -> Option<Self> {
-        let (path, pos) = s.split_once(':')?;
-        let uri = Url::from_file_path(path).ok()?;
-        let pos = Position::parse(pos)?;
-        Some(TextDocumentPositionParams {
-            text_document: TextDocumentIdentifier { uri },
-            position: pos,
-        })
-    }
-}
-
-impl Parse for Request {
-    fn parse(s: &str) -> Option<Self> {
-        let (method, params) = s.split_once(' ')?;
-        match method {
-            "GotoDefinition" => Some(Request::GotoDefinition(GotoDefinitionParams {
-                text_document_position_params: TextDocumentPositionParams::parse(params)?,
-                work_done_progress_params: Default::default(),
-                partial_result_params: Default::default(),
-            })),
-            // The format of a Completion request is the file:line:char location,
-            // followed by an optional trigger character.
-            "Completion" => {
-                let (pos, context) = if let Some((pos, trigger)) = params.split_once(' ') {
-                    (
-                        pos,
-                        Some(CompletionContext {
-                            trigger_kind: lsp_types::CompletionTriggerKind::TriggerCharacter,
-                            trigger_character: Some(trigger.to_owned()),
-                        }),
-                    )
-                } else {
-                    (params, None)
-                };
-                Some(Request::Completion(CompletionParams {
-                    text_document_position: TextDocumentPositionParams::parse(pos)?,
-                    work_done_progress_params: Default::default(),
-                    partial_result_params: Default::default(),
-                    context,
-                }))
-            }
-
-            _ => None,
-        }
-    }
-}
-
-impl Parse for TestFixture {
-    fn parse(s: &str) -> Option<Self> {
+impl TestFixture {
+    pub fn parse(s: &str) -> Option<Self> {
         let mut header_lines = Vec::new();
         let mut content = String::new();
         let mut files = Vec::new();
+        let mut push_file = |header: &[&str], content: &mut String| {
+            if header.len() > 1 {
+                error!("files can only have 1 header line");
+                return None;
+            }
+
+            let uri = Url::from_file_path(header.first()?).ok()?;
+            files.push(TestFile {
+                uri,
+                contents: std::mem::take(content),
+            });
+            Some(())
+        };
+
         for line in s.lines() {
             if line.starts_with("###") {
                 if !content.is_empty() {
-                    if header_lines.len() > 1 {
-                        error!("files can only have 1 header line");
-                        return None;
-                    }
-
-                    let uri = Url::from_file_path(header_lines.first()?).ok()?;
-                    files.push(TestFile {
-                        uri,
-                        contents: std::mem::take(&mut content),
-                    });
-
+                    push_file(&header_lines, &mut content)?;
                     header_lines.clear();
                 }
 
@@ -149,12 +69,23 @@ impl Parse for TestFixture {
             }
         }
 
-        // Remaining lines at the end of the file are for requests.
-        let mut reqs = Vec::new();
-        for req in header_lines {
-            reqs.push(Request::parse(req)?);
+        if !content.is_empty() {
+            // The text fixture ended with a nickel file; there are no lsp
+            // requests specified.
+            push_file(&header_lines, &mut content)?;
+            Some(TestFixture {
+                files,
+                reqs: Vec::new(),
+            })
+        } else {
+            // The remaining lines at the end of the file are a toml source
+            // listing the LSP requests we need to make.
+            let remaining = header_lines.join("\n");
+            let reqs: Requests = toml::from_str(&remaining).unwrap();
+            Some(TestFixture {
+                files,
+                reqs: reqs.request,
+            })
         }
-
-        Some(TestFixture { files, reqs })
     }
 }

--- a/lsp/nls/tests/inputs/completion-basic.ncl
+++ b/lsp/nls/tests/inputs/completion-basic.ncl
@@ -9,9 +9,35 @@ in
     a = config.version,
     b = config.verified.really,
 }
-### Completion /completion-basic.ncl:7:12
-### Completion /completion-basic.ncl:7:15 .
-### Completion /completion-basic.ncl:8:15 .
-### Completion /completion-basic.ncl:8:23
-### Completion /completion-basic.ncl:8:24 .
-### Completion /completion-basic.ncl:8:27
+### [[request]]
+### type = "Completion"
+### textDocument.uri = "file:///completion-basic.ncl"
+### position = { line = 7, character = 12 }
+###
+### [[request]]
+### type = "Completion"
+### textDocument.uri = "file:///completion-basic.ncl"
+### position = { line = 7, character = 15 }
+### context = { triggerKind = 2, triggerCharacter = "." }
+###
+### [[request]]
+### type = "Completion"
+### textDocument.uri = "file:///completion-basic.ncl"
+### position = { line = 8, character = 15 }
+### context = { triggerKind = 2, triggerCharacter = "." }
+###
+### [[request]]
+### type = "Completion"
+### textDocument.uri = "file:///completion-basic.ncl"
+### position = { line = 8, character = 23 }
+###
+### [[request]]
+### type = "Completion"
+### textDocument.uri = "file:///completion-basic.ncl"
+### position = { line = 8, character = 24 }
+### context = { triggerKind = 2, triggerCharacter = "." }
+###
+### [[request]]
+### type = "Completion"
+### textDocument.uri = "file:///completion-basic.ncl"
+### position = { line = 8, character = 27 }

--- a/lsp/nls/tests/inputs/goto-basic.ncl
+++ b/lsp/nls/tests/inputs/goto-basic.ncl
@@ -3,6 +3,17 @@ let
   var = "val"
 in
 { foo = var }
-### GotoDefinition /goto.ncl:3:8
-### GotoDefinition /goto.ncl:3:9
-### GotoDefinition /goto.ncl:3:10
+### [[request]]
+### type = "GotoDefinition"
+### textDocument.uri = "file:///goto.ncl"
+### position = { line = 3, character = 8 }
+###
+### [[request]]
+### type = "GotoDefinition"
+### textDocument.uri = "file:///goto.ncl"
+### position = { line = 3, character = 9 }
+###
+### [[request]]
+### type = "GotoDefinition"
+### textDocument.uri = "file:///goto.ncl"
+### position = { line = 3, character = 10 }

--- a/lsp/nls/tests/inputs/goto-cross-file.ncl
+++ b/lsp/nls/tests/inputs/goto-cross-file.ncl
@@ -5,5 +5,12 @@ let
   record = import "dep.ncl"
 in
   record.foo
-### GotoDefinition /goto.ncl:3:2
-### GotoDefinition /goto.ncl:3:9
+### [[request]]
+### type = "GotoDefinition"
+### textDocument.uri = "file:///goto.ncl"
+### position = { line = 3, character = 2 }
+###
+### [[request]]
+### type = "GotoDefinition"
+### textDocument.uri = "file:///goto.ncl"
+### position = { line = 3, character = 9 }

--- a/lsp/nls/tests/inputs/import_external_format.ncl
+++ b/lsp/nls/tests/inputs/import_external_format.ncl
@@ -2,7 +2,3 @@
 let foo = import "external_import.json" in
 let bar = import "external_import.yaml" in
 foo & bar
-# This request isn't really useful, this test simply checks that the LSP can
-# linearize this file without crashing. However, the LSP test suite currently
-# requires that we have at least one request, so here it is.
-### GotoDefinition /external_import.ncl:3:1

--- a/lsp/nls/tests/main.rs
+++ b/lsp/nls/tests/main.rs
@@ -51,6 +51,8 @@ impl TestHarness {
 
 #[test_resources("lsp/nls/tests/inputs/*.ncl")]
 fn check_snapshots(path: &str) {
+    let _ = env_logger::try_init();
+
     let full_path = project_root().join(path);
     dbg!(path, &full_path);
 
@@ -60,10 +62,6 @@ fn check_snapshots(path: &str) {
 
     if fixture.files.is_empty() {
         panic!("no files");
-    }
-
-    if fixture.reqs.is_empty() {
-        panic!("no reqs");
     }
 
     for file in fixture.files {

--- a/lsp/nls/tests/snapshots/main__lsp__nls__tests__inputs__import_external_format.ncl.snap
+++ b/lsp/nls/tests/snapshots/main__lsp__nls__tests__inputs__import_external_format.ncl.snap
@@ -2,5 +2,4 @@
 source: lsp/nls/tests/main.rs
 expression: output
 ---
-None
 


### PR DESCRIPTION
The new format is just a toml-ization of the LSP protocol itself.