### PR TITLE
Fix the release artifacts workflow

### DIFF
--- a/.github/workflows/release-artifacts.yaml
+++ b/.github/workflows/release-artifacts.yaml
@@ -52,7 +52,6 @@ jobs:
     needs:
       - start-runner
       - docker-multiplatform-image
-      - static-binary
     steps:
       - uses: aws-actions/configure-aws-credentials@v3
         with:
@@ -77,8 +76,8 @@ jobs:
             response.json
           cat response.json
 
-  static-binary:
-    name: "Build Nickel release binary"
+  release-artifacts:
+    name: "Build Nickel binary and Docker image"
     strategy:
       matrix:
         os:
@@ -110,31 +109,6 @@ jobs:
           RELEASE_TAG: ${{ github.event_name == 'release' && github.event.release.tag_name || github.event.inputs.release_tag }}
         run: |
           gh release upload --clobber $RELEASE_TAG nickel-${{ matrix.os.architecture }}-linux
-
-  docker-image:
-    name: "Build docker image"
-    strategy:
-      matrix:
-        os:
-          - runs-on: ubuntu-latest
-            architecture: x86_64
-          - runs-on: [EC2, ARM64, Linux]
-            architecture: arm64
-    runs-on: ${{ matrix.os.runs-on }}
-    needs:
-      - start-runner
-      - static-binary
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event_name == 'release' && '' || github.event.inputs.release_tag }}
-      - uses: cachix/install-nix-action@v23
-        name: "Installing Nix"
-        with:
-          extra_nix_config: |
-            experimental-features = nix-command flakes
-            accept-flake-config = true
-          nix_path: "nixpkgs=channel:nixos-unstable"
       - id: build-image
         name: "Build docker image"
         run: |
@@ -163,7 +137,7 @@ jobs:
   docker-multiplatform-image:
     name: "Assemble multi-platform Docker image"
     runs-on: ubuntu-latest
-    needs: docker-image
+    needs: release-artifacts
     steps:
       - name: Log in to registry
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u $ --password-stdin

--- a/.github/workflows/release-artifacts.yaml
+++ b/.github/workflows/release-artifacts.yaml
@@ -165,10 +165,10 @@ jobs:
       - name: "Build static binary"
         run: |
           nix build --print-build-logs .#nickel-static
-          cp ./result/bin/nickel nickel-${{ os.matrix.architecture }}-linux
+          cp ./result/bin/nickel nickel-${{ matrix.os.architecture }}-linux
       - name: "Upload static binary as release asset"
         env:
           GH_TOKEN: ${{ github.token }}
           RELEASE_TAG: ${{ github.event_name == 'release' && github.event.release.tag_name || github.event.inputs.release_tag }}
         run: |
-          gh release upload --clobber $RELEASE_TAG nickel-${{ os.matrix.architecture }}-linux
+          gh release upload --clobber $RELEASE_TAG nickel-${{ matrix.os.architecture }}-linux

--- a/.github/workflows/release-artifacts.yaml
+++ b/.github/workflows/release-artifacts.yaml
@@ -87,6 +87,8 @@ jobs:
           - runs-on: [EC2, ARM64, Linux]
             architecture: arm64
     runs-on: ${{ matrix.os.runs-on }}
+    needs:
+      - start-runner
     steps:
       - uses: actions/checkout@v4
         with:
@@ -151,6 +153,8 @@ jobs:
           - runs-on: [EC2, ARM64, Linux]
             architecture: arm64
     runs-on: ${{ matrix.os.runs-on }}
+    needs:
+      - start-runner
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/release-artifacts.yaml
+++ b/.github/workflows/release-artifacts.yaml
@@ -76,7 +76,41 @@ jobs:
             --payload '{"instance_id":"${{ needs.start-runner.outputs.instance_id }}"}' \
             response.json
           cat response.json
-  
+
+  static-binary:
+    name: "Build Nickel release binary"
+    strategy:
+      matrix:
+        os:
+          - runs-on: ubuntu-latest
+            architecture: x86_64
+          - runs-on: [EC2, ARM64, Linux]
+            architecture: arm64
+    runs-on: ${{ matrix.os.runs-on }}
+    needs:
+      - start-runner
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'release' && '' || github.event.inputs.release_tag }}
+      - uses: cachix/install-nix-action@v23
+        name: "Installing Nix"
+        with:
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+            accept-flake-config = true
+          nix_path: "nixpkgs=channel:nixos-unstable"
+      - name: "Build static binary"
+        run: |
+          nix build --log-format raw-with-logs .#nickel-static
+          cp ./result/bin/nickel nickel-${{ matrix.os.architecture }}-linux
+      - name: "Upload static binary as release asset"
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ github.event_name == 'release' && github.event.release.tag_name || github.event.inputs.release_tag }}
+        run: |
+          gh release upload --clobber $RELEASE_TAG nickel-${{ matrix.os.architecture }}-linux
+
   docker-image:
     name: "Build docker image"
     strategy:
