### PR TITLE
LSP formatting without calling the topiary binary

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1638,8 +1638,6 @@ dependencies = [
  "serde",
  "tempfile",
  "test-generator",
- "topiary",
- "tree-sitter-nickel",
 ]
 
 [[package]]
@@ -1684,6 +1682,8 @@ dependencies = [
  "termimad",
  "test-generator",
  "toml",
+ "topiary",
+ "tree-sitter-nickel",
  "typed-arena",
  "unicode-segmentation",
  "void",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -19,7 +19,7 @@ bench = false
 default = ["repl", "doc", "format"]
 repl = ["nickel-lang-core/repl"]
 doc = ["nickel-lang-core/doc"]
-format = ["topiary", "tree-sitter-nickel", "tempfile"]
+format = ["nickel-lang-core/format", "tempfile"]
 
 [dependencies]
 nickel-lang-core = { workspace = true, features = [ "markdown" ], default-features = false }
@@ -28,8 +28,6 @@ clap = { workspace = true, features = ["derive"] }
 serde = { workspace = true, features = ["derive"] }
 directories.workspace = true
 
-topiary = { workspace = true, optional = true }
-tree-sitter-nickel = { workspace = true, optional = true }
 tempfile = { workspace = true, optional = true }
 
 git-version = { workspace = true }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -14,11 +14,12 @@ readme.workspace = true
 bench = false
 
 [features]
-default = ["markdown", "repl", "doc"]
+default = ["markdown", "repl", "doc", "format"]
 markdown = ["termimad"]
 repl = ["rustyline", "rustyline-derive", "ansi_term"]
 repl-wasm = ["wasm-bindgen", "js-sys", "serde_repr"]
 doc = ["comrak"]
+format = ["topiary", "tree-sitter-nickel"]
 
 [build-dependencies]
 lalrpop.workspace = true
@@ -62,6 +63,9 @@ malachite = { workspace = true, features = ["enable_serde"] }
 malachite-q.workspace = true
 indexmap = { workspace = true, features = ["serde"] }
 strip-ansi-escapes.workspace = true
+
+topiary = { workspace = true, optional = true }
+tree-sitter-nickel = { workspace = true, optional = true }
 
 [dev-dependencies]
 pretty_assertions.workspace = true

--- a/core/src/format.rs
+++ b/core/src/format.rs
@@ -1,0 +1,38 @@
+//! Utility module for formatting Nickel files using Topiary
+
+use std::{
+    fmt::Display,
+    io::{Read, Write},
+};
+
+use topiary::TopiaryQuery;
+
+#[derive(Debug)]
+/// Errors that may be encountered during formatting
+pub struct FormatError(topiary::FormatterError);
+
+impl Display for FormatError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+/// Format a Nickel file being read from `input`, writing the result to `output`.
+pub fn format(mut input: impl Read, mut output: impl Write) -> Result<(), FormatError> {
+    let topiary_config =
+        topiary::Configuration::parse_default_configuration().map_err(FormatError)?;
+    let language = topiary::SupportedLanguage::Nickel.to_language(&topiary_config);
+    let grammar = tree_sitter_nickel::language().into();
+    topiary::formatter(
+        &mut input,
+        &mut output,
+        &TopiaryQuery::nickel(),
+        language,
+        &grammar,
+        topiary::Operation::Format {
+            skip_idempotence: true,
+            tolerate_parsing_errors: true,
+        },
+    )
+    .map_err(FormatError)
+}

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -17,3 +17,6 @@ pub mod term;
 pub mod transform;
 pub mod typ;
 pub mod typecheck;
+
+#[cfg(feature = "format")]
+pub mod format;

--- a/lsp/lsp-harness/src/lib.rs
+++ b/lsp/lsp-harness/src/lib.rs
@@ -3,7 +3,7 @@ mod output;
 
 pub use jsonrpc::Server;
 use log::error;
-use lsp_types::{CompletionParams, GotoDefinitionParams, Url};
+use lsp_types::{CompletionParams, DocumentFormattingParams, GotoDefinitionParams, Url};
 pub use output::LspDebug;
 use serde::Deserialize;
 
@@ -29,6 +29,7 @@ pub struct TestFile {
 pub enum Request {
     GotoDefinition(GotoDefinitionParams),
     Completion(CompletionParams),
+    Formatting(DocumentFormattingParams),
 }
 
 #[derive(Deserialize, Debug, Default)]

--- a/lsp/lsp-harness/src/output.rs
+++ b/lsp/lsp-harness/src/output.rs
@@ -109,3 +109,15 @@ impl LspDebug for lsp_types::CompletionResponse {
         }
     }
 }
