### PR TITLE
[REVIEW & CI] 1.2.1 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1601,7 +1601,7 @@ dependencies = [
 
 [[package]]
 name = "nickel-lang-cli"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "clap 4.4.3",
  "clap_complete",
@@ -1666,7 +1666,7 @@ dependencies = [
 
 [[package]]
 name = "nickel-lang-lsp"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2046,7 +2046,7 @@ dependencies = [
 
 [[package]]
 name = "pyckel"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "codespan-reporting",
  "nickel-lang-core",
@@ -2950,7 +2950,7 @@ dependencies = [
 [[package]]
 name = "topiary"
 version = "0.2.3"
-source = "git+https://github.com/tweag/topiary.git?rev=refs/heads/main#fe6083d2b7c762f5e8c63b9c79a8bd3ced12ea5d"
+source = "git+https://github.com/tweag/topiary.git?rev=refs/heads/main#7e6cb4f8b505eacee57aaf3c1ab0f3cf539da159"
 dependencies = [
  "clap 4.4.3",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "1.2.0"
+version = "1.2.1"
 authors = ["The Nickel Team <nickel-lang@protonmail.com>"]
 license = "MIT"
 edition = "2021"

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ highlighting and NLS.
 
 **Warning**: because the cargo registry (crates.io) requires that all
 dependencies of Nickel are published there as well, the `format` feature isn't
-enabled when installing nickel with `cargo install` as of Nickel version 1.2.0.
+enabled when installing nickel with `cargo install` as of Nickel version 1.2.1.
 In this case, please use [Topiary](https://github.com/tweag/topiary/) separately
 to format Nickel source code.
 

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -29,7 +29,9 @@ use crate::format::FormatCommand;
         env!("CARGO_PKG_VERSION"),
         // 7 is the length of self.shortRev. the string is padded out so it can
         // be searched for in the binary
-        git_version!(fallback = &env!("NICKEL_NIX_BUILD_REV")[0..7])
+        // The crate published on cargo doesn't have the git version, so we use "cargorel" as a
+        // fallback value
+        git_version!(fallback = &option_env!("NICKEL_NIX_BUILD_REV").unwrap_or("cargorel")[0..7])
     )
 )]
 pub struct Options {

--- a/lsp/nls/README.md
+++ b/lsp/nls/README.md
@@ -14,7 +14,7 @@ it in VSCode, (Neo)Vim and Emacs.
 
 **Warning**: because the cargo registry (crates.io) requires that all
 dependencies of Nickel are published there as well, the format feature isn't
-enabled when installing nls with `cargo install` as of NLS version 1.2.0. In
+enabled when installing nls with `cargo install` as of NLS version 1.2.1. In
 this case, to enable formatting in NLS, you have to make the `topiary`
 executable available in your `PATH`. Please follow [Topiary's setup
 instructions](https://github.com/tweag/topiary#installing) and ensure in


### PR DESCRIPTION
1.2.1 patch. Fix nickel not installing from `cargo` because of some undefined environment variable.