### PR TITLE
Traversal by reference

### DIFF
--- a/core/src/term/mod.rs
+++ b/core/src/term/mod.rs
@@ -304,10 +304,7 @@ impl Traverse<RichTerm> for RuntimeContract {
         Ok(RuntimeContract { contract, ..self })
     }
 
-    fn traverse_ref<F, U>(&self, f: &mut F) -> Option<U>
-    where
-        F: FnMut(&RichTerm) -> TraverseControl<U>,
-    {
+    fn traverse_ref<U>(&self, f: &mut dyn FnMut(&RichTerm) -> TraverseControl<U>) -> Option<U> {
         self.contract.traverse_ref(f)
     }
 }
@@ -458,10 +455,7 @@ impl Traverse<RichTerm> for LabeledType {
             .map(|typ| LabeledType { typ, label })
     }
 
-    fn traverse_ref<F, U>(&self, f: &mut F) -> Option<U>
-    where
-        F: FnMut(&RichTerm) -> crate::term::TraverseControl<U>,
-    {
+    fn traverse_ref<U>(&self, f: &mut dyn FnMut(&RichTerm) -> TraverseControl<U>) -> Option<U> {
         self.typ.traverse_ref(f)
     }
 }
@@ -574,10 +568,7 @@ impl Traverse<RichTerm> for TypeAnnotation {
         Ok(TypeAnnotation { typ, contracts })
     }
 
