### PR TITLE
add function to parse programs

### DIFF
--- a/core/src/program.rs
+++ b/core/src/program.rs
@@ -165,6 +165,11 @@ impl<EC: EvalCache> Program<EC> {
         })
     }
 
+    /// Only parse the program, don't typecheck or evaluate. returns the [`RichTerm`] AST
+    pub fn parse(&mut self) -> Result<RichTerm, Error> {
+        Ok(self.vm.import_resolver().parse_nocache(self.main_id)?.0)
+    }
+
     /// Retrieve the parsed term and typecheck it, and generate a fresh initial environment. Return
     /// both.
     fn prepare_eval(&mut self) -> Result<(RichTerm, eval::Environment), Error> {

--- a/core/src/program.rs
+++ b/core/src/program.rs
@@ -167,7 +167,15 @@ impl<EC: EvalCache> Program<EC> {
 
     /// Only parse the program, don't typecheck or evaluate. returns the [`RichTerm`] AST
     pub fn parse(&mut self) -> Result<RichTerm, Error> {
-        Ok(self.vm.import_resolver().parse_nocache(self.main_id)?.0)
+        self.vm
+            .import_resolver_mut()
+            .parse(self.main_id)
+            .map_err(Error::ParseErrors)?;
+        Ok(self
+            .vm
+            .import_resolver()
+            .get(self.main_id)
+            .expect("File parsed and then immediately accessed doesn't exist"))
     }
 
     /// Retrieve the parsed term and typecheck it, and generate a fresh initial environment. Return


### PR DESCRIPTION
`Program`s seem to be the main interface to nickel for libraries. Right now they can be evaluated into a `RichTerm`, and you can parse and typecheck, but without actually returning anything. There's no way to just get out the parsed AST, since `main_id` is private. This PR adds a function to do just that, since I've found myself wanting it several times recently.