### PR TITLE
Evaluate terms before extracting documentation

### DIFF
--- a/cli/src/doc.rs
+++ b/cli/src/doc.rs
@@ -41,6 +41,7 @@ pub fn export_doc(
     stdout: bool,
     format: DocFormat,
 ) -> Result<(), Error> {
+    let doc = program.extract_doc()?;
     let mut out: Box<dyn std::io::Write> = if stdout {
         Box::new(std::io::stdout())
     } else {
@@ -91,7 +92,6 @@ pub fn export_doc(
                 })?,
         )
     };
-    let doc = program.extract_doc()?;
     match format {
         DocFormat::Json => doc.write_json(&mut out),
         DocFormat::Markdown => doc.write_markdown(&mut out),

--- a/core/src/program.rs
+++ b/core/src/program.rs
@@ -263,7 +263,7 @@ impl<EC: EvalCache> Program<EC> {
     /// This needs to evaluate to WHNF, but then still descend into subfields
     /// whose values are records.
     #[cfg(feature = "doc")]
-    pub fn eval_for_docs(&mut self) -> Result<RichTerm, Error> {
+    pub fn eval_for_doc(&mut self) -> Result<RichTerm, Error> {
         use crate::eval::{Closure, Environment};
         use crate::match_sharedterm;
         use crate::term::record::RecordData;
@@ -323,7 +323,7 @@ impl<EC: EvalCache> Program<EC> {
     pub fn extract_doc(&mut self) -> Result<doc::ExtractedDocumentation, Error> {
         use crate::error::ExportError;
 
-        let term = self.eval_for_docs()?;
+        let term = self.eval_for_doc()?;
         doc::ExtractedDocumentation::extract_from_term(&term).ok_or(Error::ExportError(
             ExportError::NoDocumentation(term.clone()),
         ))


### PR DESCRIPTION
With this change, `nickel doc` evaluates a term before trying to extract
documentation. The evaluation mode needed here is somewhat between evaluating to
WHNF and a full deep evaluation. Namely, we first evaluate the term to WHNF. If
it isn't a record then there is no documentation to extract and we're done. If
it is, we iterate through all fields with a defined value and call the evaluator
recursively.

The result will be a tree of records in WHNF which our previous documentation
extraction procedure knows how to handle. In fact, the only difference to a full
deep evaluation is that we do not descend into arrays. Consequently, this change
will incur a performance penalty compared to the previous `nickel doc`. For
now, we're willing to accept this penalty for two reasons. First, documentation
extraction is expected to be rarer than fully evaluating a Nickel configuration.
Second, the evaluation algorithm presented here does strictly less work than a
full evaluation and therefore shouldn't be any slower.

There is another caveat with this implementation. For simplicity, I've
implemented an explicitly recursive version of the algorithm described above.
This means that we're using the Rust callstack when descending into deeply
nested records and we might encounter stack overflows for particularly deep
records. The Nickel evaluator itself uses a custom stack stored in the heap to
circumvent this problem. If we ever encounter stack overflows in `nickel doc` in
the wild, we should do the same here.

Fixes #1462.