-    fn traverse_ref<F, U>(&self, f: &mut F) -> Option<U>
-    where
-        F: FnMut(&RichTerm) -> crate::term::TraverseControl<U>,
-    {
+    fn traverse_ref<U>(&self, f: &mut dyn FnMut(&RichTerm) -> TraverseControl<U>) -> Option<U> {
         self.contracts
             .iter()
             .find_map(|c| c.traverse_ref(f))
@@ -1497,9 +1488,7 @@ pub trait Traverse<T>: Sized {
     ///
     /// Through its return value, `f` can short-circuit one branch of the traversal or
     /// the entire traversal.
-    fn traverse_ref<F, U>(&self, f: &mut F) -> Option<U>
-    where
-        F: FnMut(&T) -> TraverseControl<U>;
+    fn traverse_ref<U>(&self, f: &mut dyn FnMut(&T) -> TraverseControl<U>) -> Option<U>;
 }
 
 impl Traverse<RichTerm> for RichTerm {
@@ -1686,10 +1675,7 @@ impl Traverse<RichTerm> for RichTerm {
         }
     }
 
-    fn traverse_ref<F, U>(&self, f: &mut F) -> Option<U>
-    where
-        F: FnMut(&RichTerm) -> TraverseControl<U>,
-    {
+    fn traverse_ref<U>(&self, f: &mut dyn FnMut(&RichTerm) -> TraverseControl<U>) -> Option<U> {
         match f(self) {
             TraverseControl::Continue => {}
             TraverseControl::SkipBranch => {
@@ -1764,10 +1750,7 @@ impl Traverse<Type> for RichTerm {
         self.traverse(&f_on_term, state, order)
     }
 
-    fn traverse_ref<F, U>(&self, f: &mut F) -> Option<U>
-    where
-        F: FnMut(&Type) -> TraverseControl<U>,
-    {
+    fn traverse_ref<U>(&self, f: &mut dyn FnMut(&Type) -> TraverseControl<U>) -> Option<U> {
         let mut f_on_term = |rt: &RichTerm| match &*rt.term {
             Term::Type(ty) => ty.traverse_ref(f).into(),
             _ => TraverseControl::Continue,

--- a/core/src/term/mod.rs
+++ b/core/src/term/mod.rs
@@ -303,6 +303,13 @@ impl Traverse<RichTerm> for RuntimeContract {
         let contract = self.contract.traverse(f, state, order)?;
         Ok(RuntimeContract { contract, ..self })
     }
+
+    fn traverse_ref<F, U>(&self, f: &mut F) -> Option<U>
+    where
+        F: FnMut(&RichTerm) -> TraverseControl<U>,
+    {
+        self.contract.traverse_ref(f)
+    }
 }
 
 impl std::convert::TryFrom<LabeledType> for RuntimeContract {
@@ -450,6 +457,13 @@ impl Traverse<RichTerm> for LabeledType {
         typ.traverse(f, state, order)
             .map(|typ| LabeledType { typ, label })
     }
+
+    fn traverse_ref<F, U>(&self, f: &mut F) -> Option<U>
+    where
+        F: FnMut(&RichTerm) -> crate::term::TraverseControl<U>,
+    {
+        self.typ.traverse_ref(f)
+    }
 }
 
 /// A type and/or contract annotation.
@@ -558,6 +572,16 @@ impl Traverse<RichTerm> for TypeAnnotation {
             .transpose()?;
 
         Ok(TypeAnnotation { typ, contracts })
+    }
+
+    fn traverse_ref<F, U>(&self, f: &mut F) -> Option<U>
+    where
+        F: FnMut(&RichTerm) -> crate::term::TraverseControl<U>,
+    {
+        self.contracts
+            .iter()
+            .find_map(|c| c.traverse_ref(f))
+            .or_else(|| self.typ.as_ref().and_then(|t| t.traverse_ref(f)))
     }
 }
 
@@ -1440,6 +1464,25 @@ impl RichTerm {
     }
 }
 
+/// Flow control for tree traverals.
+pub enum TraverseControl<U> {
+    /// Normal control flow: continue recursing into the children.
+    Continue,
+    /// Skip this branch of the tree.
+    SkipBranch,
+    /// Finish traversing immediately (and return a value).
+    Return(U),
+}
+
+impl<U> From<Option<U>> for TraverseControl<U> {
+    fn from(value: Option<U>) -> Self {
+        match value {
+            Some(u) => TraverseControl::Return(u),
+            None => TraverseControl::Continue,
+        }
+    }
+}
+
 pub trait Traverse<T>: Sized {
     /// Apply a transformation on a object containing syntactic elements of type `T` (terms, types,
     /// etc.) by mapping a faillible function `f` on each such node as prescribed by the order.
@@ -1448,6 +1491,15 @@ pub trait Traverse<T>: Sized {
     fn traverse<F, S, E>(self, f: &F, state: &mut S, order: TraverseOrder) -> Result<Self, E>
     where
         F: Fn(T, &mut S) -> Result<T, E>;
+
+    /// Recurse through the tree of objects top-down (a.k.a. pre-order), applying `f` to
+    /// each object.
+    ///
+    /// Through its return value, `f` can short-circuit one branch of the traversal or
+    /// the entire traversal.
+    fn traverse_ref<F, U>(&self, f: &mut F) -> Option<U>
+    where
+        F: FnMut(&T) -> TraverseControl<U>;
 }
 
 impl Traverse<RichTerm> for RichTerm {
@@ -1633,6 +1685,69 @@ impl Traverse<RichTerm> for RichTerm {
             TraverseOrder::BottomUp => f(result, state),
         }
     }
+
+    fn traverse_ref<F, U>(&self, f: &mut F) -> Option<U>
+    where
+        F: FnMut(&RichTerm) -> TraverseControl<U>,
+    {
+        match f(self) {
+            TraverseControl::Continue => {}
+            TraverseControl::SkipBranch => {
+                return None;
+            }
+            TraverseControl::Return(ret) => {
+                return Some(ret);
+            }
+        };
+
+        match &*self.term {
+            Term::Null
+            | Term::Bool(_)
+            | Term::Num(_)
+            | Term::Str(_)
+            | Term::Lbl(_)
+            | Term::Var(_)
+            | Term::Enum(_)
+            | Term::Import(_)
+            | Term::ResolvedImport(_)
+            | Term::SealingKey(_)
+            | Term::ParseError(_)
+            | Term::RuntimeError(_) => None,
+            Term::StrChunks(chunks) => chunks.iter().find_map(|ch| {
+                if let StrChunk::Expr(term, _) = ch {
+                    term.traverse_ref(f)
+                } else {
+                    None
+                }
+            }),
+            Term::Fun(_, t)
+            | Term::FunPattern(_, _, t)
+            | Term::Op1(_, t)
+            | Term::Sealed(_, t, _) => t.traverse_ref(f),
+            Term::Let(_, t1, t2, _)
+            | Term::LetPattern(_, _, t1, t2)
+            | Term::App(t1, t2)
+            | Term::Op2(_, t1, t2) => t1.traverse_ref(f).or_else(|| t2.traverse_ref(f)),
+            Term::Record(data) => data.fields.values().find_map(|field| field.traverse_ref(f)),
+            Term::RecRecord(data, dyn_data, _) => data
+                .fields
+                .values()
+                .find_map(|field| field.traverse_ref(f))
+                .or_else(|| {
+                    dyn_data.iter().find_map(|(id, field)| {
+                        id.traverse_ref(f).or_else(|| field.traverse_ref(f))
+                    })
+                }),
+            Term::Match { cases, default } => cases
+                .iter()
+                .find_map(|(_id, t)| t.traverse_ref(f))
+                .or_else(|| default.as_ref().and_then(|t| t.traverse_ref(f))),
+            Term::Array(ts, _) => ts.iter().find_map(|t| t.traverse_ref(f)),
+            Term::OpN(_, ts) => ts.iter().find_map(|t| t.traverse_ref(f)),
+            Term::Annotated(annot, t) => t.traverse_ref(f).or_else(|| annot.traverse_ref(f)),
+            Term::Type(ty) => ty.traverse_ref(f),
+        }
+    }
 }
 
 impl Traverse<Type> for RichTerm {
@@ -1647,6 +1762,17 @@ impl Traverse<Type> for RichTerm {
             } else Ok(rt)}
         };
         self.traverse(&f_on_term, state, order)
+    }
+
+    fn traverse_ref<F, U>(&self, f: &mut F) -> Option<U>
+    where
+        F: FnMut(&Type) -> TraverseControl<U>,
+    {
+        let mut f_on_term = |rt: &RichTerm| match &*rt.term {
+            Term::Type(ty) => ty.traverse_ref(f).into(),
+            _ => TraverseControl::Continue,
+        };
+        self.traverse_ref(&mut f_on_term)
     }
 }
 

--- a/core/src/term/record.rs
+++ b/core/src/term/record.rs
@@ -233,6 +233,21 @@ impl Traverse<RichTerm> for Field {
             pending_contracts,
         })
     }
+
+    fn traverse_ref<F, U>(&self, f: &mut F) -> Option<U>
+    where
+        F: FnMut(&RichTerm) -> TraverseControl<U>,
+    {
+        self.metadata
+            .annotation
+            .traverse_ref(f)
+            .or_else(|| self.value.as_ref().and_then(|v| v.traverse_ref(f)))
+            .or_else(|| {
+                self.pending_contracts
+                    .iter()
+                    .find_map(|c| c.traverse_ref(f))
+            })
+    }
 }
 
 /// The base structure of a Nickel record.

--- a/core/src/term/record.rs
+++ b/core/src/term/record.rs
@@ -234,10 +234,7 @@ impl Traverse<RichTerm> for Field {
         })
     }
 
-    fn traverse_ref<F, U>(&self, f: &mut F) -> Option<U>
-    where
-        F: FnMut(&RichTerm) -> TraverseControl<U>,
-    {
+    fn traverse_ref<U>(&self, f: &mut dyn FnMut(&RichTerm) -> TraverseControl<U>) -> Option<U> {
         self.metadata
             .annotation
             .traverse_ref(f)


### PR DESCRIPTION
Here is an attempt at adding a function for (short-cuttable) tree traversals by reference. I only iterated top-down traversal, since (1) it's the one I needed and (2) short-cutting a subtree doesn't really make sense in bottom-up traversal.

I originally made the method generic over the `FnMut`, but I ran into rustc's recursion limit. Maybe this is one reason that the other traverse function separates out the mutable state? I'll try that tomorrow...