+
+impl LspDebug for lsp_types::TextEdit {
+    fn debug(&self, mut w: impl Write) -> std::io::Result<()> {
+        write!(w, "<{}> {}", self.range.debug_str(), self.new_text)
+    }
+}
+
+impl LspDebug for Vec<lsp_types::TextEdit> {
+    fn debug(&self, w: impl Write) -> std::io::Result<()> {
+        Iter(self.iter()).debug(w)
+    }
+}

--- a/lsp/nls/Cargo.toml
+++ b/lsp/nls/Cargo.toml
@@ -14,6 +14,10 @@ version.workspace = true
 name = "nls"
 path = "src/main.rs"
 
+[features]
+default = ["format"]
+format = ["nickel-lang-core/format"]
+
 [build-dependencies]
 lalrpop.workspace = true
 

--- a/lsp/nls/Cargo.toml
+++ b/lsp/nls/Cargo.toml
@@ -14,10 +14,6 @@ version.workspace = true
 name = "nls"
 path = "src/main.rs"
 
-[features]
-default = ["format"]
-format = ["nickel-lang-core/format"]
-
 [build-dependencies]
 lalrpop.workspace = true
 
@@ -31,7 +27,7 @@ serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 regex.workspace = true
 
-nickel-lang-core.workspace = true
+nickel-lang-core = { workspace = true, features = ["format"] }
 lsp-server.workspace = true
 lsp-types.workspace = true
 log.workspace = true

--- a/lsp/nls/README.md
+++ b/lsp/nls/README.md
@@ -13,10 +13,6 @@ it in VSCode, (Neo)Vim and Emacs.
 ## Formatting Capabilities
 
 Formatting in `nls` is currently based on
