### PR TITLE
Render hover documentation as Markdown in LSP

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1719,7 +1719,6 @@ dependencies = [
  "serde_json",
  "test-generator",
  "thiserror",
- "unindent 0.2.2",
 ]
 
 [[package]]
@@ -2112,7 +2111,7 @@ dependencies = [
  "pyo3-build-config",
  "pyo3-ffi",
  "pyo3-macros",
- "unindent 0.1.11",
+ "unindent",
 ]
 
 [[package]]
@@ -3183,12 +3182,6 @@ name = "unindent"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1766d682d402817b5ac4490b3c3002d91dfa0d22812f341609f97b08757359c"
-
-[[package]]
-name = "unindent"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f86d931b9d0b666761dcfcbac3ec5e9daff8a2becfff93a8fce2591ae297b95"
 
 [[package]]
 name = "unsafe-libyaml"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1223,9 +1223,9 @@ checksum = "bfa799dd5ed20a7e349f3b4639aa80d74549c81716d9ec4f994c9b5815598306"
 
 [[package]]
 name = "indoc"
-version = "2.0.1"
+version = "2.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f2cb48b81b1dc9f39676bf99f5499babfec7cd8fe14307f7b3d747208fb5690"
+checksum = "2c785eefb63ebd0e33416dfcb8d6da0bf27ce752843a45632a67bf10d4d4b5c4"
 
 [[package]]
 name = "inferno"
@@ -1652,7 +1652,7 @@ dependencies = [
  "comrak",
  "criterion",
  "indexmap 1.9.3",
- "indoc 2.0.1",
+ "indoc 2.0.3",
  "js-sys",
  "lalrpop",
  "lalrpop-util",
@@ -1719,6 +1719,7 @@ dependencies = [
  "serde_json",
  "test-generator",
  "thiserror",
+ "unindent 0.2.2",
 ]
 
 [[package]]
@@ -2111,7 +2112,7 @@ dependencies = [
  "pyo3-build-config",
  "pyo3-ffi",
  "pyo3-macros",
- "unindent",
+ "unindent 0.1.11",
 ]
 
 [[package]]
@@ -3182,6 +3183,12 @@ name = "unindent"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1766d682d402817b5ac4490b3c3002d91dfa0d22812f341609f97b08757359c"
+
+[[package]]
+name = "unindent"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f86d931b9d0b666761dcfcbac3ec5e9daff8a2becfff93a8fce2591ae297b95"
 
 [[package]]
 name = "unsafe-libyaml"

--- a/lsp/nls/Cargo.toml
+++ b/lsp/nls/Cargo.toml
@@ -37,6 +37,7 @@ derive_more.workspace = true
 lazy_static.workspace = true
 csv.workspace = true
 thiserror = "1.0.44"
+unindent = "0.2.2"
 
 [dev-dependencies]
 assert_cmd.workspace = true

--- a/lsp/nls/Cargo.toml
+++ b/lsp/nls/Cargo.toml
@@ -37,7 +37,6 @@ derive_more.workspace = true
 lazy_static.workspace = true
 csv.workspace = true
 thiserror = "1.0.44"
-unindent = "0.2.2"
 
 [dev-dependencies]
 assert_cmd.workspace = true

--- a/lsp/nls/src/requests/hover.rs
+++ b/lsp/nls/src/requests/hover.rs
@@ -3,7 +3,6 @@ use lsp_server::{RequestId, Response, ResponseError};
 use lsp_types::{Hover, HoverContents, HoverParams, LanguageString, MarkedString, Range};
 use nickel_lang_core::position::TermPos;
 use serde_json::Value;
-use unindent::Unindent;
 
 use crate::{
     cache::CacheExt,
@@ -56,18 +55,7 @@ pub fn handle(
         value: ty.to_string(),
     }));
 
-    let meta = meta
-        .iter()
-        .map(|s| {
-            s.lines()
-                .map(|s| if s.is_empty() { " " } else { s })
-                .collect::<Vec<_>>()
-                .join("\n")
-                .unindent()
-        })
-        .map(MarkedString::String)
-        .collect::<Vec<_>>();
-    contents.extend(meta);
+    contents.extend(meta.iter().cloned().map(MarkedString::String));
 
     server.reply(Response::new_ok(
         id,

--- a/lsp/nls/src/requests/hover.rs
+++ b/lsp/nls/src/requests/hover.rs
@@ -57,10 +57,13 @@ pub fn handle(
                     language: "nickel".into(),
                     value: ty.to_string(),
                 }),
-                MarkedString::LanguageString(LanguageString {
-                    language: "plain".into(),
-                    value: meta.join("\n"),
-                }),
+                MarkedString::String(
+                    meta.iter()
+                        .flat_map(|s| s.lines())
+                        .map(|s| s.trim())
+                        .collect::<Vec<_>>()
+                        .join("\n"),
+                ),
             ]),
 
             range: Some(range),

--- a/lsp/nls/src/requests/hover.rs
+++ b/lsp/nls/src/requests/hover.rs
@@ -50,28 +50,29 @@ pub fn handle(
         server.cache.files(),
     );
 
+    let mut contents = Vec::new();
+    contents.push(MarkedString::LanguageString(LanguageString {
+        language: "nickel".into(),
+        value: ty.to_string(),
+    }));
+
+    let meta = meta
+        .iter()
+        .map(|s| {
+            s.lines()
+                .map(|s| if s.is_empty() { " " } else { s })
+                .collect::<Vec<_>>()
+                .join("\n")
+                .unindent()
+        })
+        .map(MarkedString::String)
+        .collect::<Vec<_>>();
+    contents.extend(meta);
+
     server.reply(Response::new_ok(
         id,
         Hover {
-            contents: HoverContents::Array(vec![
-                MarkedString::LanguageString(LanguageString {
-                    language: "nickel".into(),
-                    value: ty.to_string(),
-                }),
-                MarkedString::String(
-                    meta.iter()
-                        .map(|s| {
-                            s.lines()
-                                .map(|s| if s.is_empty() { " " } else { s })
-                                .collect::<Vec<_>>()
-                                .join("\n")
-                                .unindent()
-                        })
-                        .collect::<Vec<_>>()
-                        .join("\n"),
-                ),
-            ]),
-
+            contents: HoverContents::Array(contents),
             range: Some(range),
         },
     ));

--- a/lsp/nls/src/requests/hover.rs
+++ b/lsp/nls/src/requests/hover.rs
@@ -3,6 +3,7 @@ use lsp_server::{RequestId, Response, ResponseError};
 use lsp_types::{Hover, HoverContents, HoverParams, LanguageString, MarkedString, Range};
 use nickel_lang_core::position::TermPos;
 use serde_json::Value;
+use unindent::Unindent;
 
 use crate::{
     cache::CacheExt,
@@ -59,8 +60,13 @@ pub fn handle(
                 }),
                 MarkedString::String(
                     meta.iter()
-                        .flat_map(|s| s.lines())
-                        .map(|s| s.trim())
+                        .map(|s| {
+                            s.lines()
+                                .map(|s| if s.is_empty() { " " } else { s })
+                                .collect::<Vec<_>>()
+                                .join("\n")
+                                .unindent()
+                        })
                         .collect::<Vec<_>>()
                         .join("\n"),
                 ),


### PR DESCRIPTION
Renders hover documentation as markdown instead of plaintext in LSP

## Before:
![image](https://github.com/tweag/nickel/assets/89555032/e884da6b-3eab-4cd0-8240-e931779d8c43)

## After:
![image](https://github.com/tweag/nickel/assets/89555032/3963a8a8-d4d6-429d-88c4-e0bf874f91c8)