### PR TITLE
Add warning for empty query path on the CLI

### DIFF
--- a/cli/src/error.rs
+++ b/cli/src/error.rs
@@ -24,9 +24,9 @@ pub enum Error {
 
 /// Warning emitted by the CLI.
 pub enum Warning {
-    /// The user queried a program without providing any path, and the result isn't a record. In
-    /// this case, querying won't show anything useful, and it's most probably not what the user
-    /// want.
+        /// The user queried a program without providing any path. In this case,
+        /// querying won't show most information, and it's most probably not
+        /// what the user wanted.
     EmptyQueryPath,
 }
 

--- a/cli/src/error.rs
+++ b/cli/src/error.rs
@@ -24,9 +24,9 @@ pub enum Error {
 
 /// Warning emitted by the CLI.
 pub enum Warning {
-        /// The user queried a program without providing any path. In this case,
-        /// querying won't show most information, and it's most probably not
-        /// what the user wanted.
+    /// The user queried a program without providing any path. In this case,
+    /// querying won't show most information, and it's most probably not
+    /// what the user wanted.
     EmptyQueryPath,
 }
 

--- a/cli/src/query.rs
+++ b/cli/src/query.rs
@@ -2,7 +2,7 @@ use nickel_lang_core::repl::query_print;
 
 use crate::{
     cli::GlobalOptions,
-    error::{CliResult, ResultErrorExt},
+    error::{CliResult, ResultErrorExt, Warning},
     eval::EvalCommand,
 };
 
@@ -52,12 +52,16 @@ impl QueryCommand {
     pub fn run(mut self, global: GlobalOptions) -> CliResult<()> {
         let mut program = self.evaluation.prepare(&global)?;
 
+        if self.path.is_none() {
+            program.report(Warning::EmptyQueryPath)
+        }
+
         program
             .query(std::mem::take(&mut self.path))
-            .map(|term| {
+            .map(|field| {
                 query_print::write_query_result(
                     &mut std::io::stdout(),
-                    &term,
+                    &field,
                     self.query_attributes(),
                 )
                 .unwrap()

--- a/core/src/error.rs
+++ b/core/src/error.rs
@@ -2,8 +2,8 @@
 //!
 //! Define error types for different phases of the execution, together with functions to generate a
 //! [codespan](https://crates.io/crates/codespan-reporting) diagnostic from them.
-use codespan::{FileId, Files};
-use codespan_reporting::diagnostic::{Diagnostic, Label, LabelStyle};
+pub use codespan::{FileId, Files};
+pub use codespan_reporting::diagnostic::{Diagnostic, Label, LabelStyle};
 use lalrpop_util::ErrorRecovery;
 use malachite::num::conversion::traits::ToSci;
 


### PR DESCRIPTION
Closes #1487.

I initially only emitted the warning when the expression wasn't a record, but in the end, even in this case, using a proper query path can show additional information. For example:

```console
$ nickel query <<< std.contract.label
Requested metadata were not found for this value.

Available fields
• append_note
• with_message
• with_notes

$ nickel query label <<< std.contract
• documentation

The label submodule provides functions that manipulate the label
associated with a contract application[..]

Available fields
• append_note
• with_message
• with_notes
```

After this PR:

```console
$ nickel query <<< std.contract.label
warning: empty query path
 = You queried a value without requesting a specific field path. This operation can't find any metadata, beside listing the fields of a record.
 = Try to query the root configuration and provide a query path instead.
 = For example, instead of querying the expression `(import "config.ncl").module.input` with an empty path, query `config.ncl` with the `module.input` path: 
   `nickel query module.input -f config.ncl`

Requested metadata were not found for this value.

Available fields
• append_note
• with_message
• with_notes
```

In the future we might be smarter and make the suggestion more specific by introspecting the term and see if it's a record access, but for now I think this will do.