### PR TITLE
Add check in CLI that the input file is a Nickel type

### DIFF
--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -1,8 +1,11 @@
 //! Command-line options and subcommands.
+use std::ffi::OsStr;
 use std::path::PathBuf;
+use std::string::String;
 
 use git_version::git_version;
 
+use crate::error::{CliResult, Error};
 use crate::{
     completions::GenCompletionsCommand, eval::EvalCommand, export::ExportCommand,
     pprint_ast::PprintAstCommand, query::QueryCommand, typecheck::TypecheckCommand,
@@ -49,6 +52,33 @@ pub struct GlobalOptions {
     pub file: Option<PathBuf>,
 }
 
+impl GlobalOptions {
+    /// Returns the input file if its extension matches one of `extensions`, or
+    /// [Error::FileType] if not.
+    pub fn file(&self, extensions: &[&str]) -> CliResult<Option<&PathBuf>> {
+        match &self.file {
+            Some(file) => {
+                let ext = file.extension().and_then(OsStr::to_str).unwrap_or("");
+                if extensions.contains(&ext) {
+                    Ok(Some(file))
+                } else {
+                    Err(Error::FileType {
+                        extension: ext.to_owned(),
+                        allowed: extensions.iter().map(|s| s.to_string()).collect(),
+                    })
+                }
+            }
+            None => Ok(None),
+        }
+    }
+
+    /// Returns the input file if it is a nickel file type, or
+    /// [Error::FileType] if not.
+    pub fn nickel_file(&self) -> CliResult<Option<&PathBuf>> {
+        self.file(NICKEL_FILE_EXTENSIONS)
+    }
+}
+
 /// Available subcommands.
 #[derive(clap::Subcommand, Debug)]
 pub enum Command {
@@ -78,3 +108,8 @@ pub enum Command {
     /// Generate shell completion files
     GenCompletions(GenCompletionsCommand),
 }
+
+/// Valid file extensions for a Nickel program. Currently
+/// only `.ncl`, but others are subject to be added
+/// (See [#357](https://github.com/tweag/nickel/issues/357))
+pub const NICKEL_FILE_EXTENSIONS: &[&str] = &["ncl"];

--- a/cli/src/error.rs
+++ b/cli/src/error.rs
@@ -12,6 +12,10 @@ pub enum Error {
     Io {
         error: std::io::Error,
     },
+    FileType {
+        extension: String,
+        allowed: Vec<String>,
+    },
     #[cfg(feature = "repl")]
     Repl {
         error: nickel_lang_core::repl::InitError,
@@ -90,6 +94,10 @@ impl Error {
             Error::Program { mut program, error } => program.report(error),
             Error::Io { error } => {
                 eprintln!("{error}")
+            }
+            Error::FileType { extension, allowed } => {
+                let allowed: Vec<String> = allowed.iter().map(|s| format!(".{s}")).collect();
+                eprintln!("Expected the input file type to be {allowed:?}, but instead found type \".{extension}\".")
             }
             #[cfg(feature = "repl")]
             Error::Repl { error } => {

--- a/cli/src/eval.rs
+++ b/cli/src/eval.rs
@@ -24,8 +24,7 @@ impl EvalCommand {
 
 pub fn prepare(global: &GlobalOptions) -> CliResult<Program<CBNCache>> {
     let mut program = global
-        .file
-        .clone()
+        .nickel_file()?
         .map(|f| Program::new_from_file(f, std::io::stderr()))
         .unwrap_or_else(|| Program::new_from_stdin(std::io::stderr()))?;
 

--- a/cli/src/format.rs
+++ b/cli/src/format.rs
@@ -90,7 +90,7 @@ impl FormatCommand {
             (None, None, _) | (None, Some(_), false) => Output::Stdout,
             (None, Some(file), true) | (Some(file), _, _) => Output::from_path(file)?,
         };
-        let input: Box<dyn Read> = match global.file {
+        let input: Box<dyn Read> = match global.nickel_file()? {
             None => Box::new(stdin()),
             Some(f) => Box::new(BufReader::new(File::open(f)?)),
         };


### PR DESCRIPTION
This ensures that the input file being passed with `-f` in `nickel export/doc/format` is a valid nickel file extension (currently just `.ncl`), before running actions that assume nickel code on it.

I'm not completely sure whether this is the correct course to take here, made this after accidentally corrupting an entire repo while attempting to format a directory (lol) since format doesn't also apply to dependencies of a file like does currently, but that could also be avoided by checking the syntax validity before making modifications. I can't really think of a case where you would be running nickel actions on non `.ncl` files, but if there are some just LMK and will close this.