### PR TITLE
Speed up CI

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -54,7 +54,15 @@ jobs:
 
     - name: Run all checks
       run: |
-        nix flake check --print-build-logs
+        # this is just `nix flake check --print-build-logs`
+        # everything else is to buffer the output for speed
+        (
+          set +e
+          nix flake check --print-build-logs >out 2>&1
+          errcode=$?
+          cat out
+          exit $errcode
+        )
 
     - name: Typecheck benchmarks
       run: find benches -type f -name "*.ncl" -print0 | xargs -0 -I file nix run . -- -f file typecheck

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -54,15 +54,7 @@ jobs:
 
     - name: Run all checks
       run: |
-        # this is just `nix flake check --print-build-logs`
-        # everything else is to buffer the output for speed
-        (
-          set +e
-          nix flake check --print-build-logs >out 2>&1
-          errcode=$?
-          cat out
-          exit $errcode
-        )
+          nix flake check --log-format raw-with-logs
 
     - name: Typecheck benchmarks
       run: find benches -type f -name "*.ncl" -print0 | xargs -0 -I file nix run . -- -f file typecheck

--- a/flake.nix
+++ b/flake.nix
@@ -218,23 +218,24 @@
             NICKEL_NIX_BUILD_REV = self.shortRev or "dirty";
           };
 
