### PR TITLE
[Fix] Fix bad lexing of mutline string closing delimiter

### DIFF
--- a/cli/tests/snapshot/inputs/errors/string_delimiter_mismatch.ncl
+++ b/cli/tests/snapshot/inputs/errors/string_delimiter_mismatch.ncl
@@ -1,0 +1,3 @@
+# capture = 'stderr'
+# command = []
+m%"Hello"%%

--- a/cli/tests/snapshot/snapshots/snapshot__error_stderr_string_delimiter_mismatch.ncl.snap
+++ b/cli/tests/snapshot/snapshots/snapshot__error_stderr_string_delimiter_mismatch.ncl.snap
@@ -1,0 +1,16 @@
+---
+source: cli/tests/snapshot/main.rs
+expression: err
+---
+error: string closing delimiter has too many `%`
+  ┌─ [INPUTS_PATH]/errors/string_delimiter_mismatch.ncl:3:9
+  │
+3 │ m%"Hello"%%
+  │ ---     ^^^ the closing delimiter
+  │ │        
+  │ the opening delimiter
+  │
+  = A special string must be opened and closed with the same number of `%` in the corresponding delimiters.
+  = Try removing the superflous `%` in the closing delimiter
+
+

--- a/core/src/error.rs
+++ b/core/src/error.rs
@@ -380,7 +380,7 @@ pub enum ParseError {
     InvalidAsciiEscapeCode(RawSpan),
     /// A multiline string was closed with a delimiter which has a `%` count higher than the
     /// opening delimiter.
-    StringEndMismatch {
+    StringDelimiterMismatch {
         opening_delimiter: RawSpan,
         closing_delimiter: RawSpan,
     },
@@ -603,10 +603,10 @@ impl ParseError {
                 InternalParseError::Lexical(LexicalError::InvalidAsciiEscapeCode(location)) => {
                     ParseError::InvalidAsciiEscapeCode(mk_span(file_id, location, location + 2))
                 }
-                InternalParseError::Lexical(LexicalError::StringEndMismatch {
+                InternalParseError::Lexical(LexicalError::StringDelimiterMismatch {
                     opening_delimiter,
                     closing_delimiter,
-                }) => ParseError::StringEndMismatch {
+                }) => ParseError::StringDelimiterMismatch {
                     opening_delimiter: mk_span(
                         file_id,
                         opening_delimiter.start,
@@ -1654,7 +1654,7 @@ impl IntoDiagnostics<FileId> for ParseError {
             ParseError::InvalidAsciiEscapeCode(span) => Diagnostic::error()
                 .with_message("invalid ascii escape code")
                 .with_labels(vec![primary(&span)]),
-            ParseError::StringEndMismatch { opening_delimiter, closing_delimiter } => Diagnostic::error()
+            ParseError::StringDelimiterMismatch { opening_delimiter, closing_delimiter } => Diagnostic::error()
                 .with_message("string closing delimiter has too many `%`")
                 .with_labels(vec![
                     primary(&closing_delimiter).with_message("the closing delimiter"),

--- a/core/src/parser/error.rs
+++ b/core/src/parser/error.rs
@@ -14,7 +14,7 @@ pub enum LexicalError {
     InvalidAsciiEscapeCode(usize),
     /// A multiline string was closed with a delimiter which has a `%` count higher than the
     /// opening delimiter.
-    StringEndMismatch {
+    StringDelimiterMismatch {
         opening_delimiter: Range<usize>,
         closing_delimiter: Range<usize>,
     },

--- a/core/src/parser/lexer.rs
+++ b/core/src/parser/lexer.rs
@@ -859,7 +859,7 @@ impl<'input> Lexer<'input> {
             // modulo operator `%` - which will fail anyway at runtime with a type error).
             // Thus, we prefer to emit a proper error right here.
             MultiStringToken::CandidateEnd(s) if s.len() > data.percent_count => {
-                return Some(Err(ParseError::Lexical(LexicalError::StringEndMismatch {
+                return Some(Err(ParseError::Lexical(LexicalError::StringDelimiterMismatch {
                     opening_delimiter: data.opening_delimiter.clone(),
                     closing_delimiter: span,
                 })))

--- a/core/src/parser/lexer.rs
+++ b/core/src/parser/lexer.rs
@@ -461,8 +461,10 @@ pub enum ModalLexer<'input> {
     MultiString {
         mode_data: MultiStrData,
         /// A token that has been buffered and must be returned at the next call to `next()`. This is
-        /// made necessary by an issue of Logos (<https://github.com/maciejhirsz/logos/issues/200>). See
-        /// [`MultiStringToken::QuotesCandidateInterpolation`].
+        /// related to lexing an possible interpolation sequence, such as `%%%{`, which requires to
+        /// split a candidate interpolation token in two. In this case, we need to emit the first
+        /// token on the spot, and bufferize the second one, to be emitted on the following call to
+        /// `next()`.
         buffer: Option<(MultiStringToken<'input>, Range<usize>)>,
         logos_lexer: MultiStringLexer<'input>,
     },

--- a/core/tests/integration/pass/strings/string_interpolation.ncl
+++ b/core/tests/integration/pass/strings/string_interpolation.ncl
@@ -25,16 +25,6 @@ let {check, ..} = import "../lib/assert.ncl" in
   let expected = "Hello, world! Welcome in the world-universe" in
   actual == expected,
 
-  # Regression tests for  [#361](https://github.com/tweag/nickel/issues/361)
-  m%""%{"foo"}""% == "\"foo\"",
-  m%"""% == "\"",
-
-  # Regression tests for [#596](https://github.com/tweag/nickel/issues/596)
-  let s = "Hello" in m%%""%%{s}" World"%% == "\"Hello\" World",
-  let s = "Hello" in m%%""%%%{s}" World"%% == "\"%Hello\" World",
-  m%"%s"% == "%s",
-  m%%"%%s"%% == "%%s",
-
   # Regression tests for [#659](https://github.com/tweag/nickel/issues/659)
   let b = "x" in m%"a%%{b}c"% == "a%xc",
   m%"%Hel%%{"1"}lo%%%{"2"}"% == "%Hel%1lo%%2",
@@ -49,9 +39,5 @@ let {check, ..} = import "../lib/assert.ncl" in
 
   let actual = m%%%"ABC %%%%{"test"}"%%% in
   let expected = "ABC %test" in
-  actual == expected,
-
-  let actual = m%%"XYZ "%%%{"CBA"}""%% in
-  let expected = "XYZ \"%CBA\"" in
   actual == expected,
 ] |> check


### PR DESCRIPTION
Closes #1429.

We introduced a hack in the lexer because of a Logo issue related backtracking. Pre Nickel 1.0, the problem was related to strings like:

```nickel
let x = "string" in m%%"some "%%{x}"%%m
```

Here, `"%%{x}` had to be interpreted as a double quote `"` followed by an interpolation sequence `%%{`. Backtracking during matching is required, because up to `{`, we don't know yet if we are lexing an end delimiter `"%%m` or a `"` followed by an interpolation sequence. Logos doesn't handle those well (see https://github.com/maciejhirsz/logos/issues/200). So we added another token for this "ambiguous" (not literally) sequence, the `CandidateQuoteInterpolation`. However, now that that the final `m` is not required, a sequence of the form `"%%{` is either an end delimiter followed by a normal, non-string token `{` (if there's as many `%` as in the opening delimiter), a "closing delimiter too long" if there's more `%` than in the opening delimiter), or otherwise a verbatim `"%%{` (if there's less `%` than in the opening delimiter). This can _never_ be interpreted as a double quote followed by an interpolated sequence.

Thus, we can get rid of the ad-hoc `CandidateQuoteInterpolation` and related special treatments. This also get rid of regression tests, because this subtlety had caused several issues in the past but they are now moot given the new 1.0 syntax.