### PR TITLE
Use the Types AST variant for completion

### DIFF
--- a/lsp/nls/src/linearization/building.rs
+++ b/lsp/nls/src/linearization/building.rs
@@ -90,7 +90,7 @@ impl<'b> Building<'b> {
             TermKind::Record(_) => (),
             // unreachable()!: add_usage can only called on let binding, functions and record
             // fields, only referring to items which support usages.
-            TermKind::Structure | TermKind::Usage(_) => unreachable!(),
+            TermKind::Types(_) | TermKind::Structure | TermKind::Usage(_) => unreachable!(),
             TermKind::Declaration { ref mut usages, .. }
             | TermKind::RecordField { ref mut usages, .. } => usages.push(usage),
         };

--- a/lsp/nls/src/linearization/interface.rs
+++ b/lsp/nls/src/linearization/interface.rs
@@ -21,7 +21,7 @@ impl ResolutionState for Resolved {}
 /// 3. Records, listing their fields
 /// 4. wildcard (Structure) for any other kind of term.
 /// Can be extended later to represent Contracts, Records, etc.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum TermKind {
     Declaration {
         id: Ident,
@@ -43,6 +43,7 @@ pub enum TermKind {
         usages: Vec<ItemId>,
         value: ValueState,
     },
+    Types(Types),
     Structure,
 }
 

--- a/lsp/nls/src/linearization/mod.rs
+++ b/lsp/nls/src/linearization/mod.rs
@@ -493,6 +493,16 @@ impl<'a> Linearizer for AnalysisHost<'a> {
                     metadata: self.meta.take(),
                 })
             }
+            Term::Types(t) => {
+                lin.push(LinearizationItem {
+                    env: self.env.clone(),
+                    id,
+                    pos,
+                    ty,
+                    kind: TermKind::Types(t.clone()),
+                    metadata: self.meta.take(),
+                });
+            }
             other => {
                 debug!("Add wildcard item: {:?}", other);
 

--- a/lsp/nls/src/requests/completion.rs
+++ b/lsp/nls/src/requests/completion.rs
@@ -186,6 +186,7 @@ fn find_fields_from_term_kind(
         TermKind::Usage(UsageState::Resolved(new_id)) => {
             find_fields_from_term_kind(new_id, path, info)
         }
+        TermKind::Types(ref ty) => find_fields_from_type(ty, path, info),
         _ => Vec::new(),
     };
     result.into_iter().chain(contract_result).collect()

--- a/lsp/nls/tests/inputs/completion-dict.ncl
+++ b/lsp/nls/tests/inputs/completion-dict.ncl
@@ -1,0 +1,17 @@
+### /input-inline.ncl
+let x | { _ : { foo : Number | default = 1 } } = {} in
+x.PATH.
+### /input-assign.ncl
+let Dict = { _ : { foo : Number | default = 1 } } in
+let x | Dict = {} in
+x.PATH.
+### [[request]]
+### type = "Completion"
+### textDocument.uri = "file:///input-inline.ncl"
+### position = { line = 1, character = 7 }
+### context = { triggerKind = 2, triggerCharacter = "." }
+### [[request]]
+### type = "Completion"
+### textDocument.uri = "file:///input-assign.ncl"
+### position = { line = 2, character = 7 }
+### context = { triggerKind = 2, triggerCharacter = "." }

--- a/lsp/nls/tests/snapshots/main__lsp__nls__tests__inputs__completion-dict.ncl.snap
+++ b/lsp/nls/tests/snapshots/main__lsp__nls__tests__inputs__completion-dict.ncl.snap
@@ -1,0 +1,7 @@
+---
+source: lsp/nls/tests/main.rs
+expression: output
+---
+[foo]
+[foo]
+


### PR DESCRIPTION
Allows the LSP to inspect types that have been converted to terms. Previously, completion would work with inputs like

```
let x | { _ : { foo: Number } } = ... in x.
```

but fail when the type annotation was bound to a variable like

```
let C = { _ : { foo: Number } } in
let x | C = ... in x.
```

With this PR, the two cases are treated the same for completion.

Fixes #1120 