### PR TITLE
[Refactor] Introduce RemoveRow trait

### DIFF
--- a/core/src/error.rs
+++ b/core/src/error.rs
@@ -257,7 +257,7 @@ pub enum TypecheckError {
     /// the direct failure to unify `{ .. , x: T1, .. }` and `{ .., x: T2, .. }`.
     RowConflict(
         Ident,
-        /* the second type assignment which violates the constraint */ Option<Types>,
+        /* the second type assignment which violates the constraint */ Types,
         /* the expected type of the subexpression */ Types,
         /* the actual type of the subexpression */ Types,
         TermPos,
@@ -2015,7 +2015,7 @@ impl IntoDiagnostics<FileId> for TypecheckError {
                         .with_message("multiple rows declaration")
                         .with_labels(mk_expr_label(&span_opt))
                         .with_notes(vec![
-                            format!("Found an expression of a record type `{}` with the row `{}`", conflict.as_ref().cloned().unwrap(), ident),
+                            format!("Found an expression of a record type `{}` with the row `{}`", conflict, ident),
                             format!("But this type appears inside another row type, which already has a declaration for the field `{ident}`"),
                             String::from("A type cannot have two conflicting declarations for the same row"),
                         ])]

--- a/core/src/typecheck/error.rs
+++ b/core/src/typecheck/error.rs
@@ -23,7 +23,7 @@ pub enum RowUnifError {
     /// There were two incompatible definitions for the same row.
     RowMismatch(Ident, Box<UnifError>),
     /// A [row constraint][super::RowConstr] was violated.
-    UnsatConstr(Ident, Option<UnifType>),
+    UnsatConstr(Ident, UnifType),
     /// Tried to unify a type constant with another different type.
     WithConst(VarKindDiscriminant, usize, UnifType),
     /// Tried to unify two distinct type constants.
@@ -88,7 +88,7 @@ pub enum UnifError {
     ExtraDynTail(UnifType, UnifType),
     /// Tried to unify a unification variable with a row type violating the [row
     /// constraints][super::RowConstr] of the variable.
-    RowConflict(Ident, Option<UnifType>, UnifType, UnifType),
+    RowConflict(Ident, UnifType, UnifType, UnifType),
     /// Tried to unify a type constant with another different type.
     WithConst(VarKindDiscriminant, usize, UnifType),
     /// A flat type, which is an opaque type corresponding to custom contracts, contained a Nickel
@@ -213,7 +213,7 @@ impl UnifError {
             ),
             UnifError::RowConflict(id, uty, left, right) => TypecheckError::RowConflict(
                 id,
-                uty.map(|uty| reporting::to_type(state.table, state.names, names, uty)),
+                reporting::to_type(state.table, state.names, names, uty),
                 reporting::to_type(state.table, state.names, names, left),
                 reporting::to_type(state.table, state.names, names, right),
                 pos_opt,

--- a/core/src/typecheck/unif.rs
+++ b/core/src/typecheck/unif.rs
@@ -1324,14 +1324,15 @@ trait RemoveRow: Sized {
     type RowContent;
     type Error;
 
-    // Fetch a specific row with the same id as `row.id` from a row type, and return the found row
-    // together with the original row type with the found row removed.
+    // Fetch a specific `row_id` from a row type, and return the content of the row together with
+    // the original row type without the found row.
     //
-    // If the row isn't found directly in the row type:
-    // - If the row type is extensible, i.e. it ends with a free unification variable for the tail,
-    //   this function adds the missing row (with `row.types` as a type for record rows, if allowed by [row
-    //   constraints][RowConstr]) and then acts as if `remove_row` was called on extended row type. That is, `remove_row` then returns the new
-    //   row and the extended type without the added row).
+    // If the searched row isn't found directly:
+    // - If the row type is extensible, i.e. it ends with a free unification variable in tail
+    //   position, this function adds the missing row (with `row.types` as a type for record rows,
+    //   if allowed by row constraints) and then acts as if `remove_row` was called again on
+    //   this extended row type. That is, `remove_row` returns the new row and the extended type
+    //   without the added row).
     // - Otherwise, raise a missing row error.
     fn remove_row(
         self,
@@ -1343,7 +1344,7 @@ trait RemoveRow: Sized {
 
 #[derive(Clone, Copy, Debug)]
 enum RemoveRRowError {
-    // The row to add was missing and the row type was closed (no free unification variable in free
+    // The row to add was missing and the row type was closed (no free unification variable in tail
     // position).
     Missing,
     // The row to add was missing and the row type couldn't be extended because of row constraints.


### PR DESCRIPTION
The free-standing functions `erows_add` and `rrows_add` are very similar. The name and documentation was also misleading: what those methods do is rather to remove a row than adding a new one (although they first ensure the row is present, which might lead to adding it first).

This refactoring put them in their own trait, `RemoveRow`, and update the documentation accordingly. Doing so, we also get rid of an `Option` wrapper for a parameter of `UnsatConstr` error, which was unwrapped when reporting anyway.