### PR TITLE
Add a linebreak between contract and the documentation in the doc output

### DIFF
--- a/cli/tests/snapshot/snapshots/snapshot__doc_stdout_record.ncl.snap
+++ b/cli/tests/snapshot/snapshots/snapshot__doc_stdout_record.ncl.snap
@@ -4,5 +4,6 @@ expression: out
 ---
 # `Hello`
 
+\
 World\!
 

--- a/cli/tests/snapshot/snapshots/snapshot__doc_stdout_types.ncl.snap
+++ b/cli/tests/snapshot/snapshots/snapshot__doc_stdout_types.ncl.snap
@@ -6,5 +6,6 @@ expression: out
 
 - `Hello : Number`
 - `Hello | std.string.Stringable`
+\
 World\!
 

--- a/core/src/program.rs
+++ b/core/src/program.rs
@@ -575,6 +575,8 @@ mod doc {
                     ))
                 }
 
+                document.append(arena.alloc(AstNode::from(NodeValue::LineBreak)));
+
                 if let Some(ref doc) = field.documentation {
                     document.append(parse_markdown_string(header_level + 1, arena, doc, options));
                 }


### PR DESCRIPTION
The markdown output of `nickel doc` for record fields with both a contract and a documentation currently looks like

```markdown
- `foo | Dyn`
documentation
```

which in strict markdown is equivalent to

```markdown
- `foo | Dyn` documentation
```

and isn't really nice once converted to Html.

Change that to

```markdown
- `foo | Dyn`
\
documentation
```

which renders `documentation` on a newline (still whithin the same bullet point though).

Screenshots on a basic `pandoc` rendering:

- before 
  ![image](https://github.com/tweag/nickel/assets/7226587/bb93356b-60cf-4082-a993-3b72e72e0d8e)
- after
    ![image](https://github.com/tweag/nickel/assets/7226587/dec79b47-139a-484f-b5b1-32eb69f464bc)
