### PR TITLE
Improve type variables name allocation when reporting type errors

### DIFF
--- a/core/src/error.rs
+++ b/core/src/error.rs
@@ -2128,7 +2128,7 @@ impl IntoDiagnostics<FileId> for TypecheckError {
                 let mut labels = mk_expr_label(&pos);
 
                 if let Some(span) = constant.pos.into_opt() {
-                    labels.push(secondary(&span).with_message("this polymorphic type"));
+                    labels.push(secondary(&span).with_message("this polymorphic type variable"));
                 }
 
                 vec![Diagnostic::error()
@@ -2142,7 +2142,7 @@ impl IntoDiagnostics<FileId> for TypecheckError {
                         format!(
                             "The type of this expression escapes the scope of the \
                                 corresponding `forall` and can't be generalized to the \
-                                polymorphic type `{constant}`"
+                                polymorphic type variable `{constant}`"
                         ),
                     ])]
             }

--- a/core/src/typecheck/error.rs
+++ b/core/src/typecheck/error.rs
@@ -109,16 +109,6 @@ pub enum UnifError {
 
 impl UnifError {
     /// Convert a unification error to a typechecking error.
-    ///
-    /// Wrapper that calls [`Self::into_typecheck_err_`] with a [name registry][reporting::NameReg]
-    /// initialized from the current state.
-    pub fn into_typecheck_err(self, state: &State, pos_opt: TermPos) -> TypecheckError {
-        let mut names = reporting::NameReg::new(state.names.clone());
-        self.into_typecheck_err_(state, &mut names, pos_opt)
-    }
-
-    /// Convert a unification error to a typechecking error.
-    ///
     /// There is a hierarchy between error types, from the most local/specific to the most high-level:
     /// - [`RowUnifError`]
     /// - [`UnifError`]
@@ -131,9 +121,15 @@ impl UnifError {
     ///
     /// - `state`: the state of unification. Used to access the unification table, and the original
     /// names of of unification variable or type constant.
-    /// - `names`: a [name registry][reporting::NameReg], structure used to assign
-    /// unique a humain-readable names to unification variables and type constants.
     /// - `pos_opt`: the position span of the expression that failed to typecheck.
+    pub fn into_typecheck_err(self, state: &State, pos_opt: TermPos) -> TypecheckError {
+        let mut names = reporting::NameReg::new(state.names.clone());
+        self.into_typecheck_err_(state, &mut names, pos_opt)
+    }
+
+    /// Convert a unification error to a typechecking error, given a populated [name
+    /// registry][reporting::NameReg]. Actual meat of the implementation of
+    /// [`Self::into_typecheck_err`].
     fn into_typecheck_err_(
         self,
         state: &State,

--- a/core/src/typecheck/error.rs
+++ b/core/src/typecheck/error.rs
@@ -110,10 +110,10 @@ pub enum UnifError {
 impl UnifError {
     /// Convert a unification error to a typechecking error.
     ///
-    /// Wrapper that calls [`Self::into_typecheck_err_`] with an empty [name
-    /// registry][reporting::NameReg].
-    pub fn into_typecheck_err(self, state: &mut State, pos_opt: TermPos) -> TypecheckError {
-        let mut names = reporting::NameReg::new(std::mem::take(state.names));
+    /// Wrapper that calls [`Self::into_typecheck_err_`] with a [name registry][reporting::NameReg]
+    /// initialized from the current state.
+    pub fn into_typecheck_err(self, state: &State, pos_opt: TermPos) -> TypecheckError {
+        let mut names = reporting::NameReg::new(state.names.clone());
         self.into_typecheck_err_(state, &mut names, pos_opt)
     }
 
@@ -134,7 +134,7 @@ impl UnifError {
     /// - `names`: a [name registry][reporting::NameReg], structure used to assign
     /// unique a humain-readable names to unification variables and type constants.
     /// - `pos_opt`: the position span of the expression that failed to typecheck.
-    pub fn into_typecheck_err_(
+    fn into_typecheck_err_(
         self,
         state: &State,
         names_reg: &mut reporting::NameReg,

--- a/core/src/typecheck/error.rs
+++ b/core/src/typecheck/error.rs
@@ -112,8 +112,9 @@ impl UnifError {
     ///
     /// Wrapper that calls [`Self::into_typecheck_err_`] with an empty [name
     /// registry][reporting::NameReg].
-    pub fn into_typecheck_err(self, state: &State, pos_opt: TermPos) -> TypecheckError {
-        self.into_typecheck_err_(state, &mut reporting::NameReg::new(), pos_opt)
+    pub fn into_typecheck_err(self, state: &mut State, pos_opt: TermPos) -> TypecheckError {
+        let mut names = reporting::NameReg::new(std::mem::take(state.names));
+        self.into_typecheck_err_(state, &mut names, pos_opt)
     }
 
     /// Convert a unification error to a typechecking error.
@@ -136,54 +137,39 @@ impl UnifError {
     pub fn into_typecheck_err_(
         self,
         state: &State,
-        names: &mut reporting::NameReg,
+        names_reg: &mut reporting::NameReg,
         pos_opt: TermPos,
     ) -> TypecheckError {
         match self {
             UnifError::TypeMismatch(ty1, ty2) => TypecheckError::TypeMismatch(
-                reporting::to_type(state.table, state.names, names, ty1),
-                reporting::to_type(state.table, state.names, names, ty2),
+                names_reg.to_type(state.table, ty1),
+                names_reg.to_type(state.table, ty2),
                 pos_opt,
             ),
             UnifError::RowMismatch(ident, uty1, uty2, err) => TypecheckError::RowMismatch(
                 ident,
-                reporting::to_type(state.table, state.names, names, uty1),
-                reporting::to_type(state.table, state.names, names, uty2),
-                Box::new((*err).into_typecheck_err_(state, names, TermPos::None)),
+                names_reg.to_type(state.table, uty1),
+                names_reg.to_type(state.table, uty2),
+                Box::new((*err).into_typecheck_err_(state, names_reg, TermPos::None)),
                 pos_opt,
             ),
             // TODO: for now, failure to unify with a type constant causes the same error as a
             // usual type mismatch. It could be nice to have a specific error message in the
             // future.
             UnifError::ConstMismatch(k, c1, c2) => TypecheckError::TypeMismatch(
-                reporting::to_type(
-                    state.table,
-                    state.names,
-                    names,
-                    UnifType::from_constant_of_kind(c1, k),
-                ),
-                reporting::to_type(
-                    state.table,
-                    state.names,
-                    names,
-                    UnifType::from_constant_of_kind(c2, k),
-                ),
+                names_reg.to_type(state.table, UnifType::from_constant_of_kind(c1, k)),
+                names_reg.to_type(state.table, UnifType::from_constant_of_kind(c2, k)),
                 pos_opt,
             ),
             UnifError::WithConst(VarKindDiscriminant::Type, c, ty) => TypecheckError::TypeMismatch(
-                reporting::to_type(state.table, state.names, names, UnifType::Constant(c)),
-                reporting::to_type(state.table, state.names, names, ty),
+                names_reg.to_type(state.table, UnifType::Constant(c)),
+                names_reg.to_type(state.table, ty),
                 pos_opt,
             ),
             UnifError::WithConst(kind, c, ty) => TypecheckError::ForallParametricityViolation {
                 kind,
-                tail: reporting::to_type(
-                    state.table,
-                    state.names,
-                    names,
-                    UnifType::from_constant_of_kind(c, kind),
-                ),
-                violating_type: reporting::to_type(state.table, state.names, names, ty),
+                tail: names_reg.to_type(state.table, UnifType::from_constant_of_kind(c, kind)),
+                violating_type: names_reg.to_type(state.table, ty),
                 pos: pos_opt,
             },
             UnifError::IncomparableFlatTypes(rt1, rt2) => {
@@ -191,31 +177,31 @@ impl UnifError {
             }
             UnifError::MissingRow(id, uty1, uty2) => TypecheckError::MissingRow(
                 id,
-                reporting::to_type(state.table, state.names, names, uty1),
-                reporting::to_type(state.table, state.names, names, uty2),
+                names_reg.to_type(state.table, uty1),
+                names_reg.to_type(state.table, uty2),
                 pos_opt,
             ),
             UnifError::MissingDynTail(uty1, uty2) => TypecheckError::MissingDynTail(
-                reporting::to_type(state.table, state.names, names, uty1),
-                reporting::to_type(state.table, state.names, names, uty2),
+                names_reg.to_type(state.table, uty1),
+                names_reg.to_type(state.table, uty2),
                 pos_opt,
             ),
             UnifError::ExtraRow(id, uty1, uty2) => TypecheckError::ExtraRow(
                 id,
-                reporting::to_type(state.table, state.names, names, uty1),
-                reporting::to_type(state.table, state.names, names, uty2),
+                names_reg.to_type(state.table, uty1),
+                names_reg.to_type(state.table, uty2),
                 pos_opt,
             ),
             UnifError::ExtraDynTail(uty1, uty2) => TypecheckError::ExtraDynTail(
-                reporting::to_type(state.table, state.names, names, uty1),
-                reporting::to_type(state.table, state.names, names, uty2),
+                names_reg.to_type(state.table, uty1),
+                names_reg.to_type(state.table, uty2),
                 pos_opt,
             ),
             UnifError::RowConflict(id, uty, left, right) => TypecheckError::RowConflict(
                 id,
-                reporting::to_type(state.table, state.names, names, uty),
-                reporting::to_type(state.table, state.names, names, left),
-                reporting::to_type(state.table, state.names, names, right),
+                names_reg.to_type(state.table, uty),
+                names_reg.to_type(state.table, left),
+                names_reg.to_type(state.table, right),
                 pos_opt,
             ),
             UnifError::UnboundTypeVariable(ident) => TypecheckError::UnboundTypeVariable(ident),
@@ -223,10 +209,10 @@ impl UnifError {
             | err @ UnifError::DomainMismatch(_, _, _) => {
                 let (expd, actual, path, err_final) = err.into_type_path().unwrap();
                 TypecheckError::ArrowTypeMismatch(
-                    reporting::to_type(state.table, state.names, names, expd),
-                    reporting::to_type(state.table, state.names, names, actual),
+                    names_reg.to_type(state.table, expd),
+                    names_reg.to_type(state.table, actual),
                     path,
-                    Box::new(err_final.into_typecheck_err_(state, names, TermPos::None)),
+                    Box::new(err_final.into_typecheck_err_(state, names_reg, TermPos::None)),
                     pos_opt,
                 )
             }
@@ -234,7 +220,7 @@ impl UnifError {
                 constant_id,
                 var_kind,
             } => TypecheckError::VarLevelMismatch {
-                type_var: reporting::cst_name(state.names, names, constant_id, var_kind),
+                type_var: names_reg.gen_cst_name(constant_id, var_kind),
                 pos: pos_opt,
             },
         }

--- a/lsp/nls/src/linearization/mod.rs
+++ b/lsp/nls/src/linearization/mod.rs
@@ -12,7 +12,7 @@ use nickel_lang_core::{
     typ::TypeF,
     typecheck::{
         linearization::{Linearization, Linearizer},
-        reporting::{to_type, NameReg},
+        reporting::NameReg,
         UnifType,
     },
 };
@@ -542,6 +542,7 @@ impl<'a> Linearizer for AnalysisHost<'a> {
         }: Extra,
     ) -> Linearization<Completed> {
         debug!("linearizing {:?}", self.file);
+        let mut name_reg = NameReg::new(reported_names);
 
         // TODO: Storing defers while linearizing?
         let mut defers: Vec<(ItemId, ItemId, Ident)> = lin
@@ -603,7 +604,7 @@ impl<'a> Linearizer for AnalysisHost<'a> {
                      kind,
                      metadata: meta,
                  }| LinearizationItem {
-                    ty: to_type(&table, &reported_names, &mut NameReg::new(), ty),
+                    ty: name_reg.to_type(&table, ty),
                     env,
                     id,
                     pos,


### PR DESCRIPTION
The implementation of the conversion from unification type to human-readable types was a bit confused, using two name tables without really making it clear which table corresponds to which. The implementation didn't correctly update correctly the set of variables already in use, and failed to propagate position information for user-written type variables.

This PR simplifies the implementation, moving free-standing functions into `NameReg`, diminishing the number of arguments and gets rid of the additional table, with the effect of correctly propagating position information for user-written type variables.

This improves the error reporting of the variable level mismatch error. Previously, the offending type variable wasn't pointed at, but after this PR, it is:

```
let eval : forall a. (forall b. b -> b) -> a -> a =
fun f x => f x
in (let g = fun x => x
in eval g) : _
error: function types mismatch
  ┌─ <unknown> (generated by evaluation):1:1
  │
1 │ b -> b
  │ - this part of the expected type
  │
  ┌─ <unknown> (generated by evaluation):1:1
  │
1 │ _a -> _a
  │ -- does not match this part of the inferred type
  │
  ┌─ repl-input-0:4:9
  │
4 │ in eval g) : _
  │         ^ this expression
  │
  = Expected an expression of type `b -> b`
  = Found an expression of type `_a -> _a`
  = Could not match the two function types

error: while matching function types: invalid polymorphic generalization
  ┌─ repl-input-0:1:30
  │
1 │ let eval : forall a. (forall b. b -> b) -> a -> a =
  │                              - this polymorphic type variable
  │
  = While the type of this expression is still undetermined, it appears indirectly in the type of another expression introduced before the `forall` block.
  = The type of this expression escapes the scope of the corresponding `forall` and can't be generalized to the polymorphic type variable `b`
```