### PR TITLE
Fix "wich" typo in documentation

### DIFF
--- a/doc/manual/syntax.md
+++ b/doc/manual/syntax.md
@@ -671,7 +671,7 @@ constructors we've just listed), and types can appear anywhere.
 
 Nickel features the following builtin types and type constructors:
 
-- Primitive types: `Number`, `String`, `Bool`, and `Dyn` (the dynamic type, wich
+- Primitive types: `Number`, `String`, `Bool`, and `Dyn` (the dynamic type, which
 represents any value)
 - Arrays: `Array <type>` is an array whose elements are of type `<type>`.
 - Dictionaries: `{_ : <type>}` is a record whose fields are of type `<type>`.


### PR DESCRIPTION
Changes "wich" to "which"