### PR TITLE
Invalidate importers in NLS (plus a couple other import-related issues)

### DIFF
--- a/core/src/cache.rs
+++ b/core/src/cache.rs
@@ -510,14 +510,13 @@ impl Cache {
                     self.update_state(file_id, EntryState::Typechecking);
                     self.wildcards.insert(file_id, wildcards);
 
-                    // Here and below, update the state before recursing so that circular
-                    // imports don't cause an infinite loop.
-                    self.update_state(file_id, EntryState::Typechecked);
                     if let Some(imports) = self.imports.get(&file_id).cloned() {
                         for f in imports.into_iter() {
                             self.typecheck(f, initial_ctxt)?;
                         }
                     }
+
+                    self.update_state(file_id, EntryState::Typechecked);
                 }
                 // The else case correponds to `EntryState::Typechecking`. There is nothing to do:
                 // cf (grep for) [transitory_entry_state]
@@ -550,13 +549,13 @@ impl Cache {
                             ..cached_term
                         },
                     );
-                }
 
-                self.update_state(file_id, EntryState::Transformed);
-                if let Some(imports) = self.imports.get(&file_id).cloned() {
-                    for f in imports.into_iter() {
-                        self.transform(f)?;
+                    if let Some(imports) = self.imports.get(&file_id).cloned() {
+                        for f in imports.into_iter() {
+                            self.transform(f)?;
+                        }
                     }
+                    self.update_state(file_id, EntryState::Transformed);
                 }
                 Ok(CacheOp::Done(()))
             }
@@ -655,13 +654,13 @@ impl Cache {
                             parse_errs,
                         },
                     );
-                }
 
-                self.update_state(file_id, EntryState::Transformed);
-                if let Some(imports) = self.imports.get(&file_id).cloned() {
-                    for f in imports.into_iter() {
-                        self.transform(f).map_err(|_| CacheError::NotParsed)?;
+                    if let Some(imports) = self.imports.get(&file_id).cloned() {
+                        for f in imports.into_iter() {
+                            self.transform(f).map_err(|_| CacheError::NotParsed)?;
+                        }
                     }
+                    self.update_state(file_id, EntryState::Transformed);
                 }
 
                 Ok(CacheOp::Done(()))

--- a/core/src/cache.rs
+++ b/core/src/cache.rs
@@ -936,9 +936,13 @@ impl Cache {
         Some(file)
     }
 
-    pub fn get_imports(&self, file: &FileId) -> Option<Vec<FileId>> {
-        let imports_set = self.imports.get(file)?;
-        Some(imports_set.iter().copied().collect())
+    /// Returns the set of files that this file imports.
+    pub fn get_imports(&self, file: FileId) -> impl Iterator<Item = FileId> + '_ {
+        self.imports
+            .get(&file)
+            .into_iter()
+            .flat_map(|s| s.iter())
+            .copied()
     }
 
     /// Returns the set of files that import this file.

--- a/lsp/lsp-harness/src/jsonrpc.rs
+++ b/lsp/lsp-harness/src/jsonrpc.rs
@@ -6,11 +6,15 @@ use anyhow::{bail, Context, Result};
 use log::debug;
 use lsp_server::ResponseError;
 use lsp_types::{
-    notification::{DidOpenTextDocument, Exit, Initialized, Notification as LspNotification},
+    notification::{
+        DidChangeTextDocument, DidOpenTextDocument, Exit, Initialized,
+        Notification as LspNotification,
+    },
     request::{GotoDefinition, Initialize, Request as LspRequest, Shutdown},
-    ClientCapabilities, DidOpenTextDocumentParams, GotoDefinitionParams, GotoDefinitionResponse,
-    InitializeParams, InitializedParams, Position, TextDocumentIdentifier,
-    TextDocumentPositionParams, Url,
+    ClientCapabilities, DidChangeTextDocumentParams, DidOpenTextDocumentParams,
+    GotoDefinitionParams, GotoDefinitionResponse, InitializeParams, InitializedParams, Position,
+    TextDocumentContentChangeEvent, TextDocumentIdentifier, TextDocumentPositionParams, Url,
+    VersionedTextDocumentIdentifier,
 };
 use std::{
     io::{BufRead, BufReader, Read, Write},
@@ -114,6 +118,18 @@ impl Server {
                 version: 1,
                 text: contents.to_owned(),
             },
+        })
+    }
+
+    /// Replace the contents of a file with new contents.
+    pub fn replace_file(&mut self, uri: Url, version: i32, contents: &str) -> Result<()> {
+        self.send_notification::<DidChangeTextDocument>(DidChangeTextDocumentParams {
+            content_changes: vec![TextDocumentContentChangeEvent {
+                range: None,
+                range_length: None,
+                text: contents.to_owned(),
+            }],
+            text_document: VersionedTextDocumentIdentifier { uri, version },
         })
     }
 

