### PR TITLE
Add a `Nullable` contract to the stdlib

### DIFF
--- a/core/stdlib/std.ncl
+++ b/core/stdlib/std.ncl
@@ -869,6 +869,28 @@
                 |> from_predicate ((==) constant) ctr_label,
           },
 
+    Nullable
+      | doc m%"
+          `Nullable sub_contract` is a contract that gets verified if the value
+          is either `null` or verified by `sub_contract`.
+
+          # Examples
+
+          ```
+          1 | std.contract.Nullable Number
+            => 1
+          null | std.contract.Nullable Number
+            => null
+          "foo" | std.contract.Nullable Number
+            => error
+          ```
+        "%
+      = fun sub_contract label value =>
+        if value == null then
+          null
+        else
+          std.contract.apply sub_contract label value,
+
     blame
       | doc m%"
           Raises blame for a given label.

--- a/core/tests/integration/fail/contracts/nullable.ncl
+++ b/core/tests/integration/fail/contracts/nullable.ncl
@@ -1,0 +1,7 @@
+# test.type = 'error'
+#
+# [test.metadata]
+# error = 'EvalError::BlameError'
+
+3 | std.contract.Nullable String
+

--- a/core/tests/integration/pass/contracts/contracts.ncl
+++ b/core/tests/integration/pass/contracts/contracts.ncl
@@ -171,6 +171,11 @@ let {check, Assert, ..} = import "../lib/assert.ncl" in
   let three = 3 | std.contract.Sequence [ Number, std.contract.from_predicate (fun x => x < 5) ] in
   # preserves order
   let tag = "some_tag" | std.contract.Sequence [ std.enum.TagOrString, [| 'some_tag |] ]
-  in true
+  in true,
+
+  # std.contract.Nullable
+  let three = 3 | std.contract.Nullable Number in
+  let nul = null | std.contract.Nullable Number in
+  true
 ]
 |> check


### PR DESCRIPTION
Add a contract function that extends the domain of its argument by also
allowing `null`.

This is a very widely used construct, so it deserves being implemented
once and for once here.

From https://github.com/nickel-lang/nickel-nix/pull/101#discussion_r1277651805
