### PR TITLE
Statically merge partial record definitions

### DIFF
--- a/core/src/eval/merge.rs
+++ b/core/src/eval/merge.rs
@@ -26,12 +26,13 @@
 //! depend on each metadata.
 
 use super::*;
+use crate::combine::Combine;
 use crate::error::{EvalError, IllegalPolymorphicTailAction};
 use crate::label::{Label, MergeLabel};
 use crate::position::TermPos;
 use crate::term::{
     record::{self, Field, FieldDeps, FieldMetadata, RecordAttrs, RecordData},
-    BinaryOp, IndexMap, RichTerm, Term, TypeAnnotation,
+    BinaryOp, IndexMap, RichTerm, Term,
 };
 use crate::transform::Closurizable;
 
@@ -320,7 +321,7 @@ Append `, ..` at the end of the record contract, as in `{some_field | SomeContra
                     // about them anymore, and dependencies are stored at the level of revertible
                     // cache elements directly.
                     Term::RecRecord(
-                        RecordData::new(m, RecordAttrs::merge(r1.attrs, r2.attrs), None),
+                        RecordData::new(m, RecordAttrs::combine(r1.attrs, r2.attrs), None),
                         Vec::new(),
                         None,
                     ),
@@ -407,47 +408,23 @@ fn merge_fields<'a, C: Cache, I: DoubleEndedIterator<Item = &'a LocIdent> + Clon
     let mut pending_contracts = pending_contracts1.revert_closurize(cache, env_final, env1.clone());
     pending_contracts.extend(pending_contracts2.revert_closurize(cache, env_final, env2.clone()));
 
-    // Annotation aren't used anymore at runtime. We still accumulate them to answer metadata
-    // queries, but we don't need to e.g. closurize or revert them.
-    let mut annot1 = metadata1.annotation;
-    let mut annot2 = metadata2.annotation;
-
-    // If both have type annotations, we arbitrarily choose the first one as the type annotation
-    // for the resulting field. This doesn't make any difference operationally.
-    let typ = match (annot1.typ.take(), annot2.typ.take()) {
-        (Some(ctr1), Some(ctr2)) => {
-            annot1.contracts.push(ctr2);
-            Some(ctr1)
-        }
-        (ty1, ty2) => ty1.or(ty2),
-    };
-
-    let contracts: Vec<_> = annot1
-        .contracts
-        .into_iter()
-        .chain(annot2.contracts)
-        .collect();
-
-    let metadata = FieldMetadata {
-        doc: merge_doc(metadata1.doc, metadata2.doc),
-        annotation: TypeAnnotation { typ, contracts },
-        // If one of the record requires this field, then it musn't be optional. The
-        // resulting field is optional iff both are.
-        opt: metadata1.opt && metadata2.opt,
-        // The resulting field will be suppressed from serialization if either of the fields to be merged is.
-        not_exported: metadata1.not_exported || metadata2.not_exported,
-        priority,
-    };
-
     Ok(Field {
-        metadata,
+        metadata: FieldMetadata {
+            doc: merge_doc(metadata1.doc, metadata2.doc),
+            annotation: Combine::combine(metadata1.annotation, metadata2.annotation),
+            // If one of the record requires this field, then it musn't be optional. The
+            // resulting field is optional iff both are.
+            opt: metadata1.opt && metadata2.opt,
+            not_exported: metadata1.not_exported || metadata2.not_exported,
+            priority,
+        },
         value,
         pending_contracts,
     })
 }
 
 /// Merge two optional documentations.
-fn merge_doc(doc1: Option<String>, doc2: Option<String>) -> Option<String> {
+pub(crate) fn merge_doc(doc1: Option<String>, doc2: Option<String>) -> Option<String> {
     //FIXME: how to merge documentation? Just concatenate?
     doc1.or(doc2)
 }

--- a/core/src/parser/utils.rs
+++ b/core/src/parser/utils.rs
@@ -11,7 +11,7 @@ use super::error::ParseError;
 use crate::{
     combine::Combine,
     destructuring::FieldPattern,
-    eval::operation::RecPriority,
+    eval::{merge::merge_doc, operation::RecPriority},
     identifier::LocIdent,
     label::{Label, MergeKind, MergeLabel},
     mk_app, mk_fun,
@@ -292,9 +292,10 @@ impl Combine for FieldMetadata {
         };
 
         FieldMetadata {
-            doc: left.doc.or(right.doc),
+            doc: merge_doc(left.doc, right.doc),
             annotation: Combine::combine(left.annotation, right.annotation),
             opt: left.opt || right.opt,
+            // The resulting field will be suppressed from serialization if either of the fields to be merged is.
             not_exported: left.not_exported || right.not_exported,
             priority,
         }

--- a/core/src/term/record.rs
+++ b/core/src/term/record.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::{
+    combine::Combine,
     error::EvalError,
     identifier::{Ident, LocIdent},
     label::Label,
@@ -14,10 +15,10 @@ pub struct RecordAttrs {
     pub open: bool,
 }
 
-impl RecordAttrs {
-    pub fn merge(attrs1: RecordAttrs, attrs2: RecordAttrs) -> RecordAttrs {
+impl Combine for RecordAttrs {
+    fn combine(left: Self, right: Self) -> Self {
         RecordAttrs {
-            open: attrs1.open || attrs2.open,
+            open: left.open || right.open,
         }
     }
 }


### PR DESCRIPTION
This is an attempt implementing @yannham's suggestion for resolving #1427. Instead of always translating a partial definition into an application of `&`, I'm statically resolving merges of non-recursive records.

Unfortunately, I've had to duplicate some of the merging logic from `eval::merge::merge_fields`. The latter function is too tightly coupled to the evaluator to use in the parser and I haven't found a nice way to factor out the common elements.

Fixes #1427
Fixes #1597 