--- a/lsp/nls/src/cache.rs
+++ b/lsp/nls/src/cache.rs
@@ -40,14 +40,12 @@ impl CacheExt for Cache {
             }
         }
 
-        if let Some(ids) = self.get_imports(&file_id) {
-            for id in ids {
-                // If we have typechecked a file correctly, its imports should be
-                // in the `lin_registry`. The imports that are not in `lin_registry`
-                // were not typechecked correctly.
-                if !lin_registry.map.contains_key(&id) {
-                    typecheck_import_diagnostics.push(id);
-                }
+        for id in self.get_imports(file_id) {
+            // If we have typechecked a file correctly, its imports should be
+            // in the `lin_registry`. The imports that are not in `lin_registry`
+            // were not typechecked correctly.
+            if !lin_registry.map.contains_key(&id) {
+                typecheck_import_diagnostics.push(id);
             }
         }
 

--- a/lsp/nls/src/files.rs
+++ b/lsp/nls/src/files.rs
@@ -5,7 +5,7 @@ use log::trace;
 use lsp_server::RequestId;
 use lsp_types::{
     notification::{DidOpenTextDocument, Notification},
-    DidChangeTextDocumentParams, DidOpenTextDocumentParams, PublishDiagnosticsParams, Url,
+    DidChangeTextDocumentParams, DidOpenTextDocumentParams,
 };
 use nickel_lang_core::{
     cache::{CacheError, CacheOp},
@@ -15,7 +15,6 @@ use nickel_lang_core::{
 use crate::trace::{param::FileUpdate, Enrich, Trace};
 
 use super::cache::CacheExt;
-use super::diagnostic::DiagnosticCompat;
 use super::server::Server;
 
 pub fn handle_open(server: &mut Server, params: DidOpenTextDocumentParams) -> Result<()> {
@@ -36,8 +35,9 @@ pub fn handle_open(server: &mut Server, params: DidOpenTextDocumentParams) -> Re
         params.text_document.uri.to_file_path().unwrap(),
         params.text_document.text,
     );
+    server.file_uris.insert(file_id, params.text_document.uri);
 
-    parse_and_typecheck(server, params.text_document.uri, file_id)?;
+    parse_and_typecheck(server, file_id)?;
     Trace::reply(id);
     Ok(())
 }
@@ -62,10 +62,22 @@ pub fn handle_save(server: &mut Server, params: DidChangeTextDocumentParams) -> 
         params.content_changes[0].text.to_owned(),
     );
 
+    // Any transitive dependency of the modified file needs to be re-type-checked (but not re-parsed).
+    let invalid = server.cache.get_rev_imports_transitive(file_id);
+    for f in &invalid {
+        server.lin_registry.remove_file(*f);
+    }
+
     // TODO: make this part more abstracted
     //       implement typecheck (at least) as part of a persistent AST representation
     //       for now execute the same as above for handling `open` notifications
-    parse_and_typecheck(server, params.text_document.uri, file_id)?;
+    parse_and_typecheck(server, file_id)?;
+
+    for f in &invalid {
+        if let Err(e) = typecheck(server, *f) {
+            server.issue_diagnostics(*f, e);
+        }
+    }
     Trace::reply(id);
     Ok(())
 }
@@ -88,35 +100,20 @@ fn typecheck(server: &mut Server, file_id: FileId) -> Result<CacheOp<()>, Vec<Di
         })
 }
 
