### PR TITLE
Handle let, static access, and contract annotations in completion

### DIFF
--- a/lsp/nls/tests/inputs/completion-basic.ncl
+++ b/lsp/nls/tests/inputs/completion-basic.ncl
@@ -18,6 +18,9 @@ in
   (config & config.verified).real,
   (import "included.ncl").lala
   (import "included.ncl")."has a space".fala
+  ({} | { field = 1 }).fiel
+  ({} | (let x = { field = 1 } in x)).fiel
+  ({} | { field = { subfield = 1 } }.field).subfiel
 ]
 ### [[request]]
 ### type = "Completion"
@@ -66,3 +69,18 @@ in
 ### type = "Completion"
 ### textDocument.uri = "file:///completion-basic.ncl"
 ### position = { line = 13, character = 44 }
+###
+### [[request]]
+### type = "Completion"
+### textDocument.uri = "file:///completion-basic.ncl"
+### position = { line = 14, character = 27 }
+###
+### [[request]]
+### type = "Completion"
+### textDocument.uri = "file:///completion-basic.ncl"
+### position = { line = 15, character = 42 }
+###
+### [[request]]
+### type = "Completion"
+### textDocument.uri = "file:///completion-basic.ncl"
+### position = { line = 16, character = 51 }

--- a/lsp/nls/tests/snapshots/main__lsp__nls__tests__inputs__completion-basic.ncl.snap
+++ b/lsp/nls/tests/snapshots/main__lsp__nls__tests__inputs__completion-basic.ncl.snap
@@ -11,4 +11,7 @@ expression: output
 [foo, really, verified, version]
 ["has a space", lalala]
 [falala]
+[config, field]
+[field]
+[config, subfield]
 


### PR DESCRIPTION
This improves the term-based completion to handle three more of the rules laid out in the lsp semantics notes. With this change, the only thing missing compared to the old completer is handling static types.