### PR TITLE
Improve query inteface

### DIFF
--- a/core/src/program.rs
+++ b/core/src/program.rs
@@ -59,7 +59,7 @@ impl QueryPath {
     /// # Post-conditions
     ///
     /// If this function succeeds and returns `Ok(query_path)`, then `query_path.0` is non empty.
-    /// Indeed, there's no such thing as a valid empty field path. If `input` is empty, or consist
+    /// Indeed, there's no such thing as a valid empty field path. If `input` is empty, or consists
     /// only of spaces, `parse` returns a parse error.
     pub fn parse(cache: &mut Cache, input: String) -> Result<Self, ParseError> {
         use crate::parser::{

--- a/core/src/program.rs
+++ b/core/src/program.rs
@@ -55,6 +55,12 @@ impl QueryPath {
     /// Identifiers can be enclosed by double quotes when they contain characters that aren't
     /// allowed inside bare identifiers. The accepted grammar is the same as a sequence of record
     /// accesses in Nickel, although string interpolation is forbidden.
+    ///
+    /// # Post-conditions
+    ///
+    /// If this function succeeds and returns `Ok(query_path)`, then `query_path.0` is non empty.
+    /// Indeed, there's no such thing as a valid empty field path. If `input` is empty, or consist
+    /// only of spaces, `parse` returns a parse error.
     pub fn parse(cache: &mut Cache, input: String) -> Result<Self, ParseError> {
         use crate::parser::{
             grammar::FieldPathParser, lexer::Lexer, utils::FieldPathElem, ErrorTolerantParser,

--- a/core/src/repl/command.rs
+++ b/core/src/repl/command.rs
@@ -25,10 +25,7 @@ impl CommandType {
 pub enum Command {
     Load(OsString),
     Typecheck(String),
-    Query {
-        target: String,
-        path: Option<String>,
-    },
+    Query(String),
     Print(String),
     Help(Option<String>),
     Exit,
@@ -130,22 +127,7 @@ impl FromStr for Command {
             }
             CommandType::Query => {
                 require_arg(cmd, &arg, None)?;
-                let mut args_iter = arg.chars();
-
-                let first_arg = args_iter.by_ref().take_while(|c| *c != ' ').collect();
-                let rest = args_iter.collect::<String>();
-                let rest = rest.trim();
-
-                let path = if !rest.is_empty() {
-                    Some(String::from(rest))
-                } else {
-                    None
-                };
-
-                Ok(Command::Query {
-                    target: first_arg,
-                    path,
-                })
+                Ok(Command::Query(arg))
             }
             CommandType::Print => {
                 require_arg(cmd, &arg, None)?;

--- a/core/src/repl/mod.rs
+++ b/core/src/repl/mod.rs
@@ -428,7 +428,7 @@ pub fn print_help(out: &mut impl Write, arg: Option<&str>) -> std::io::Result<()
                     out,
                     "<field path> is a dot-separated sequence of identifiers pointing to a field. \
                     Fields can be quoted if they contain special characters, \
-                    very much as in normal Nickel source code.\n"
+                    just like in normal Nickel source code.\n"
                 )?;
                 writeln!(out, "Examples:")?;
                 writeln!(out, "- `:{c} std.array.any`")?;

--- a/core/src/repl/rustyline_frontend.rs
+++ b/core/src/repl/rustyline_frontend.rs
@@ -88,7 +88,7 @@ pub fn repl(histfile: PathBuf, color_opt: ColorOpt) -> Result<(), InitError> {
                     Ok(Command::Typecheck(exp)) => {
                         repl.typecheck(&exp).map(|types| println!("Ok: {types}"))
                     }
-                    Ok(Command::Query {target, path}) => repl.query(target, path).map(|field| {
+                    Ok(Command::Query(path)) => repl.query(path).map(|field| {
                         query_print::write_query_result(
                             &mut stdout,
                             &field,

--- a/core/src/repl/simple_frontend.rs
+++ b/core/src/repl/simple_frontend.rs
@@ -49,8 +49,8 @@ pub fn input<R: Repl>(repl: &mut R, line: &str) -> Result<InputResult, InputErro
                 .typecheck(&exp)
                 .map(|types| InputResult::Success(format!("Ok: {types}")))
                 .map_err(InputError::from),
-            Ok(Command::Query { target, path }) => repl
-                .query(target, path)
+            Ok(Command::Query(path)) => repl
+                .query(path)
                 .map(|t| {
                     let mut buffer = Cursor::new(Vec::<u8>::new());
                     query_print::write_query_result(


### PR DESCRIPTION
Closes #1446.

Previously, the query command of the REPL would accept a first argument that could be a record access chain, followed by a second one which could also be a field path. This means that, for querying a given path `foo.bar.baz.blo`, there are 3 different but equivalent query invocations:

- `:query foo bar.baz.blo`
- `:query foo.bar baz.blo`
- `:query foo.bar.baz blo`

Moreover, `:query foo.bar.baz.blo` without a second argument wouldn't fail but pretend that there are no metadata, even if there are.

This PR simplifies the overall interface of the query command by just accepting one argument which is a field path.