### PR TITLE
Rename the `typ` field in JSON documentation to `type`

### DIFF
--- a/core/src/program.rs
+++ b/core/src/program.rs
@@ -457,6 +457,7 @@ mod doc {
         /// Field value [`ExtractedDocumentation`], if any
         fields: Option<ExtractedDocumentation>,
         /// Rendered type annotation, if any
+        #[serde(rename = "type")]
         typ: Option<String>,
         /// Rendered contract annotations
         contracts: Vec<String>,


### PR DESCRIPTION
There is no reason to restrict ourselves to the Rust field names.