### PR TITLE
Resolve imports for incomplete inputs also

### DIFF
--- a/lsp/nls/src/files.rs
+++ b/lsp/nls/src/files.rs
@@ -81,7 +81,10 @@ pub fn handle_save(server: &mut Server, params: DidChangeTextDocumentParams) -> 
     Ok(())
 }
 
-fn typecheck(server: &mut Server, file_id: FileId) -> Result<CacheOp<()>, Vec<Diagnostic<FileId>>> {
+pub(crate) fn typecheck(
+    server: &mut Server,
+    file_id: FileId,
+) -> Result<CacheOp<()>, Vec<Diagnostic<FileId>>> {
     server
         .cache
         .typecheck_with_analysis(


### PR DESCRIPTION
When encountering a `import "foo.ncl"` statement as part of an incomplete input, load and check the imported file. (This was already done for imports in files that parse completely.)

Fixes #1479 