### PR TITLE
Temporary fix for https://github.com/luser/strip-ansi-escapes/issues/17

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,7 +81,10 @@ sha-1 = "0.10.0"
 sha2 = "0.10.6"
 similar = "2.2.1"
 simple-counter = "0.1.0"
-strip-ansi-escapes = "0.1.1"
+# Temporary fix for https://github.com/luser/strip-ansi-escapes/issues/17
+# Pinning can be removed (and strip-ansi-escape be updated to 0.2.0, probably)
+# once 0.1.2 has been yanked.
+strip-ansi-escapes = "=0.1.1"
 termimad = "0.23.1"
 test-generator = "0.3.1"
 toml = "0.7.2"


### PR DESCRIPTION
In particular, because `cargo install` seems to be workspace-unaware, doing `cargo install --path nls/lsp` currently fails because of https://github.com/luser/strip-ansi-escapes/issues/17, while it builds correctly from `cargo build -p nickel-lang-lsp` (`cargo install` seems to ignore the workspace's lockfile)