### PR TITLE
Update strip-ansi-escape deps, remove corresponding temporary fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2674,9 +2674,9 @@ dependencies = [
 
 [[package]]
 name = "strip-ansi-escapes"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "011cbb39cf7c1f62871aea3cc46e5817b0937b49e9447370c93cacbe93a766d8"
+checksum = "55ff8ef943b384c414f54aefa961dd2bd853add74ec75e7ac74cf91dba62bcfa"
 dependencies = [
  "vte",
 ]
@@ -3228,11 +3228,10 @@ checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 
 [[package]]
 name = "vte"
-version = "0.10.1"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cbce692ab4ca2f1f3047fcf732430249c0e971bfdd2b234cf2c47ad93af5983"
+checksum = "f5022b5fbf9407086c180e9557be968742d839e68346af7792b8592489732197"
 dependencies = [
- "arrayvec 0.5.2",
  "utf8parse",
  "vte_generate_state_changes",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,10 +81,7 @@ sha-1 = "0.10.0"
 sha2 = "0.10.6"
 similar = "2.2.1"
 simple-counter = "0.1.0"
-# Temporary fix for https://github.com/luser/strip-ansi-escapes/issues/17
-# Pinning can be removed (and strip-ansi-escape be updated to 0.2.0, probably)
-# once 0.1.2 has been yanked.
-strip-ansi-escapes = "=0.1.1"
+strip-ansi-escapes = "0.2.0"
 termimad = "0.23.1"
 test-generator = "0.3.1"
 toml = "0.7.2"

--- a/core/src/error.rs
+++ b/core/src/error.rs
@@ -605,11 +605,8 @@ impl From<ExportError> for EvalError {
 /// messages, which can contain ASCII code sequences, and in particular ANSI escape codes, that
 /// could alter Nickel's error messages.
 pub fn escape(s: &str) -> String {
-    String::from_utf8(
-        strip_ansi_escapes::strip(s)
-            .expect("escape(): unexpected IO error when writing inside a in-memory buffer"),
-    )
-    .expect("escape(): converting from a string should give back a valid UTF8 string")
+    String::from_utf8(strip_ansi_escapes::strip(s))
+        .expect("escape(): converting from a string should give back a valid UTF8 string")
 }
 
 impl From<ReplError> for Error {


### PR DESCRIPTION
Get rid of the temporary fix introduced in #1515, now that strip-ansi-escape 0.1.2 has been yanked and they published a new 0.2.0 version.