### PR TITLE
Fix cursor desyncing when using REPL

### DIFF
--- a/core/src/repl/mod.rs
+++ b/core/src/repl/mod.rs
@@ -25,6 +25,8 @@ use std::result::Result;
 use std::str::FromStr;
 
 #[cfg(feature = "repl")]
+use ansi_term::{Colour, Style};
+#[cfg(feature = "repl")]
 use rustyline::validate::{ValidationContext, ValidationResult};
 
 generate_counter!(InputNameCounter, usize);
@@ -342,7 +344,6 @@ pub enum InputStatus {
     derive(
         rustyline_derive::Completer,
         rustyline_derive::Helper,
-        rustyline_derive::Highlighter,
         rustyline_derive::Hinter
     )
 )]
@@ -384,6 +385,18 @@ impl InputParser {
             Err(e) if partial(&e) => InputStatus::Partial,
             Err(err) => InputStatus::Failed(err.into()),
         }
+    }
+}
+
+#[cfg(feature = "repl")]
+impl rustyline::highlight::Highlighter for InputParser {
+    fn highlight_prompt<'b, 's: 'b, 'p: 'b>(
+        &'s self,
+        prompt: &'p str,
+        _default: bool,
+    ) -> std::borrow::Cow<'b, str> {
+        let style = Style::new().fg(Colour::Green);
+        std::borrow::Cow::Owned(style.paint(prompt).to_string())
     }
 }
 

--- a/core/src/repl/rustyline_frontend.rs
+++ b/core/src/repl/rustyline_frontend.rs
@@ -6,7 +6,7 @@ use super::*;
 
 use crate::eval::cache::CacheImpl;
 use crate::program::{self, ColorOpt};
-use ansi_term::{Colour, Style};
+use ansi_term::Style;
 use rustyline::error::ReadlineError;
 use rustyline::{Config, EditMode, Editor};
 
@@ -53,18 +53,8 @@ pub fn repl(histfile: PathBuf, color_opt: ColorOpt) -> Result<(), InitError> {
     let _ = editor.load_history(&histfile);
     editor.set_helper(Some(validator));
 
-    let prompt = {
-        let style = Style::new();
-        let style = if color_opt.0 != clap::ColorChoice::Never {
-            style.fg(Colour::Green)
-        } else {
-            style
-        };
-        style.paint("nickel> ").to_string()
-    };
-
     let result = loop {
-        let line = editor.readline(&prompt);
+        let line = editor.readline("nickel> ");
         let mut stdout = std::io::stdout();
 
         match line {


### PR DESCRIPTION
When using the REPL on windows, the cursor appears out of sync because of [an issue](https://github.com/kkawakam/rustyline/issues/562) with rustyline causing colored prompts to behave strangely:

https://github.com/tweag/nickel/assets/89555032/8c129db5-09d8-4038-b3fb-e17269782e33

This changes it to use the intended `highlight_prompt` helper instead.
