### PR TITLE
Get rid of uninformative generic notes for higher-order contract errors

### DIFF
--- a/cli/tests/snapshot/snapshots/snapshot__error_stderr_caller_contract_violation.ncl.snap
+++ b/cli/tests/snapshot/snapshots/snapshot__error_stderr_caller_contract_violation.ncl.snap
@@ -12,12 +12,6 @@ error: contract broken by the caller of `map`
     │
   3 │ std.array.map std.function.id 'not-an-array
     │                               ------------- evaluated to this expression
-    │
-    = This error may happen in the following situation:
-          1. A function `f` is bound by a contract: e.g. `Number -> Number`.
-          2. `f` is called with an argument of the wrong type: e.g. `f false`.
-    = Either change the contract accordingly, or call `f` with an argument of the right type.
-    = Note: this is an illustrative example. The actual error may involve deeper nested functions calls.
 
 note: 
   ┌─ [INPUTS_PATH]/errors/caller_contract_violation.ncl:3:1

--- a/cli/tests/snapshot/snapshots/snapshot__error_stderr_fun_contract_range_nested.ncl.snap
+++ b/cli/tests/snapshot/snapshots/snapshot__error_stderr_fun_contract_range_nested.ncl.snap
@@ -14,10 +14,5 @@ error: contract broken by a function
   │
 1 │ "a"
   │ --- evaluated to this value
-  │
-  = This error may happen in the following situation:
-        1. A function `f` is bound by a contract: e.g. `Bool -> Number`.
-        2. `f` returns a value of the wrong type: e.g. `f = fun c => "string"` while `Number` is expected.
-  = Either change the contract accordingly, or change the return value of `f`
 
 

--- a/cli/tests/snapshot/snapshots/snapshot__error_stderr_function_contract_violation.ncl.snap
+++ b/cli/tests/snapshot/snapshots/snapshot__error_stderr_function_contract_violation.ncl.snap
@@ -9,10 +9,5 @@ error: contract broken by the function `f`
   │                         ------            ------------- evaluated to this expression
   │                         │                  
   │                         expected return type
-  │
-  = This error may happen in the following situation:
-        1. A function `f` is bound by a contract: e.g. `Bool -> Number`.
-        2. `f` returns a value of the wrong type: e.g. `f = fun c => "string"` while `Number` is expected.
-  = Either change the contract accordingly, or change the return value of `f`
 
 

--- a/cli/tests/snapshot/snapshots/snapshot__error_stderr_record_forall_constraints_contract.ncl.snap
+++ b/cli/tests/snapshot/snapshots/snapshot__error_stderr_record_forall_constraints_contract.ncl.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/snapshot/main.rs
+source: cli/tests/snapshot/main.rs
 expression: err
 ---
 error: contract broken by the caller: field not allowed in tail: `x`
@@ -14,12 +14,6 @@ error: contract broken by the caller: field not allowed in tail: `x`
   │
 1 │ { ... }
   │ ------- evaluated to this value
-  │
-  = This error may happen in the following situation:
-        1. A function `f` is bound by a contract: e.g. `Number -> Number`.
-        2. `f` is called with an argument of the wrong type: e.g. `f false`.
-  = Either change the contract accordingly, or call `f` with an argument of the right type.
-  = Note: this is an illustrative example. The actual error may involve deeper nested functions calls.
 
 note: 
   ┌─ [INPUTS_PATH]/errors/record_forall_constraints_contract.ncl:3:58

--- a/cli/tests/snapshot/snapshots/snapshot__error_stderr_subcontract_type_path_underline.ncl.snap
+++ b/cli/tests/snapshot/snapshots/snapshot__error_stderr_subcontract_type_path_underline.ncl.snap
@@ -15,10 +15,5 @@ error: contract broken by a function
   │
 1 │ "string"
   │ -------- evaluated to this value
-  │
-  = This error may happen in the following situation:
-        1. A function `f` is bound by a contract: e.g. `Bool -> Number`.
-        2. `f` returns a value of the wrong type: e.g. `f = fun c => "string"` while `Number` is expected.
-  = Either change the contract accordingly, or change the return value of `f`
 
 


### PR DESCRIPTION
Upon the failure of a higher-order contract, we used to include quite generic notes showing a plain illustration of the kind of higher-order violation that happened. However, this text was totally generic (the example didn't relate to the source code at all), quite verbose (around 4-5 lines of notes), and to be honest, not very helpful.

We now have good mechanisms to point at the right part of the function contract that failed, together with customized label (e.g. "broken by the caller"), which feel like the original generic notes aren't very valuable anymore.

This patch ditches those notes altogether in the error messages, making them smaller.