### PR TITLE
Fix problem with Program::parse()

### DIFF
--- a/core/src/program.rs
+++ b/core/src/program.rs
@@ -175,8 +175,11 @@ impl<EC: EvalCache> Program<EC> {
         Ok(self
             .vm
             .import_resolver()
-            .get(self.main_id)
-            .expect("File parsed and then immediately accessed doesn't exist"))
+            .terms()
+            .get(&self.main_id)
+            .expect("File parsed and then immediately accessed doesn't exist")
+            .term
+            .clone())
     }
 
     /// Retrieve the parsed term and typecheck it, and generate a fresh initial environment. Return


### PR DESCRIPTION
`Program::parse()` was calling `ImportResolver::get()` which assumed that as an `ImportResolver`, we can only get terms when all the imports are resolved, so it had a `debug_assert!()` to ensure this. In this case, we are only parsing the file and returning its AST, so we can get the `terms` field of the `Cache` and call `get()` on that.

We had discussed a much more complicated solution that essentially amounted to this, plus a refactor of how `ImportResolver` works. But as I was implementing it started seeming less like a good idea, and also I realized not necessary to solve this problem. We can revisit that refactor, but for now this solves the problem.