-[topiary](https://github.com/tweag/topiary).
-
-To enable formatting in NLS, you have to make the `topiary` executable available
-in your `PATH`. Please follow [Topiary's setup
-instructions](https://github.com/tweag/topiary#installing) and ensure in
-particular that the environment variable `TOPIARY_LANGUAGE_DIR` is correctly set
-(this is covered in the setup instructions).
+[topiary](https://github.com/tweag/topiary). NLS exposes a formatting capability
+when compiled with the `format` Cargo feature, which is enabled by default. No
+configuration or external dependencies are necessary.

--- a/lsp/nls/README.md
+++ b/lsp/nls/README.md
@@ -13,6 +13,5 @@ it in VSCode, (Neo)Vim and Emacs.
 ## Formatting Capabilities
 
 Formatting in `nls` is currently based on
-[Topiary](https://github.com/tweag/topiary). NLS exposes a formatting capability
-when compiled with the `format` Cargo feature, which is enabled by default. No
-configuration or external dependencies are necessary.
+[Topiary](https://github.com/tweag/topiary), used as a library. No configuration
+or external dependencies are necessary.

--- a/lsp/nls/README.md
+++ b/lsp/nls/README.md
@@ -13,6 +13,6 @@ it in VSCode, (Neo)Vim and Emacs.
 ## Formatting Capabilities
 
 Formatting in `nls` is currently based on
-[topiary](https://github.com/tweag/topiary). NLS exposes a formatting capability
+[Topiary](https://github.com/tweag/topiary). NLS exposes a formatting capability
 when compiled with the `format` Cargo feature, which is enabled by default. No
 configuration or external dependencies are necessary.

--- a/lsp/nls/src/error.rs
+++ b/lsp/nls/src/error.rs
@@ -13,7 +13,6 @@ pub enum Error {
     #[error("Method not supported")]
     MethodNotFound,
 
-    #[cfg(feature = "format")]
     #[error("formatting failed for file {file}: {details}")]
     FormattingFailed { details: String, file: Url },
 }
@@ -24,7 +23,6 @@ impl From<Error> for ResponseError {
             Error::FileNotFound(_) => ErrorCode::InvalidParams,
             Error::InvalidPosition { .. } => ErrorCode::InvalidParams,
             Error::MethodNotFound => ErrorCode::MethodNotFound,
-            #[cfg(feature = "format")]
             Error::FormattingFailed { .. } => ErrorCode::InternalError,
         };
         ResponseError {

--- a/lsp/nls/src/error.rs
+++ b/lsp/nls/src/error.rs
@@ -9,6 +9,13 @@ pub enum Error {
 
     #[error("position {pos:?} invalid for file {file}")]
     InvalidPosition { pos: Position, file: Url },
+
+    #[error("Method not supported")]
+    MethodNotFound,
+
+    #[cfg(feature = "format")]
+    #[error("formatting failed for file {file}: {details}")]
+    FormattingFailed { details: String, file: Url },
 }
 
 impl From<Error> for ResponseError {
@@ -16,6 +23,9 @@ impl From<Error> for ResponseError {
         let code = match value {
             Error::FileNotFound(_) => ErrorCode::InvalidParams,
             Error::InvalidPosition { .. } => ErrorCode::InvalidParams,
+            Error::MethodNotFound => ErrorCode::MethodNotFound,
+            #[cfg(feature = "format")]
+            Error::FormattingFailed { .. } => ErrorCode::InternalError,
         };
         ResponseError {
             code: code as i32,

--- a/lsp/nls/src/requests/mod.rs
+++ b/lsp/nls/src/requests/mod.rs
@@ -1,7 +1,5 @@
 pub mod completion;
+pub mod formatting;
 pub mod goto;
 pub mod hover;
 pub mod symbols;
-
-#[cfg(feature = "format")]
-pub mod formatting;

--- a/lsp/nls/src/requests/mod.rs
+++ b/lsp/nls/src/requests/mod.rs
@@ -1,5 +1,7 @@
 pub mod completion;
-pub mod formatting;
 pub mod goto;
 pub mod hover;
 pub mod symbols;
+
+#[cfg(feature = "format")]
+pub mod formatting;

--- a/lsp/nls/src/server.rs
+++ b/lsp/nls/src/server.rs
@@ -28,7 +28,6 @@ use nickel_lang_core::{stdlib, typecheck::Context};
 use crate::{
     cache::CacheExt,
     diagnostic::DiagnosticCompat,
-    error::Error,
     linearization::{completed::Completed, Environment, ItemId, LinRegistry},
     requests::{completion, goto, hover, symbols},
     trace::Trace,

--- a/lsp/nls/src/server.rs
+++ b/lsp/nls/src/server.rs
@@ -12,10 +12,10 @@ use lsp_types::{
     notification::{DidChangeTextDocument, DidOpenTextDocument},
     request::{Request as RequestTrait, *},
     CompletionOptions, CompletionParams, DidChangeTextDocumentParams, DidOpenTextDocumentParams,
-    DocumentFormattingParams, DocumentSymbolParams, GotoDefinitionParams, HoverOptions,
-    HoverParams, HoverProviderCapability, OneOf, PublishDiagnosticsParams, ReferenceParams,
-    ServerCapabilities, TextDocumentSyncCapability, TextDocumentSyncKind, TextDocumentSyncOptions,
-    Url, WorkDoneProgressOptions,
+    DocumentSymbolParams, GotoDefinitionParams, HoverOptions, HoverParams, HoverProviderCapability,
+    OneOf, PublishDiagnosticsParams, ReferenceParams, ServerCapabilities,
+    TextDocumentSyncCapability, TextDocumentSyncKind, TextDocumentSyncOptions, Url,
+    WorkDoneProgressOptions,
 };
 
 use nickel_lang_core::{
@@ -28,13 +28,18 @@ use nickel_lang_core::{stdlib, typecheck::Context};
 use crate::{
     cache::CacheExt,
     diagnostic::DiagnosticCompat,
+    error::Error,
     linearization::{completed::Completed, Environment, ItemId, LinRegistry},
-    requests::{completion, formatting, goto, hover, symbols},
+    requests::{completion, goto, hover, symbols},
     trace::Trace,
 };
 
+#[cfg(feature = "format")]
+use crate::requests::formatting;
+#[cfg(feature = "format")]
+use lsp_types::DocumentFormattingParams;
+
 pub const DOT_COMPL_TRIGGER: &str = ".";
-pub const FORMATTING_COMMAND: [&str; 3] = ["topiary", "--language", "nickel"];
 
 pub struct Server {
     pub connection: Connection,
@@ -68,6 +73,7 @@ impl Server {
                 ..Default::default()
             }),
             document_symbol_provider: Some(OneOf::Left(true)),
+            #[cfg(feature = "format")]
             document_formatting_provider: Some(OneOf::Left(true)),
             ..ServerCapabilities::default()
         }
@@ -243,11 +249,15 @@ impl Server {
                 symbols::handle_document_symbols(params, req.id.clone(), self)
             }
 
+            #[cfg(feature = "format")]
             Formatting::METHOD => {
                 debug!("handle formatting");
                 let params: DocumentFormattingParams = serde_json::from_value(req.params).unwrap();
                 formatting::handle_format_document(params, req.id.clone(), self)
             }
+
+            #[cfg(not(feature = "format"))]
+            Formatting::METHOD => Err(Error::MethodNotFound.into()),
 
             _ => Ok(()),
         };

--- a/lsp/nls/tests/inputs/formatting.ncl
+++ b/lsp/nls/tests/inputs/formatting.ncl
@@ -1,0 +1,9 @@
+### /formatting.ncl
+{ foo = "bar",
+baz = 7}
+### [[request]]
+### type = "Formatting"
+### textDocument.uri = "file:///formatting.ncl"
+### [request.options]
+### tabSize = 2
+### insertSpaces = true

--- a/lsp/nls/tests/main.rs
+++ b/lsp/nls/tests/main.rs
@@ -1,7 +1,7 @@
 use std::collections::{hash_map::Entry, HashMap};
 
 use assert_cmd::cargo::CommandCargoExt;
-use lsp_types::request::{Completion, GotoDefinition, Request as LspRequest};
+use lsp_types::request::{Completion, Formatting, GotoDefinition, Request as LspRequest};
 use nickel_lang_utils::project_root::project_root;
 use test_generator::test_resources;
 
@@ -35,6 +35,7 @@ impl TestHarness {
         match req {
             Request::GotoDefinition(d) => self.request::<GotoDefinition>(d),
             Request::Completion(c) => self.request::<Completion>(c),
+            Request::Formatting(f) => self.request::<Formatting>(f),
         }
     }
 

--- a/lsp/nls/tests/snapshots/main__lsp__nls__tests__inputs__formatting.ncl.snap
+++ b/lsp/nls/tests/snapshots/main__lsp__nls__tests__inputs__formatting.ncl.snap
@@ -1,0 +1,10 @@
+---
+source: lsp/nls/tests/main.rs
+expression: output
+---
+[<0:0-1:8> {
+  foo = "bar",
+  baz = 7
+}
+]
+


### PR DESCRIPTION
With this change formatting in the LSP uses topiary as a library instead of calling an external binary, just like the implementation of `nickel format`. The result is formatting capability in the LSP without any external dependencies enabled by default.