### PR TITLE
Static linking with `nickel format`

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -16,7 +16,7 @@ path = "bin/nickel.rs"
 bench = false
 
 [features]
-default = ["repl", "doc"]
+default = ["repl", "doc", "format"]
 repl = ["nickel-lang-core/repl"]
 doc = ["nickel-lang-core/doc"]
 format = ["topiary", "tree-sitter-nickel", "tempfile"]

--- a/flake.nix
+++ b/flake.nix
@@ -262,7 +262,7 @@
                   CARGO_BUILD_TARGET = pkgs.rust.toRustTarget pkgs.pkgsMusl.stdenv.hostPlatform;
                   # For some reason, the rust build doesn't pick up the paths
                   # to `libcxx` and `libcxxabi` from the stdenv. So we specify
-                  # them explicitly. Also, `libcxx` expects to be linked fith
+                  # them explicitly. Also, `libcxx` expects to be linked with
                   # `libcxxabi` at the end, and we need to make the rust linker
                   # aware of that.
                   RUSTFLAGS = "-L${pkgs.pkgsMusl.llvmPackages.libcxx}/lib -L${pkgs.pkgsMusl.llvmPackages.libcxxabi}/lib -lstatic=c++abi";

--- a/flake.nix
+++ b/flake.nix
@@ -241,10 +241,7 @@
         rec {
           inherit cargoArtifacts;
           nickel-lang-core = buildPackage { pname = "nickel-lang-core"; };
-          nickel-lang-cli = buildPackage {
-            pname = "nickel-lang-cli";
-            extraBuildArgs = "--features format";
-          };
+          nickel-lang-cli = buildPackage { pname = "nickel-lang-cli"; };
           lsp-nls = buildPackage { pname = "nickel-lang-lsp"; };
 
           # Static building isn't really possible on MacOS because the system call ABIs aren't stable.
@@ -257,7 +254,6 @@
             # tried building with libstdc++ but without success.
               buildPackage {
                 pname = "nickel-lang-cli";
-                extraBuildArgs = "--features format";
                 extraArgs = {
                   CARGO_BUILD_TARGET = pkgs.rust.toRustTarget pkgs.pkgsMusl.stdenv.hostPlatform;
                   # For some reason, the rust build doesn't pick up the paths

--- a/flake.nix
+++ b/flake.nix
@@ -487,18 +487,21 @@
           nickel-lang-cli
           benchmarks
           lsp-nls
-          cargoArtifacts
-          nickel-static;
+          cargoArtifacts;
         default = pkgs.buildEnv {
           name = "nickel";
           paths = [ packages.nickel-lang-cli packages.lsp-nls ];
         };
         nickelWasm = buildNickelWasm { };
-        dockerImage = buildDocker packages.nickel-static; # TODO: docker image should be a passthru
+        dockerImage = buildDocker packages.nickel-lang-cli; # TODO: docker image should be a passthru
         inherit vscodeExtension;
         inherit userManual;
         stdlibMarkdown = stdlibDoc "markdown";
         stdlibJson = stdlibDoc "json";
+      } // pkgs.lib.optionalAttrs (!pkgs.stdenv.hostPlatform.isDarwin) {
+        inherit (mkCraneArtifacts { }) nickel-static;
+        # Use the statically linked binary for the docker image if we're not on MacOS.
+        dockerImage = buildDocker packages.nickel-static;
       };
 
       apps = {


### PR DESCRIPTION
This is the result of experiments together with @jneem and @Radvendii. Using the musl libc and clang with libc++ we can statically link a Nickel binary which includes the new `format` feature.