### PR TITLE
[Fix] Fix contract.Sequence reversing order

### DIFF
--- a/core/stdlib/std.ncl
+++ b/core/stdlib/std.ncl
@@ -2975,4 +2975,3 @@
     "%
     = fun msg => null | FailWith msg,
 }
-

--- a/core/stdlib/std.ncl
+++ b/core/stdlib/std.ncl
@@ -968,7 +968,11 @@
           ```
         "%
       = fun contracts label value =>
-        std.array.fold_right (fun contract => std.contract.apply contract label) value contracts,
+        std.array.fold_left
+          (fun acc contract => std.contract.apply contract label acc)
+          value
+          contracts,
+
     label
       | doc m%"
           The label submodule provides functions that manipulate the label
@@ -2971,3 +2975,4 @@
     "%
     = fun msg => null | FailWith msg,
 }
+

--- a/core/tests/integration/pass/contracts/contracts.ncl
+++ b/core/tests/integration/pass/contracts/contracts.ncl
@@ -165,12 +165,17 @@ let {check, Assert, ..} = import "../lib/assert.ncl" in
   let f | forall r. { ; r } -> { g : forall r. { ; r } -> { z : Number ; r }; r }
         = fun r => %record_insert% "g" r g in
   let res = f { z = 3 }
-  in true,
+  in std.seq res true,
 
   # std.contract.Sequence
-  let three = 3 | std.contract.Sequence [ Number, std.contract.from_predicate (fun x => x < 5) ] in
-  # preserves order
-  let tag = "some_tag" | std.contract.Sequence [ std.enum.TagOrString, [| 'some_tag |] ]
-  in true
+  let SmallerThanFive = std.contract.from_predicate (fun x => x < 5) in
+  let three | std.contract.Sequence [ Number, SmallerThanFive] = 3 in
+  three == 3,
+
+  # std.contract.Sequence preserves order
+  let tag | std.contract.Sequence [std.enum.TagOrString, [| 'some_tag |]]
+    = "some_tag"
+  in
+  tag == 'some_tag,
 ]
 |> check


### PR DESCRIPTION
This PR started by noticing in an unrelated code review that some tests involving contracts were incorrect, because they never evaluated any value (thus, by lazyness, contract checks wouldn't fire).

One of those tests failed after being fixed, indicating that `std.contract.Sequence` wasn't preserving the order of applied contracts as required. This PR fixes the aforementioned tests and the ordering issue by using `fold_left` instead of `fold_right` in the implementation of `Sequence`.