### PR TITLE
Update the version number in the manual introduction

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -27,6 +27,8 @@ Other crates carry the version number of the Nickel language. These are
 - `nickel-lang-lsp`
 - `pyckel`
 
+Finally, update the version number in `doc/manual/introduction.md`.
+
 ### Prepare
 
 1. Branch out from `master` to a dedicated branch `X.Y.Z-release`:

--- a/doc/manual/introduction.md
+++ b/doc/manual/introduction.md
@@ -74,7 +74,7 @@ website.
 
 ## Current state and roadmap
 
-Nickel is currently released in version `1.1`. We expect the core design of the
+Nickel is currently released in version `1.2`. We expect the core design of the
 language to be stable and the language to be useful for real-world applications.
 The next steps we plan to work on are:
 


### PR DESCRIPTION
Update the version number to `1.2` and add a note to `RELEASING.md` so we don't forget quite as often.