### PR TITLE
Exit with nonzero exit code on failure

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -16,11 +16,13 @@ mod pprint_ast;
 mod query;
 mod typecheck;
 
+use std::process::ExitCode;
+
 use eval::EvalCommand;
 
 use crate::cli::{Command, Options};
 
-fn main() {
+fn main() -> ExitCode {
     let opts = <Options as clap::Parser>::parse();
 
     let result = match opts.command.unwrap_or(Command::Eval(EvalCommand {})) {
@@ -41,5 +43,10 @@ fn main() {
         Command::Format(format) => format.run(opts.global),
     };
 
-    result.unwrap_or_else(|e| e.report())
+    if let Err(e) = result {
+        e.report();
+        ExitCode::FAILURE
+    } else {
+        ExitCode::SUCCESS
+    }
 }


### PR DESCRIPTION
We previously just reported the error and then pretended to exit successfully. With this change the process returns `ExitCode::FAILURE` whenever it needed to report an error, and `ExitCode::SUCCESS` otherwise.

Fixes #1575