-fn parse_and_typecheck(server: &mut Server, uri: Url, file_id: FileId) -> Result<()> {
-    let diagnostics = server
-        .cache
-        .parse(file_id)
-        .map_err(|parse_err| parse_err.into_diagnostics(server.cache.files_mut(), None))
-        .map(|parse_errs| {
-            // Parse errors are not fatal
-            let mut d = parse_errs
-                .inner()
-                .into_diagnostics(server.cache.files_mut(), None);
-            trace!("Parsed, checking types");
-            let _ = typecheck(server, file_id).map_err(|mut ty_d| d.append(&mut ty_d));
-            d
-        })
-        .unwrap_or_else(|d| d);
+fn parse_and_typecheck(server: &mut Server, file_id: FileId) -> Result<()> {
+    let (parse_errs, fatal) = match server.cache.parse(file_id) {
+        Ok(errs) => (errs.inner(), false),
+        Err(errs) => (errs, true),
+    };
+    let diags = parse_errs.into_diagnostics(server.cache.files_mut(), None);
+    server.issue_diagnostics(file_id, diags);
 
-    let diagnostics = diagnostics
-        .into_iter()
-        .flat_map(|d| lsp_types::Diagnostic::from_codespan(d, server.cache.files_mut()))
-        .collect();
-
-    server.notify(lsp_server::Notification::new(
-        "textDocument/publishDiagnostics".into(),
-        PublishDiagnosticsParams {
-            uri,
-            diagnostics,
-            version: None,
-        },
-    ));
+    if !fatal {
+        trace!("Parsed, checking types");
+        if let Err(e) = typecheck(server, file_id) {
+            server.issue_diagnostics(file_id, e);
+        }
+    }
 
     Ok(())
 }

--- a/lsp/nls/src/files.rs
+++ b/lsp/nls/src/files.rs
@@ -65,7 +65,7 @@ pub fn handle_save(server: &mut Server, params: DidChangeTextDocumentParams) -> 
     // Any transitive dependency of the modified file needs to be re-type-checked (but not re-parsed).
     let invalid = server.cache.get_rev_imports_transitive(file_id);
     for f in &invalid {
-        server.lin_registry.remove_file(*f);
+        server.lin_registry.map.remove(f);
     }
 
     // TODO: make this part more abstracted

--- a/lsp/nls/src/linearization/mod.rs
+++ b/lsp/nls/src/linearization/mod.rs
@@ -51,6 +51,11 @@ impl LinRegistry {
         let lin = self.map.get(&id.file_id).unwrap();
         lin.get_item(id)
     }
+
+    /// Remove a file's linearization from the registry.
+    pub fn remove_file(&mut self, file_id: FileId) {
+        self.map.remove(&file_id);
+    }
 }
 
 #[derive(PartialEq, Copy, Debug, Clone, Eq, Hash)]

--- a/lsp/nls/src/linearization/mod.rs
+++ b/lsp/nls/src/linearization/mod.rs
@@ -51,11 +51,6 @@ impl LinRegistry {
         let lin = self.map.get(&id.file_id).unwrap();
         lin.get_item(id)
     }
-
-    /// Remove a file's linearization from the registry.
-    pub fn remove_file(&mut self, file_id: FileId) {
-        self.map.remove(&file_id);
-    }
 }
 
 #[derive(PartialEq, Copy, Debug, Clone, Eq, Hash)]


### PR DESCRIPTION
Fix a few related import issues.

  - record imports correctly even if the imported file is already cached.
  - avoid infinite recursion with circular imports. This previously
    worked only because the imports weren't correctly recorded.
  - track reverse-dependencies also, and invalidate the LSP correctly.