### PR TITLE
Ignore missing field definition errors during documentation extraction

### DIFF
--- a/core/src/program.rs
+++ b/core/src/program.rs
@@ -287,6 +287,15 @@ impl<EC: EvalCache> Program<EC> {
                 initial_env,
             );
 
+            // We expect to hit `MissingFieldDef` errors. When a configuration
+            // contains undefined record fields they most likely will be used
+            // recursively in the definition of some other fields. So instead of
+            // bubbling up an evaluation error in this case we just leave fields
+            // that depend on as yet undefined fields unevaluated; we wouldn't
+            // be able to extract dcoumentation from their values anyways. All
+            // other evaluation errors should however be reported to the user
+            // instead of resulting in documentation being silently skipped.
+
             let (rt, env) = match result {
                 Err(EvalError::MissingFieldDef { .. }) => return Ok(t),
                 _ => result,


### PR DESCRIPTION
My first implementation of a shallow evaluation mode for extracting documentation tried to evaluate to WHNF every record field that has a value. Then it reports any error that it encounters. But we actually expect to hit `EvalError::MissingFieldDef` in normal partial configurations because presumably an undefined field is intended to be used recursively somewhere. With this change, we report all errors except for `MissingFieldDef`.