### PR TITLE
Make the lexer accept scientific notation

### DIFF
--- a/core/src/parser/lexer.rs
+++ b/core/src/parser/lexer.rs
@@ -69,7 +69,7 @@ pub enum NormalToken<'input> {
     // regex for checking identifiers at ../lsp/nls/src/requests/completion.rs
     #[regex("_?[a-zA-Z][_a-zA-Z0-9-']*")]
     Identifier(&'input str),
-    #[regex("[0-9]*\\.?[0-9]+", |lex| parse_number(lex.slice()))]
+    #[regex("[0-9]*\\.?[0-9]+([eE][+\\-]?[0-9]+)?", |lex| parse_number(lex.slice()))]
     NumLiteral(Number),
 
     // **IMPORTANT**

--- a/core/tests/integration/pass/core/numbers.ncl
+++ b/core/tests/integration/pass/core/numbers.ncl
@@ -1,0 +1,10 @@
+# test.type = 'pass'
+let {check, ..} = import "../lib/assert.ncl" in
+
+[
+  5 + 5 == 10,
+  5 * 5 == 25,
+  1e6 == 1000000,
+  1e+3 / 2e-3 == 0.5e6,
+]
+|> check

--- a/doc/manual/syntax.md
+++ b/doc/manual/syntax.md
@@ -39,12 +39,14 @@ fit exactly into a 64-bit signed integer or a 64-bit unsigned integer. They
 are serialized as a 64-bit float otherwise. The latter conversion might lose
 precision as well, for example when serializing `1/3`.
 
-Here are some examples of number literals in Nickel:
+Here are some examples of number literals in Nickel; scientific notation for
+decimal is supported:
 
 ```nickel
 1
 0.543
-42
+1.7e217
+-3e-3
 -1000000
 -6.8
 ```


### PR DESCRIPTION
Since we were alread using `malachite`'s scientific notation parser for parsing numbers, the only thing stopping #1361 was the lexer not supporting scientific notation. This would technically be a breaking change, since previously `f 1e6` would be parsed as `f` applied to the number `1` and the variable `e6`, while now it would be parsed as `f` applied to one million. I hope that nobody relies on this behaviour but it's worth considering, given our (informal, for now) stability guarantee.