@@ -89,6 +123,7 @@ jobs:
     runs-on: ${{ matrix.os.runs-on }}
     needs:
       - start-runner
+      - static-binary
     steps:
       - uses: actions/checkout@v4
         with:
@@ -141,38 +176,4 @@ jobs:
             --amend ghcr.io/tweag/nickel:$RELEASE_TAG-x86_64 \
             --amend ghcr.io/tweag/nickel:$RELEASE_TAG-arm64 \
           docker manifest push ghcr.io/tweag/nickel:$RELEASE_TAG
-        
-
-  static-binary:
-    name: "Build Nickel release binary"
-    strategy:
-      matrix:
-        os:
-          - runs-on: ubuntu-latest
-            architecture: x86_64
-          - runs-on: [EC2, ARM64, Linux]
-            architecture: arm64
-    runs-on: ${{ matrix.os.runs-on }}
-    needs:
-      - start-runner
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event_name == 'release' && '' || github.event.inputs.release_tag }}
-      - uses: cachix/install-nix-action@v23
-        name: "Installing Nix"
-        with:
-          extra_nix_config: |
-            experimental-features = nix-command flakes
-            accept-flake-config = true
-          nix_path: "nixpkgs=channel:nixos-unstable"
-      - name: "Build static binary"
-        run: |
-          nix build --log-format raw-with-logs .#nickel-static
-          cp ./result/bin/nickel nickel-${{ matrix.os.architecture }}-linux
-      - name: "Upload static binary as release asset"
-        env:
-          GH_TOKEN: ${{ github.token }}
-          RELEASE_TAG: ${{ github.event_name == 'release' && github.event.release.tag_name || github.event.inputs.release_tag }}
-        run: |
-          gh release upload --clobber $RELEASE_TAG nickel-${{ matrix.os.architecture }}-linux
+       

--- a/.github/workflows/release-artifacts.yaml
+++ b/.github/workflows/release-artifacts.yaml
@@ -145,9 +145,5 @@ jobs:
         env:
           RELEASE_TAG: ${{ github.event_name == 'release' && github.event.release.tag_name || github.event.inputs.release_tag }}
         run: |
-          docker manifest create \
-            ghcr.io/tweag/nickel:$RELEASE_TAG \
-            --amend ghcr.io/tweag/nickel:$RELEASE_TAG-x86_64 \
-            --amend ghcr.io/tweag/nickel:$RELEASE_TAG-arm64 \
-          docker manifest push ghcr.io/tweag/nickel:$RELEASE_TAG
-       
+          docker buildx imagetools create -t ghcr.io/tweag/nickel:$RELEASE_TAG ghcr.io/tweag/nickel:$RELEASE_TAG-x86_64 ghcr.io/tweag/nickel:$RELEASE_TAG-arm64
+          docker buildx imagetools inspect ghcr.io/tweag/nickel:$RELEASE_TAG 

--- a/.github/workflows/release-artifacts.yaml
+++ b/.github/workflows/release-artifacts.yaml
@@ -103,7 +103,7 @@ jobs:
       - id: build-image
         name: "Build docker image"
         run: |
-          nix build --print-build-logs .#dockerImage
+          nix build --log-format raw-with-logs .#dockerImage
           cp ./result nickel-${{ matrix.os.architecture }}-docker-image.tar.gz
           echo "imageName=$(nix eval --raw .#dockerImage.imageName)" >> "$GITHUB_OUTPUT"
           echo "imageTag=$(nix eval --raw .#dockerImage.imageTag)" >> "$GITHUB_OUTPUT"
@@ -168,7 +168,7 @@ jobs:
           nix_path: "nixpkgs=channel:nixos-unstable"
       - name: "Build static binary"
         run: |
-          nix build --print-build-logs .#nickel-static
+          nix build --log-format raw-with-logs .#nickel-static
           cp ./result/bin/nickel nickel-${{ matrix.os.architecture }}-linux
       - name: "Upload static binary as release asset"
         env:

--- a/flake.nix
+++ b/flake.nix
@@ -271,7 +271,9 @@
                   # them explicitly. Also, `libcxx` expects to be linked with
                   # `libcxxabi` at the end, and we need to make the rust linker
                   # aware of that.
-                  RUSTFLAGS = "-L${pkgs.pkgsMusl.llvmPackages.libcxx}/lib -L${pkgs.pkgsMusl.llvmPackages.libcxxabi}/lib -lstatic=c++abi";
+                  #
+                  # We also explicitly add `libc` because of https://github.com/rust-lang/rust/issues/89626.
+                  RUSTFLAGS = "-L${pkgs.pkgsMusl.llvmPackages.libcxx}/lib -L${pkgs.pkgsMusl.llvmPackages.libcxxabi}/lib -lstatic=c++abi -C link-arg=-lc";
                   # Explain to `cc-rs` that it should use the `libcxx` C++
                   # standard library, and a static version of it, when building
                   # C++ libraries. The `cc-rs` crate is typically used in

