### PR TITLE
Add a Types variant to Term

### DIFF
--- a/core/src/error.rs
+++ b/core/src/error.rs
@@ -293,9 +293,12 @@ pub enum TypecheckError {
         RichTerm, /* the inferred flat type */
         TermPos,
     ),
-    /// Types can appear in term position, like the `Number` in `let c = Number in 5 | c`.
-    /// These types are treated as contracts, but they are not allowed to contain flat types.
-    /// For example, `let c = { foo : 5 } in ...` is disallowed.
+    /// Within statically typed code, the typechecker must reject terms containing nonsensical
+    /// contracts such as `let C = { foo : 5} in ({ foo = 5 } | C)`, which will fail at runtime.
+    /// The typechecker is currently quite conservative and simply forbids to store any custom
+    /// contract (flat type) in a type that appears in term position. Note that this restriction
+    /// doesn't apply to annotations, which aren't considered part of the statically typed block.
+    /// For example, `{foo = 5} | {foo : 5}` is accepted by the typechecker.
     FlatTypeInTermPosition {
         /// The term that was in a flat type (the `5` in the example above).
         flat: RichTerm,

--- a/core/src/eval/mod.rs
+++ b/core/src/eval/mod.rs
@@ -968,7 +968,7 @@ pub fn subst<C: Cache>(
         | v @ Term::ResolvedImport(_)
         // We could recurse here, because types can contain terms which would then be subject to
         // substitution. Not recursing should be fine, though, because a type in term position
-        // turns into a contract, and we don't serialize contracts.
+        // turns into a contract, and we don't substitute inside contracts either currently.
         | v @ Term::Types(_) => RichTerm::new(v, pos),
         Term::Let(id, t1, t2, attrs) => {
             let t1 = subst(cache, t1, initial_env, env);

--- a/core/src/eval/mod.rs
+++ b/core/src/eval/mod.rs
@@ -966,6 +966,9 @@ pub fn subst<C: Cache>(
         | v @ Term::Enum(_)
         | v @ Term::Import(_)
         | v @ Term::ResolvedImport(_)
+        // We could recurse here, because types can contain terms which would then be subject to
+        // substitution. Not recursing should be fine, though, because a type in term position
+        // turns into a contract, and we don't serialize contracts.
         | v @ Term::Types(_) => RichTerm::new(v, pos),
         Term::Let(id, t1, t2, attrs) => {
             let t1 = subst(cache, t1, initial_env, env);

--- a/core/src/eval/mod.rs
+++ b/core/src/eval/mod.rs
@@ -709,6 +709,11 @@ impl<R: ImportResolver, C: Cache> VirtualMachine<R, C> {
                         env,
                     }
                 }
+                // Evaluating a type turns it into a contract.
+                Term::Types(ty) => Closure {
+                    body: ty.contract()?,
+                    env,
+                },
                 // Continuation of operations and element update
                 _ if self.stack.is_top_idx() || self.stack.is_top_cont() => {
                     clos = Closure {
@@ -960,7 +965,8 @@ pub fn subst<C: Cache>(
         | v @ Term::SealingKey(_)
         | v @ Term::Enum(_)
         | v @ Term::Import(_)
-        | v @ Term::ResolvedImport(_) => RichTerm::new(v, pos),
+        | v @ Term::ResolvedImport(_)
+        | v @ Term::Types(_) => RichTerm::new(v, pos),
         Term::Let(id, t1, t2, attrs) => {
             let t1 = subst(cache, t1, initial_env, env);
             let t2 = subst(cache, t2, initial_env, env);

--- a/core/src/eval/operation.rs
+++ b/core/src/eval/operation.rs
@@ -1395,7 +1395,7 @@ impl<R: ImportResolver, C: Cache> VirtualMachine<R, C> {
 
                             Ok(Closure { body, env: new_env })
                         }
-                        _ => Err(mk_type_error!("assuem", "Contract", 1, t1, pos1)),
+                        _ => Err(mk_type_error!("assume", "Contract", 1, t1, pos1)),
                     }
                 } else {
                     Err(mk_type_error!("assume", "Label", 2, t2, pos2))

--- a/core/src/parser/uniterm.rs
+++ b/core/src/parser/uniterm.rs
@@ -109,7 +109,11 @@ impl TryFrom<UniTerm> for RichTerm {
             UniTermNode::Record(r) => RichTerm::try_from(r)?,
             UniTermNode::Types(mut ty) => {
                 ty.fix_type_vars(pos.unwrap())?;
-                RichTerm::new(Term::Types(ty), pos)
+                if let TypeF::Flat(rt) = ty.types {
+                    rt.with_pos(pos)
+                } else {
+                    RichTerm::new(Term::Types(ty), pos)
+                }
             }
             UniTermNode::Term(rt) => rt,
         };

--- a/core/src/pretty.rs
+++ b/core/src/pretty.rs
@@ -755,7 +755,7 @@ where
             EnumRowsF::Extend { row, tail } => {
                 let builder = allocator
                     .text("'")
-                    .append(allocator.text(ident_quoted(&row)));
+                    .append(allocator.text(ident_quoted(row)));
                 let builder = if let EnumRowsF::Extend { .. } = tail.0 {
                     builder
                         .append(allocator.text(","))
@@ -794,7 +794,7 @@ where
                 tail,
             } => {
                 let builder = allocator
-                    .text(ident_quoted(&id))
+                    .text(ident_quoted(id))
                     .append(allocator.text(":"))
                     .append(allocator.space())
                     .append(types.pretty(allocator));

--- a/core/src/pretty.rs
+++ b/core/src/pretty.rs
@@ -426,7 +426,7 @@ where
     }
 }
 
-impl<'a, D, A> Pretty<'a, D, A> for RichTerm
+impl<'a, D, A> Pretty<'a, D, A> for &RichTerm
 where
     D: NickelAllocatorExt<'a, A>,
     D::Doc: Clone,
@@ -731,20 +731,21 @@ where
                 .append(allocator.space())
                 .append(allocator.as_string(f.to_string_lossy()).double_quotes()),
             ResolvedImport(id) => allocator.text(format!("import <file_id: {id:?}>")),
+            Types(ty) => ty.pretty(allocator),
             ParseError(_) => allocator.text("%<PARSE ERROR>"),
             RuntimeError(_) => allocator.text("%<RUNTIME ERROR>"),
         }
     }
 }
 
-impl<'a, D, A> Pretty<'a, D, A> for EnumRows
+impl<'a, D, A> Pretty<'a, D, A> for &EnumRows
 where
     D: NickelAllocatorExt<'a, A>,
     D::Doc: Clone,
     A: Clone + 'a,
 {
     fn pretty(self, allocator: &'a D) -> DocBuilder<'a, D, A> {
-        match self.0 {
+        match &self.0 {
             EnumRowsF::Empty => allocator.nil(),
             EnumRowsF::TailVar(id) => allocator
                 .space()
@@ -769,14 +770,14 @@ where
     }
 }
 
-impl<'a, D, A> Pretty<'a, D, A> for RecordRows
+impl<'a, D, A> Pretty<'a, D, A> for &RecordRows
 where
     D: NickelAllocatorExt<'a, A>,
     D::Doc: Clone,
     A: Clone + 'a,
 {
     fn pretty(self, allocator: &'a D) -> DocBuilder<'a, D, A> {
-        match self.0 {
+        match &self.0 {
             RecordRowsF::Empty => allocator.nil(),
             RecordRowsF::TailDyn => allocator
                 .space()
@@ -812,7 +813,7 @@ where
     }
 }
 
-impl<'a, D, A> Pretty<'a, D, A> for Types
+impl<'a, D, A> Pretty<'a, D, A> for &Types
 where
     D: NickelAllocatorExt<'a, A>,
     D::Doc: Clone,
@@ -820,7 +821,7 @@ where
 {
     fn pretty(self, allocator: &'a D) -> DocBuilder<'a, D, A> {
         use TypeF::*;
-        match self.types {
+        match &self.types {
             Dyn => allocator.text("Dyn"),
             Number => allocator.text("Number"),
             Bool => allocator.text("Bool"),
@@ -839,7 +840,7 @@ where
             Var(var) => allocator.as_string(var),
             Forall { var, ref body, .. } => {
                 let mut curr = body.as_ref();
-                let mut foralls = vec![&var];
+                let mut foralls = vec![var];
                 while let Types {
                     types: Forall { var, ref body, .. },
                     ..

--- a/core/src/repl/mod.rs
+++ b/core/src/repl/mod.rs
@@ -113,7 +113,7 @@ impl<EC: EvalCache> ReplImpl<EC> {
             resolved_ids: pending,
         } = import_resolution::strict::resolve_imports(t, self.vm.import_resolver_mut())?;
         for id in &pending {
-            self.vm.import_resolver_mut().resolve_imports(*id).unwrap();
+            dbg!(self.vm.import_resolver_mut().resolve_imports(*id)).unwrap();
         }
 
         let wildcards =

--- a/core/src/term/mod.rs
+++ b/core/src/term/mod.rs
@@ -759,7 +759,6 @@ impl Term {
             | Term::SealingKey(..)
             | Term::Op1(UnaryOp::StaticAccess(_), _)
             | Term::Op2(BinaryOp::DynAccess(), _, _)
-            | Term::Types(_)
             // Those special cases aren't really atoms, but mustn't be parenthesized because they
             // are really functions taking additional non-strict arguments and printed as "partial"
             // infix operators.
@@ -785,6 +784,7 @@ impl Term {
             | Term::Annotated(..)
             | Term::Import(..)
             | Term::ResolvedImport(..)
+            | Term::Types(_)
             | Term::ParseError(_)
             | Term::RuntimeError(_) => false,
         }

--- a/core/src/term/mod.rs
+++ b/core/src/term/mod.rs
@@ -24,7 +24,7 @@ use crate::{
     label::{Label, MergeLabel},
     match_sharedterm,
     position::TermPos,
-    types::{TypeF, Types, UnboundTypeVariableError},
+    types::{Types, UnboundTypeVariableError},
 };
 
 use codespan::FileId;
@@ -180,6 +180,12 @@ pub enum Term {
     /// A resolved import (which has already been loaded and parsed).
     #[serde(skip)]
     ResolvedImport(FileId),
+
+    /// A type.
+    ///
+    /// During evaluation, this will get turned into a contract.
+    #[serde(skip)]
+    Types(Types),
 
     /// A term that couldn't be parsed properly. Used by the LSP to handle partially valid
     /// programs.
@@ -570,82 +576,6 @@ impl<E> StrChunk<E> {
 }
 
 impl Term {
-    /// Recursively apply a function to all `Term`s contained in a `RichTerm`.
-    pub fn apply_to_rich_terms<F>(&mut self, func: F)
-    where
-        F: Fn(&mut RichTerm),
-    {
-        use self::Term::*;
-        match self {
-            Null | ParseError(_) | RuntimeError(_) => (),
-            Match {
-                ref mut cases,
-                ref mut default,
-            } => {
-                cases.iter_mut().for_each(|c| {
-                    let (_, t) = c;
-                    func(t);
-                });
-                if let Some(default) = default {
-                    func(default)
-                }
-            }
-            Record(ref mut r) => {
-                r.fields.iter_mut().for_each(|(_, field)| {
-                    if let Some(ref mut value) = field.value {
-                        func(value);
-                    }
-                });
-            }
-            RecRecord(ref mut r, ref mut dyn_fields, ..) => {
-                r.fields.iter_mut().for_each(|(_, field)| {
-                    if let Some(ref mut value) = field.value {
-                        func(value);
-                    }
-                });
-                dyn_fields.iter_mut().for_each(|(id_t, field)| {
-                    func(id_t);
-
-                    if let Some(ref mut value) = field.value {
-                        func(value);
-                    }
-                });
-            }
-            Bool(_) | Num(_) | Str(_) | Lbl(_) | Var(_) | SealingKey(_) | Enum(_) | Import(_)
-            | ResolvedImport(_) => {}
-            Fun(_, ref mut t)
-            | FunPattern(_, _, ref mut t)
-            | Op1(_, ref mut t)
-            | Sealed(_, ref mut t, _) => {
-                func(t);
-            }
-            Annotated(ref mut annot, ref mut t) => {
-                annot.iter_mut().for_each(|LabeledType { types, .. }| {
-                    if let TypeF::Flat(ref mut rt) = types.types {
-                        func(rt)
-                    }
-                });
-
-                func(t);
-            }
-            Let(_, ref mut t1, ref mut t2, _)
-            | LetPattern(_, _, ref mut t1, ref mut t2)
-            | App(ref mut t1, ref mut t2)
-            | Op2(_, ref mut t1, ref mut t2) => {
-                func(t1);
-                func(t2);
-            }
-            OpN(_, ref mut terms) => terms.iter_mut().for_each(|t| {
-                func(t);
-            }),
-            Array(ref mut terms, _) => terms.make_mut().iter_mut().for_each(func),
-            StrChunks(chunks) => chunks.iter_mut().for_each(|chunk| match chunk {
-                StrChunk::Literal(_) => (),
-                StrChunk::Expr(e, _) => func(e),
-            }),
-        }
-    }
-
     /// Return the class of an expression in WHNF.
     ///
     /// The class of an expression is an approximation of its type used in error reporting. Class
@@ -677,6 +607,7 @@ impl Term {
             | Term::Import(_)
             | Term::ResolvedImport(_)
             | Term::StrChunks(_)
+            | Term::Types(_)
             | Term::ParseError(_)
             | Term::RuntimeError(_) => None,
         }
@@ -723,6 +654,7 @@ impl Term {
             Term::Var(id) => id.to_string(),
             Term::ParseError(_) => String::from("<parse error>"),
             Term::RuntimeError(_) => String::from("<runtime error>"),
+            Term::Types(_) => String::from("<type>"),
             Term::Let(..)
             | Term::LetPattern(..)
             | Term::App(_, _)
@@ -734,7 +666,7 @@ impl Term {
         }
     }
 
-    /// Determine if a term is in evaluated from, called weak head normal form (WHNF).
+    /// Determine if a term is in evaluated form, called weak head normal form (WHNF).
     pub fn is_whnf(&self) -> bool {
         match self {
             Term::Null
@@ -763,6 +695,7 @@ impl Term {
             | Term::ResolvedImport(_)
             | Term::StrChunks(_)
             | Term::RecRecord(..)
+            | Term::Types(_)
             | Term::ParseError(_)
             | Term::RuntimeError(_) => false,
         }
@@ -804,6 +737,7 @@ impl Term {
             | Term::ResolvedImport(_)
             | Term::StrChunks(_)
             | Term::RecRecord(..)
+            | Term::Types(_)
             | Term::ParseError(_)
             | Term::RuntimeError(_) => false,
         }
@@ -825,6 +759,7 @@ impl Term {
             | Term::SealingKey(..)
             | Term::Op1(UnaryOp::StaticAccess(_), _)
             | Term::Op2(BinaryOp::DynAccess(), _, _)
+            | Term::Types(_)
             // Those special cases aren't really atoms, but mustn't be parenthesized because they
             // are really functions taking additional non-strict arguments and printed as "partial"
             // infix operators.
@@ -1443,14 +1378,19 @@ impl RichTerm {
     ///
     /// It allows to use rust `Eq` trait to compare the values of the underlying terms.
     //#[cfg(test)]
-    pub fn without_pos(mut self) -> Self {
-        fn clean_pos(rt: &mut RichTerm) {
-            rt.pos = TermPos::None;
-            SharedTerm::make_mut(&mut rt.term).apply_to_rich_terms(clean_pos);
-        }
-
-        clean_pos(&mut self);
-        self
+    pub fn without_pos(self) -> Self {
+        self.traverse::<_, _, ()>(
+            &|t, _| {
+                let term = match t.term.into_owned() {
+                    Term::Types(ty) => Term::Types(ty.without_pos()),
+                    t => t,
+                };
+                Ok(RichTerm::new(term, TermPos::None))
+            },
+            &mut (),
+            TraverseOrder::BottomUp,
+        )
+        .unwrap()
     }
 
     /// Set the position and return the term updated.
@@ -1980,6 +1920,8 @@ pub mod make {
 
 #[cfg(test)]
 mod tests {
+    use crate::types::TypeF;
+
     use super::*;
 
     /// Regression test for issue [#548](https://github.com/tweag/nickel/issues/548)

--- a/core/src/term/mod.rs
+++ b/core/src/term/mod.rs
@@ -1377,7 +1377,7 @@ impl RichTerm {
     /// Erase recursively the positional information.
     ///
     /// It allows to use rust `Eq` trait to compare the values of the underlying terms.
-    //#[cfg(test)]
+    #[cfg(test)]
     pub fn without_pos(self) -> Self {
         self.traverse::<_, _, ()>(
             &|t, _| {

--- a/core/src/term/mod.rs
+++ b/core/src/term/mod.rs
@@ -181,7 +181,7 @@ pub enum Term {
     #[serde(skip)]
     ResolvedImport(FileId),
 
-    /// A type.
+    /// A type in term position, such as in `let my_contract = Number -> Number in ...`.
     ///
     /// During evaluation, this will get turned into a contract.
     #[serde(skip)]

--- a/core/src/transform/free_vars.rs
+++ b/core/src/transform/free_vars.rs
@@ -172,6 +172,9 @@ impl CollectFreeVars for RichTerm {
 
                 t.collect_free_vars(free_vars);
             }
+            Term::Types(ty) => {
+                ty.collect_free_vars(free_vars);
+            }
         }
     }
 }

--- a/core/src/typecheck/mod.rs
+++ b/core/src/typecheck/mod.rs
@@ -1590,11 +1590,13 @@ fn check<L: Linearizer>(
             );
             unify(state, &ctxt, ty, ty_import).map_err(|err| err.into_typecheck_err(state, rt.pos))
         }
-        // Types in term position are converted to contracts, so convert it before type-checking
-        // it. Note that we'll throw away the converted contract here and then do the conversion
-        // again during evaluation. If we had a mutable pass instead (like `subst`) we could
-        // do this work once.
-        Term::Types(typ) => check(state, ctxt, lin, linearizer, &typ.contract()?, ty),
+        Term::Types(typ) => {
+            if let Some(flat) = typ.find_flat() {
+                Err(TypecheckError::FlatTypeInTermPosition { flat, pos: *pos })
+            } else {
+                Ok(())
+            }
+        }
     }
 }
 

--- a/core/src/types.rs
+++ b/core/src/types.rs
@@ -892,6 +892,7 @@ impl Types {
     }
 
     /// Returns the same type with the position cleared (set to `None`).
+    #[cfg(test)]
     pub fn without_pos(self) -> Types {
         self.traverse::<_, _, ()>(
             &|t: Types, _| {

--- a/core/src/types.rs
+++ b/core/src/types.rs
@@ -894,10 +894,15 @@ impl Types {
     /// Returns the same type with the position cleared (set to `None`).
     pub fn without_pos(self) -> Types {
         self.traverse::<_, _, ()>(
-            &|t, _| {
+            &|t: Types, _| {
+                let types = match t.types {
+                    TypeF::Flat(rt) => TypeF::Flat(rt.without_pos()),
+                    ty => ty,
+                };
+
                 Ok(Types {
                     pos: TermPos::None,
-                    ..t
+                    types,
                 })
             },
             &mut (),

--- a/core/src/types.rs
+++ b/core/src/types.rs
@@ -1048,6 +1048,29 @@ impl Types {
             _ => false,
         }
     }
+
+    /// Searches for a `TypeF::Flat`. If one is found, returns the term it contains.
+    pub fn find_flat(&self) -> Option<RichTerm> {
+        match &self.types {
+            TypeF::Flat(f) => Some(f.clone().with_pos(self.pos)),
+            TypeF::Dyn
+            | TypeF::Number
+            | TypeF::Bool
+            | TypeF::String
+            | TypeF::Symbol
+            | TypeF::Wildcard(_)
+            | TypeF::Enum(_)
+            | TypeF::Var(_) => None,
+            TypeF::Arrow(dom, codom) => dom.find_flat().or_else(|| codom.find_flat()),
+            TypeF::Forall { body, .. } => body.find_flat(),
+            TypeF::Record(rrows) => rrows.iter().find_map(|t| match t {
+                RecordRowsIteratorItem::Row(r) => r.types.find_flat(),
+                _ => None,
+            }),
+            TypeF::Dict { type_fields, .. } => type_fields.find_flat(),
+            TypeF::Array(t) => t.find_flat(),
+        }
+    }
 }
 
 impl Traverse<Types> for Types {
@@ -1093,7 +1116,9 @@ impl Traverse<RichTerm> for Types {
         F: Fn(RichTerm, &mut S) -> Result<RichTerm, E>,
     {
         let f_on_type = |ty: Types, s: &mut S| match ty.types {
-            TypeF::Flat(t) => t.traverse(f, s, order).map(|t| Types::from(TypeF::Flat(t))),
+            TypeF::Flat(t) => t
+                .traverse(f, s, order)
+                .map(|t| Types::from(TypeF::Flat(t)).with_pos(ty.pos)),
             _ => Ok(ty),
         };
 

--- a/core/src/types.rs
+++ b/core/src/types.rs
@@ -892,18 +892,26 @@ impl Types {
     }
 
     /// Returns the same type with the position cleared (set to `None`).
-    #[cfg(test)]
+    ///
+    /// This is currently only used in test code, but because it's used from integration
+    /// tests we cannot hide it behind cfg(test).
     pub fn without_pos(self) -> Types {
         self.traverse::<_, _, ()>(
             &|t: Types, _| {
-                let types = match t.types {
-                    TypeF::Flat(rt) => TypeF::Flat(rt.without_pos()),
-                    ty => ty,
-                };
-
                 Ok(Types {
                     pos: TermPos::None,
-                    types,
+                    ..t
+                })
+            },
+            &mut (),
+            TraverseOrder::BottomUp,
+        )
+        .unwrap()
+        .traverse::<_, _, ()>(
+            &|t: RichTerm, _| {
+                Ok(RichTerm {
+                    pos: TermPos::None,
+                    ..t
                 })
             },
             &mut (),

--- a/core/tests/integration/main.rs
+++ b/core/tests/integration/main.rs
@@ -163,6 +163,8 @@ enum ErrorExpectation {
     TypecheckExtraDynTail,
     #[serde(rename = "TypecheckError::MissingDynTail")]
     TypecheckMissingDynTail,
+    #[serde(rename = "TypecheckError::FlatTypeInTermPosition")]
+    TypecheckFlatTypeInTermPosition,
     #[serde(rename = "ParseError")]
     AnyParseError,
     #[serde(rename = "ParseError::DuplicateIdentInRecordPattern")]
@@ -197,6 +199,10 @@ impl PartialEq<Error> for ErrorExpectation {
                 Error::TypecheckError(TypecheckError::MissingDynTail(..)),
             )
             | (TypecheckExtraDynTail, Error::TypecheckError(TypecheckError::ExtraDynTail(..)))
+            | (
+                TypecheckFlatTypeInTermPosition,
+                Error::TypecheckError(TypecheckError::FlatTypeInTermPosition { .. }),
+            )
             | (ImportParseError, Error::ImportError(ImportError::ParseErrors(..))) => true,
             (e, Error::ParseErrors(es)) => {
                 let first_error = es
@@ -330,6 +336,7 @@ impl std::fmt::Display for ErrorExpectation {
             }
             TypecheckExtraDynTail => "TypecheckError::ExtraDynTail".to_owned(),
             TypecheckMissingDynTail => "TypecheckError::MissingDynTail".to_owned(),
+            TypecheckFlatTypeInTermPosition => "TypecheckError::FlatTypeInTermPosition".to_owned(),
         };
         write!(f, "{}", name)
     }

--- a/core/tests/integration/typecheck/fail/type_in_term_position.ncl
+++ b/core/tests/integration/typecheck/fail/type_in_term_position.ncl
@@ -1,0 +1,6 @@
+# test.type = 'error'
+# eval = 'typecheck'
+# 
+# [test.metadata]
+# error = 'TypecheckError::FlatTypeInTermPosition'
+(let c = Number -> 5 in 3): _


### PR DESCRIPTION
Types can get converted into terms (by turning them into contracts). Previously, this conversion was carried out at the parsing stage. This PR postpones the conversion to evaluation (or typechecking), by allowing the AST to store a `Types` directly, and then converting it as-needed.

One part I wasn't sure about: is it worth adding a mutable pass (like `subst`) to convert the `Types` to contracts? Right now I'm doing the conversion as-needed, so it might get converted twice (in typechecking, and then again in evaluation).

I also rewrote `RichTerm::without_pos` to use `traverse` instead of `apply_to_rich_term`, and then removed `apply_to_rich_term` because nothing else was using it.