### PR TITLE
display icon for nickel file in vscode explorer

### DIFF
--- a/lsp/vscode-extension/package.json
+++ b/lsp/vscode-extension/package.json
@@ -38,7 +38,11 @@
         "extensions": [
           ".ncl"
         ],
-        "configuration": "./language-configuration.json"
+        "configuration": "./language-configuration.json",
+        "icon": {
+          "dark": "./images/nickel-logo-256.png",
+          "light": "./images/nickel-logo-256.png"
+        }
       }
     ],
     "grammars": [


### PR DESCRIPTION
I've taken the liberty to reuse the logo file within the vscode extension as the icon for nickel files displayed in vscode explorer directory tree. Currently there's no distinction between light & dark mode, nevertheless the official logo is reasonably visible under both.

Dark mode:

![image](https://github.com/tweag/nickel/assets/812576/2d6f2f4c-ee28-4d29-9f90-42f5bb87723c)

Light mode:

![image](https://github.com/tweag/nickel/assets/812576/15297b32-fa5c-40a4-a9ab-be713ade4cd8)
