### PR TITLE
Disable recursive priorities

### DIFF
--- a/core/src/parser/grammar.lalrpop
+++ b/core/src/parser/grammar.lalrpop
@@ -158,14 +158,18 @@ SimpleFieldAnnotAtom<TypeRule>: FieldMetadata = {
 // rule).
 FieldAnnotAtom<TypeRule>: FieldExtAnnot = {
     <SimpleFieldAnnotAtom<TypeRule>> => <>.into(),
-    "|" "rec" "force" => FieldExtAnnot {
-        rec_force: true,
-        ..Default::default()
-    },
-    "|" "rec" "default" => FieldExtAnnot {
-        rec_default: true,
-        ..Default::default()
-    },
+// Recursive priorities are disabled as of 1.2.0. Their semantics is non trivial
+// to adapt to RFC005 that landed in 1.0.0, so they are currently on hold. If we
+// drop them altogether, we'll have to clean the corresponding code floating
+// around (not only in the parser, but in the internals module, etc.)
+//    "|" "rec" "force" => FieldExtAnnot {
+//        rec_force: true,
+//        ..Default::default()
+//    },
+//    "|" "rec" "default" => FieldExtAnnot {
+//        rec_default: true,
+//        ..Default::default()
+//    },
 }
 
 // An annotation, with possibly many annotations chained.

--- a/core/tests/integration/pass/merging/multiple_overrides.ncl
+++ b/core/tests/integration/pass/merging/multiple_overrides.ncl
@@ -90,11 +90,22 @@ let {check, ..} = import "../lib/assert.ncl" in
                | default = "",
       snd_data = "snd",
     },
-    final_override | rec force = {
-      fst_data = "override",
-      snd_data = "override",
-      common.final = fst_data ++ "_" ++ snd_data,
+    # Recursive priorities are currently on hold since the implementation of
+    # RFC005, which changes their semantics. In the meantime, this test has been
+    # rewritten temporarily with the expected result of the original "rec force"
+    # instead
+    #
+    # final_override | rec force = {
+    #   fst_data = "override",
+    #   snd_data = "override",
+    #   common.final = fst_data ++ "_" ++ snd_data,
+    # },
+    final_override = {
+      fst_data | force = "override",
+      snd_data | force = "override",
+      common.final | force = fst_data ++ "_" ++ snd_data,
     },
+
   } in
   [
     parent.fst_data & parent.snd_data == {

--- a/core/tests/integration/pass/merging/priorities.ncl
+++ b/core/tests/integration/pass/merging/priorities.ncl
@@ -42,29 +42,31 @@ let {Assert, check, ..} =  import "../lib/assert.ncl" in
     d = 1,
   } | Assert,
 
-  # TODO: restore (or not?). The previous behavior is harder to simulate after
-  # RFC005.
-  # {foo | rec default = 1} & {foo = 2} == {foo = 2} | Assert,
-  # {foo | rec force = 1} & {foo = 2} == {foo = 1} | Assert,
-  {val | rec default = {foo = 1}} & {val.foo = 2} == {val.foo = 2} | Assert,
-  {val | rec force = {foo = 1}} & {val.foo = 2} == {val.foo = 1} | Assert,
+  # All the following commented out tests are related to recursive priorities,
+  # which are on hold since RFC005 (and were disabled in 1.2.0). We need to
+  # rethink their semantics before proceeding further.
+
+  #{foo | rec default = 1} & {foo = 2} == {foo = 2} | Assert,
+  #{foo | rec force = 1} & {foo = 2} == {foo = 1} | Assert,
+  #{val | rec default = {foo = 1}} & {val.foo = 2} == {val.foo = 2} | Assert,
+  #{val | rec force = {foo = 1}} & {val.foo = 2} == {val.foo = 1} | Assert,
 
   # Pushed priorities should only modifies fields without explicitly set priorities
-  {val | rec force = {foo | priority -1 = 1}} & {val.foo = 2} == {val.foo = 2} | Assert,
-  {val | rec force = {foo | default = 1}} & {val.foo = 2} == {val.foo = 2} | Assert,
-  {val | rec default = {foo | priority 1 = 1}} & {val.foo = 2} == {val.foo = 1} | Assert,
-  {val | rec default = {foo | force = 1}} & {val.foo = 2} == {val.foo = 1} | Assert,
+  #{val | rec force = {foo | priority -1 = 1}} & {val.foo = 2} == {val.foo = 2} | Assert,
+  #{val | rec force = {foo | default = 1}} & {val.foo = 2} == {val.foo = 2} | Assert,
+  #{val | rec default = {foo | priority 1 = 1}} & {val.foo = 2} == {val.foo = 1} | Assert,
+  #{val | rec default = {foo | force = 1}} & {val.foo = 2} == {val.foo = 1} | Assert,
 
-  let x = {
-    foo | force = "old",
-    bar = {
-        baz = "old",
-        baz' = "old"
-      } |> std.record.map (fun _name value => value)
-  } in
-  {val | rec default = x} & {val = {foo = "new", bar.baz = "new"}}
-    == { val = {foo = "old", bar = {baz = "new", baz' = "old"}}}
-    | Assert,
+  #let x = {
+  #  foo | force = "old",
+  #  bar = {
+  #      baz = "old",
+  #      baz' = "old"
+  #    } |> std.record.map (fun _name value => value)
+  #} in
+  #{val | rec default = x} & {val = {foo = "new", bar.baz = "new"}}
+  #  == { val = {foo = "old", bar = {baz = "new", baz' = "old"}}}
+  #  | Assert,
 
   # Interaction of recursive overriding and recursive priorities
   #
@@ -73,8 +75,6 @@ let {Assert, check, ..} =  import "../lib/assert.ncl" in
   # 1}`. This is not an overriding bug, as writing the term above directly
   # (without `rec force` but with `force` directly) works.
   # Maybe some field update issue?
-  #
-  # TODO: restore and understand what's going on
   #
   # let context = 1 in
   # let x = {


### PR DESCRIPTION
Closes #1581.

Recursive priorities were added pre-RFC005, where their semantics was straightforward. Because metadata could appear anywhere, recursive priorities (or also called push priorities) just amounted to have a primop that pushed the priorities down a term, in one lazy step.

Since RFC005, this isn't possible anymore, because only record fields can hold metadata. It's now more intricate to implement, because when encountering a `rec force` at the field level, we first need to know if there's any value able to receive it underneath the field to know if we should attach it to the field or no. To know that, we need to evaluate the field first, and then decide.

Before sorting out both a new semantics and implementation, this commit disables the syntax (but keep the rest of the machinery) for 1.2.0 so that we can do some design before shipping new recursive priorities or scraping them entirely. Recursive priorities were undocumented, and should have been disabled from 1.0.0, so it's not considered a breaking change.