-          buildPackage = { pname, extraBuildArgs ? "", extraArgs ? { } }:
+          buildPackage = { pnameSuffix, extraBuildArgs ? "", extraArgs ? { } }:
             craneLib.buildPackage ({
               inherit
                 pname
+                pnameSuffix
                 src
                 version
                 cargoArtifacts
                 env;
 
-              cargoExtraArgs = "${cargoBuildExtraArgs} ${extraBuildArgs} --package ${pname}";
+              cargoExtraArgs = "${cargoBuildExtraArgs} ${extraBuildArgs} --package ${pname}${pnameSuffix}";
             } // extraArgs);
         in
         rec {
           inherit cargoArtifacts;
-          nickel-lang-core = buildPackage { pname = "nickel-lang-core"; };
-          nickel-lang-cli = buildPackage { pname = "nickel-lang-cli"; };
-          lsp-nls = buildPackage { pname = "nickel-lang-lsp"; };
+          nickel-lang-core = buildPackage { pnameSuffix = "-core"; };
+          nickel-lang-cli = buildPackage { pnameSuffix = "-cli"; };
+          lsp-nls = buildPackage { pnameSuffix = "-lsp"; };
 
           # Static building isn't really possible on MacOS because the system call ABIs aren't stable.
           nickel-static =
@@ -245,7 +246,7 @@
             # libc and clang with libc++ to build C and C++ dependencies. We
             # tried building with libstdc++ but without success.
               buildPackage {
-                pname = "nickel-lang-cli-static";
+                pnameSuffix = "-static";
                 extraArgs = {
                   CARGO_BUILD_TARGET = pkgs.rust.toRustTarget pkgs.pkgsMusl.stdenv.hostPlatform;
                   # For some reason, the rust build doesn't pick up the paths

--- a/flake.nix
+++ b/flake.nix
@@ -206,7 +206,7 @@
           cargoArtifacts = craneLib.buildDepsOnly {
             pname = "nickel-lang";
             inherit src;
-            cargoExtraArgs = "${cargoBuildExtraArgs} --workspace";
+            cargoExtraArgs = "${cargoBuildExtraArgs} --workspace --all-features";
             # pyo3 needs a Python interpreter in the build environment
             # https://pyo3.rs/v0.17.3/building_and_distribution#configuring-the-python-version
             buildInputs = [ pkgs.python3 ];
@@ -275,15 +275,15 @@
           };
 
           # Check that documentation builds without warnings or errors
-          checkRustDoc = craneLib.mkCargoDerivation {
+          checkRustDoc = craneLib.cargoDoc {
             inherit src version cargoArtifacts env;
             inherit (cargoArtifacts) buildInputs;
 
             pname = "nickel-lang-doc";
 
-            buildPhaseCargoCommand = ''
-              RUSTDOCFLAGS='-D warnings' cargo doc --no-deps --workspace --all-features
-            '';
+            RUSTDOCFLAGS = "-D warnings";
+
+            cargoExtraArgs = "${cargoBuildExtraArgs} --workspace --all-features";
 
             doInstallCargoArtifacts = false;
           };

--- a/flake.nix
+++ b/flake.nix
@@ -54,7 +54,7 @@
       cargoTOML = builtins.fromTOML (builtins.readFile ./Cargo.toml);
       cargoLock = builtins.fromTOML (builtins.readFile ./Cargo.lock);
 
-      version = "${cargoTOML.workspace.package.version}_${builtins.substring 0 8 self.lastModifiedDate}_${self.shortRev or "dirty"}";
+      inherit (cargoTOML.workspace.package) version;
 
     in
     flake-utils.lib.eachSystem SYSTEMS (system:

--- a/flake.nix
+++ b/flake.nix
@@ -218,11 +218,10 @@
             NICKEL_NIX_BUILD_REV = self.shortRev or "dirty";
           };
 
-          buildPackage = { pnameSuffix, extraBuildArgs ? "", extraArgs ? { } }:
+          buildPackage = { pname, extraBuildArgs ? "", extraArgs ? { } }:
             craneLib.buildPackage ({
               inherit
                 pname
-                pnameSuffix
                 src
                 version
                 cargoArtifacts
@@ -233,9 +232,9 @@
         in
         rec {
           inherit cargoArtifacts;
-          nickel-lang-core = buildPackage { pnameSuffix = "core"; };
-          nickel-lang-cli = buildPackage { pnameSuffix = "cli"; };
-          lsp-nls = buildPackage { pnameSuffix = "lsp"; };
+          nickel-lang-core = buildPackage { pname = "nickel-lang-core"; };
+          nickel-lang-cli = buildPackage { pname = "nickel-lang-cli"; };
+          lsp-nls = buildPackage { pname = "nickel-lang-lsp"; };
 
           # Static building isn't really possible on MacOS because the system call ABIs aren't stable.
           nickel-static =
@@ -246,7 +245,7 @@
             # libc and clang with libc++ to build C and C++ dependencies. We
             # tried building with libstdc++ but without success.
               buildPackage {
-                pnameSuffix = "cli-static";
+                pname = "nickel-lang-cli-static";
                 extraArgs = {
                   CARGO_BUILD_TARGET = pkgs.rust.toRustTarget pkgs.pkgsMusl.stdenv.hostPlatform;
                   # For some reason, the rust build doesn't pick up the paths
@@ -268,7 +267,7 @@
           benchmarks = craneLib.mkCargoDerivation {
             inherit pname src version cargoArtifacts env;
 
-            pnameSuffix = "bench";
+            pnameSuffix = "-bench";
 
             buildPhaseCargoCommand = ''
               cargo bench -p nickel-lang-core ${pkgs.lib.optionalString noRunBench "--no-run"}


### PR DESCRIPTION
- [x] Shorten version string so more things hit the cache
- [x] Fix double pname suffix (doesn't speed anything up; was just bothering me)
- [x] Fix doc build rebuilding all dependencies
- [x] Seems to fix wasm rebuilding dependencies as well
- [x] ~~Buffer CI stdout/stderr~~ get rid of status bar in logs
  - On my machine, doing this sped up a nix build by 33%.
  - this only applied to some terminal emulators (gnome-terminal, st) but less so or not at all for others (xterm, kitty)
  - it can't hurt though. we don't need the status bar in CI certainly

---

I also looked into speeding up local builds / the LSP. One thing that struck me is that rust-analyzer rebuilds every crate, even if you've only changed one. This seems to be intentional, as people were claiming that you get downstream errors that way (if changing `nickel-lang-core` results in an error in `nickel-lang-cli`). I've never actually seen this myself, and in fact I've definitely had downstream errors missed by the LSP before, so I don't know if / how this works.

In any case, even if we wanted to "fix" this and only recompile the changed crate, it seems we're blocked on [an upstream issue](https://github.com/rust-lang/rust-analyzer/issues/12882). Helix's `workspace-lsp-roots` is not enough.