### PR TITLE
Update `KEYWORDS` with new builtin type names

### DIFF
--- a/core/src/parser/lexer.rs
+++ b/core/src/parser/lexer.rs
@@ -351,9 +351,9 @@ pub enum NormalToken<'input> {
 
 pub const KEYWORDS: &[&str] = &[
     "Dyn",
-    "Num",
+    "Number",
     "Bool",
-    "Str",
+    "String",
     "Array",
     "if",
     "then",


### PR DESCRIPTION
The `KEYWORDS` list still contained `Num` and `Str` instead of `Number` and `String`.