### PR TITLE
Linearize imports dependents-first

### DIFF
--- a/core/src/cache.rs
+++ b/core/src/cache.rs
@@ -680,6 +680,11 @@ impl Cache {
     /// component: this return value is currently used by the LSP to re-run code analysis on new
     /// files/modified files.
     ///
+    /// The resolved imports are ordered by a pre-order depth-first-search. In
+    /// particular, earlier elements in the returned list might import later
+    /// elements but -- unless there are cyclic imports -- later elements do not
+    /// import earlier elements.
+    ///
     /// It only accumulates errors if the cache is in error tolerant mode, otherwise it returns an
     /// `Err(..)` containing  a `CacheError`.
     #[allow(clippy::type_complexity)]
@@ -705,7 +710,7 @@ impl Cache {
                     }
                 };
 
-                // unwrap!(): we called `unwrap()` at the beggining of the enclosing if branch
+                // unwrap!(): we called `unwrap()` at the beginning of the enclosing if branch
                 // on the result of `self.terms.get(&file_id)`. We only made recursive calls to
                 // `resolve_imports` in between, which don't remove anything from `self.terms`.
                 let cached_term = self.terms.get_mut(&file_id).unwrap();

--- a/lsp/nls/src/cache.rs
+++ b/lsp/nls/src/cache.rs
@@ -35,7 +35,8 @@ impl CacheExt for Cache {
         let mut typecheck_import_diagnostics: Vec<FileId> = Vec::new();
         if let Ok(CacheOp::Done((ids, errors))) = self.resolve_imports(file_id) {
             import_errors = errors;
-            for id in ids {
+            // Reverse the imports, so we try to typecheck the leaf dependencies first.
+            for &id in ids.iter().rev() {
                 let _ = self.typecheck_with_analysis(id, initial_ctxt, initial_env, lin_registry);
             }
         }

--- a/lsp/nls/src/linearization/mod.rs
+++ b/lsp/nls/src/linearization/mod.rs
@@ -541,7 +541,7 @@ impl<'a> Linearizer for AnalysisHost<'a> {
             wildcards,
         }: Extra,
     ) -> Linearization<Completed> {
-        debug!("linearizing");
+        debug!("linearizing {:?}", self.file);
 
         // TODO: Storing defers while linearizing?
         let mut defers: Vec<(ItemId, ItemId, Ident)> = lin


### PR DESCRIPTION
When file 1 imports file 2, which imports file 3, and we load file 1 into nls, we need to linearize 3 first, then 2, then 1. Prior to this PR, we would linearize 2, 3, 1.

I wasn't able to write a test for this, unfortunately. Our nls testing harness only sees files that you explicitly send to it, and so either you send the files in the order 3, 2, 1 (in which case there's no difference in behavior before/after this PR) or else you send them in some other order and some import (correctly) fails because the imported file doesn't exist anywhere nls can find it.

Fixes #1480