### PR TITLE
actually cache dependencies

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -205,7 +205,7 @@
           # Build *just* the cargo dependencies, so we can reuse all of that work (e.g. via cachix) when running in CI
           cargoArtifacts = craneLib.buildDepsOnly {
             pname = "nickel-lang";
-            inherit src version;
+            inherit src;
             cargoExtraArgs = "${cargoBuildExtraArgs} --workspace";
             # pyo3 needs a Python interpreter in the build environment
             # https://pyo3.rs/v0.17.3/building_and_distribution#configuring-the-python-version
@@ -367,10 +367,7 @@
           # Build *just* the cargo dependencies, so we can reuse all of that work (e.g. via cachix) when running in CI
           cargoArtifacts = craneLib.buildDepsOnly {
             pname = "nickel-lang-wasm";
-            inherit
-              src
-              version
-              cargoExtraArgs;
+            inherit src cargoExtraArgs;
             doCheck = false;
           };
 


### PR DESCRIPTION
The `version` field of the `nickel-lang-deps` nix derivation was being set to include the current git commit, which was **always** invalidating the cache.

In this case it definitely makes sense to remove the version string to cache as aggressively as possible. It might also make sense to make the version string looser (i.e. only include the actual version) for the other derivations, but on most commits the derivations will change anyways, so it won't help us that much. I guess it depends on why the version string is like this to begin with.

~~I'll leave this in draft form while I test the CI caching.~~

This brings CI speed down to 5 minutes in cases where dependencies are cached: https://github.com/tweag/nickel/actions/runs/5870270848