### PR TITLE
Testing Nickel snippets in the manual

### DIFF
--- a/core/tests/manual/main.rs
+++ b/core/tests/manual/main.rs
@@ -16,6 +16,8 @@ enum CodeBlockType {
     /// A code block containing multiple lines, each of which should be
     /// evaluated separately
     Lines,
+    /// A code block that should only be parsed, not evaluated
+    Parse,
     /// A code block containing a REPL session, e.g.
     /// ```nickel repl
     /// > let foo =
@@ -45,6 +47,7 @@ impl CodeBlockType {
             "nickel" => Some(CodeBlockType::Single),
             "nickel-lines" => Some(CodeBlockType::Lines),
             "nickel-repl" => Some(CodeBlockType::Repl),
+            "nickel-parse" => Some(CodeBlockType::Parse),
             _ => None,
         }
     }
@@ -72,6 +75,11 @@ fn check_parse_extended(program: String) {
     test_program::parse_extended(&program).unwrap();
 }
 
+fn check_parse(program: String) {
+    eprintln!("{program}"); // Print the program to stderr to make tracking test failures easier
+    test_program::parse(&program).unwrap();
+}
+
 impl CodeBlock {
     fn check(self) {
         match self.typ {
@@ -81,6 +89,7 @@ impl CodeBlock {
                     check_eval(line.to_owned());
                 }
             }
+            CodeBlockType::Parse => check_parse(self.content),
             CodeBlockType::Repl => check_repl_parts(self.content),
         }
     }

