### PR TITLE
Import YAML files containing multiple documents as arrays

### DIFF
--- a/core/tests/integration/imports/imported/multiple.yaml
+++ b/core/tests/integration/imports/imported/multiple.yaml
@@ -1,0 +1,6 @@
+---
+type: event
+id: 1
+---
+type: event
+id: 2

--- a/core/tests/integration/imports/yaml_import.ncl
+++ b/core/tests/integration/imports/yaml_import.ncl
@@ -1,0 +1,12 @@
+# test.type = 'pass'
+
+let {check, ..} = import "../pass/lib/assert.ncl" in
+[
+  (import "imported/empty.yaml") == null,
+
+  (import "imported/multiple.yaml") == [
+    { type = "event", id = 1 },
+    { type = "event", id = 2 }
+  ],
+]
+|> check

--- a/flake.nix
+++ b/flake.nix
@@ -188,6 +188,7 @@
           txtFilter = mkFilter ".*txt$";
           snapFilter = mkFilter ".*snap$";
           scmFilter = mkFilter ".*scm$";
+          importsFilter = mkFilter ".*/core/tests/integration/imports/imported/.*$"; # include all files that are imported in tests
         in
         pkgs.lib.cleanSourceWith {
           src = pkgs.lib.cleanSource ./.;
@@ -202,6 +203,7 @@
               snapFilter
               scmFilter
               filterCargoSources
+              importsFilter
             ];
         };
 


### PR DESCRIPTION
For example, in Kubernetes deployments it is common practice to package multiple YAML documents into a single file. For processing such files with Nickel we need to support importing multiple YAML documents from a single file. The concern with this is: how does such a file fit into Nickel's data model? Importing it as an array of Nickel values felt most reasonable to me. At the same time, a YAML file containing a single document should still be transparently serialized as that document, not as a single element array.