### PR TITLE
Use the pretty printer in the  `Display` implementation for `Type`

### DIFF
--- a/cli/tests/snapshot/inputs/pretty/simple_record.ncl
+++ b/cli/tests/snapshot/inputs/pretty/simple_record.ncl
@@ -3,6 +3,6 @@
 { 
   a | Number | default = 1, 
   b : String | force = "some long string that goes past the 80 character line limit for pretty printing", 
-  c : { x : Number, y: Number } = { x = 999.8979, y = 500 },
+  c | { x : Number, y: Number } = { x = 999.8979, y = 500 },
   d | Array std.string.NonEmpty = ["a", "list", "of", "non", "empty", "strings"],
 }

--- a/cli/tests/snapshot/snapshots/snapshot__pprint-ast_stdout_simple_record.ncl.snap
+++ b/cli/tests/snapshot/snapshots/snapshot__pprint-ast_stdout_simple_record.ncl.snap
@@ -8,8 +8,8 @@ expression: out
   b : String | force
     =
     "some long string that goes past the 80 character line limit for pretty printing",
-  c : {x: Number, y: Number}
+  c | { x: Number, y: Number }
     = { x = 999.8979, y = 500, },
-  d | Array (std.string.NonEmpty)
+  d | Array std.string.NonEmpty
     = [ "a", "list", "of", "non", "empty", "strings" ],
 }

