### PR TITLE
Fix REPL panic on transitive imports

### DIFF
--- a/core/src/repl/mod.rs
+++ b/core/src/repl/mod.rs
@@ -6,7 +6,7 @@
 //! Dually, the frontend is the user-facing part, which may be a CLI, a web application, a
 //! jupyter-kernel (which is not exactly user-facing, but still manages input/output and
 //! formatting), etc.
-use crate::cache::{Cache, CacheError, Envs, ErrorTolerance};
+use crate::cache::{Cache, Envs, ErrorTolerance};
 use crate::error::{Error, EvalError, IOError, ParseError, ParseErrors, ReplError};
 use crate::eval::cache::Cache as EvalCache;
 use crate::eval::{Closure, VirtualMachine};

--- a/core/src/repl/mod.rs
+++ b/core/src/repl/mod.rs
@@ -6,7 +6,7 @@
 //! Dually, the frontend is the user-facing part, which may be a CLI, a web application, a
 //! jupyter-kernel (which is not exactly user-facing, but still manages input/output and
 //! formatting), etc.
-use crate::cache::{Cache, Envs, ErrorTolerance};
+use crate::cache::{Cache, CacheError, Envs, ErrorTolerance};
 use crate::error::{Error, EvalError, IOError, ParseError, ParseErrors, ReplError};
 use crate::eval::cache::Cache as EvalCache;
 use crate::eval::{Closure, VirtualMachine};
@@ -113,7 +113,12 @@ impl<EC: EvalCache> ReplImpl<EC> {
             resolved_ids: pending,
         } = import_resolution::strict::resolve_imports(t, self.vm.import_resolver_mut())?;
         for id in &pending {
-            dbg!(self.vm.import_resolver_mut().resolve_imports(*id)).unwrap();
+            self.vm
+                .import_resolver_mut()
+                .resolve_imports(*id)
+                .map_err(|cache_err| {
+                    cache_err.unwrap_error("repl::eval_(): expected imports to be parsed")
+                })?;
         }
 
         let wildcards =


### PR DESCRIPTION
I also refactored one of the functions i had trouble understanding. I don't feel too strongly about it though if someone else objects to the refactor.

Something that took me a while to track down, and I still am having a little trouble understanding:
We can safely call `unwrap_error()` because the only case where `.resolve_imports()` returns `NotParsed` is when the call to `entry_state()`, in other words `terms.get()` is `None`.

And we've already called `import-resolution::strict::resolve_imports()`, and if I'm reading the code correctly everything passed back in `resolved_ids` must have been put in `terms` (ultimately by `parse_lax_multi()`)

My confusion is... we haven't parsed the file at that point though, right? We clearly parse them during hte call to `.resolve_imports()`, because that's where parse errors are being generated. But they must already have state `>= EntryState::Parsed` before that call.

---

Also, do we have any mechanism for testing the repl?