--- a/flake.nix
+++ b/flake.nix
@@ -63,6 +63,18 @@
         inherit system;
         overlays = [
           (import rust-overlay)
+          # gnulib tests in diffutils fail for musl arm64, cf. https://github.com/NixOS/nixpkgs/pull/241281
+          (final: prev: {
+            diffutils =
+              if !(final.stdenv.hostPlatform.isMusl && final.stdenv.hostPlatform.isAarch64) then
+                prev.diffutils
+              else
+                prev.diffutils.overrideAttrs (old: {
+                  postPatch = ''
+                    sed -i 's:gnulib-tests::g' Makefile.in
+                  '';
+                });
+          })
         ];
       };
 

--- a/flake.nix
+++ b/flake.nix
@@ -234,7 +234,7 @@
             NICKEL_NIX_BUILD_REV = self.shortRev or "dirty";
           };
 
-          buildPackage = { pnameSuffix, extraBuildArgs ? "", extraArgs ? { } }:
+          buildPackage = { pnameSuffix, cargoPackage ? "${pname}${pnameSuffix}", extraBuildArgs ? "", extraArgs ? { } }:
             craneLib.buildPackage ({
               inherit
                 pname
@@ -244,7 +244,7 @@
                 cargoArtifacts
                 env;
 
-              cargoExtraArgs = "${cargoBuildExtraArgs} ${extraBuildArgs} --package ${pname}${pnameSuffix}";
+              cargoExtraArgs = "${cargoBuildExtraArgs} ${extraBuildArgs} --package ${cargoPackage}";
             } // extraArgs);
         in
         rec {
@@ -262,6 +262,7 @@
             # libc and clang with libc++ to build C and C++ dependencies. We
             # tried building with libstdc++ but without success.
               buildPackage {
+                cargoPackage = "nickel-lang-cli";
                 pnameSuffix = "-static";
                 extraArgs = {
                   CARGO_BUILD_TARGET = pkgs.rust.toRustTarget pkgs.pkgsMusl.stdenv.hostPlatform;

--- a/infra/github-runner.nix
+++ b/infra/github-runner.nix
@@ -7,6 +7,8 @@ in
   imports = [ <nixpkgs/nixos/modules/virtualisation/amazon-image.nix> ];
   ec2.hvm = true;
 
+
+
   services.github-runner = {
     enable = true;
     replace = true;
@@ -35,6 +37,11 @@ in
     extraLabels = [
       "EC2"
     ];
+  };
+
+  nix.settings = {
+    experimental-features = [ "nix-command" "flakes" ];
+    accept-flake-config = true;
   };
 
   systemd.services.github-runner-init = {

--- a/infra/github-runner.nix
+++ b/infra/github-runner.nix
@@ -27,6 +27,8 @@ in
     };
     nodeRuntimes = [ "node16" "node20" ];
     extraPackages = with pkgs; [
+      gh
+      docker
       gawk
       nix
     ];
@@ -36,6 +38,8 @@ in
       "EC2"
     ];
   };
+
+  virtualisation.docker.enable = true;
 
   nix.settings = {
     experimental-features = [ "nix-command" "flakes" ];

--- a/infra/github-runner.nix
+++ b/infra/github-runner.nix
@@ -37,6 +37,9 @@ in
     extraLabels = [
       "EC2"
     ];
+    serviceOverrides = {
+      Group = "docker";
+    };
   };
 
   virtualisation.docker.enable = true;

--- a/infra/github-runner.nix
+++ b/infra/github-runner.nix
@@ -7,8 +7,6 @@ in
   imports = [ <nixpkgs/nixos/modules/virtualisation/amazon-image.nix> ];
   ec2.hvm = true;
 
-
-
   services.github-runner = {
     enable = true;
     replace = true;
@@ -41,6 +39,8 @@ in
 
   nix.settings = {
     experimental-features = [ "nix-command" "flakes" ];
+    substituters = [ "https://tweag-nickel.cachix.org" ];
+    trusted-public-keys = [ "tweag-nickel.cachix.org-1:GIthuiK4LRgnW64ALYEoioVUQBWs0jexyoYVeLDBwRA=" ];
     accept-flake-config = true;
   };
 

--- a/infra/github-runner.nix
+++ b/infra/github-runner.nix
@@ -25,6 +25,7 @@ in
           };
       });
     };
+    nodeRuntimes = [ "node16" "node20" ];
     extraPackages = with pkgs; [
       gawk
       nix


### PR DESCRIPTION
These are necessary changes to the release workflow, the static binary build on arm64 and the GitHub runner infrastructure for the release artifact building to work.