--- a/core/src/error.rs
+++ b/core/src/error.rs
@@ -2208,7 +2208,7 @@ impl IntoDiagnostics<FileId> for ExportError {
                 .with_message("non serializable term")
                 .with_labels(vec![primary_term(&rt, files)])
                 .with_notes(vec![
-                    "Nickel only supports serlializing to and from strings, booleans, numbers, \
+                    "Nickel only supports serializing to and from strings, booleans, numbers, \
                     enum tags, `null` (depending on the format), as well as records and arrays \
                     of serializable values."
                         .into(),

--- a/core/src/pretty.rs
+++ b/core/src/pretty.rs
@@ -755,10 +755,7 @@ where
                 .append(allocator.hardline()),
             // TODO
             Sealed(_i, _rt, _lbl) => allocator.text("#<sealed>").append(allocator.hardline()),
-            Annotated(annot, rt) => allocator
-                .atom(rt)
-                .append(allocator.space())
-                .append(allocator.annot(annot)),
+            Annotated(annot, rt) => allocator.atom(rt).append(allocator.annot(annot)),
             Import(f) => allocator
                 .text("import")
                 .append(allocator.space())
@@ -790,9 +787,7 @@ where
                     .text("'")
                     .append(allocator.text(ident_quoted(row)));
                 let builder = if let EnumRowsF::Extend { .. } = tail.0 {
-                    builder
-                        .append(allocator.text(","))
-                        .append(allocator.space())
+                    builder.append(allocator.text(",")).append(allocator.line())
                 } else {
                     builder
                 };
@@ -833,9 +828,7 @@ where
                     .append(typ.pretty(allocator));
 
                 let builder = if let RecordRowsF::Extend { .. } = tail.0 {
-                    builder
-                        .append(allocator.text(","))
-                        .append(allocator.space())
+                    builder.append(allocator.text(",")).append(allocator.line())
                 } else {
                     builder
                 };
@@ -888,19 +881,31 @@ where
                     .group()
                     .append(allocator.intersperse(
                         foralls.iter().map(|i| allocator.as_string(i)),
-                        allocator.space(), //allocator.softline(),
+                        allocator.space(),
                     ))
                     .append(allocator.text("."))
-                    .append(allocator.line())
+                    .append(allocator.softline())
                     .append(curr.to_owned().pretty(allocator))
             }
-            Enum(erows) => erows.pretty(allocator).enclose("[|", "|]"),
-            Record(rrows) => rrows.pretty(allocator).braces(),
+            Enum(erows) => allocator
+                .line()
+                .append(erows.pretty(allocator))
+                .nest(2)
+                .append(allocator.line())
+                .group()
+                .enclose("[|", "|]"),
+            Record(rrows) => allocator
+                .line()
+                .append(rrows.pretty(allocator))
+                .nest(2)
+                .append(allocator.line())
+                .group()
+                .braces(),
             Dict {
                 type_fields: ty,
                 flavour: attrs,
             } => allocator
-                .line()
+                .softline()
                 .append(allocator.text("_"))
                 .append(allocator.space())
                 .append(match attrs {
@@ -909,7 +914,7 @@ where
                 })
                 .append(allocator.space())
                 .append(ty.pretty(allocator))
-                .append(allocator.line())
+                .append(allocator.softline())
                 .braces(),
             Arrow(dom, codom) => match dom.typ {
                 Arrow(..) | Forall { .. } => dom

--- a/core/src/typ.rs
+++ b/core/src/typ.rs
@@ -1045,7 +1045,7 @@ impl Type {
             | TypeF::Var(_)
             | TypeF::Record(_)
             | TypeF::Enum(_) => true,
-            TypeF::Flat(rt) if matches!(*rt.term, Term::Var(_)) => true,
+            TypeF::Flat(rt) if rt.as_ref().is_atom() => true,
             _ => false,
         }
     }
@@ -1149,89 +1149,14 @@ impl Traverse<RichTerm> for Type {
     }
 }
 
-impl Display for RecordRows {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self.0 {
-            RecordRowsF::Extend { ref row, ref tail } => {
-                write!(f, "{}: {}", row.id, row.typ)?;
-
-                match tail.0 {
-                    RecordRowsF::Extend { .. } => write!(f, ", {tail}"),
-                    _ => write!(f, "{tail}"),
-                }
-            }
-            RecordRowsF::Empty => Ok(()),
-            RecordRowsF::TailVar(id) => write!(f, " ; {id}"),
-            RecordRowsF::TailDyn => write!(f, " ; Dyn"),
-        }
-    }
-}
-
-impl Display for EnumRows {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self.0 {
-            EnumRowsF::Extend { ref row, ref tail } => {
-                write!(f, "'{row}")?;
-
-                match tail.0 {
-                    EnumRowsF::Extend { .. } => write!(f, ", {tail}"),
-                    _ => write!(f, "{tail}"),
-                }
-            }
-            EnumRowsF::Empty => Ok(()),
-            EnumRowsF::TailVar(id) => write!(f, " ; {id}"),
-        }
-    }
-}
-
 impl Display for Type {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match &self.typ {
-            TypeF::Dyn => write!(f, "Dyn"),
-            TypeF::Number => write!(f, "Number"),
-            TypeF::Bool => write!(f, "Bool"),
-            TypeF::String => write!(f, "String"),
-            TypeF::Array(ty) => {
-                write!(f, "Array ")?;
+        use crate::pretty::*;
 
-                if ty.fmt_is_atom() {
-                    write!(f, "{ty}")
-                } else {
-                    write!(f, "({ty})")
-                }
-            }
-            TypeF::Symbol => write!(f, "Sym"),
-            TypeF::Flat(ref t) => write!(f, "{}", t.pretty_print_cap(32)),
-            TypeF::Var(var) => write!(f, "{var}"),
-            TypeF::Forall { var, ref body, .. } => {
-                let mut curr: &Type = body.as_ref();
-                write!(f, "forall {var}")?;
-                while let Type {
-                    typ: TypeF::Forall { var, ref body, .. },
-                    ..
-                } = curr
-                {
-                    write!(f, " {var}")?;
-                    curr = body;
-                }
-                write!(f, ". {curr}")
-            }
-            TypeF::Enum(row) => write!(f, "[| {row} |]"),
-            TypeF::Record(row) => write!(f, "{{ {row} }}"),
-            TypeF::Dict {
-                type_fields,
-                flavour: DictTypeFlavour::Type,
-            } => write!(f, "{{ _ : {type_fields} }}"),
-            TypeF::Dict {
-                type_fields,
-                flavour: DictTypeFlavour::Contract,
-            } => write!(f, "{{ _ | {type_fields} }}"),
-            TypeF::Arrow(dom, codom) => match dom.typ {
-                TypeF::Arrow(_, _) | TypeF::Forall { .. } => write!(f, "({dom}) -> {codom}"),
-                _ => write!(f, "{dom} -> {codom}"),
-            },
-            TypeF::Wildcard(_) => write!(f, "_"),
-        }
+        let allocator = pretty::BoxAllocator;
+
+        let doc: DocBuilder<_, ()> = self.clone().pretty(&allocator);
+        doc.render_fmt(80, f)
     }
 }
 


### PR DESCRIPTION
We previously used a bespoke formatting algorithm for `Type`. I replaced the analogous code for `Term`s by the pretty printer in #1262 but we were worried about some questionable code for contract error reporting before doing the same for types. Namely, at some point it relied on hard coded string offsets for pointing at parts of types that were inferred by Nickel and consequently had no `TermPos`. In #1229 we ripped out that code and replaced it by reparsing the pretty printer output when necessary.

Incidentally, this change also fixes some terms being truncated when formatted. For example, previously

```
SomeUserDefinedContract "that" "takes" "many" "arguments"
```

would be printed as `SomeUserDefinedContract "that" …`. This is somewhat useful to prevent huge screenfuls of error messages sometimes, but it makes the `Display` implementation useless for other natural purposes.