### PR TITLE
Two issues with incomplete input

### DIFF
--- a/lsp/nls/tests/inputs/completion-basic.ncl
+++ b/lsp/nls/tests/inputs/completion-basic.ncl
@@ -60,7 +60,7 @@ in
 ### [[request]]
 ### type = "Completion"
 ### textDocument.uri = "file:///completion-basic.ncl"
-### position = { line = 12, character = 30 }
+### position = { line = 12, character = 26 }
 ###
 ### [[request]]
 ### type = "Completion"

--- a/lsp/nls/tests/inputs/completion-incomplete.ncl
+++ b/lsp/nls/tests/inputs/completion-incomplete.ncl
@@ -59,7 +59,7 @@ in
 ### [[request]]
 ### type = "Completion"
 ### textDocument.uri = "file:///completion-basic.ncl"
-### position = { line = 12, character = 30 }
+### position = { line = 12, character = 26 }
 ###
 ### [[request]]
 ### type = "Completion"

--- a/lsp/nls/tests/snapshots/main__lsp__nls__tests__inputs__completion-incomplete.ncl.snap
+++ b/lsp/nls/tests/snapshots/main__lsp__nls__tests__inputs__completion-incomplete.ncl.snap
@@ -6,9 +6,9 @@ expression: output
 [foo, verified, version]
 [foo, verified, version]
 [foo, verified, version]
-[foo, really, verified, version]
+[really]
 [really]
 [foo, really, verified, version]
-[]
-[]
+["has a space", lalala]
+[falala]
 


### PR DESCRIPTION
This fixes an off-by-one error in the handling of incomplete input. It also makes import resolution in incomplete input more reliable -- previously it would only work when the file being opened is in the current working directory.