### PR TITLE
Actually persist output files for formatting

### DIFF
--- a/cli/src/format.rs
+++ b/cli/src/format.rs
@@ -44,6 +44,7 @@ impl Display for FormatError {
     }
 }
 
+#[derive(Debug)]
 pub enum Output {
     Stdout,
     Disk {
@@ -57,7 +58,13 @@ impl Output {
         match path {
             None => Ok(Self::Stdout),
             Some(path) => {
-                let path = path.canonicalize()?;
+                // `canonicalize()` will fail if `path` does not exist. In this
+                // case, our best bet will be to just use `path` as given by
+                // the user.
+                let path = path.canonicalize().or_else(|e| match e.kind() {
+                    io::ErrorKind::NotFound => Ok(path.to_owned()),
+                    _ => Err(e),
+                })?;
                 Ok(Self::Disk {
                     staged: NamedTempFile::new_in(path.parent().ok_or_else(|| {
                         FormatError::NotAFile {

--- a/cli/src/format.rs
+++ b/cli/src/format.rs
@@ -116,7 +116,7 @@ fn do_format(
     let topiary_config = topiary::Configuration::parse_default_configuration()?;
     let language = topiary::SupportedLanguage::Nickel.to_language(&topiary_config);
     let grammar = tree_sitter_nickel::language().into();
-    Ok(topiary::formatter(
+    topiary::formatter(
         &mut input,
         &mut output,
         &TopiaryQuery::nickel(),
@@ -126,5 +126,7 @@ fn do_format(
             skip_idempotence: true,
             tolerate_parsing_errors: true,
         },
-    )?)
+    )?;
+    output.persist();
+    Ok(())
 }

--- a/cli/tests/integration/main.rs
+++ b/cli/tests/integration/main.rs
@@ -1,0 +1,46 @@
+use std::{
+    io::Write,
+    process::{Command, Stdio},
+};
+
+use tempfile::tempdir;
+
+fn test_creates_output_files(command: &[&str]) {
+    let nickel_bin = env!("CARGO_BIN_EXE_nickel");
+    let output = tempdir()
+        .expect("should be able to make a temporary directory")
+        .into_path()
+        .join("output");
+    let mut nickel = Command::new(nickel_bin)
+        .args(command)
+        .arg("-o")
+        .arg(&output)
+        .stdin(Stdio::piped())
+        .spawn()
+        .expect("Nickel should be runnable");
+    let Some(mut stdin) = nickel.stdin.take() else {
+            panic!("couldn't retrieve stdin handle to Nickel")
+        };
+    stdin
+        .write_all(b"{foo=1}")
+        .expect("writing into Nickel stdin should work");
+    drop(stdin);
+
+    nickel.wait().expect("Nickel should exit successfully");
+    assert!(output.exists());
+}
+
+#[test]
+fn export_creates_output_files() {
+    test_creates_output_files(&["export"]);
+}
+
+#[test]
+fn doc_creates_output_files() {
+    test_creates_output_files(&["doc", "--format", "json"]);
+}
+
+#[test]
+fn format_creates_output_files() {
+    test_creates_output_files(&["format"]);
+}


### PR DESCRIPTION
All the code for properly formatting files in-place was there, but in the original PR I forgot to persist the output file. As a result, formatting works for as a pipeline from stdin to stdout but when an output file is specified, the formatted Nickel code is silently discarded.

With this change we actually persist the formatted result.