### PR TITLE
Move goto away from the linearizer

### DIFF
--- a/core/src/error.rs
+++ b/core/src/error.rs
@@ -1904,7 +1904,7 @@ impl IntoDiagnostics<FileId> for TypecheckError {
 
                 let note1 = if let TypeF::Record(rrows) = &expd.typ {
                     match rrows.row_find_path(path.as_slice()) {
-                        Some(ty) => mk_expected_row_msg(&field, ty),
+                        Some(row) => mk_expected_row_msg(&field, row.typ),
                         None => mk_expected_msg(&expd),
                     }
                 } else {
@@ -1913,7 +1913,7 @@ impl IntoDiagnostics<FileId> for TypecheckError {
 
                 let note2 = if let TypeF::Record(rrows) = &actual.typ {
                     match rrows.row_find_path(path.as_slice()) {
-                        Some(ty) => mk_inferred_row_msg(&field, ty),
+                        Some(row) => mk_inferred_row_msg(&field, row.typ),
                         None => mk_inferred_msg(&actual),
                     }
                 } else {

--- a/core/src/error.rs
+++ b/core/src/error.rs
@@ -1903,7 +1903,7 @@ impl IntoDiagnostics<FileId> for TypecheckError {
                 };
 
                 let note1 = if let TypeF::Record(rrows) = &expd.typ {
-                    match rrows.row_find_path(path.as_slice()) {
+                    match rrows.find_path(path.as_slice()) {
                         Some(row) => mk_expected_row_msg(&field, row.typ),
                         None => mk_expected_msg(&expd),
                     }
@@ -1912,7 +1912,7 @@ impl IntoDiagnostics<FileId> for TypecheckError {
                 };
 
                 let note2 = if let TypeF::Record(rrows) = &actual.typ {
-                    match rrows.row_find_path(path.as_slice()) {
+                    match rrows.find_path(path.as_slice()) {
                         Some(row) => mk_inferred_row_msg(&field, row.typ),
                         None => mk_inferred_msg(&actual),
                     }

--- a/core/src/typ.rs
+++ b/core/src/typ.rs
@@ -853,11 +853,7 @@ impl RecordRows {
     /// - self: ` {a : {b : Number }}`
     /// - path: `["a", "b"]`
     /// - result: `Some(Number)`
-    pub fn row_find_path(&self, path: &[Ident]) -> Option<Type> {
-        self.row_find_path_row(path).map(|r| r.typ.clone())
-    }
-
-    pub fn row_find_path_row(&self, path: &[Ident]) -> Option<RecordRowF<&Type>> {
+    pub fn row_find_path(&self, path: &[Ident]) -> Option<RecordRowF<&Type>> {
         if path.is_empty() {
             return None;
         }
@@ -871,7 +867,7 @@ impl RecordRows {
             next
         } else {
             match next.map(|row| &row.typ.typ) {
-                Some(TypeF::Record(rrows)) => rrows.row_find_path_row(&path[1..]),
+                Some(TypeF::Record(rrows)) => rrows.row_find_path(&path[1..]),
                 _ => None,
             }
         }

--- a/core/src/typ.rs
+++ b/core/src/typ.rs
@@ -854,20 +854,24 @@ impl RecordRows {
     /// - path: `["a", "b"]`
     /// - result: `Some(Number)`
     pub fn row_find_path(&self, path: &[Ident]) -> Option<Type> {
+        self.row_find_path_row(path).map(|r| r.typ.clone())
+    }
+
+    pub fn row_find_path_row(&self, path: &[Ident]) -> Option<RecordRowF<&Type>> {
         if path.is_empty() {
             return None;
         }
 
         let next = self.iter().find_map(|item| match item {
-            RecordRowsIteratorItem::Row(row) if row.id.ident() == path[0] => Some(row.typ.clone()),
+            RecordRowsIteratorItem::Row(row) if row.id.ident() == path[0] => Some(row.clone()),
             _ => None,
         });
 
         if path.len() == 1 {
             next
         } else {
-            match next.map(|ty| ty.typ) {
-                Some(TypeF::Record(rrows)) => rrows.row_find_path(&path[1..]),
+            match next.map(|row| &row.typ.typ) {
+                Some(TypeF::Record(rrows)) => rrows.row_find_path_row(&path[1..]),
                 _ => None,
             }
         }

--- a/core/src/typ.rs
+++ b/core/src/typ.rs
@@ -853,7 +853,7 @@ impl RecordRows {
     /// - self: ` {a : {b : Number }}`
     /// - path: `["a", "b"]`
     /// - result: `Some(Number)`
-    pub fn row_find_path(&self, path: &[Ident]) -> Option<RecordRowF<&Type>> {
+    pub fn find_path(&self, path: &[Ident]) -> Option<RecordRowF<&Type>> {
         if path.is_empty() {
             return None;
         }
@@ -867,7 +867,7 @@ impl RecordRows {
             next
         } else {
             match next.map(|row| &row.typ.typ) {
-                Some(TypeF::Record(rrows)) => rrows.row_find_path(&path[1..]),
+                Some(TypeF::Record(rrows)) => rrows.find_path(&path[1..]),
                 _ => None,
             }
         }

--- a/lsp/lsp-harness/src/lib.rs
+++ b/lsp/lsp-harness/src/lib.rs
@@ -4,7 +4,8 @@ mod output;
 pub use jsonrpc::Server;
 use log::error;
 use lsp_types::{
-    CompletionParams, DocumentFormattingParams, GotoDefinitionParams, HoverParams, Url,
+    CompletionParams, DocumentFormattingParams, GotoDefinitionParams, HoverParams, ReferenceParams,
+    Url,
 };
 pub use output::LspDebug;
 use serde::Deserialize;
@@ -30,6 +31,7 @@ pub struct TestFile {
 #[serde(tag = "type")]
 pub enum Request {
     GotoDefinition(GotoDefinitionParams),
+    References(ReferenceParams),
     Completion(CompletionParams),
     Formatting(DocumentFormattingParams),
     Hover(HoverParams),

--- a/lsp/lsp-harness/src/output.rs
+++ b/lsp/lsp-harness/src/output.rs
@@ -48,6 +48,12 @@ impl<T: LspDebug, I: Iterator<Item = T> + Clone> LspDebug for Iter<I> {
     }
 }
 
+impl<T: LspDebug> LspDebug for Vec<T> {
+    fn debug(&self, w: impl Write) -> std::io::Result<()> {
+        Iter(self.iter()).debug(w)
+    }
+}
+
 impl LspDebug for lsp_types::Range {
     fn debug(&self, mut w: impl Write) -> std::io::Result<()> {
         write!(
@@ -113,12 +119,6 @@ impl LspDebug for lsp_types::CompletionResponse {
 impl LspDebug for lsp_types::TextEdit {
     fn debug(&self, mut w: impl Write) -> std::io::Result<()> {
         write!(w, "<{}> {}", self.range.debug_str(), self.new_text)
-    }
-}
-
-impl LspDebug for Vec<lsp_types::TextEdit> {
-    fn debug(&self, w: impl Write) -> std::io::Result<()> {
-        Iter(self.iter()).debug(w)
     }
 }
 

--- a/lsp/nls/src/field_walker.rs
+++ b/lsp/nls/src/field_walker.rs
@@ -30,7 +30,9 @@ impl FieldHaver {
                 .get(&id)
                 .map(|field| FieldContent::RecordField(field.clone())),
             FieldHaver::Dict(ty) => Some(FieldContent::Type(ty.clone())),
-            FieldHaver::RecordType(rows) => rows.row_find_path(&[id]).map(FieldContent::Type),
+            FieldHaver::RecordType(rows) => rows
+                .row_find_path(&[id])
+                .map(|row| FieldContent::Type(row.typ.clone())),
         }
     }
 
@@ -40,7 +42,7 @@ impl FieldHaver {
                 .fields
                 .get_key_value(&id)
                 .map(|(id, _field)| (*id).into()),
-            FieldHaver::RecordType(rows) => rows.row_find_path_row(&[id]).map(|r| r.id.into()),
+            FieldHaver::RecordType(rows) => rows.row_find_path(&[id]).map(|r| r.id.into()),
             FieldHaver::Dict(_) => None,
         }
     }

--- a/lsp/nls/src/field_walker.rs
+++ b/lsp/nls/src/field_walker.rs
@@ -34,6 +34,17 @@ impl FieldHaver {
         }
     }
 
+    pub fn get_definition_pos(&self, id: Ident) -> Option<LocIdent> {
+        match self {
+            FieldHaver::RecordTerm(data) => data
+                .fields
+                .get_key_value(&id)
+                .map(|(id, _field)| (*id).into()),
+            FieldHaver::RecordType(rows) => rows.row_find_path_row(&[id]).map(|r| r.id.into()),
+            FieldHaver::Dict(_) => None,
+        }
+    }
+
     /// Returns all fields in this `FieldHaver`, rendered as LSP completion items.
     pub fn completion_items(&self) -> impl Iterator<Item = CompletionItem> + '_ {
         match self {
@@ -197,7 +208,7 @@ impl<'a> FieldResolver<'a> {
     /// This a best-effort thing; it doesn't do full evaluation but it has some reasonable
     /// heuristics. For example, it knows that the fields defined on a merge of two records
     /// are the fields defined on either record.
-    fn resolve_term(&self, rt: &RichTerm) -> Vec<FieldHaver> {
+    pub fn resolve_term(&self, rt: &RichTerm) -> Vec<FieldHaver> {
         let term_fields = match rt.term.as_ref() {
             Term::Record(data) | Term::RecRecord(data, ..) => {
                 vec![FieldHaver::RecordTerm(data.clone())]

--- a/lsp/nls/src/field_walker.rs
+++ b/lsp/nls/src/field_walker.rs
@@ -31,7 +31,7 @@ impl FieldHaver {
                 .map(|field| FieldContent::RecordField(field.clone())),
             FieldHaver::Dict(ty) => Some(FieldContent::Type(ty.clone())),
             FieldHaver::RecordType(rows) => rows
-                .row_find_path(&[id])
+                .find_path(&[id])
                 .map(|row| FieldContent::Type(row.typ.clone())),
         }
     }
@@ -42,7 +42,7 @@ impl FieldHaver {
                 .fields
                 .get_key_value(&id)
                 .map(|(id, _field)| (*id).into()),
-            FieldHaver::RecordType(rows) => rows.row_find_path(&[id]).map(|r| r.id.into()),
+            FieldHaver::RecordType(rows) => rows.find_path(&[id]).map(|r| r.id.into()),
             FieldHaver::Dict(_) => None,
         }
     }

--- a/lsp/nls/src/linearization/mod.rs
+++ b/lsp/nls/src/linearization/mod.rs
@@ -78,6 +78,17 @@ impl LinRegistry {
         self.usage_lookups.get(&file)?.def(ident)
     }
 
+    pub fn get_usages(&self, ident: &LocIdent) -> impl Iterator<Item = &LocIdent> {
+        fn inner<'a>(
+            slf: &'a LinRegistry,
+            ident: &LocIdent,
+        ) -> Option<impl Iterator<Item = &'a LocIdent>> {
+            let file = ident.pos.as_opt_ref()?.src_id;
+            Some(slf.usage_lookups.get(&file)?.usages(ident))
+        }
+        inner(self, ident).into_iter().flatten()
+    }
+
     pub fn get_env(&self, rt: &RichTerm) -> Option<&crate::usage::Environment> {
         let file = rt.pos.as_opt_ref()?.src_id;
         self.usage_lookups.get(&file)?.env(rt)

--- a/lsp/nls/src/requests/goto.rs
+++ b/lsp/nls/src/requests/goto.rs
@@ -1,19 +1,50 @@
-use codespan::ByteIndex;
-use log::debug;
 use lsp_server::{RequestId, Response, ResponseError};
-use lsp_types::{
-    GotoDefinitionParams, GotoDefinitionResponse, Location, Range, ReferenceParams, Url,
-};
-use nickel_lang_core::position::RawSpan;
+use lsp_types::{GotoDefinitionParams, GotoDefinitionResponse, Location, ReferenceParams};
+use nickel_lang_core::term::{RichTerm, Term, UnaryOp};
 use serde_json::Value;
 
 use crate::{
-    cache::CacheExt,
-    diagnostic::LocationCompat,
-    linearization::interface::{TermKind, UsageState},
+    cache::CacheExt, diagnostic::LocationCompat, field_walker::FieldResolver, identifier::LocIdent,
     server::Server,
-    trace::{Enrich, Trace},
 };
+
+fn get_defs(term: &RichTerm, server: &Server) -> Vec<LocIdent> {
+    match term.as_ref() {
+        Term::Var(id) => {
+            if let Some(loc) = server
+                .lin_registry
+                .get_def(&(*id).into())
+                .map(|def| def.ident)
+            {
+                vec![loc]
+            } else {
+                vec![]
+            }
+        }
+        Term::Op1(UnaryOp::StaticAccess(id), parent) => {
+            let resolver = FieldResolver::new(server);
+            let parents = resolver.resolve_term(parent);
+            parents
+                .iter()
+                .filter_map(|parent| parent.get_definition_pos(id.ident()))
+                .collect()
+        }
+        _ => vec![],
+    }
+}
+
+fn ids_to_locations(ids: impl IntoIterator<Item = LocIdent>, server: &Server) -> Vec<Location> {
+    let mut spans: Vec<_> = ids.into_iter().filter_map(|id| id.pos.into_opt()).collect();
+
+    // The sort order of our response is a little arbitrary. But we want to deduplicate, and we
+    // don't want the response to be random.
+    spans.sort_by_key(|span| (server.cache.files().name(span.src_id), span.start, span.end));
+    spans.dedup();
+    spans
+        .iter()
+        .map(|loc| Location::from_span(loc, server.cache.files()))
+        .collect()
+}
 
 pub fn handle_to_definition(
     params: GotoDefinitionParams,
@@ -23,53 +54,21 @@ pub fn handle_to_definition(
     let pos = server
         .cache
         .position(&params.text_document_position_params)?;
-    let linearization = server.lin_cache_get(&pos.src_id)?;
 
-    Trace::enrich(&id, linearization);
+    let locations = server
+        .lookup_term_by_position(pos)?
+        .map(|term| ids_to_locations(get_defs(term, server), server))
+        .unwrap_or_default();
 
-    let Some(item) = linearization.item_at(pos) else {
-        server.reply(Response::new_ok(id, Value::Null));
-        return Ok(());
-    };
-
-    debug!("found referencing item: {:?}", item);
-
-    let location = match item.kind {
-        TermKind::Usage(UsageState::Resolved(usage_id)) => {
-            let definition = linearization
-                .get_item_with_reg(usage_id, &server.lin_registry)
-                .unwrap();
-            if server.cache.is_stdlib_module(definition.id.file_id) {
-                // The standard library files are embedded in the executable,
-                // so we can't possibly go to their definition on disk.
-                server.reply(Response::new_ok(id, Value::Null));
-                return Ok(());
-            }
-            let RawSpan {
-                start: ByteIndex(start),
-                end: ByteIndex(end),
-                src_id,
-            } = definition.pos.unwrap();
-            let location = Location {
-                uri: Url::from_file_path(server.cache.name(src_id)).unwrap(),
-                range: Range::from_codespan(
-                    &src_id,
-                    &(start as usize..end as usize),
-                    server.cache.files(),
-                ),
-            };
-            Some(location)
-        }
-        _ => None,
-    };
-
-    debug!("referenced location: {:?}", location);
-
-    if let Some(response) = location.map(GotoDefinitionResponse::Scalar) {
-        server.reply(Response::new_ok(id, response));
+    let response = if locations.is_empty() {
+        Response::new_ok(id, Value::Null)
+    } else if locations.len() == 1 {
+        Response::new_ok(id, GotoDefinitionResponse::Scalar(locations[0].clone()))
     } else {
-        server.reply(Response::new_ok(id, Value::Null));
-    }
+        Response::new_ok(id, GotoDefinitionResponse::Array(locations))
+    };
+
+    server.reply(response);
     Ok(())
 }
 
@@ -79,45 +78,24 @@ pub fn handle_to_usages(
     server: &mut Server,
 ) -> Result<(), ResponseError> {
     let pos = server.cache.position(&params.text_document_position)?;
-    let linearization = server.lin_cache_get(&pos.src_id)?;
 
-    let Some(item) = linearization.item_at(pos) else {
-        server.reply(Response::new_ok(id, Value::Null));
-        return Ok(());
-    };
-
-    debug!("found referencing item: {:?}", item);
-
-    let locations: Option<Vec<Location>> = match &item.kind {
-        TermKind::Declaration { usages, .. } | TermKind::RecordField { usages, .. } => Some(
-            usages
-                .iter()
-                .filter_map(|reference_id| {
-                    linearization
-                        .get_item_with_reg(*reference_id, &server.lin_registry)
-                        .unwrap()
-                        .pos
-                        .as_opt_ref()
-                        .map(|RawSpan { start, end, src_id }| Location {
-                            uri: Url::from_file_path(server.cache.name(*src_id)).unwrap(),
-                            range: Range::from_codespan(
-                                src_id,
-                                &((*start).into()..(*end).into()),
-                                server.cache.files(),
-                            ),
-                        })
-                })
-                .collect(),
-        ),
-        _ => None,
-    };
-
-    debug!("referencing locations: {:?}", locations);
-
-    if let Some(response) = locations {
-        server.reply(Response::new_ok(id, response));
+    let usages = if let Some(term) = server.lookup_term_by_position(pos)? {
+        let def_locs = get_defs(term, server);
+        def_locs
+            .into_iter()
+            .flat_map(|id| server.lin_registry.get_usages(&id))
+            .cloned()
+            .collect()
     } else {
+        Vec::new()
+    };
+
+    let locations = ids_to_locations(usages, server);
+
+    if locations.is_empty() {
         server.reply(Response::new_ok(id, Value::Null));
+    } else {
+        server.reply(Response::new_ok(id, locations));
     }
     Ok(())
 }

--- a/lsp/nls/src/server.rs
+++ b/lsp/nls/src/server.rs
@@ -231,7 +231,7 @@ impl Server {
             References::METHOD => {
                 debug!("handle goto defnition");
                 let params: ReferenceParams = serde_json::from_value(req.params).unwrap();
-                goto::handle_to_usages(params, req.id.clone(), self)
+                goto::handle_references(params, req.id.clone(), self)
             }
 
             Completion::METHOD => {
@@ -287,6 +287,22 @@ impl Server {
                 code: ErrorCode::ParseError as i32,
             })?
             .get(pos.index))
+    }
+
+    pub fn lookup_ident_by_position(
+        &self,
+        pos: RawPos,
+    ) -> Result<Option<crate::identifier::LocIdent>, ResponseError> {
+        Ok(self
+            .lin_registry
+            .position_lookups
+            .get(&pos.src_id)
+            .ok_or_else(|| ResponseError {
+                data: None,
+                message: "File has not yet been parsed or cached.".to_owned(),
+                code: ErrorCode::ParseError as i32,
+            })?
+            .get_ident(pos.index))
     }
 
     pub fn issue_diagnostics(&mut self, file_id: FileId, diagnostics: Vec<Diagnostic<FileId>>) {

--- a/lsp/nls/src/usage.rs
+++ b/lsp/nls/src/usage.rs
@@ -102,7 +102,6 @@ impl UsageLookup {
     }
 
     /// Return all the usages of `ident`.
-    #[allow(dead_code)] // Not used yet...
     pub fn usages(&self, ident: &LocIdent) -> impl Iterator<Item = &LocIdent> {
         self.usage_table
             .get(ident)

--- a/lsp/nls/tests/inputs/goto-basic.ncl
+++ b/lsp/nls/tests/inputs/goto-basic.ncl
@@ -17,3 +17,39 @@ in
 ### type = "GotoDefinition"
 ### textDocument.uri = "file:///goto.ncl"
 ### position = { line = 3, character = 10 }
+###
+### [[request]]
+### type = "References"
+### textDocument.uri = "file:///goto.ncl"
+### position = { line = 1, character = 3 }
+### context = { includeDeclaration = true }
+###
+### [[request]]
+### type = "References"
+### textDocument.uri = "file:///goto.ncl"
+### position = { line = 1, character = 3 }
+### context = { includeDeclaration = false }
+###
+### [[request]]
+### type = "References"
+### textDocument.uri = "file:///goto.ncl"
+### position = { line = 3, character = 3 }
+### context = { includeDeclaration = true }
+###
+### [[request]]
+### type = "References"
+### textDocument.uri = "file:///goto.ncl"
+### position = { line = 3, character = 3 }
+### context = { includeDeclaration = false }
+###
+### [[request]]
+### type = "References"
+### textDocument.uri = "file:///goto.ncl"
+### position = { line = 3, character = 9 }
+### context = { includeDeclaration = true }
+###
+### [[request]]
+### type = "References"
+### textDocument.uri = "file:///goto.ncl"
+### position = { line = 3, character = 9 }
+### context = { includeDeclaration = false }

--- a/lsp/nls/tests/inputs/goto-multiple.ncl
+++ b/lsp/nls/tests/inputs/goto-multiple.ncl
@@ -1,0 +1,24 @@
+### /goto.ncl
+let record = { foo = 1, bar = { baz = "hi" } } in
+let toMerge = { bar = { baz = "hi", quux = "bye" } } in
+let Contract = { baz | String } in
+let another | Contract = (record & toMerge).bar in
+[
+  another.baz,
+  another.quux,
+  (toMerge.bar | Contract).baz,
+]
+### [[request]]
+### type = "GotoDefinition"
+### textDocument.uri = "file:///goto.ncl"
+### position = { line = 5, character = 12 }
+###
+### [[request]]
+### type = "GotoDefinition"
+### textDocument.uri = "file:///goto.ncl"
+### position = { line = 6, character = 12 }
+###
+### [[request]]
+### type = "GotoDefinition"
+### textDocument.uri = "file:///goto.ncl"
+### position = { line = 7, character = 29 }

--- a/lsp/nls/tests/inputs/goto-scoping.ncl
+++ b/lsp/nls/tests/inputs/goto-scoping.ncl
@@ -1,0 +1,14 @@
+### /goto.ncl
+let person | { name: String } = null in 
+# The "person" on the rhs here refers to the person in the line above
+let person = person in
+person
+### [[request]]
+### type = "GotoDefinition"
+### textDocument.uri = "file:///goto.ncl"
+### position = { line = 2, character = 16 }
+###
+### [[request]]
+### type = "GotoDefinition"
+### textDocument.uri = "file:///goto.ncl"
+### position = { line = 3, character = 3 }

--- a/lsp/nls/tests/inputs/goto-scoping.ncl
+++ b/lsp/nls/tests/inputs/goto-scoping.ncl
@@ -12,3 +12,27 @@ person
 ### type = "GotoDefinition"
 ### textDocument.uri = "file:///goto.ncl"
 ### position = { line = 3, character = 3 }
+###
+### [[request]]
+### type = "References"
+### textDocument.uri = "file:///goto.ncl"
+### position = { line = 2, character = 16 }
+### context = { includeDeclaration = true }
+###
+### [[request]]
+### type = "References"
+### textDocument.uri = "file:///goto.ncl"
+### position = { line = 2, character = 16 }
+### context = { includeDeclaration = false }
+###
+### [[request]]
+### type = "References"
+### textDocument.uri = "file:///goto.ncl"
+### position = { line = 3, character = 3 }
+### context = { includeDeclaration = true }
+###
+### [[request]]
+### type = "References"
+### textDocument.uri = "file:///goto.ncl"
+### position = { line = 3, character = 3 }
+### context = { includeDeclaration = false }

--- a/lsp/nls/tests/main.rs
+++ b/lsp/nls/tests/main.rs
@@ -1,8 +1,11 @@
 use std::collections::{hash_map::Entry, HashMap};
 
 use assert_cmd::cargo::CommandCargoExt;
-use lsp_types::request::{
-    Completion, Formatting, GotoDefinition, HoverRequest, Request as LspRequest,
+use lsp_types::{
+    request::{
+        Completion, Formatting, GotoDefinition, HoverRequest, References, Request as LspRequest,
+    },
+    ReferenceParams,
 };
 use nickel_lang_utils::project_root::project_root;
 use test_generator::test_resources;
@@ -39,6 +42,7 @@ impl TestHarness {
             Request::Completion(c) => self.request::<Completion>(c),
             Request::Formatting(f) => self.request::<Formatting>(f),
             Request::Hover(h) => self.request::<HoverRequest>(h),
+            Request::References(r) => self.request::<References>(r),
         }
     }
 

--- a/lsp/nls/tests/main.rs
+++ b/lsp/nls/tests/main.rs
@@ -1,11 +1,8 @@
 use std::collections::{hash_map::Entry, HashMap};
 
 use assert_cmd::cargo::CommandCargoExt;
-use lsp_types::{
-    request::{
-        Completion, Formatting, GotoDefinition, HoverRequest, References, Request as LspRequest,
-    },
-    ReferenceParams,
+use lsp_types::request::{
+    Completion, Formatting, GotoDefinition, HoverRequest, References, Request as LspRequest,
 };
 use nickel_lang_utils::project_root::project_root;
 use test_generator::test_resources;

--- a/lsp/nls/tests/snapshots/main__lsp__nls__tests__inputs__goto-basic.ncl.snap
+++ b/lsp/nls/tests/snapshots/main__lsp__nls__tests__inputs__goto-basic.ncl.snap
@@ -5,4 +5,10 @@ expression: output
 file:///goto.ncl:1:2-1:5
 file:///goto.ncl:1:2-1:5
 file:///goto.ncl:1:2-1:5
+[file:///goto.ncl:1:2-1:5, file:///goto.ncl:3:8-3:11]
+[file:///goto.ncl:3:8-3:11]
+[file:///goto.ncl:3:2-3:5]
+None
+[file:///goto.ncl:1:2-1:5, file:///goto.ncl:3:8-3:11]
+[file:///goto.ncl:3:8-3:11]
 

--- a/lsp/nls/tests/snapshots/main__lsp__nls__tests__inputs__goto-multiple.ncl.snap
+++ b/lsp/nls/tests/snapshots/main__lsp__nls__tests__inputs__goto-multiple.ncl.snap
@@ -1,0 +1,8 @@
+---
+source: lsp/nls/tests/main.rs
+expression: output
+---
+[file:///goto.ncl:0:32-0:35, file:///goto.ncl:1:24-1:27, file:///goto.ncl:2:17-2:20]
+file:///goto.ncl:1:36-1:40
+[file:///goto.ncl:1:24-1:27, file:///goto.ncl:2:17-2:20]
+

--- a/lsp/nls/tests/snapshots/main__lsp__nls__tests__inputs__goto-scoping.ncl.snap
+++ b/lsp/nls/tests/snapshots/main__lsp__nls__tests__inputs__goto-scoping.ncl.snap
@@ -1,0 +1,7 @@
+---
+source: lsp/nls/tests/main.rs
+expression: output
+---
+file:///goto.ncl:0:4-0:10
+file:///goto.ncl:2:4-2:10
+

--- a/lsp/nls/tests/snapshots/main__lsp__nls__tests__inputs__goto-scoping.ncl.snap
+++ b/lsp/nls/tests/snapshots/main__lsp__nls__tests__inputs__goto-scoping.ncl.snap
@@ -4,4 +4,8 @@ expression: output
 ---
 file:///goto.ncl:0:4-0:10
 file:///goto.ncl:2:4-2:10
+[file:///goto.ncl:0:4-0:10, file:///goto.ncl:2:13-2:19]
+[file:///goto.ncl:2:13-2:19]
+[file:///goto.ncl:2:4-2:10, file:///goto.ncl:3:0-3:6]
+[file:///goto.ncl:3:0-3:6]
 


### PR DESCRIPTION
Rewrites goto definition and references to use the new machinery instead of the linearizer.

Fixes #881.