### PR TITLE
Usage/definition lookup table

### DIFF
--- a/core/src/destructuring.rs
+++ b/core/src/destructuring.rs
@@ -217,7 +217,7 @@ impl Match {
                 field,
                 FieldPattern::RecordPattern(ref pattern @ RecordPattern { ref matches, .. }),
             ) => {
-                let span = get_span(&id, pattern);
+                let span = get_span(id, pattern);
                 let pattern = pattern.clone();
                 let mut field = field.clone();
                 field
@@ -236,7 +236,7 @@ impl Match {
                     pattern: ref pattern @ RecordPattern { ref matches, .. },
                 },
             ) => {
-                let span = get_span(&id, pattern);
+                let span = get_span(id, pattern);
                 let pattern = pattern.clone();
                 let mut field = field.clone();
                 field

--- a/core/src/destructuring.rs
+++ b/core/src/destructuring.rs
@@ -33,7 +33,8 @@ pub enum FieldPattern {
 #[derive(Debug, PartialEq, Clone)]
 pub enum Match {
     /// `{..., a=b, ...}` will bind the field `a` of the record to variable `b`. Here, `a` is the
-    /// first field of this variant and `b` the optional one. The last field can actualy be a
+    /// first field of this variant. Any annotations or metadata associated with `a` go into
+    /// the `Field` field, and `b` goes into the `FieldPattern` field, which can actually be a
     /// nested destruct pattern.
     Assign(LocIdent, Field, FieldPattern),
     /// Simple binding. the `Ident` is bind to a variable with the same name.
@@ -187,7 +188,7 @@ impl Match {
     /// Returns info about each variable bound in a particular pattern.
     /// It also tells the "path" to the bound variable; this is just the
     /// record field names traversed to get to a pattern.
-    pub fn as_flattened_bindings(self) -> Vec<(Vec<LocIdent>, Option<LocIdent>, Field)> {
+    pub fn to_flattened_bindings(&self) -> Vec<(Vec<LocIdent>, LocIdent, Field)> {
         fn get_span(id: &LocIdent, pattern: &RecordPattern) -> RawSpan {
             RawSpan::fuse(id.pos.unwrap(), pattern.span).unwrap()
         }
@@ -195,10 +196,10 @@ impl Match {
         fn flatten_matches(
             id: &LocIdent,
             matches: &[Match],
-        ) -> Vec<(Vec<LocIdent>, Option<LocIdent>, Field)> {
+        ) -> Vec<(Vec<LocIdent>, LocIdent, Field)> {
             matches
                 .iter()
-                .flat_map(|m| m.clone().as_flattened_bindings())
+                .flat_map(|m| m.clone().to_flattened_bindings())
                 .map(|(mut path, bind, field)| {
                     path.push(*id);
                     (path, bind, field)
@@ -207,28 +208,29 @@ impl Match {
         }
 
         match self {
-            Match::Simple(id, field) => vec![(vec![id], None, field)],
+            Match::Simple(id, field) => vec![(vec![*id], *id, field.clone())],
             Match::Assign(id, field, FieldPattern::Ident(bind_id)) => {
-                vec![(vec![id], Some(bind_id), field)]
+                vec![(vec![*id], *bind_id, field.clone())]
             }
             Match::Assign(
                 id,
-                mut field,
+                field,
                 FieldPattern::RecordPattern(ref pattern @ RecordPattern { ref matches, .. }),
             ) => {
                 let span = get_span(&id, pattern);
                 let pattern = pattern.clone();
+                let mut field = field.clone();
                 field
                     .metadata
                     .annotation
                     .contracts
                     .push(pattern.into_contract_with_span(span));
 
-                flatten_matches(&id, matches)
+                flatten_matches(id, matches)
             }
             Match::Assign(
                 id,
-                mut field,
+                field,
                 FieldPattern::AliasedRecordPattern {
                     alias: bind_id,
                     pattern: ref pattern @ RecordPattern { ref matches, .. },
@@ -236,14 +238,15 @@ impl Match {
             ) => {
                 let span = get_span(&id, pattern);
                 let pattern = pattern.clone();
+                let mut field = field.clone();
                 field
                     .metadata
                     .annotation
                     .contracts
                     .push(pattern.into_contract_with_span(span));
 
-                let mut flattened = flatten_matches(&id, matches);
-                flattened.push((vec![id], Some(bind_id), field));
+                let mut flattened = flatten_matches(id, matches);
+                flattened.push((vec![*id], *bind_id, field));
                 flattened
             }
         }

--- a/core/src/destructuring.rs
+++ b/core/src/destructuring.rs
@@ -199,7 +199,7 @@ impl Match {
         ) -> Vec<(Vec<LocIdent>, LocIdent, Field)> {
             matches
                 .iter()
-                .flat_map(|m| m.clone().to_flattened_bindings())
+                .flat_map(|m| m.to_flattened_bindings())
                 .map(|(mut path, bind, field)| {
                     path.push(*id);
                     (path, bind, field)

--- a/core/src/identifier.rs
+++ b/core/src/identifier.rs
@@ -15,7 +15,7 @@ static INTERNER: Lazy<interner::Interner> = Lazy::new(interner::Interner::new);
 //
 // Implementation-wise, this is just a wrapper around interner::Symbol that uses a hard-coded,
 // static `Interner`.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(into = "String", from = "String")]
 pub struct Ident(interner::Symbol);
 
@@ -37,6 +37,12 @@ impl Ident {
 impl fmt::Display for Ident {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.label())
+    }
+}
+
+impl fmt::Debug for Ident {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "`{}`", self.label())
     }
 }
 

--- a/lsp/nls/src/identifier.rs
+++ b/lsp/nls/src/identifier.rs
@@ -1,0 +1,26 @@
+use nickel_lang_core::{identifier::Ident, position::TermPos};
+
+/// An identifier with a location.
+///
+/// This differs from [`nickel_lang_core::identifier::LocIdent`] in that the
+/// location is used in comparisons and hashes.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct LocIdent {
+    pub symbol: Ident,
+    pub pos: TermPos,
+}
+
+impl From<LocIdent> for nickel_lang_core::identifier::LocIdent {
+    fn from(ours: LocIdent) -> Self {
+        Self::from(ours.symbol).with_pos(ours.pos)
+    }
+}
+
+impl From<nickel_lang_core::identifier::LocIdent> for LocIdent {
+    fn from(theirs: nickel_lang_core::identifier::LocIdent) -> Self {
+        Self {
+            symbol: theirs.symbol(),
+            pos: theirs.pos,
+        }
+    }
+}

--- a/lsp/nls/src/linearization/building.rs
+++ b/lsp/nls/src/linearization/building.rs
@@ -4,7 +4,7 @@ use codespan::FileId;
 use log::debug;
 use nickel_lang_core::{
     cache::Cache,
-    identifier::{Ident, LocIdent},
+    identifier::Ident,
     position::TermPos,
     term::{record::Field, IndexMap, RichTerm},
     typ::TypeF,
@@ -115,7 +115,7 @@ impl<'b> Building<'b> {
         &mut self,
         current_file: FileId,
         record_term: &RichTerm,
-        record_fields: &IndexMap<LocIdent, Field>,
+        record_fields: &IndexMap<nickel_lang_core::identifier::LocIdent, Field>,
         record: ItemId,
         env: &mut Environment,
     ) {
@@ -235,9 +235,9 @@ impl<'b> Building<'b> {
     pub(super) fn resolve_record_references(
         &mut self,
         current_file: FileId,
-        mut defers: Vec<(ItemId, ItemId, LocIdent)>,
-    ) -> Vec<(ItemId, ItemId, LocIdent)> {
-        let mut unresolved: Vec<(ItemId, ItemId, LocIdent)> = Vec::new();
+        mut defers: Vec<(ItemId, ItemId, Ident)>,
+    ) -> Vec<(ItemId, ItemId, Ident)> {
+        let mut unresolved: Vec<(ItemId, ItemId, Ident)> = Vec::new();
 
         while let Some(deferred) = defers.pop() {
             // child_item: current deferred usage item
@@ -274,11 +274,9 @@ impl<'b> Building<'b> {
                 // get record field
                 .and_then(|parent_declaration| match &parent_declaration {
                     TermKind::Record(fields) => {
-                        fields
-                            .get(&child_ident.symbol())
-                            .and_then(|child_declaration_id| {
-                                self.get_item_kind_with_id(current_file, *child_declaration_id)
-                            })
+                        fields.get(child_ident).and_then(|child_declaration_id| {
+                            self.get_item_kind_with_id(current_file, *child_declaration_id)
+                        })
                     }
                     _ => None,
                 });

--- a/lsp/nls/src/linearization/mod.rs
+++ b/lsp/nls/src/linearization/mod.rs
@@ -18,10 +18,7 @@ use nickel_lang_core::{
 };
 
 use crate::{
-    field_walker::{Def, DefWithPath},
-    identifier::LocIdent,
-    position::PositionLookup,
-    usage::UsageLookup,
+    field_walker::DefWithPath, identifier::LocIdent, position::PositionLookup, usage::UsageLookup,
 };
 
 use self::{

--- a/lsp/nls/src/linearization/mod.rs
+++ b/lsp/nls/src/linearization/mod.rs
@@ -573,7 +573,7 @@ impl<'a> Linearizer for AnalysisHost<'a> {
             .iter()
             .filter_map(|item| match &item.kind {
                 TermKind::Usage(UsageState::Deferred { parent, child }) => {
-                    Some((item.id, *parent, (*child).symbol()))
+                    Some((item.id, *parent, child.symbol()))
                 }
                 _ => None,
             })

--- a/lsp/nls/src/main.rs
+++ b/lsp/nls/src/main.rs
@@ -17,6 +17,7 @@ mod server;
 use server::Server;
 mod term;
 mod trace;
+mod usage;
 
 use crate::trace::Trace;
 

--- a/lsp/nls/src/main.rs
+++ b/lsp/nls/src/main.rs
@@ -10,6 +10,7 @@ mod diagnostic;
 mod error;
 mod field_walker;
 mod files;
+mod identifier;
 mod linearization;
 mod position;
 mod requests;

--- a/lsp/nls/src/position.rs
+++ b/lsp/nls/src/position.rs
@@ -122,7 +122,7 @@ impl PositionLookup {
             TraverseControl::<()>::Continue
         };
 
-        rt.traverse_ref(&mut (&mut fun as &mut dyn FnMut(&RichTerm) -> _));
+        rt.traverse_ref(&mut fun);
 
         PositionLookup {
             ranges: make_disjoint(all_ranges),

--- a/lsp/nls/src/requests/completion.rs
+++ b/lsp/nls/src/requests/completion.rs
@@ -666,6 +666,7 @@ fn extract_static_path(mut rt: RichTerm) -> (RichTerm, Vec<Ident>) {
             path.push(id.symbol());
             rt = parent.clone();
         } else {
+            path.reverse();
             return (rt, path);
         }
     }

--- a/lsp/nls/src/requests/completion.rs
+++ b/lsp/nls/src/requests/completion.rs
@@ -658,12 +658,12 @@ fn get_completion_identifiers(
     Ok(remove_duplicates(&in_scope))
 }
 
-fn extract_static_path(mut rt: RichTerm) -> (RichTerm, Vec<LocIdent>) {
+fn extract_static_path(mut rt: RichTerm) -> (RichTerm, Vec<Ident>) {
     let mut path = Vec::new();
 
     loop {
         if let Term::Op1(UnaryOp::StaticAccess(id), parent) = rt.term.as_ref() {
-            path.push(*id);
+            path.push(id.symbol());
             rt = parent.clone();
         } else {
             return (rt, path);

--- a/lsp/nls/src/requests/completion.rs
+++ b/lsp/nls/src/requests/completion.rs
@@ -15,7 +15,7 @@ use nickel_lang_core::{
 
 use crate::{
     cache::CacheExt,
-    field_walker,
+    field_walker::{Def, FieldDefs},
     linearization::{
         completed::Completed,
         interface::{TermKind, UsageState, ValueState},
@@ -687,8 +687,8 @@ fn term_based_completion(
 
     let (start_term, path) = extract_static_path(parent.clone());
 
-    let defs = field_walker::resolve_path(&start_term, &path, linearization, server);
-    Ok(defs.map(|d| d.to_completion_item()).collect())
+    let defs = FieldDefs::resolve_path(&start_term, &path, linearization, server);
+    Ok(defs.defs().map(Def::to_completion_item).collect())
 }
 
 pub fn handle_completion(

--- a/lsp/nls/src/term.rs
+++ b/lsp/nls/src/term.rs
@@ -1,7 +1,28 @@
-use std::ops::Range;
+use std::{hash::Hash, ops::Range};
 
 use codespan::FileId;
-use nickel_lang_core::position::RawSpan;
+use nickel_lang_core::{
+    position::RawSpan,
+    term::{RichTerm, SharedTerm, Term},
+};
+
+// A term that uses source position and a pointer to Term to implement Eq and Hash.
+#[derive(Clone, Debug)]
+pub struct RichTermPtr(pub RichTerm);
+
+impl PartialEq for RichTermPtr {
+    fn eq(&self, other: &Self) -> bool {
+        self.0.pos == other.0.pos && SharedTerm::ptr_eq(&self.0.term, &other.0.term)
+    }
+}
+
+impl Hash for RichTermPtr {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        (self.0.pos, self.0.term.as_ref() as *const Term).hash(state)
+    }
+}
+
+impl Eq for RichTermPtr {}
 
 pub trait RawSpanExt {
     fn to_range(self) -> (FileId, Range<usize>);

--- a/lsp/nls/src/usage.rs
+++ b/lsp/nls/src/usage.rs
@@ -7,11 +7,11 @@ use nickel_lang_core::{
 };
 
 use crate::{
-    field_walker::{Def, TermAtPath},
+    field_walker::{DefWithPath, TermAtPath},
     identifier::LocIdent,
 };
 
-type Environment = GenericEnvironment<Ident, Def>;
+type Environment = GenericEnvironment<Ident, DefWithPath>;
 
 trait EnvExt {
     fn def(
@@ -36,7 +36,7 @@ impl EnvExt for Environment {
         let ident = id.into();
         self.insert(
             ident.symbol,
-            Def {
+            DefWithPath {
                 ident,
                 value: val.map(Into::into),
                 metadata: meta,
@@ -47,7 +47,7 @@ impl EnvExt for Environment {
 
 #[derive(Clone, Debug, Default)]
 pub struct UsageLookup {
-    def_table: HashMap<LocIdent, Def>,
+    def_table: HashMap<LocIdent, DefWithPath>,
     usage_table: HashMap<LocIdent, Vec<LocIdent>>,
 }
 
@@ -65,7 +65,7 @@ impl UsageLookup {
             .unwrap_or([].iter())
     }
 
-    pub fn def(&self, ident: &LocIdent) -> Option<&Def> {
+    pub fn def(&self, ident: &LocIdent) -> Option<&DefWithPath> {
         self.def_table.get(ident)
     }
 

--- a/lsp/nls/src/usage.rs
+++ b/lsp/nls/src/usage.rs
@@ -1,0 +1,117 @@
+use std::collections::HashMap;
+
+use nickel_lang_core::{
+    environment::Environment,
+    identifier::{Ident, LocIdent},
+    term::{RichTerm, Term, Traverse, TraverseControl},
+};
+
+use crate::{
+    field_walker::{Def, DefValue},
+    term::RichTermPtr,
+};
+
+#[derive(Clone, Debug, Default)]
+pub struct UsageLookup {
+    def_table: HashMap<RichTermPtr, Def>,
+    usage_table: HashMap<Ident, RichTerm>,
+}
+
+impl UsageLookup {
+    pub fn new(rt: &RichTerm) -> Self {
+        let mut table = Self::default();
+        table.fill(rt, &Environment::new());
+        table
+    }
+
+    fn fill(&mut self, rt: &RichTerm, env: &Environment<Ident, Def>) {
+        // Static accesses count as usage (but probably not for us?)
+        // Resolved imports count as usage
+        // Let and Fun count as declarations
+        // LetPattern and FunPattern count as declarations
+        rt.traverse_ref(&mut |term: &RichTerm| match term.term.as_ref() {
+            Term::Fun(id, body) => {
+                let mut new_env = env.clone();
+                new_env.insert(
+                    id.symbol(),
+                    Def {
+                        ident: *id,
+                        value: None,
+                        metadata: None,
+                    },
+                );
+
+                self.fill(body, &new_env);
+                TraverseControl::SkipBranch
+            }
+            Term::Let(id, val, body, attrs) => {
+                let mut new_env = env.clone();
+                new_env.insert(
+                    id.symbol(),
+                    Def {
+                        ident: *id,
+                        value: Some(val.clone().into()),
+                        metadata: None,
+                    },
+                );
+
+                self.fill(val, if attrs.rec { &new_env } else { env });
+                self.fill(body, &new_env);
+
+                TraverseControl::SkipBranch
+            }
+            Term::LetPattern(maybe_id, pat, val, body) => {
+                let mut new_env = env.clone();
+                if let Some(id) = maybe_id {
+                    new_env.insert(
+                        id.symbol(),
+                        Def {
+                            ident: *id,
+                            value: Some(val.clone().into()),
+                            metadata: None,
+                        },
+                    );
+                }
+
+                for m in &pat.matches {
+                    for (path, id, field) in m.to_flattened_bindings() {
+                        let path = path.iter().map(LocIdent::symbol).collect();
+                        new_env.insert(
+                            id.symbol(),
+                            Def {
+                                ident: id,
+                                value: Some(DefValue {
+                                    term: val.clone(),
+                                    path,
+                                }),
+                                metadata: Some(field.metadata),
+                            },
+                        );
+                    }
+                }
+                self.fill(body, &new_env);
+                TraverseControl::SkipBranch
+            }
+            Term::Var(id) => {
+                if let Some(def) = env.get(&id.symbol()) {
+                    self.def_table.insert(RichTermPtr(rt.clone()), def.clone());
+                    self.usage_table.insert(def.ident.symbol(), rt.clone());
+                }
+                TraverseControl::Continue
+            }
+            _ => TraverseControl::<()>::Continue,
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{position::tests::parse, usage::UsageLookup};
+
+    #[test]
+    fn let_and_var() {
+        let rt = parse("let x = 1 in x");
+        let table = UsageLookup::new(&rt);
+        dbg!(table);
+    }
+}

--- a/lsp/nls/src/usage.rs
+++ b/lsp/nls/src/usage.rs
@@ -1,20 +1,54 @@
 use std::collections::HashMap;
 
 use nickel_lang_core::{
-    environment::Environment,
-    identifier::{Ident, LocIdent},
-    term::{RichTerm, Term, Traverse, TraverseControl},
+    environment::Environment as GenericEnvironment,
+    identifier::Ident,
+    term::{record::FieldMetadata, RichTerm, Term, Traverse, TraverseControl},
 };
 
 use crate::{
-    field_walker::{Def, DefValue},
-    term::RichTermPtr,
+    field_walker::{Def, TermAtPath},
+    identifier::LocIdent,
 };
+
+type Environment = GenericEnvironment<Ident, Def>;
+
+trait EnvExt {
+    fn def(
+        &mut self,
+        id: impl Into<LocIdent>,
+        val: Option<impl Into<TermAtPath>>,
+        meta: Option<FieldMetadata>,
+    );
+
+    fn def_noval(&mut self, id: impl Into<LocIdent>, meta: Option<FieldMetadata>) {
+        self.def(id, None::<TermAtPath>, meta);
+    }
+}
+
+impl EnvExt for Environment {
+    fn def(
+        &mut self,
+        id: impl Into<LocIdent>,
+        val: Option<impl Into<TermAtPath>>,
+        meta: Option<FieldMetadata>,
+    ) {
+        let ident = id.into();
+        self.insert(
+            ident.symbol,
+            Def {
+                ident,
+                value: val.map(Into::into),
+                metadata: meta,
+            },
+        );
+    }
+}
 
 #[derive(Clone, Debug, Default)]
 pub struct UsageLookup {
-    def_table: HashMap<RichTermPtr, Def>,
-    usage_table: HashMap<Ident, RichTerm>,
+    def_table: HashMap<LocIdent, Def>,
+    usage_table: HashMap<LocIdent, Vec<LocIdent>>,
 }
 
 impl UsageLookup {
@@ -24,7 +58,18 @@ impl UsageLookup {
         table
     }
 
-    fn fill(&mut self, rt: &RichTerm, env: &Environment<Ident, Def>) {
+    pub fn usages(&self, ident: &LocIdent) -> impl Iterator<Item = &LocIdent> {
+        self.usage_table
+            .get(ident)
+            .map(|v| v.iter())
+            .unwrap_or([].iter())
+    }
+
+    pub fn def(&self, ident: &LocIdent) -> Option<&Def> {
+        self.def_table.get(ident)
+    }
+
+    fn fill(&mut self, rt: &RichTerm, env: &Environment) {
         // Static accesses count as usage (but probably not for us?)
         // Resolved imports count as usage
         // Let and Fun count as declarations
@@ -32,28 +77,27 @@ impl UsageLookup {
         rt.traverse_ref(&mut |term: &RichTerm| match term.term.as_ref() {
             Term::Fun(id, body) => {
                 let mut new_env = env.clone();
-                new_env.insert(
-                    id.symbol(),
-                    Def {
-                        ident: *id,
-                        value: None,
-                        metadata: None,
-                    },
-                );
+                new_env.def_noval(*id, None);
+                self.fill(body, &new_env);
+                TraverseControl::SkipBranch
+            }
+            Term::FunPattern(maybe_id, pat, body) => {
+                let mut new_env = env.clone();
+                if let Some(id) = maybe_id {
+                    new_env.def_noval(*id, None);
+                }
 
+                for m in &pat.matches {
+                    for (_path, id, field) in m.to_flattened_bindings() {
+                        new_env.def_noval(id, Some(field.metadata));
+                    }
+                }
                 self.fill(body, &new_env);
                 TraverseControl::SkipBranch
             }
             Term::Let(id, val, body, attrs) => {
                 let mut new_env = env.clone();
-                new_env.insert(
-                    id.symbol(),
-                    Def {
-                        ident: *id,
-                        value: Some(val.clone().into()),
-                        metadata: None,
-                    },
-                );
+                new_env.def(*id, Some(val.clone()), None);
 
                 self.fill(val, if attrs.rec { &new_env } else { env });
                 self.fill(body, &new_env);
@@ -63,39 +107,27 @@ impl UsageLookup {
             Term::LetPattern(maybe_id, pat, val, body) => {
                 let mut new_env = env.clone();
                 if let Some(id) = maybe_id {
-                    new_env.insert(
-                        id.symbol(),
-                        Def {
-                            ident: *id,
-                            value: Some(val.clone().into()),
-                            metadata: None,
-                        },
-                    );
+                    new_env.def(*id, Some(val.clone()), None);
                 }
 
                 for m in &pat.matches {
                     for (path, id, field) in m.to_flattened_bindings() {
-                        let path = path.iter().map(LocIdent::symbol).collect();
-                        new_env.insert(
-                            id.symbol(),
-                            Def {
-                                ident: id,
-                                value: Some(DefValue {
-                                    term: val.clone(),
-                                    path,
-                                }),
-                                metadata: Some(field.metadata),
-                            },
-                        );
+                        let path = path.iter().map(|i| i.symbol()).rev().collect();
+                        let term = TermAtPath {
+                            term: val.clone(),
+                            path,
+                        };
+                        new_env.def(id, Some(term), Some(field.metadata));
                     }
                 }
                 self.fill(body, &new_env);
                 TraverseControl::SkipBranch
             }
             Term::Var(id) => {
-                if let Some(def) = env.get(&id.symbol()) {
-                    self.def_table.insert(RichTermPtr(rt.clone()), def.clone());
-                    self.usage_table.insert(def.ident.symbol(), rt.clone());
+                let id = LocIdent::from(*id);
+                if let Some(def) = env.get(&id.symbol) {
+                    self.def_table.insert(id, def.clone());
+                    self.usage_table.entry(def.ident).or_default().push(id);
                 }
                 TraverseControl::Continue
             }
@@ -106,12 +138,70 @@ impl UsageLookup {
 
 #[cfg(test)]
 mod tests {
-    use crate::{position::tests::parse, usage::UsageLookup};
+    use assert_matches::assert_matches;
+    use codespan::FileId;
+    use nickel_lang_core::{identifier::Ident, position::RawSpan, term::Term};
+
+    use crate::{identifier::LocIdent, position::tests::parse, usage::UsageLookup};
+
+    fn locced(ident: impl Into<Ident>, src_id: FileId, range: std::ops::Range<u32>) -> LocIdent {
+        LocIdent {
+            symbol: ident.into(),
+            pos: RawSpan {
+                src_id,
+                start: range.start.into(),
+                end: range.end.into(),
+            }
+            .into(),
+        }
+    }
 
     #[test]
     fn let_and_var() {
-        let rt = parse("let x = 1 in x");
+        let (file, rt) = parse("let x = 1 in x + x");
+        let x = Ident::new("x");
+        let x0 = locced(x, file, 4..5);
+        let x1 = locced(x, file, 13..14);
+        let x2 = locced(x, file, 17..18);
         let table = UsageLookup::new(&rt);
-        dbg!(table);
+
+        assert_eq!(table.usages(&x0).cloned().collect::<Vec<_>>(), vec![x1, x2]);
+        assert_eq!(table.def(&x1), table.def(&x2));
+        assert_eq!(table.def(&x0), None);
+
+        let def = table.def(&x1).unwrap();
+        assert_eq!(def.ident, x0);
+        assert_matches!(def.value.as_ref().unwrap().term.as_ref(), &Term::Num(_));
+    }
+
+    #[test]
+    fn pattern_path() {
+        let (file, rt) = parse("let x@{ foo = a@{ bar = baz } } = 'Undefined in x + a + baz");
+        let x0 = locced("x", file, 4..5);
+        let x1 = locced("x", file, 48..49);
+        let a0 = locced("a", file, 14..15);
+        let a1 = locced("a", file, 52..53);
+        let baz0 = locced("baz", file, 24..27);
+        let baz1 = locced("baz", file, 56..59);
+        let table = UsageLookup::new(&rt);
+
+        assert_eq!(table.usages(&x0).cloned().collect::<Vec<_>>(), vec![x1]);
+        assert_eq!(table.usages(&a0).cloned().collect::<Vec<_>>(), vec![a1]);
+        assert_eq!(table.usages(&baz0).cloned().collect::<Vec<_>>(), vec![baz1]);
+
+        let x_def = table.def(&x1).unwrap();
+        assert_eq!(x_def.ident, x0);
+        assert!(x_def.value.as_ref().unwrap().path.is_empty());
+
+        let a_def = table.def(&a1).unwrap();
+        assert_eq!(a_def.ident, a0);
+        assert_eq!(a_def.value.as_ref().unwrap().path, vec!["foo".into()]);
+
+        let baz_def = table.def(&baz1).unwrap();
+        assert_eq!(baz_def.ident, baz0);
+        assert_eq!(
+            baz_def.value.as_ref().unwrap().path,
+            vec!["foo".into(), "bar".into()]
+        );
     }
 }

--- a/lsp/nls/tests/inputs/completion-patterns.ncl
+++ b/lsp/nls/tests/inputs/completion-patterns.ncl
@@ -1,0 +1,45 @@
+### /input.ncl
+let outer@{ foo = inner@{ bar = innermost, .. }, .. } = {
+  extra = 1,
+  foo = {
+    more = 1,
+    bar = {
+      most = 1,
+      baz = 1,
+    }
+  },
+}
+in
+[
+  # The merge here prevents the old completer from working, so we're only testing the new one.
+  (outer & {}).foo,
+  (outer & {}).foo.bar,
+  (outer & {}).foo.bar.baz,
+  (inner & {}).bar,
+  (inner & {}).bar.baz,
+  (innermost & {}).baz,
+]
+### [[request]]
+### type = "Completion"
+### textDocument.uri = "file:///input.ncl"
+### position = { line = 13, character = 18 }
+### [[request]]
+### type = "Completion"
+### textDocument.uri = "file:///input.ncl"
+### position = { line = 14, character = 22 }
+### [[request]]
+### type = "Completion"
+### textDocument.uri = "file:///input.ncl"
+### position = { line = 15, character = 26 }
+### [[request]]
+### type = "Completion"
+### textDocument.uri = "file:///input.ncl"
+### position = { line = 16, character = 18 }
+### [[request]]
+### type = "Completion"
+### textDocument.uri = "file:///input.ncl"
+### position = { line = 17, character = 22 }
+### [[request]]
+### type = "Completion"
+### textDocument.uri = "file:///input.ncl"
+### position = { line = 18, character = 22 }

--- a/lsp/nls/tests/snapshots/main__lsp__nls__tests__inputs__completion-patterns.ncl.snap
+++ b/lsp/nls/tests/snapshots/main__lsp__nls__tests__inputs__completion-patterns.ncl.snap
@@ -1,0 +1,11 @@
+---
+source: lsp/nls/tests/main.rs
+expression: output
+---
+[extra, foo, inner, innermost, outer]
+[bar, inner, innermost, more, outer]
+[baz, inner, innermost, most, outer]
+[bar, inner, innermost, more, outer]
+[baz, inner, innermost, most, outer]
+[baz, inner, innermost, most, outer]
+


### PR DESCRIPTION
This adds a lookup table for variable usages and definitions, and updates the new completer to use this table. The table is populated using a separate (and fairly straightforward) tree traversal, instead of linearization.

This is the second of the step in the grand plan to refactor/remove linearization:

- [x] position lookup table
- [x] variable usage/definition lookup table (this PR)
- [ ] store inferred types somewhere
- [ ] refactor the existing lsp methods to use the new things instead of the linearization 

Edit: while doing this PR, I noticed that the symbol -> ident name change was incomplete (e.g., `LocIdent` has a `symbol` field instead of an `ident` field). I'll fix the naming in a separate PR.