### PR TITLE
Fix release artifacts workflow failure

### DIFF
--- a/.github/workflows/release-artifacts.yaml
+++ b/.github/workflows/release-artifacts.yaml
@@ -68,7 +68,7 @@ jobs:
       - name: "Build x86_64 static binary"
         run: |
           nix build --print-build-logs .#nickel-static
-          cp ./result nickel-x86_64-linux
+          cp ./result/bin/nickel nickel-x86_64-linux
       - name: "Upload x86_64 static binary as release asset"
         env:
           GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
An unintended and unnoticed side effect of reorganizing the workspace crates seems to have been that crane puts the built static binary in a subdirectory. Previously the derivation output was the static executable directly. This throws off the release artifacts GitHub action.

This commit should probably be cherry-picked onto `1.1.1-release` as well, so we can rerun the release artifacts workflow.