### PR TITLE
Issue diagnostics, even if empty.

### DIFF
--- a/lsp/nls/src/server.rs
+++ b/lsp/nls/src/server.rs
@@ -284,15 +284,15 @@ impl Server {
             .flat_map(|d| lsp_types::Diagnostic::from_codespan(d, self.cache.files_mut()))
             .collect();
 
-        if !diagnostics.is_empty() {
-            self.notify(lsp_server::Notification::new(
-                "textDocument/publishDiagnostics".into(),
-                PublishDiagnosticsParams {
-                    uri,
-                    diagnostics,
-                    version: None,
-                },
-            ));
-        }
+        // Issue diagnostics even if they're empty (empty diagnostics are how the editor knows
+        // that any previous errors were resolved).
+        self.notify(lsp_server::Notification::new(
+            "textDocument/publishDiagnostics".into(),
+            PublishDiagnosticsParams {
+                uri,
+                diagnostics,
+                version: None,
+            },
+        ));
     }
 }


### PR DESCRIPTION
This fixes an issues where diagnostic errors would remain even after the problems were fixed.

There isn't a corresponding issue, but it was mentioned on [matrix](https://matrix.to/#/!CTCVXeJTucJbViJokz:matrix.org/$wHupl8ghnvoOmjlDupmN70fERtX1IHgUsXMrT7NFeSQ?via=matrix.org&via=kleen.org&via=midnightthoughts.space)