### PR TITLE
print nice logs without losing speedup

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -58,7 +58,7 @@ jobs:
           # an output file. Everything else is just capturing the error code
           # while still printing the logs
           set +e
-          nix flake check --print-build-logs > logs
+          nix flake check --print-build-logs > logs 2>&1
           errcode=$?
           cat logs
           exit $errcode

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -54,7 +54,14 @@ jobs:
 
     - name: Run all checks
       run: |
-          nix flake check --log-format raw-with-logs
+          # see https://github.com/NixOS/nix/issues/8949 for why we redirect to
+          # an output file. Everything else is just capturing the error code
+          # while still printing the logs
+          set +e
+          nix flake check --print-build-logs > logs
+          errcode=$?
+          cat logs
+          exit $errcode
 
     - name: Typecheck benchmarks
       run: find benches -type f -name "*.ncl" -print0 | xargs -0 -I file nix run . -- -f file typecheck


### PR DESCRIPTION
Bring back ` [build name] >` prefix to log lines, but maintain speed up by writing to non-tty file so nix doesn't bother with the status bar