### PR TITLE
[Refactoring] Better separation of lexer mode

### DIFF
--- a/core/src/parser/error.rs
+++ b/core/src/parser/error.rs
@@ -2,6 +2,7 @@ use codespan::FileId;
 use codespan_reporting::diagnostic::Label;
 
 use crate::{identifier::Ident, position::RawSpan};
+use std::ops::Range;
 
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub enum LexicalError {
@@ -11,8 +12,14 @@ pub enum LexicalError {
     InvalidEscapeSequence(usize),
     /// Invalid escape ASCII code in a string literal.
     InvalidAsciiEscapeCode(usize),
+    /// A multiline string was closed with a delimiter which has a `%` count higher than the
+    /// opening delimiter.
+    StringEndMismatch {
+        opening_delimiter: Range<usize>,
+        closing_delimiter: Range<usize>,
+    },
     /// Generic lexer error
-    Generic(usize, usize),
+    Generic(Range<usize>),
 }
 
 /// Error indicating that a construct is not allowed when trying to interpret an `UniRecord` as a

--- a/core/src/parser/lexer.rs
+++ b/core/src/parser/lexer.rs
@@ -888,9 +888,11 @@ impl<'input> Lexer<'input> {
     // unreachable `panic!`. In practice, the fact that `handle_normal_token` might both mutate
     // `mode_data` or switch mode (and thus get rid of the current lexer, which holds mode_data)
     // altogether makes it hard to do something that is both ergonomic and satisfies the borrow
-    // checker. We tried to thread `data` through `handle_normal_token`, but this not only requires
-    // to clone the data to avoid multiple mutable borrows to `self`, but also had a subtly wrong
-    // behavior because when reaching a comment, we call `self.next()`, which led to
+    // checker.
+    // We initially tried to thread `data` through `handle_normal_token`, but this not only
+    // requires to clone the data to avoid multiple mutable borrows to `self`, but also had a
+    // subtly wrong behavior because when reaching a comment, we call `self.next()`, and threading
+    // data properly becomes non trivial.
     fn normal_mode_data_mut(&mut self) -> &mut NormalData {
         match self.lexer {
             Some(ModalLexer::Normal {
@@ -907,7 +909,7 @@ impl<'input> Lexer<'input> {
         }
     }
 
-    //WARNING: this method expects the lexer to be in multistring mode. Panics otherwise.
+    // WARNING: this method expects the lexer to be in multistring mode. Panics otherwise.
     fn bufferize(&mut self, token: MultiStringToken<'input>, span: Range<usize>) {
         match self.lexer {
             Some(ModalLexer::MultiString { ref mut buffer, .. }) => *buffer = Some((token, span)),

--- a/core/src/parser/lexer.rs
+++ b/core/src/parser/lexer.rs
@@ -854,7 +854,7 @@ impl<'input> Lexer<'input> {
             // `%` should be split between multistring end token, plus a variable number of `%`
             // tokens. This is annoying because we only buffer one token currently. We could use a
             // stack instead of a 1-length buffer, but in practice a string such as `m%" "%%` is
-            // almost surely meaningless: there's now meaningful way of interpreting it
+            // almost surely meaningless: there's no meaningful way of interpreting it
             // (although according to the grammar, it might be valid as a string followed by a
             // modulo operator `%` - which will fail anyway at runtime with a type error).
             // Thus, we prefer to emit a proper error right here.

--- a/core/src/parser/lexer.rs
+++ b/core/src/parser/lexer.rs
@@ -426,7 +426,7 @@ pub enum MultiStringToken<'input> {
     /// variable number of `%` character, so the lexer matches candidate end delimiter, compare the
     /// number of characters, and either emit the `End` token above, or turn the `CandidateEnd` to a
     /// `FalseEnd` otherwise
-    #[regex("\"%+")] // m%%""%%{x}"%%m
+    #[regex("\"%+")]
     CandidateEnd(&'input str),
     /// Same as `CandidateEnd`, but for interpolation
     #[regex("%+\\{")]


### PR DESCRIPTION
Preliminary work toward fixing #1429. Refactors the lexer for a better and cleaner separation between different lexer modes, making it more readable and statically forbid more invalid states.

The added error `StrEndMismatch` is more related to #1429, but at this point it's easier to leave it there than to artificially split it from this PR - the corresponding code is relatively small.