--- a/core/tests/manual/main.rs
+++ b/core/tests/manual/main.rs
@@ -19,7 +19,7 @@ enum CodeBlockType {
     /// A code block that should only be parsed, not evaluated
     Parse,
     /// A code block containing a REPL session, e.g.
-    /// ```nickel repl
+    /// ```nickel #repl
     /// > let foo =
     ///     fun x => x
     ///   in foo 5
@@ -45,9 +45,9 @@ impl CodeBlockType {
     fn from_info(info: impl AsRef<str>) -> Option<CodeBlockType> {
         match info.as_ref() {
             "nickel" => Some(CodeBlockType::Single),
-            "nickel-lines" => Some(CodeBlockType::Lines),
-            "nickel-repl" => Some(CodeBlockType::Repl),
-            "nickel-parse" => Some(CodeBlockType::Parse),
+            "nickel #lines" => Some(CodeBlockType::Lines),
+            "nickel #repl" => Some(CodeBlockType::Repl),
+            "nickel #parse" => Some(CodeBlockType::Parse),
             _ => None,
         }
     }

--- a/core/tests/manual/main.rs
+++ b/core/tests/manual/main.rs
@@ -26,10 +26,10 @@ enum CodeBlockType {
     /// > std.function.id 5
     /// 5
     /// ```
-    /// We interpret lines starting with `> ` and followed by indented lines
-    /// (starting with at least one `' '`) as a single Nickel program and try
-    /// to parse them. For now, we don't check evaluation. REPL inputs must be
-    /// separated by an empty line.
+    /// We interpret lines starting with `> ` directly after an empty line
+    /// and followed by indented lines (starting with at least one `' '`) as
+    /// a single Nickel program and try to parse them. For now, we don't check
+    /// evaluation. REPL inputs must be separated by an empty line.
     Repl,
 }
 
@@ -43,8 +43,8 @@ impl CodeBlockType {
     fn from_info(info: impl AsRef<str>) -> Option<CodeBlockType> {
         match info.as_ref() {
             "nickel" => Some(CodeBlockType::Single),
-            "nickel lines" => Some(CodeBlockType::Lines),
-            "nickel repl" => Some(CodeBlockType::Repl),
+            "nickel-lines" => Some(CodeBlockType::Lines),
+            "nickel-repl" => Some(CodeBlockType::Repl),
             _ => None,
         }
     }
@@ -52,23 +52,23 @@ impl CodeBlockType {
 
 fn check_repl_parts(content: String) {
     for piece in content.split("\n\n") {
-        let program: String = piece
-            .strip_prefix('>')
-            .unwrap()
-            .split_inclusive('\n')
-            .take_while(|l| l.starts_with(' '))
-            .collect();
-        check_parse_extended(program);
+        if let Some(piece) = piece.strip_prefix('>') {
+            let program = piece
+                .split_inclusive('\n')
+                .take_while(|l| l.starts_with(' '))
+                .collect();
+            check_parse_extended(program);
+        }
     }
 }
 
 fn check_eval(program: String) {
-    eprintln!("{}", program);
+    eprintln!("{program}"); // Print the program to stderr to make tracking test failures easier
     test_program::eval(program).unwrap();
 }
 
 fn check_parse_extended(program: String) {
-    eprintln!("{}", program);
+    eprintln!("{program}"); // Print the program to stderr to make tracking test failures easier
     test_program::parse_extended(&program).unwrap();
 }
 
@@ -111,5 +111,4 @@ fn check_manual_snippets(path: &str) {
     for code_block in snippets {
         code_block.check();
     }
-    panic!();
 }

--- a/core/tests/manual/main.rs
+++ b/core/tests/manual/main.rs
@@ -1,0 +1,136 @@
+use std::{fs::File, io::read_to_string};
+
+use comrak::{
+    arena_tree::{Node, NodeEdge},
+    nodes::{Ast, AstNode, NodeCodeBlock, NodeValue},
+    parse_document, ComrakOptions,
+};
+use nickel_lang_utils::{project_root::project_root, test_program};
+use test_generator::test_resources;
+use typed_arena::Arena;
+
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+enum CodeBlockType {
+    /// A code block intended to be evaluated in its entirety
+    Single,
+    /// A code block containing multiple lines, each of which should be
+    /// evaluated separately
+    Lines,
+    /// A code block containing a REPL session, e.g.
+    /// ```nickel repl
+    /// > let foo =
+    ///     fun x => x
+    ///   in foo 5
+    /// 5
+    ///
+    /// > std.function.id 5
+    /// 5
+    /// ```
+    /// We interpret lines starting with `> ` and followed by indented lines
+    /// (starting with at least one `' '`) as a single Nickel program and try
+    /// to parse them. For now, we don't check evaluation. REPL inputs must be
+    /// separated by an empty line.
+    Repl,
+}
+
+#[derive(Debug, Clone)]
+struct CodeBlock {
+    typ: CodeBlockType,
+    content: String,
+}
+
+#[derive(Debug, Clone)]
+enum TestCase {
+    Evaluate(String),
+    ParseExtended(String),
+}
+
+impl CodeBlockType {
+    fn from_info(info: impl AsRef<str>) -> Option<CodeBlockType> {
+        match info.as_ref() {
+            "nickel" => Some(CodeBlockType::Single),
+            "nickel lines" => Some(CodeBlockType::Lines),
+            "nickel repl" => Some(CodeBlockType::Repl),
+            _ => None,
+        }
+    }
+}
+
+fn repl_parts(content: String) -> Vec<TestCase> {
+    content
+        .split("\n\n")
+        .map(|piece| {
+            let program: String = piece
+                .strip_prefix('>')
+                .unwrap()
+                .lines()
+                .take_while(|l| l.starts_with(' '))
+                .collect();
+            TestCase::ParseExtended(program)
+        })
+        .collect()
+}
+
+impl CodeBlock {
+    fn split(self) -> Vec<TestCase> {
+        match self.typ {
+            CodeBlockType::Single => vec![TestCase::Evaluate(self.content)],
+            CodeBlockType::Lines => self
+                .content
+                .lines()
+                .map(|line| TestCase::Evaluate(line.to_owned()))
+                .collect(),
+            CodeBlockType::Repl => repl_parts(self.content),
+        }
+    }
+
+    fn check(self) {
+        for case in self.split() {
+            case.check()
+        }
+    }
+}
+
+impl TestCase {
+    fn check(self) {
+        use TestCase::*;
+        match self {
+            Evaluate(program) => {
+                eprintln!("{}", program);
+                test_program::eval(program).unwrap();
+            }
+            ParseExtended(program) => {
+                eprintln!("{}", program);
+                test_program::parse_extended(&program).unwrap();
+            }
+        }
+    }
+}
+
+fn nickel_code_blocks<'a>(document: &'a AstNode<'a>) -> impl Iterator<Item = CodeBlock> + 'a {
+    document.traverse().filter_map(|ne| match ne {
+        NodeEdge::Start(Node { data, .. }) => match &*data.borrow() {
+            Ast {
+                value: NodeValue::CodeBlock(NodeCodeBlock { info, literal, .. }),
+                ..
+            } => Some(CodeBlock {
+                typ: CodeBlockType::from_info(info)?,
+                content: literal.clone(),
+            }),
+            _ => None,
+        },
+        _ => None,
+    })
+}
+
+#[test_resources("doc/manual/*.md")]
+fn check_manual_snippets(path: &str) {
+    let contents = read_to_string(File::open(project_root().join(path)).unwrap()).unwrap();
+    let arena = Arena::new();
+    let snippets = nickel_code_blocks(parse_document(&arena, &contents, &ComrakOptions::default()));
+
+    for code_block in snippets {
+        code_block.check();
+    }
+    panic!();
+}

--- a/doc/manual/contracts.md
+++ b/doc/manual/contracts.md
@@ -19,8 +19,8 @@ using the `|` operator:
 let x = (1 + 1 | Number) in x
 ```
 
-Contracts can also be attached to identifiers in a definition. In let bindings,
-the following is equivalent to the previous example:
+Contracts can also be attached to identifiers in a let binding.
+The following is equivalent to the previous example:
 
 ```nickel
 let x | Number = 1 + 1 in x
@@ -104,7 +104,7 @@ In `IsFoo`, we first test if the value is a string, and then if it is equal to
 appropriate error messages. Let us try:
 
 ```nickel-repl
-nickel> 1 | IsFoo
+> 1 | IsFoo
 error: contract broken by a value [not a string].
 [..]
 

--- a/doc/manual/contracts.md
+++ b/doc/manual/contracts.md
@@ -44,7 +44,7 @@ are performed:
 2. Check that the result is a number.
 3. If it is, return the expression unchanged. Otherwise, raise an error.
 
-```nickel-repl
+```nickel #repl
 > 1 + 1 | Number
 2
 
@@ -91,7 +91,7 @@ the label to customize error reporting upon failure using the functions
 from `std.contract.label`, which set various attributes of the label.
 `std.contract.blame_with_message message label` is just shorthand for:
 
-```nickel-parse
+```nickel #parse
 label
 |> std.contract.label.with_message message
 |> std.contract.blame
@@ -103,7 +103,7 @@ In `IsFoo`, we first test if the value is a string, and then if it is equal to
 `"foo"`, in which case the contract succeeds. Otherwise, the contract fails with
 appropriate error messages. Let us try:
 
-```nickel-repl
+```nickel #repl
 > 1 | IsFoo
 error: contract broken by a value [not a string].
 [..]
@@ -357,7 +357,7 @@ In addition to defining the contracts of fields, record contracts can also
 attach metadata (see [merging](./merging.md)) to fields, such as documentation
 or default values:
 
-```nickel-repl
+```nickel #repl
 > let Schema = {
     foo
       | doc "This documentation will propagate to the final value!"
@@ -386,7 +386,7 @@ or default values:
 
 By default, record contracts are closed, meaning that additional fields are forbidden:
 
-```nickel-repl
+```nickel #repl
 > let Contract = {foo | String}
 
 > {foo = "a", bar = 1} | Contract
@@ -397,7 +397,7 @@ error: contract broken by a value [extra field `bar`].
 If you want to allow additional fields, append `, ..` after the last field
 definition to define an open contract:
 
-```nickel-repl
+```nickel #repl
 > let Contract = {foo | String, ..}
 
 > {foo = "a", bar = 1} | Contract
@@ -412,7 +412,7 @@ contract or a normal value. If a field is defined both in the contract and the
 checked value, the two definitions will be merged in the final result. For
 example:
 
-```nickel-repl
+```nickel #repl
 > let Secure = {
     must_be_very_secure | Bool = true,
     data | String,
@@ -455,7 +455,7 @@ fields: thus, the contract `{bar | String}` attached to `foo` will actually
 behave like an open contract, even if you didn't use `..`. This might or might not
 be what you want:
 
-```nickel-repl
+```nickel #repl
 > let ContractPipe = {
     sub_field | {foo | String}
   }
@@ -487,7 +487,7 @@ system](./typing.md) can be used to combine contracts.
 An array contract checks that the value is an array and applies its parameter
 contract to each element:
 
-```nickel-repl
+```nickel #repl
 > let VeryBig =
   std.contract.from_predicate (
       fun value =>
@@ -518,7 +518,7 @@ for the return value of the function.
 Function contracts, as opposed to a contract like `Number`, have the peculiarity
 of involving two parties. For example:
 
-```nickel-no-check
+```nickel #no-check
 let add_semi | String -> String = fun x => x ++ ";" in
 add_semi 1
 
@@ -543,7 +543,7 @@ is a bug you have to fix.
 The interpreter automatically performs bookkeeping for function contracts in
 order to make this caller/callee distinction:
 
-```nickel-repl
+```nickel #repl
 > let add_semi | String -> String = fun x => x ++ ";" in
   add_semi 1
 error: contract broken by the caller.
@@ -561,7 +561,7 @@ The beauty of function contracts is that they gracefully scale to higher-order
 functions as well. Higher-order functions are functions that take other
 functions as parameters. Here is an example:
 
-```nickel-repl
+```nickel #repl
 > let apply_fun | (Number -> Number) -> Number = fun f => f 0 in
   apply_fun (fun x => "a")
 error: contract broken by the caller
@@ -583,7 +583,7 @@ not constrained but whose field values must satisfy `Contract`. In practice,
 records as an extensible dictionary, that is a key/value store, where keys are
 strings and values satisfy `Contract`, for example:
 
-```nickel-repl
+```nickel #repl
 > let occurrences | {_: Number} = {a = 2, b = 3, "!" = 5, "^" = 1} in
   occurrences."!"
 5
@@ -608,7 +608,7 @@ laziness, you can for example query specific information on a large
 configuration without having to actually evaluate everything. We will use the
 always failing contract `std.FailWith` to observe where evaluation takes place:
 
-```nickel-repl
+```nickel #repl
 > let config = {
     fail | std.FailWith "ooch" = null,
     data | doc "Some information" = 42
@@ -689,7 +689,7 @@ iterate through the array without building up anything interesting.
 
 For laziness, the interesting bit happens here:
 
-```nickel-parse
+```nickel #parse
 value
 |> std.record.map
   (
@@ -717,7 +717,7 @@ value and continues with the second argument (here, our wrapped `value`).
 
 Let us see if we indeed preserved laziness:
 
-```nickel-repl
+```nickel #repl
 > let config | NumberBoolDict = {
     "1" | std.FailWith "ooch" = null, # same as our previous "fail"
     "0" | doc "Some information" = true,
@@ -731,7 +731,7 @@ Let us see if we indeed preserved laziness:
 Yes! Our contract doesn't unduly cause the evaluation of the field `"1"`. Does
 it check anything, though?
 
-```nickel-repl
+```nickel #repl
 > let config | NumberBoolDict = {
     not_a_number = false,
     "0" | doc "Some information" = false,

--- a/doc/manual/correctness.md
+++ b/doc/manual/correctness.md
@@ -79,26 +79,26 @@ Types and contracts are enforced similarly, via annotations.
 
 Type annotations are introduced with `:`. For example:
 
-```nickel
-nickel> 1 + 1.5 : Number
+```nickel-repl
+> 1 + 1.5 : Number
 2.5
 
-nickel> let f : Number -> Number = fun x => x + 1
-nickel> f 0
+> let f : Number -> Number = fun x => x + 1
+
+> f 0
 1
 
-nickel> "not a Number" : Number
+> "not a Number" : Number
 error: incompatible types
 [..]
 ```
 
 Contract annotations are introduced with `|`. For example:
 
-```nickel
-nickel> let GreaterThan = fun bound =>
-  std.contract.from_predicate (fun val => val >= bound) in
--1 | GreaterThan 10
-
+```nickel-repl
+> let GreaterThan = fun bound =>
+    std.contract.from_predicate (fun val => val >= bound) in
+  -1 | GreaterThan 10
 error: contract broken by value
 [..]
 ```
@@ -119,15 +119,15 @@ practical differences between types and contracts.
 Suppose we need a function to convert an array of key-value pairs into an array
 of keys and an array of values. Let's call it `split`:
 
-```nickel
-nickel> split [{key = "foo", value = 1}, {key = "bar", value = 2}]
+```nickel-repl
+> split [{key = "foo", value = 1}, {key = "bar", value = 2}]
 {keys = ["foo", "bar"], values = [1, 2]}
 
-nickel> split [
-  {key = "firewall", value = true},
-  {key = "grsec", value = false},
-  {key = "iptables", value = true},
-]
+> split [
+    {key = "firewall", value = true},
+    {key = "grsec", value = false},
+    {key = "iptables", value = true},
+  ]
 { keys: ["firewall", "grsec", "iptables"], values [true, false, true] }
 ```
 
@@ -156,7 +156,7 @@ first wrapping it in an array (note that in real life, you should rather use
 
 We call `split` from our configuration file:
 
-```nickel
+```nickel-parse
 # config.ncl
 let {split} = import "lib.ncl" in
 split [{key = "foo", value = 1}, {key = "bar", value = 2}]
@@ -176,7 +176,7 @@ elements of the same type as the input `value`s.
 An idiomatic way to express these properties in Nickel is to use the following
 annotation:
 
-```nickel
+```nickel-no-check
 forall a. Array {key: String, value: a}
           -> {keys: Array String, values: Array a}
 ```
@@ -191,7 +191,7 @@ using contract and type annotations.
 
 `split` can be given a contract annotation as follows:
 
-```nickel
+```nickel-no-check
 split | forall a. Array {key: String, value: a} -> {keys: Array String, values: Array a} = # etc.
 ```
 
@@ -251,7 +251,7 @@ that:
 
 `split` can be given a type annotation as follows:
 
-```nickel
+```nickel-no-check
 split : forall a. Array {key: String, value: a} -> {keys: Array String, values: Array a} = # etc.
 ```
 
@@ -321,7 +321,7 @@ As in the previous example, we will consider the differences arising when using
 
 If we write:
 
-```nickel
+```nickel-parse
 # config.ncl
 let {OptLevel} = import "lib.ncl" in
 let level = 1 in
@@ -360,7 +360,7 @@ relevant section in the typing documentation].
 For validating custom properties such as `OptLevel`, a contract is the way to
 go:
 
-```nickel
+```nickel-parse
 # config.ncl
 let {OptLevel} = import "lib.ncl" in
 let level = 4 in

--- a/doc/manual/correctness.md
+++ b/doc/manual/correctness.md
@@ -79,7 +79,7 @@ Types and contracts are enforced similarly, via annotations.
 
 Type annotations are introduced with `:`. For example:
 
-```nickel-repl
+```nickel #repl
 > 1 + 1.5 : Number
 2.5
 
@@ -95,7 +95,7 @@ error: incompatible types
 
 Contract annotations are introduced with `|`. For example:
 
-```nickel-repl
+```nickel #repl
 > let GreaterThan = fun bound =>
     std.contract.from_predicate (fun val => val >= bound) in
   -1 | GreaterThan 10
@@ -119,7 +119,7 @@ practical differences between types and contracts.
 Suppose we need a function to convert an array of key-value pairs into an array
 of keys and an array of values. Let's call it `split`:
 
-```nickel-repl
+```nickel #repl
 > split [{key = "foo", value = 1}, {key = "bar", value = 2}]
 {keys = ["foo", "bar"], values = [1, 2]}
 
@@ -156,7 +156,7 @@ first wrapping it in an array (note that in real life, you should rather use
 
 We call `split` from our configuration file:
 
-```nickel-parse
+```nickel #parse
 # config.ncl
 let {split} = import "lib.ncl" in
 split [{key = "foo", value = 1}, {key = "bar", value = 2}]
@@ -176,7 +176,7 @@ elements of the same type as the input `value`s.
 An idiomatic way to express these properties in Nickel is to use the following
 annotation:
 
-```nickel-no-check
+```nickel #no-check
 forall a. Array {key: String, value: a}
           -> {keys: Array String, values: Array a}
 ```
@@ -191,7 +191,7 @@ using contract and type annotations.
 
 `split` can be given a contract annotation as follows:
 
-```nickel-no-check
+```nickel #no-check
 split | forall a. Array {key: String, value: a} -> {keys: Array String, values: Array a} = # etc.
 ```
 
@@ -251,7 +251,7 @@ that:
 
 `split` can be given a type annotation as follows:
 
-```nickel-no-check
+```nickel #no-check
 split : forall a. Array {key: String, value: a} -> {keys: Array String, values: Array a} = # etc.
 ```
 
@@ -321,7 +321,7 @@ As in the previous example, we will consider the differences arising when using
 
 If we write:
 
-```nickel-parse
+```nickel #parse
 # config.ncl
 let {OptLevel} = import "lib.ncl" in
 let level = 1 in
@@ -360,7 +360,7 @@ relevant section in the typing documentation].
 For validating custom properties such as `OptLevel`, a contract is the way to
 go:
 
-```nickel-parse
+```nickel #parse
 # config.ncl
 let {OptLevel} = import "lib.ncl" in
 let level = 4 in

--- a/doc/manual/merging.md
+++ b/doc/manual/merging.md
@@ -51,7 +51,7 @@ evaluates to `{foo = 1, bar = "bar", baz = false}`.
 
 Formally, if we write the left operand as
 
-```nickel-no-check
+```nickel #no-check
 left = {
   field_left_1 = value_left_1,
   ..,
@@ -61,7 +61,7 @@ left = {
 
 and the right operand as
 
-```nickel-no-check
+```nickel #no-check
 right = {
   field_right_1 = value_right_1,
   ..,
@@ -71,7 +71,7 @@ right = {
 
 then the merge `left & right` evaluates to the record:
 
-```nickel-no-check
+```nickel #no-check
 {
   field_left_1 = value_left_1,
   ..,
@@ -90,7 +90,7 @@ In other words, `left & right` is the union of `left` and `right`.
 
 You can split a configuration into subdomains:
 
-```nickel-no-check
+```nickel #no-check
 # file: server.ncl
 {
     host_name = "example",
@@ -126,7 +126,7 @@ This gives:
 
 Given a configuration, you can use merge to add new fields:
 
-```nickel-no-check
+```nickel #no-check
 # file: safe-network.ncl
 let base = import "network.ncl" in
 base & {use_iptables = true}
@@ -170,7 +170,7 @@ unless one of the following condition hold:
 
 Formally, let's write the left operand as
 
-```nickel-no-check
+```nickel #no-check
 left = {
   field_left_1 = value_left_1,
   ..,
@@ -183,7 +183,7 @@ left = {
 
 and the right operand as
 
-```nickel-no-check
+```nickel #no-check
 right = {
   field_right_1 = value_right_1,
   ..,
@@ -197,7 +197,7 @@ right = {
 where the `field_left_i` and `field_right_j` are distinct for all `i` and `j`.
 Then the merge `left & right` evaluates to the record:
 
-```nickel-no-check
+```nickel #no-check
 {
   field_left_1 = value_left_1,
   ..,
@@ -225,7 +225,7 @@ v1 & v2 = v1               if (type_of(v1) is Number, Bool, String, Enum or
 
 ### Example
 
-```nickel-no-check
+```nickel #no-check
 # file: udp.ncl
 {
     # same as firewall = {open_ports = {udp = [...]}},
@@ -325,7 +325,7 @@ optional field also becomes a regular field as soon as it is merged with the
 same field that doesn't have the `optional` annotation. This holds **even if the
 other field doesn't have a definition**:
 
-```nickel-repl
+```nickel #repl
 > {foo = 1, bar | optional} & {bar | optional}
 { foo = 1 }
 
@@ -349,7 +349,7 @@ record operations. Optional fields without a value don't show up in
 `std.record.fields`, they won't make `std.record.values` throw a missing field
 definition error, etc.
 
-```nickel-repl
+```nickel #repl
 > let Contract = {foo = 1, bar | optional}
 > std.record.values Contract
 [ 1 ]
@@ -378,7 +378,7 @@ values are given the priority `0`. Values with the same priority are recursively
 merged as specified in this document, which can mean failure if the values can't
 be meaningfully combined:
 
-```nickel-repl
+```nickel #repl
 > {foo = 1} & {foo = 2}
 error: non mergeable terms
   ┌─ repl-input-1:1:8
@@ -394,7 +394,7 @@ error: non mergeable terms
 If the priorities differ, the value with the highest priority simply erases the
 other:
 
-```nickel-repl
+```nickel #repl
 > {foo | priority 1 = 1} & {foo = 2}
 { foo = 1 }
 
@@ -549,7 +549,7 @@ which is not propagated by merging.
 Consider two operands with one field each, which is the same on both side, and
 respective contracts `Left1, .., Leftn` and `Right1, .., Rightk` attached
 
-```nickel-no-check
+```nickel #no-check
 left = {
   common | Left1
          | ..
@@ -559,7 +559,7 @@ left = {
 
 and
 
-```nickel-no-check
+```nickel #no-check
 right = {
   common | Right1
          | ..
@@ -593,7 +593,7 @@ If we try to observe the intermediate result (`deep_seq` recursively forces the
 evaluation of its first argument and proceeds with evaluating the second
 argument), we do get a contract violation error:
 
-```nickel-no-check
+```nickel #no-check
 let FooContract = {
   required_field1,
   required_field2,

--- a/doc/manual/merging.md
+++ b/doc/manual/merging.md
@@ -51,7 +51,7 @@ evaluates to `{foo = 1, bar = "bar", baz = false}`.
 
 Formally, if we write the left operand as
 
-```nickel
+```nickel-no-check
 left = {
   field_left_1 = value_left_1,
   ..,
@@ -61,7 +61,7 @@ left = {
 
 and the right operand as
 
-```nickel
+```nickel-no-check
 right = {
   field_right_1 = value_right_1,
   ..,
@@ -71,7 +71,7 @@ right = {
 
 then the merge `left & right` evaluates to the record:
 
-```nickel
+```nickel-no-check
 {
   field_left_1 = value_left_1,
   ..,
@@ -90,7 +90,7 @@ In other words, `left & right` is the union of `left` and `right`.
 
 You can split a configuration into subdomains:
 
-```nickel
+```nickel-no-check
 # file: server.ncl
 {
     host_name = "example",
@@ -126,7 +126,7 @@ This gives:
 
 Given a configuration, you can use merge to add new fields:
 
-```nickel
+```nickel-no-check
 # file: safe-network.ncl
 let base = import "network.ncl" in
 base & {use_iptables = true}
@@ -170,7 +170,7 @@ unless one of the following condition hold:
 
 Formally, let's write the left operand as
 
-```nickel
+```nickel-no-check
 left = {
   field_left_1 = value_left_1,
   ..,
@@ -183,7 +183,7 @@ left = {
 
 and the right operand as
 
-```nickel
+```nickel-no-check
 right = {
   field_right_1 = value_right_1,
   ..,
@@ -197,7 +197,7 @@ right = {
 where the `field_left_i` and `field_right_j` are distinct for all `i` and `j`.
 Then the merge `left & right` evaluates to the record:
 
-```nickel
+```nickel-no-check
 {
   field_left_1 = value_left_1,
   ..,
@@ -225,7 +225,7 @@ v1 & v2 = v1               if (type_of(v1) is Number, Bool, String, Enum or
 
 ### Example
 
-```nickel
+```nickel-no-check
 # file: udp.ncl
 {
     # same as firewall = {open_ports = {udp = [...]}},
@@ -301,6 +301,17 @@ contract to - or merging it with - a record which defines a value for this
 field:
 
 ```nickel
+# hide-start
+let Command = {
+    command
+      | String,
+    arg_type
+      | [| 'String, 'Number |],
+    alias
+      | String
+      | optional,
+  } in
+# hide-end
 {
   command = "exit",
   arg_type = 'String,
@@ -314,11 +325,11 @@ optional field also becomes a regular field as soon as it is merged with the
 same field that doesn't have the `optional` annotation. This holds **even if the
 other field doesn't have a definition**:
 
-```nickel
-nickel> {foo = 1, bar | optional} & {bar | optional}
+```nickel-repl
+> {foo = 1, bar | optional} & {bar | optional}
 { foo = 1 }
 
-nickel> {foo = 1, bar | optional} & {bar}
+> {foo = 1, bar | optional} & {bar}
 error: missing definition for `bar`
   ┌─ repl-input-0:1:11
   │
@@ -338,12 +349,12 @@ record operations. Optional fields without a value don't show up in
 `std.record.fields`, they won't make `std.record.values` throw a missing field
 definition error, etc.
 
-```nickel
-nickel> let Contract = {foo = 1, bar | optional}
-nickel> std.record.values Contract
+```nickel-repl
+> let Contract = {foo = 1, bar | optional}
+> std.record.values Contract
 [ 1 ]
 
-nickel> std.record.has_field "bar" Contract
+> std.record.has_field "bar" Contract
 false
 ```
 
@@ -367,8 +378,8 @@ values are given the priority `0`. Values with the same priority are recursively
 merged as specified in this document, which can mean failure if the values can't
 be meaningfully combined:
 
-```nickel
-nickel> {foo = 1} & {foo = 2}
+```nickel-repl
+> {foo = 1} & {foo = 2}
 error: non mergeable terms
   ┌─ repl-input-1:1:8
   │
@@ -383,11 +394,11 @@ error: non mergeable terms
 If the priorities differ, the value with the highest priority simply erases the
 other:
 
-```nickel
-nickel> {foo | priority 1 = 1} & {foo = 2}
+```nickel-repl
+> {foo | priority 1 = 1} & {foo = 2}
 { foo = 1 }
 
-nickel> {foo | priority -1 = 1} & {foo = 2}
+> {foo | priority -1 = 1} & {foo = 2}
 { foo = 2 }
 ```
 
@@ -538,7 +549,7 @@ which is not propagated by merging.
 Consider two operands with one field each, which is the same on both side, and
 respective contracts `Left1, .., Leftn` and `Right1, .., Rightk` attached
 
-```nickel
+```nickel-no-check
 left = {
   common | Left1
          | ..
@@ -548,7 +559,7 @@ left = {
 
 and
 
-```nickel
+```nickel-no-check
 right = {
   common | Right1
          | ..
@@ -582,7 +593,7 @@ If we try to observe the intermediate result (`deep_seq` recursively forces the
 evaluation of its first argument and proceeds with evaluating the second
 argument), we do get a contract violation error:
 
-```nickel
+```nickel-no-check
 let FooContract = {
   required_field1,
   required_field2,
@@ -723,7 +734,7 @@ query `foo` by running `nickel -f config.ncl query foo` on:
 # config.ncl
 {
   foo | doc "Some documentation"
-      | = {}
+      | default = {}
 } & {
   foo.field = null,
 }

--- a/doc/manual/syntax.md
+++ b/doc/manual/syntax.md
@@ -42,7 +42,7 @@ precision as well, for example when serializing `1/3`.
 Here are some examples of number literals in Nickel; scientific notation for
 decimal is supported:
 
-```nickel lines
+```nickel-lines
 1
 0.543
 1.7e217
@@ -95,7 +95,7 @@ evaluates to `false`.
 
 Here are some examples of boolean operators in Nickel:
 
-```nickel repl
+```nickel-repl
 > true && false
 false
 
@@ -119,7 +119,7 @@ The string interpolation syntax is
 
 Here are some examples of string handling in Nickel:
 
-```nickel repl
+```nickel-repl
 > "Hello, World!"
 "Hello, World!"
 
@@ -147,7 +147,7 @@ present on all lines of the string is stripped. This way, multiline strings can
 be indented for nicer code formatting without producing unwanted whitespaces in
 the output. For example:
 
-```nickel repl
+```nickel-repl
 > m%"
     This line has no indentation.
       This line is indented.
@@ -162,7 +162,7 @@ This line has no more indentation."
 
 The only special sequence in a multiline string is the string interpolation:
 
-```nickel repl
+```nickel-repl
 > m%"Multiline\nString?"%
 "Multiline\nString?"
 
@@ -177,7 +177,7 @@ delimiter. If you want to use string interpolation, you must use the same amount
 of `%` signs as in the delimiters. This can be useful for writing a literal `"%`
 or `%{` sequence in a string without escaping:
 
-```nickel repl
+```nickel-repl
 > m%%"Hello World"%%
 "Hello World"
 
@@ -194,7 +194,7 @@ or `%{` sequence in a string without escaping:
 Multiline string interpolation is "indentation-aware". This means that you can
 interpolate a string with indentation and the result will be as expected:
 
-```nickel repl
+```nickel-repl
 > let log = m%"
   if log:
     print("log:", s)
@@ -221,7 +221,7 @@ potential string literal prefix `"%..%` followed by an interpolation sequence
 opening delimiter, **even if the leading `"%..%` could also act as a string end
 delimiter**:
 
-```nickel repl
+```nickel-repl
 > let msg = "Hello, world!" in m%"
     echo "%{msg}"
   "%
@@ -304,7 +304,7 @@ which uses symbolic strings, remember that:
 
 The following examples show how symbolic strings are desugared:
 
-```nickel repl
+```nickel-repl
 > mytag-s%"I'm %{"symbolic"} with %{"fragments"}"%
 {
   tag = 'SymbolicString,
@@ -333,7 +333,7 @@ They are formed by writing a single quote `'` followed by any valid identifier
 or by a quoted string. For example, `std.serialize` takes an export format as a
 first argument, which is an enum tag among `'Json`, `'Toml` or `'Yaml`:
 
-```nickel repl
+```nickel-repl
 > std.serialize 'Json {foo = 1}
 "{
    \"foo\": 1
@@ -346,7 +346,7 @@ first argument, which is an enum tag among `'Json`, `'Toml` or `'Yaml`:
 
 An enum tag `'foo` is serialized as the string `"foo"`:
 
-```nickel repl
+```nickel-repl
 > std.serialize 'Json {foo = 'bar}
 "{
   \"foo\": \"bar\"
@@ -368,7 +368,7 @@ types are never equal: that is, `==` doesn't perform implicit conversions.
 
 Here are some examples of equality comparisons in Nickel:
 
-```nickel repl
+```nickel-repl
 > 1 == 1
 true
 
@@ -397,7 +397,7 @@ elements are separated with `,`.
 
 The following are valid Nickel arrays, for example:
 
-```nickel lines
+```nickel-lines
 [1, 2, 3]
 ["Hello", "World"]
 [1, true, "true"]
@@ -406,7 +406,7 @@ The following are valid Nickel arrays, for example:
 
 Arrays can be concatenated with the operator `@`:
 
-```nickel repl
+```nickel-repl
 > [1] @ [2, 3]
 [ 1, 2, 3 ]
 ```
@@ -423,7 +423,7 @@ merging in the [section on merging](./merging.md).
 
 Here are some valid Nickel records:
 
-```nickel lines
+```nickel-lines
 {}
 {a = 3}
 {my_id_n5 = "my id number 5", "my id n4" = "my id number 4" }
@@ -432,7 +432,7 @@ Here are some valid Nickel records:
 
 Record fields can be accessed using the `.` operator :
 
-```nickel repl
+```nickel-repl
 > { a = 1, b = 5 }.a
 1
 
@@ -446,7 +446,7 @@ error: Missing field
 It is possible to write records of records via *piecewise syntax*, where we
 separate fields by dots:
 
-```nickel repl
+```nickel-repl
 > { a = { b = 1 } }
 { a = { b = 1 } }
 
@@ -460,7 +460,7 @@ separate fields by dots:
 When fields are enclosed in double quotes (`"`), you can use string
 interpolation to create or access fields:
 
-```nickel repl
+```nickel-repl
 > let k = "a" in { "%{k}" = 1 }
 { a = 1 }
 
@@ -477,7 +477,7 @@ This construct allows conditional branching in your code. You can use it like
 
 Here are some valid conditional expressions in Nickel:
 
-```nickel repl
+```nickel-repl
 > if true then "TRUE :)" else "false :("
 "TRUE :)"
 
@@ -501,7 +501,7 @@ Currently, only a single variable can be bound per let binding.
 
 Here are some examples of let bindings in Nickel:
 
-```nickel repl
+```nickel-repl
 > let r = { a = "a", b = "b" } in r.a
 "a"
 
@@ -533,7 +533,7 @@ arguments, and so on.
 
 Here are some examples of function definitions in Nickel:
 
-```nickel repl
+```nickel-repl
 > (fun a b => a + b) 1 2
 3
 
@@ -549,7 +549,7 @@ Here are some examples of function definitions in Nickel:
 All existing infix operators in Nickel can be turned into functions by putting
 them inside parentheses, for example:
 
-```nickel repl
+```nickel-repl
 > 1 + 2
 3
 
@@ -573,7 +573,7 @@ Functions may be composed using the *pipe operator*. The pipe operator allows
 for a function application `f x` to be written as `x |> f`. This operator is
 left-associative, so `x |> f |> g` will be interpreted as `g (f x)`. For example:
 
-```nickel repl
+```nickel-repl
 > "Hello World" |> std.string.split " "
 ["Hello", "World"]
 
@@ -611,7 +611,7 @@ expression without having to come up with a type.
 
 Here are some examples of type annotations in Nickel:
 
-```nickel repl
+```nickel-repl
 > 5 : Number
 5
 
@@ -647,7 +647,7 @@ syntactically all the same and can be arbitrary Nickel expressions in practice.
 
 Here are some examples of contract annotations in Nickel:
 
-```nickel repl
+```nickel-repl
 > 5 | Number
 5
 
@@ -713,7 +713,7 @@ Type variables bound by a `forall` are only visible inside types (any of the
 constructor listed above). As soon as a term expression appears under a `forall`
 binder, the type variables aren't in scope anymore:
 
-```nickel repl
+```nickel-repl
 > forall a. a -> (a -> a) -> {_ : {foo : a}}
 <func>
 
@@ -727,7 +727,7 @@ error: unbound identifier
 
 Here are some examples of more complicated types in Nickel:
 
-```nickel repl
+```nickel-repl
 > let f : forall a. a -> a = fun x => x in (f 5 : Number)
 5
 
@@ -787,7 +787,7 @@ is a parse error.
 
 Here are some examples of record types in Nickel:
 
-```nickel repl
+```nickel-repl
 > {foo = 1, bar = "foo" } : {foo : Number, bar: String}
 { bar = "foo", foo = 1 }
 
@@ -799,7 +799,7 @@ Here, the right-hand side is missing a type annotation for `baz`, so it doesn't
 qualify as a record type and is parsed as a record contract. This throws an
 "incompatible types" error:
 
-```nickel repl
+```nickel-repl
 > {foo = 1, bar = "foo" } : {foo : Number, bar : String, baz : Bool}
 error: type error: missing row `baz`
   ┌─ <repl-input-0:1:1
@@ -815,7 +815,7 @@ If there's a metadata annotation apart from the type, the record cannot be
 parsed as a type. Consequently, it is considered a record contract and converted
 into an opaque type, yielding an error:
 
-```nickel repl parse-error
+```nickel-no-check
 > {foo = 1, bar = "foo" } : {foo : Number, bar : String | optional}
 error: incompatible types
 [..]
@@ -825,7 +825,7 @@ While in the following `MyDyn` isn't a proper type, the record literal `{foo :
 Number, bar : MyDyn}` respects all the requirements for a record type and is
 parsed as such:
 
-```nickel repl
+```nickel-repl
 > let MyDyn = fun label value => value in
     {foo = 1, bar | MyDyn = "foo"} : {foo : Number, bar : MyDyn}
 { bar = "foo", foo = 1 }
@@ -841,12 +841,14 @@ is introduced with the syntax `<field_name> | <metadata1> | .. | <metadataN>
 
 Documentation can be attached with `| doc <string>`. For example:
 
-```nickel repl
+```nickel-repl
 > let record = {
     value
       | doc "The number five"
       | default = 5
   }
+
+# Stop `core/tests/manual` from parsing this hide-line
 > :query record value
 • default: 5
 • documentation: The number five
@@ -877,7 +879,7 @@ about this in the [dedicated section on merging](./merging.md).
 
 Here are some examples using merge priorities in Nickel:
 
-```nickel repl
+```nickel-repl
 > let Ais2ByDefault = { a | default = 2 } in
     {} | Ais2ByDefault
 { a = 2 }
@@ -905,7 +907,7 @@ Here are some examples using merge priorities in Nickel:
 The `optional` annotation indicates that a field is not mandatory. It is usually
 found in record contracts.
 
-```nickel repl
+```nickel-repl
 > let Contract = {
     foo | Num,
     bar | Num
@@ -923,7 +925,7 @@ error: missing definition for `foo`
 The `not_exported` annotation indicates that a field should be skipped when a
 record is serialized. This includes the output of the `nickel export` command:
 
-```nickel repl
+```nickel-repl
 > let value = { foo = 1, bar | not_exported = 2}
 > value
 { foo = 1, bar = 2 }

--- a/doc/manual/syntax.md
+++ b/doc/manual/syntax.md
@@ -42,7 +42,7 @@ precision as well, for example when serializing `1/3`.
 Here are some examples of number literals in Nickel; scientific notation for
 decimal is supported:
 
-```nickel
+```nickel lines
 1
 0.543
 1.7e217
@@ -95,7 +95,7 @@ evaluates to `false`.
 
 Here are some examples of boolean operators in Nickel:
 
-```nickel
+```nickel repl
 > true && false
 false
 
@@ -119,12 +119,12 @@ The string interpolation syntax is
 
 Here are some examples of string handling in Nickel:
 
-```nickel
+```nickel repl
 > "Hello, World!"
 "Hello, World!"
 
 > m%"Well, if this isn't a multiline string?
-Yes it is, indeed it is"%
+  Yes it is, indeed it is"%
 "Well, if this isn't a multiline string?
 Yes it is, indeed it is"
 
@@ -147,13 +147,13 @@ present on all lines of the string is stripped. This way, multiline strings can
 be indented for nicer code formatting without producing unwanted whitespaces in
 the output. For example:
 
-```nickel
+```nickel repl
 > m%"
-  This line has no indentation.
-    This line is indented.
-      This line is even more indented.
-  This line has no more indentation.
-"%
+    This line has no indentation.
+      This line is indented.
+        This line is even more indented.
+    This line has no more indentation.
+  "%
 "This line has no indentation.
   This line is indented.
     This line is even more indented.
@@ -162,7 +162,7 @@ This line has no more indentation."
 
 The only special sequence in a multiline string is the string interpolation:
 
-```nickel
+```nickel repl
 > m%"Multiline\nString?"%
 "Multiline\nString?"
 
@@ -177,7 +177,7 @@ delimiter. If you want to use string interpolation, you must use the same amount
 of `%` signs as in the delimiters. This can be useful for writing a literal `"%`
 or `%{` sequence in a string without escaping:
 
-```nickel
+```nickel repl
 > m%%"Hello World"%%
 "Hello World"
 
@@ -194,7 +194,7 @@ or `%{` sequence in a string without escaping:
 Multiline string interpolation is "indentation-aware". This means that you can
 interpolate a string with indentation and the result will be as expected:
 
-```nickel
+```nickel repl
 > let log = m%"
   if log:
     print("log:", s)
@@ -221,7 +221,7 @@ potential string literal prefix `"%..%` followed by an interpolation sequence
 opening delimiter, **even if the leading `"%..%` could also act as a string end
 delimiter**:
 
-```nickel
+```nickel repl
 > let msg = "Hello, world!" in m%"
     echo "%{msg}"
   "%
@@ -248,6 +248,7 @@ a string syntax would still feel natural.
 That is precisely the use-case for symbolic strings:
 
 ```nickel
+let inputs = { gcc = "", hello = "", coreutils = "" } in # hide-line
 {
   args = [
       "-c",
@@ -303,7 +304,7 @@ which uses symbolic strings, remember that:
 
 The following examples show how symbolic strings are desugared:
 
-```nickel
+```nickel repl
 > mytag-s%"I'm %{"symbolic"} with %{"fragments"}"%
 {
   tag = 'SymbolicString,
@@ -316,6 +317,7 @@ The following examples show how symbolic strings are desugared:
     resource = "foo",
     field = "id",
   }
+
 > tf-s%"id: %{terraform_computed_field}, port: %{5}"%
 {
   tag = 'SymbolicString
@@ -331,7 +333,7 @@ They are formed by writing a single quote `'` followed by any valid identifier
 or by a quoted string. For example, `std.serialize` takes an export format as a
 first argument, which is an enum tag among `'Json`, `'Toml` or `'Yaml`:
 
-```nickel
+```nickel repl
 > std.serialize 'Json {foo = 1}
 "{
    \"foo\": 1
@@ -344,7 +346,7 @@ first argument, which is an enum tag among `'Json`, `'Toml` or `'Yaml`:
 
 An enum tag `'foo` is serialized as the string `"foo"`:
 
-```nickel
+```nickel repl
 > std.serialize 'Json {foo = 'bar}
 "{
   \"foo\": \"bar\"
@@ -366,7 +368,7 @@ types are never equal: that is, `==` doesn't perform implicit conversions.
 
 Here are some examples of equality comparisons in Nickel:
 
-```nickel
+```nickel repl
 > 1 == 1
 true
 
@@ -395,7 +397,7 @@ elements are separated with `,`.
 
 The following are valid Nickel arrays, for example:
 
-```nickel
+```nickel lines
 [1, 2, 3]
 ["Hello", "World"]
 [1, true, "true"]
@@ -404,7 +406,7 @@ The following are valid Nickel arrays, for example:
 
 Arrays can be concatenated with the operator `@`:
 
-```nickel
+```nickel repl
 > [1] @ [2, 3]
 [ 1, 2, 3 ]
 ```
@@ -421,7 +423,7 @@ merging in the [section on merging](./merging.md).
 
 Here are some valid Nickel records:
 
-```nickel
+```nickel lines
 {}
 {a = 3}
 {my_id_n5 = "my id number 5", "my id n4" = "my id number 4" }
@@ -430,7 +432,7 @@ Here are some valid Nickel records:
 
 Record fields can be accessed using the `.` operator :
 
-```nickel
+```nickel repl
 > { a = 1, b = 5 }.a
 1
 
@@ -444,7 +446,7 @@ error: Missing field
 It is possible to write records of records via *piecewise syntax*, where we
 separate fields by dots:
 
-```nickel
+```nickel repl
 > { a = { b = 1 } }
 { a = { b = 1 } }
 
@@ -458,7 +460,7 @@ separate fields by dots:
 When fields are enclosed in double quotes (`"`), you can use string
 interpolation to create or access fields:
 
-```nickel
+```nickel repl
 > let k = "a" in { "%{k}" = 1 }
 { a = 1 }
 
@@ -475,7 +477,7 @@ This construct allows conditional branching in your code. You can use it like
 
 Here are some valid conditional expressions in Nickel:
 
-```nickel
+```nickel repl
 > if true then "TRUE :)" else "false :("
 "TRUE :)"
 
@@ -499,7 +501,7 @@ Currently, only a single variable can be bound per let binding.
 
 Here are some examples of let bindings in Nickel:
 
-```nickel
+```nickel repl
 > let r = { a = "a", b = "b" } in r.a
 "a"
 
@@ -531,7 +533,7 @@ arguments, and so on.
 
 Here are some examples of function definitions in Nickel:
 
-```nickel
+```nickel repl
 > (fun a b => a + b) 1 2
 3
 
@@ -547,7 +549,7 @@ Here are some examples of function definitions in Nickel:
 All existing infix operators in Nickel can be turned into functions by putting
 them inside parentheses, for example:
 
-```nickel
+```nickel repl
 > 1 + 2
 3
 
@@ -571,7 +573,7 @@ Functions may be composed using the *pipe operator*. The pipe operator allows
 for a function application `f x` to be written as `x |> f`. This operator is
 left-associative, so `x |> f |> g` will be interpreted as `g (f x)`. For example:
 
-```nickel
+```nickel repl
 > "Hello World" |> std.string.split " "
 ["Hello", "World"]
 
@@ -609,7 +611,7 @@ expression without having to come up with a type.
 
 Here are some examples of type annotations in Nickel:
 
-```nickel
+```nickel repl
 > 5 : Number
 5
 
@@ -645,7 +647,7 @@ syntactically all the same and can be arbitrary Nickel expressions in practice.
 
 Here are some examples of contract annotations in Nickel:
 
-```nickel
+```nickel repl
 > 5 | Number
 5
 
@@ -654,11 +656,11 @@ error: contract broken by a value.
 [..]
 
 > let SmallNumber = std.contract.from_predicate (fun x => x < 5) in
-1 | SmallNumber
+  1 | SmallNumber
 1
 
 > let SmallNumber = std.contract.from_predicate (fun x => x < 5) in
-10 | SmallNumber
+  10 | SmallNumber
 error: contract broken by a value.
 [..]
 
@@ -711,7 +713,7 @@ Type variables bound by a `forall` are only visible inside types (any of the
 constructor listed above). As soon as a term expression appears under a `forall`
 binder, the type variables aren't in scope anymore:
 
-```nickel
+```nickel repl
 > forall a. a -> (a -> a) -> {_ : {foo : a}}
 <func>
 
@@ -725,7 +727,7 @@ error: unbound identifier
 
 Here are some examples of more complicated types in Nickel:
 
-```nickel
+```nickel repl
 > let f : forall a. a -> a = fun x => x in (f 5 : Number)
 5
 
@@ -745,8 +747,8 @@ true
 
 > let add_foo : forall a. {_: a} -> a -> {_: a} = fun dict value =>
     record.insert "foo" value dict
-in
-add_foo {bar = 1} 5 : _
+  in
+  add_foo {bar = 1} 5 : _
 { bar = 1, foo = 5 }
 
 > {foo = 1, bar = "string"} : {_ : Number}
@@ -785,7 +787,7 @@ is a parse error.
 
 Here are some examples of record types in Nickel:
 
-```nickel
+```nickel repl
 > {foo = 1, bar = "foo" } : {foo : Number, bar: String}
 { bar = "foo", foo = 1 }
 
@@ -797,24 +799,23 @@ Here, the right-hand side is missing a type annotation for `baz`, so it doesn't
 qualify as a record type and is parsed as a record contract. This throws an
 "incompatible types" error:
 
-```nickel
-> {foo = 1, bar = "foo" } : {foo : Number, bar : String, baz}
-error: incompatible types
-  ┌─ repl-input-6:1:1
+```nickel repl
+> {foo = 1, bar = "foo" } : {foo : Number, bar : String, baz : Bool}
+error: type error: missing row `baz`
+  ┌─ <repl-input-0:1:1
   │
-1 │ {foo = 1, bar = "foo" } : {foo : Number, bar : String, baz}
+1 │ {foo = 1, bar = "foo" } : {foo : Number, bar : String, baz : Bool}
   │ ^^^^^^^^^^^^^^^^^^^^^^^ this expression
   │
-  = The type of the expression was expected to be `{ bar : String, baz, foo : Numb…` (a contract)
-  = The type of the expression was inferred to be `{bar: _a, foo: _b}`
-  = Static types and contracts are not compatible
+  = Expected an expression of type `{ foo : Number, bar : String, baz : Bool }`, which contains the field `baz`
+  = Found an expression of type `{ bar : String, foo : Number }`, which does not contain the field `baz`
 ```
 
 If there's a metadata annotation apart from the type, the record cannot be
 parsed as a type. Consequently, it is considered a record contract and converted
 into an opaque type, yielding an error:
 
-```nickel
+```nickel repl parse-error
 > {foo = 1, bar = "foo" } : {foo : Number, bar : String | optional}
 error: incompatible types
 [..]
@@ -824,7 +825,7 @@ While in the following `MyDyn` isn't a proper type, the record literal `{foo :
 Number, bar : MyDyn}` respects all the requirements for a record type and is
 parsed as such:
 
-```nickel
+```nickel repl
 > let MyDyn = fun label value => value in
     {foo = 1, bar | MyDyn = "foo"} : {foo : Number, bar : MyDyn}
 { bar = "foo", foo = 1 }
@@ -840,7 +841,7 @@ is introduced with the syntax `<field_name> | <metadata1> | .. | <metadataN>
 
 Documentation can be attached with `| doc <string>`. For example:
 
-```nickel
+```nickel repl
 > let record = {
     value
       | doc "The number five"
@@ -876,7 +877,7 @@ about this in the [dedicated section on merging](./merging.md).
 
 Here are some examples using merge priorities in Nickel:
 
-```nickel
+```nickel repl
 > let Ais2ByDefault = { a | default = 2 } in
     {} | Ais2ByDefault
 { a = 2 }
@@ -904,7 +905,7 @@ Here are some examples using merge priorities in Nickel:
 The `optional` annotation indicates that a field is not mandatory. It is usually
 found in record contracts.
 
-```nickel
+```nickel repl
 > let Contract = {
     foo | Num,
     bar | Num
@@ -922,7 +923,7 @@ error: missing definition for `foo`
 The `not_exported` annotation indicates that a field should be skipped when a
 record is serialized. This includes the output of the `nickel export` command:
 
-```nickel
+```nickel repl
 > let value = { foo = 1, bar | not_exported = 2}
 > value
 { foo = 1, bar = 2 }

--- a/doc/manual/syntax.md
+++ b/doc/manual/syntax.md
@@ -42,7 +42,7 @@ precision as well, for example when serializing `1/3`.
 Here are some examples of number literals in Nickel; scientific notation for
 decimal is supported:
 
-```nickel-lines
+```nickel #lines
 1
 0.543
 1.7e217
@@ -95,7 +95,7 @@ evaluates to `false`.
 
 Here are some examples of boolean operators in Nickel:
 
-```nickel-repl
+```nickel #repl
 > true && false
 false
 
@@ -119,7 +119,7 @@ The string interpolation syntax is
 
 Here are some examples of string handling in Nickel:
 
-```nickel-repl
+```nickel #repl
 > "Hello, World!"
 "Hello, World!"
 
@@ -146,7 +146,7 @@ present on all lines of the string is stripped. This way, multiline strings can
 be indented for nicer code formatting without producing unwanted whitespaces in
 the output. For example:
 
-```nickel-repl
+```nickel #repl
 > m%"
     This line has no indentation.
       This line is indented.
@@ -161,7 +161,7 @@ This line has no more indentation."
 
 The only special sequence in a multiline string is the string interpolation:
 
-```nickel-repl
+```nickel #repl
 > m%"Multiline\nString?"%
 "Multiline\\nString?"
 
@@ -176,7 +176,7 @@ delimiter. If you want to use string interpolation, you must use the same amount
 of `%` signs as in the delimiters. This can be useful for writing a literal `"%`
 or `%{` sequence in a string without escaping:
 
-```nickel-repl
+```nickel #repl
 > m%%"Hello World"%%
 "Hello World"
 
@@ -193,7 +193,7 @@ or `%{` sequence in a string without escaping:
 Multiline string interpolation is "indentation-aware". This means that you can
 interpolate a string with indentation and the result will be as expected:
 
-```nickel-repl
+```nickel #repl
 > let log = m%"
   if log:
     print("log:", s)
@@ -220,7 +220,7 @@ potential string literal prefix `"%..%` followed by an interpolation sequence
 opening delimiter, **even if the leading `"%..%` could also act as a string end
 delimiter**:
 
-```nickel-repl
+```nickel #repl
 > let msg = "Hello, world!" in m%"
     echo "%{msg}"
   "%
@@ -303,7 +303,7 @@ which uses symbolic strings, remember that:
 
 The following examples show how symbolic strings are desugared:
 
-```nickel-repl
+```nickel #repl
 > mytag-s%"I'm %{"symbolic"} with %{"fragments"}"%
 {
   tag = 'SymbolicString,
@@ -332,7 +332,7 @@ They are formed by writing a single quote `'` followed by any valid identifier
 or by a quoted string. For example, `std.serialize` takes an export format as a
 first argument, which is an enum tag among `'Json`, `'Toml` or `'Yaml`:
 
-```nickel-repl
+```nickel #repl
 > std.serialize 'Json {foo = 1}
 "{
    \"foo\": 1
@@ -345,7 +345,7 @@ first argument, which is an enum tag among `'Json`, `'Toml` or `'Yaml`:
 
 An enum tag `'foo` is serialized as the string `"foo"`:
 
-```nickel-repl
+```nickel #repl
 > std.serialize 'Json {foo = 'bar}
 "{
   \"foo\": \"bar\"
@@ -367,7 +367,7 @@ types are never equal: that is, `==` doesn't perform implicit conversions.
 
 Here are some examples of equality comparisons in Nickel:
 
-```nickel-repl
+```nickel #repl
 > 1 == 1
 true
 
@@ -396,7 +396,7 @@ elements are separated with `,`.
 
 The following are valid Nickel arrays, for example:
 
-```nickel-lines
+```nickel #lines
 [1, 2, 3]
 ["Hello", "World"]
 [1, true, "true"]
@@ -405,7 +405,7 @@ The following are valid Nickel arrays, for example:
 
 Arrays can be concatenated with the operator `@`:
 
-```nickel-repl
+```nickel #repl
 > [1] @ [2, 3]
 [ 1, 2, 3 ]
 ```
@@ -422,7 +422,7 @@ merging in the [section on merging](./merging.md).
 
 Here are some valid Nickel records:
 
-```nickel-lines
+```nickel #lines
 {}
 {a = 3}
 {my_id_n5 = "my id number 5", "my id n4" = "my id number 4" }
@@ -431,7 +431,7 @@ Here are some valid Nickel records:
 
 Record fields can be accessed using the `.` operator :
 
-```nickel-repl
+```nickel #repl
 > { a = 1, b = 5 }.a
 1
 
@@ -445,7 +445,7 @@ error: Missing field
 It is possible to write records of records via *piecewise syntax*, where we
 separate fields by dots:
 
-```nickel-repl
+```nickel #repl
 > { a = { b = 1 } }
 { a = { b = 1 } }
 
@@ -459,7 +459,7 @@ separate fields by dots:
 When fields are enclosed in double quotes (`"`), you can use string
 interpolation to create or access fields:
 
-```nickel-repl
+```nickel #repl
 > let k = "a" in { "%{k}" = 1 }
 { a = 1 }
 
@@ -476,7 +476,7 @@ This construct allows conditional branching in your code. You can use it like
 
 Here are some valid conditional expressions in Nickel:
 
-```nickel-repl
+```nickel #repl
 > if true then "TRUE :)" else "false :("
 "TRUE :)"
 
@@ -500,7 +500,7 @@ Currently, only a single variable can be bound per let binding.
 
 Here are some examples of let bindings in Nickel:
 
-```nickel-repl
+```nickel #repl
 > let r = { a = "a", b = "b" } in r.a
 "a"
 
@@ -532,7 +532,7 @@ arguments, and so on.
 
 Here are some examples of function definitions in Nickel:
 
-```nickel-repl
+```nickel #repl
 > (fun a b => a + b) 1 2
 3
 
@@ -548,7 +548,7 @@ Here are some examples of function definitions in Nickel:
 All existing infix operators in Nickel can be turned into functions by putting
 them inside parentheses, for example:
 
-```nickel-repl
+```nickel #repl
 > 1 + 2
 3
 
@@ -572,7 +572,7 @@ Functions may be composed using the *pipe operator*. The pipe operator allows
 for a function application `f x` to be written as `x |> f`. This operator is
 left-associative, so `x |> f |> g` will be interpreted as `g (f x)`. For example:
 
-```nickel-repl
+```nickel #repl
 > "Hello World" |> std.string.split " "
 ["Hello", "World"]
 
@@ -610,7 +610,7 @@ expression without having to come up with a type.
 
 Here are some examples of type annotations in Nickel:
 
-```nickel-repl
+```nickel #repl
 > 5 : Number
 5
 
@@ -646,7 +646,7 @@ syntactically all the same and can be arbitrary Nickel expressions in practice.
 
 Here are some examples of contract annotations in Nickel:
 
-```nickel-repl
+```nickel #repl
 > 5 | Number
 5
 
@@ -712,7 +712,7 @@ Type variables bound by a `forall` are only visible inside types (any of the
 constructor listed above). As soon as a term expression appears under a `forall`
 binder, the type variables aren't in scope anymore:
 
-```nickel-repl
+```nickel #repl
 > forall a. a -> (a -> a) -> {_ : {foo : a}}
 <func>
 
@@ -726,7 +726,7 @@ error: unbound identifier
 
 Here are some examples of more complicated types in Nickel:
 
-```nickel-repl
+```nickel #repl
 > let f : forall a. a -> a = fun x => x in (f 5 : Number)
 5
 
@@ -786,7 +786,7 @@ is a parse error.
 
 Here are some examples of record types in Nickel:
 
-```nickel-repl
+```nickel #repl
 > {foo = 1, bar = "foo" } : {foo : Number, bar: String}
 { bar = "foo", foo = 1 }
 
@@ -798,7 +798,7 @@ Here, the right-hand side is missing a type annotation for `baz`, so it doesn't
 qualify as a record type and is parsed as a record contract. This throws an
 "incompatible types" error:
 
-```nickel-repl
+```nickel #repl
 > {foo = 1, bar = "foo" } : {foo : Number, bar : String, baz : Bool}
 error: type error: missing row `baz`
   ┌─ <repl-input-0:1:1
@@ -814,7 +814,7 @@ If there's a metadata annotation apart from the type, the record cannot be
 parsed as a type. Consequently, it is considered a record contract and converted
 into an opaque type, yielding an error:
 
-```nickel-no-check
+```nickel #no-check
 > {foo = 1, bar = "foo" } : {foo : Number, bar : String | optional}
 error: incompatible types
 [..]
@@ -824,7 +824,7 @@ While in the following `MyDyn` isn't a proper type, the record literal `{foo :
 Number, bar : MyDyn}` respects all the requirements for a record type and is
 parsed as such:
 
-```nickel-repl
+```nickel #repl
 > let MyDyn = fun label value => value in
     {foo = 1, bar | MyDyn = "foo"} : {foo : Number, bar : MyDyn}
 { bar = "foo", foo = 1 }
@@ -840,7 +840,7 @@ is introduced with the syntax `<field_name> | <metadata1> | .. | <metadataN>
 
 Documentation can be attached with `| doc <string>`. For example:
 
-```nickel-repl
+```nickel #repl
 > let record = {
     value
       | doc "The number five"
@@ -878,7 +878,7 @@ about this in the [dedicated section on merging](./merging.md).
 
 Here are some examples using merge priorities in Nickel:
 
-```nickel-repl
+```nickel #repl
 > let Ais2ByDefault = { a | default = 2 } in
     {} | Ais2ByDefault
 { a = 2 }
@@ -906,7 +906,7 @@ Here are some examples using merge priorities in Nickel:
 The `optional` annotation indicates that a field is not mandatory. It is usually
 found in record contracts.
 
-```nickel-repl
+```nickel #repl
 > let Contract = {
     foo | Num,
     bar | Num
@@ -924,7 +924,7 @@ error: missing definition for `foo`
 The `not_exported` annotation indicates that a field should be skipped when a
 record is serialized. This includes the output of the `nickel export` command:
 
-```nickel-repl
+```nickel #repl
 > let value = { foo = 1, bar | not_exported = 2}
 > value
 { foo = 1, bar = 2 }

--- a/doc/manual/syntax.md
+++ b/doc/manual/syntax.md
@@ -125,8 +125,7 @@ Here are some examples of string handling in Nickel:
 
 > m%"Well, if this isn't a multiline string?
   Yes it is, indeed it is"%
-"Well, if this isn't a multiline string?
-Yes it is, indeed it is"
+"Well, if this isn't a multiline string?\n  Yes it is, indeed it is"
 
 > "Hello" ++ "World"
 "HelloWorld"
@@ -164,7 +163,7 @@ The only special sequence in a multiline string is the string interpolation:
 
 ```nickel-repl
 > m%"Multiline\nString?"%
-"Multiline\nString?"
+"Multiline\\nString?"
 
 > m%"Multiline%{"\n"}String"%
 "Multiline

--- a/doc/manual/tutorial.md
+++ b/doc/manual/tutorial.md
@@ -86,7 +86,7 @@ Now, create a text file named `users.ncl` that will import our contract
 file created previously. This file will contain the actual data we need
 to use.
 
-```nickel-parse
+```nickel #parse
 let { UserSchema, .. } = import "users-schema.ncl" in
 {
   users | Array UserSchema = [

--- a/doc/manual/tutorial.md
+++ b/doc/manual/tutorial.md
@@ -86,7 +86,7 @@ Now, create a text file named `users.ncl` that will import our contract
 file created previously. This file will contain the actual data we need
 to use.
 
-```nickel
+```nickel-parse
 let { UserSchema, .. } = import "users-schema.ncl" in
 {
   users | Array UserSchema = [

--- a/doc/manual/types-vs-contracts.md
+++ b/doc/manual/types-vs-contracts.md
@@ -44,7 +44,7 @@ What to do depends on the context:
 
     Example:
 
-    ```nickel-repl
+    ```nickel #repl
     > let foo : Number =
         let addTwo = fun x => x + 2 in
         addTwo 4

--- a/doc/manual/types-vs-contracts.md
+++ b/doc/manual/types-vs-contracts.md
@@ -44,17 +44,17 @@ What to do depends on the context:
 
     Example:
 
-    ```nickel
-    let foo : Number =
-      let addTwo = fun x => x + 2 in
-      addTwo 4
-    in ...
+    ```nickel-repl
+    > let foo : Number =
+        let addTwo = fun x => x + 2 in
+        addTwo 4
+      in {}
 
-    let foo : Number =
-      let ev : ((Number -> Number) -> Number) -> Number -> Number
-        = fun f x => f (std.function.const x) in
-      ev (fun f => f 0) 1
-    in ...
+    > let foo : Number =
+        let ev : ((Number -> Number) -> Number) -> Number -> Number
+          = fun f x => f (std.function.const x) in
+        ev (fun f => f 0) 1
+      in {}
     ```
 
 ## Data (records and arrays)
@@ -66,6 +66,9 @@ flexible and expressive.
 Example:
 
 ```nickel
+let PkgVersion = String in # hide-line
+let BuildSteps = String in # hide-line
+let command = fun x => x in # hide-line
 let Schema = {
   name
     | String

--- a/doc/manual/typing.md
+++ b/doc/manual/typing.md
@@ -149,7 +149,7 @@ Nickel performs type inference, so that you don't have to write the type for
 You can use a *type wildcard*, written `_`, when you want the typechecker to
 infer the part of a type for you:
 
-```nickel-parse
+```nickel
 # will infer `Array String`
 let foo : Array _ = ["hello", "there"] in
 
@@ -157,7 +157,7 @@ let foo : Array _ = ["hello", "there"] in
 let r : {first: _, second: _} = {first = 0 + 1, second = 1 < 2} in
 
 # will infer String
-std.array.first foo : _
+std.array.first ["hello", "there"] : _
 ```
 
 For debugging purpose, the quickest way to have the typechecker kick in is

--- a/doc/manual/typing.md
+++ b/doc/manual/typing.md
@@ -60,7 +60,7 @@ error: type error
 While dynamic typing is fine for configuration code, the trouble begins once we
 are using functions. Say we want to filter over an array of elements:
 
-```nickel-parse
+```nickel #parse
 let filter = fun pred l =>
   std.array.fold_left (fun acc x => if pred x then acc @ [x] else acc) [] l in
 filter (fun x => if x % 2 == 0 then x else -1) [1,2,3,4,5,6]
@@ -120,7 +120,7 @@ Let us try on the filter example. We want the call to be inside the statically
 typechecked block. The easiest way is to capture the whole expression by adding
 a type annotation at the top-level:
 
-```nickel-parse
+```nickel #parse
 (let filter = fun pred l =>
   std.array.fold_left (fun acc x => if pred x then acc @ [x] else acc) [] l in
 filter (fun x => if x % 2 == 0 then x else -1) [1,2,3,4,5,6]) : Array Number
@@ -267,7 +267,7 @@ That is, `filter` is *generic*. Genericity is expressed in Nickel through
 which introduces type variables that can later be substituted for any concrete
 type. Here is our polymorphic type annotation for `filter`:
 
-```nickel-no-check
+```nickel #no-check
 {
   filter : forall a. (a -> Bool) -> Array a -> Array a = ...,
 }
@@ -310,7 +310,7 @@ Let's go back to our first statically typed `filter`, without the polymorphic
 annotation. If we try to add a call to `filter` on an array of strings, the
 typechecker surprisingly rejects our code:
 
-```nickel-no-check
+```nickel #no-check
 (let filter = ... in
 let result = filter (fun x => x % 2 == 0) [1,2,3,4,5,6] in
 let dummy = filter (fun s => std.string.length s > 2) ["a","ab","abcd"] in
@@ -354,7 +354,7 @@ like Nickel.
 In a configuration language, you will often find yourself handling records of
 various kinds. In a simple type system, you can hit the following issue:
 
-```nickel-parse
+```nickel #parse
 (
   let add_total : { total : Number } -> { total : Number } -> Number
     = fun r1 r2 => r1.total + r2.total
@@ -476,7 +476,7 @@ Fortunately, Nickel does have a mechanism to prevent this from happening and to
 provide good error reporting in this situation. Let us see that by ourselves by
 calling to the statically typed `std.array.filter` from dynamically typed code:
 
-```nickel-parse
+```nickel #parse
 std.array.filter (fun x => if x % 2 == 0 then x else null) [1,2,3,4,5,6]
 ```
 
@@ -532,7 +532,7 @@ In the other direction, we face a different issue. Because dynamically typed
 code just get assigned the `Dyn` type most of the time, we can't use a
 dynamically typed value inside a statically typed block directly:
 
-```nickel-parse
+```nickel #parse
 let x = 0 + 1 in
 (1 + x : Number)
 ```
@@ -583,7 +583,7 @@ code that you know is correct but wouldn't typecheck:
 The typechecker accepts the code above, while it rejects a fully statically
 typed version because of the type mismatch between the if branches:
 
-```nickel-parse
+```nickel #parse
 (1 + (if true then 0 else "a")) : Number
 ```
 
@@ -643,7 +643,7 @@ Type annotations and contracts share the same syntax. This means that you can
 technically use custom contracts as any other type inside a static type
 annotation.
 
-```nickel-parse
+```nickel #parse
 let Port = std.contract.from_predicate (fun value =>
   std.is_number value
   && value % 1 == 0

--- a/flake.nix
+++ b/flake.nix
@@ -183,6 +183,7 @@
           txtFilter = mkFilter ".*txt$";
           snapFilter = mkFilter ".*snap$";
           scmFilter = mkFilter ".*scm$";
+          mdFilter = mkFilter ".*md$"; # include markdown files for checking snippets in the documentation
           importsFilter = mkFilter ".*/core/tests/integration/imports/imported/.*$"; # include all files that are imported in tests
 
           infraFilter = mkFilter ".*/infra/.*$";
@@ -199,6 +200,7 @@
               txtFilter
               snapFilter
               scmFilter
+              mdFilter
               filterCargoSources
               importsFilter
             ] && !(builtins.any (filter: filter path type) [

--- a/utils/src/test_program.rs
+++ b/utils/src/test_program.rs
@@ -3,7 +3,7 @@ use codespan::Files;
 use nickel_lang_core::{
     error::{Error, ParseError},
     eval::cache::CacheImpl,
-    parser::{grammar, lexer, ErrorTolerantParser},
+    parser::{grammar, lexer, ErrorTolerantParser, ExtendedTerm},
     program::Program,
     term::{RichTerm, Term},
 };
@@ -31,6 +31,14 @@ pub fn parse(s: &str) -> Result<RichTerm, ParseError> {
     let id = Files::new().add("<test>", String::from(s));
 
     grammar::TermParser::new()
+        .parse_strict(id, lexer::Lexer::new(s))
+        .map_err(|errs| errs.errors.first().unwrap().clone())
+}
+
+pub fn parse_extended(s: &str) -> Result<ExtendedTerm, ParseError> {
+    let id = Files::new().add("<test>", String::from(s));
+
+    grammar::ExtendedTermParser::new()
         .parse_strict(id, lexer::Lexer::new(s))
         .map_err(|errs| errs.errors.first().unwrap().clone())
 }


### PR DESCRIPTION
Add a new test suite in `core/tests/manual` which parses the Markdown files in `doc/manual` to extract all Nickel code blocks and checks that they parse or evaluate correctly. For now, REPL sessions in the manual aren't evaluated during testing but only parsed.

To facilitate this, code blocks in the manual are annotated with `nickel`, `nickel-lines`, `nickel-parse`, `nickel-repl` or `nickel-no-check` depending on the parsing or evaluation mode desired.

Closes #1154 