### PR TITLE
add std.contract.Sequence

### DIFF
--- a/core/stdlib/std.ncl
+++ b/core/stdlib/std.ncl
@@ -934,6 +934,27 @@
         "%
       = fun pred label value => if pred value then value else %blame% label,
 
+    Sequence
+      | doc m%"
+          Apply multiple contracts from left to right.
+
+          Type: `Array Contract -> Contract`
+          (for technical reasons, this function isn't actually statically typed)
+
+          # Examples
+
+          ```nickel
+          x | std.contract.Sequence [ Foo Bar ]
+          ```
+
+          is equivalent to
+
+          ```nickel
+          (x | Foo) | Bar
+          ```
+        "%
+      = fun contracts label value =>
+        std.array.fold_right (fun contract acc => std.contract.apply contract label acc) value contracts,
     label
       | doc m%"
           The label submodule provides functions that manipulate the label

--- a/core/stdlib/std.ncl
+++ b/core/stdlib/std.ncl
@@ -957,13 +957,13 @@
           such as an argument to another contract:
 
           ```nickel
-          x | Array (std.contract.sequence [ Foo, Bar ])
+          x | Array (std.contract.Sequence [ Foo, Bar ])
           ```
 
           Or stored in a variable:
 
           ```nickel
-          let C = std.contract.sequence [ Foo, Bar ] in
+          let C = std.contract.Sequence [ Foo, Bar ] in
           x | C
           ```
         "%

--- a/core/stdlib/std.ncl
+++ b/core/stdlib/std.ncl
@@ -954,7 +954,7 @@
           ```
         "%
       = fun contracts label value =>
-        std.array.fold_right (fun contract acc => std.contract.apply contract label acc) value contracts,
+        std.array.fold_right (fun contract => std.contract.apply contract label) value contracts,
     label
       | doc m%"
           The label submodule provides functions that manipulate the label

--- a/core/stdlib/std.ncl
+++ b/core/stdlib/std.ncl
@@ -952,6 +952,20 @@
           ```nickel
           (x | Foo) | Bar
           ```
+
+          This is useful in positions where one cannot apply multiple contracts,
+          such as an argument to another contract:
+
+          ```nickel
+          x | Array (std.contract.sequence [ Foo, Bar ])
+          ```
+
+          Or stored in a variable:
+
+          ```nickel
+          let C = std.contract.sequence [ Foo, Bar ] in
+          x | C
+          ```
         "%
       = fun contracts label value =>
         std.array.fold_right (fun contract => std.contract.apply contract label) value contracts,

--- a/core/stdlib/std.ncl
+++ b/core/stdlib/std.ncl
@@ -944,7 +944,7 @@
           # Examples
 
           ```nickel
-          x | std.contract.Sequence [ Foo Bar ]
+          x | std.contract.Sequence [ Foo, Bar ]
           ```
 
           is equivalent to

--- a/core/tests/integration/fail/contracts/sequence.ncl
+++ b/core/tests/integration/fail/contracts/sequence.ncl
@@ -1,0 +1,6 @@
+# test.type = 'error'
+#
+# [test.metadata]
+# error = 'EvalError::BlameError'
+
+3 | std.contract.Sequence [ Number, std.contract.from_predicate (fun x => x < 5), std.contract.from_predicate (fun x => x > 5) ]

--- a/core/tests/integration/pass/contracts/contracts.ncl
+++ b/core/tests/integration/pass/contracts/contracts.ncl
@@ -166,5 +166,11 @@ let {check, Assert, ..} = import "../lib/assert.ncl" in
         = fun r => %record_insert% "g" r g in
   let res = f { z = 3 }
   in true,
+
+  # std.contract.Sequence
+  let three = 3 | std.contract.Sequence [ Number, std.contract.from_predicate (fun x => x < 5) ] in
+  # preserves order
+  let tag = "some_tag" | std.contract.Sequence [ std.enum.TagOrString, [| 'some_tag |] ]
+  in true
 ]
 |> check


### PR DESCRIPTION
This new function isn't so useful for applying directly, but there;s currently no way to store multiple contracts in a variable to be applied later. In other words
```nickel
'foo | [| 'foo |]
```
is to
```nickel
let Foo = [| 'foo |] in
'foo | Foo
```
as
```nickel
"foo" | std.contract.TagOrString | [| 'foo |]
```
is to
???

Well, before there were no options. with this PR we can do
```nickel
let Foo = std.contract.Sequence [ std.contract.TagOrString, [| 'foo |] ] in
"foo" | Foo
```

Eventually, it would be nice if the LSP could recognize this and get the same niceties as if you'd directly applied the two contracts.