### PR TITLE
Run a REPL session for `nickel #repl` snippets

### DIFF
--- a/core/src/cache.rs
+++ b/core/src/cache.rs
@@ -283,7 +283,7 @@ impl From<SourcePath> for OsString {
             SourcePath::Std(StdlibModule::Std) => "<stdlib/std.ncl>".into(),
             SourcePath::Std(StdlibModule::Internals) => "<stdlib/internals.ncl>".into(),
             SourcePath::Query => "<query>".into(),
-            SourcePath::ReplInput(idx) => format!("<repl-input-{idx}").into(),
+            SourcePath::ReplInput(idx) => format!("<repl-input-{idx}>").into(),
             SourcePath::ReplTypecheck => "<repl-typecheck>".into(),
             SourcePath::ReplQuery => "<repl-query>".into(),
             SourcePath::Override(path) => format!("<override {}>", path.join(".")).into(),

--- a/core/src/repl/mod.rs
+++ b/core/src/repl/mod.rs
@@ -43,6 +43,7 @@ pub mod simple_frontend;
 pub mod wasm_frontend;
 
 /// Result of the evaluation of an input.
+#[derive(Debug, Clone)]
 pub enum EvalResult {
     /// The input has been evaluated to a term.
     Evaluated(RichTerm),

--- a/core/tests/manual/main.rs
+++ b/core/tests/manual/main.rs
@@ -1,11 +1,18 @@
-use std::{fs::File, io::read_to_string};
+use std::{fs::File, io::read_to_string, iter::once};
 
+use codespan_reporting::term::termcolor::NoColor;
 use comrak::{
     arena_tree::{Node, NodeEdge},
     nodes::{Ast, AstNode, NodeCodeBlock, NodeValue},
     parse_document, ComrakOptions,
 };
+use nickel_lang_core::{
+    error,
+    eval::cache::CacheImpl,
+    repl::{EvalResult, Repl, ReplImpl},
+};
 use nickel_lang_utils::{project_root::project_root, test_program};
+use pretty_assertions::assert_str_eq;
 use test_generator::test_resources;
 use typed_arena::Arena;
 
@@ -28,10 +35,17 @@ enum CodeBlockType {
     /// > std.function.id 5
     /// 5
     /// ```
-    /// We interpret lines starting with `> ` directly after an empty line
-    /// and followed by indented lines (starting with at least one `' '`) as
-    /// a single Nickel program and try to parse them. For now, we don't check
-    /// evaluation. REPL inputs must be separated by an empty line.
+    /// We start a separate REPL session for each such block and interpret lines
+    /// starting with `> ` directly after an empty line and followed by indented
+    /// lines (starting with at least one `' '`) as a single REPL input. In
+    /// particular REPL inputs must be separated by an empty line.
+    ///
+    /// Any text following a REPL input directly, without containing an empty
+    /// line, is interpreted as an expected result. If it starts with `error:`,
+    /// we expect the evaluation to produce an error and match the error report
+    /// with the expected result. A final `[...]` means that the expected
+    /// result is merely a prefix of the error report. If it doesn't start with
+    /// `error:`, the evaluation is expected to succeed.
     Repl,
 }
 
@@ -53,14 +67,98 @@ impl CodeBlockType {
     }
 }
 
-fn check_repl_parts(content: String) {
+#[derive(Debug, Clone)]
+enum MessageExpectation {
+    Full(String),
+    Abridged(String),
+}
+
+#[derive(Debug, Clone)]
+enum ReplResult {
+    Value(String),
+    Error(MessageExpectation),
+    Empty,
+}
+
+fn extract_repl_piece(piece: impl AsRef<str>) -> (String, ReplResult) {
+    let lines: Vec<&str> = piece.as_ref().split_inclusive('\n').collect();
+    let split_index = lines
+        .iter()
+        .position(|l| !l.starts_with(' '))
+        .unwrap_or(lines.len());
+    let (program_lines, result_lines) = lines.split_at(split_index);
+
+    let result_string = result_lines.concat();
+    let result = if result_string.is_empty() {
+        ReplResult::Empty
+    } else if result_string.starts_with("error:") {
+        if let Some((result_string, _)) = result_string.rsplit_once("[...]") {
+            ReplResult::Error(MessageExpectation::Abridged(result_string.to_owned()))
+        } else {
+            ReplResult::Error(MessageExpectation::Full(result_string))
+        }
+    } else {
+        ReplResult::Value(result_string)
+    };
+
+    (program_lines.concat(), result)
+}
+
+#[track_caller]
+fn assert_str_eq_approx(actual: impl AsRef<str>, expected: impl AsRef<str>) {
+    assert_str_eq!(
+        actual
+            .as_ref()
+            .lines()
+            .flat_map(|l| once(l.trim_end()).chain(once("\n")))
+            .collect::<String>()
+            .trim_end(),
+        expected.as_ref().trim_end()
+    );
+}
+
+#[track_caller]
+fn assert_prefix(actual: impl AsRef<str>, prefix: impl AsRef<str>) {
+    assert!(
+        actual.as_ref().starts_with(prefix.as_ref()),
+        "{} was expected to be a prefix of {}",
+        prefix.as_ref(),
+        actual.as_ref()
+    );
+}
+
+fn check_error_report(actual: impl AsRef<str>, expected: MessageExpectation) {
+    match expected {
+        MessageExpectation::Full(expected) => assert_str_eq_approx(actual, expected),
+        MessageExpectation::Abridged(prefix) => assert_prefix(actual, prefix),
+    }
+}
+
+fn check_repl(content: String) {
+    let mut repl = ReplImpl::<CacheImpl>::new(std::io::sink());
+    repl.load_stdlib().unwrap();
     for piece in content.split("\n\n") {
         if let Some(piece) = piece.strip_prefix('>') {
-            let program = piece
-                .split_inclusive('\n')
-                .take_while(|l| l.starts_with(' '))
-                .collect();
-            check_parse_extended(program);
+            let (input, result) = extract_repl_piece(piece);
+
+            eprintln!(">{input}"); // Print the input to stderr to make tracking test failures easier
+            match (repl.eval_full(&input), result) {
+                (Ok(EvalResult::Evaluated(rt)), ReplResult::Value(expected)) => {
+                    assert_str_eq_approx(format!("{rt}"), expected)
+                }
+                (Ok(EvalResult::Bound(_)), ReplResult::Empty) => (),
+                (Err(e), ReplResult::Error(expected)) => {
+                    let mut error = NoColor::new(Vec::<u8>::new());
+                    let stdlib_ids = repl.cache_mut().get_all_stdlib_modules_file_id();
+                    let files = repl.cache_mut().files_mut();
+                    error::report_with(&mut error, files, stdlib_ids.as_ref(), e);
+
+                    check_error_report(String::from_utf8(error.into_inner()).unwrap(), expected);
+                }
+                (actual, expected) => {
+                    panic!("Evaluation produced {actual:?}, expected {expected:?}");
+                }
+            }
         }
     }
 }
@@ -68,11 +166,6 @@ fn check_repl_parts(content: String) {
 fn check_eval(program: String) {
     eprintln!("{program}"); // Print the program to stderr to make tracking test failures easier
     test_program::eval(program).unwrap();
-}
-
-fn check_parse_extended(program: String) {
-    eprintln!("{program}"); // Print the program to stderr to make tracking test failures easier
-    test_program::parse_extended(&program).unwrap();
 }
 
 fn check_parse(program: String) {
@@ -90,7 +183,7 @@ impl CodeBlock {
                 }
             }
             CodeBlockType::Parse => check_parse(self.content),
-            CodeBlockType::Repl => check_repl_parts(self.content),
+            CodeBlockType::Repl => check_repl(self.content),
         }
     }
 }

--- a/core/tests/manual/main.rs
+++ b/core/tests/manual/main.rs
@@ -104,6 +104,9 @@ fn extract_repl_piece(piece: impl AsRef<str>) -> (String, ReplResult) {
     (program_lines.concat(), result)
 }
 
+/// Assert that two strings are equal except for possible trailing whitespace.
+/// The error reporting by `codespan` sometimes produces trailing whitespace
+/// which will be removed from the documentation markdown files.
 #[track_caller]
 fn assert_str_eq_approx(actual: impl AsRef<str>, expected: impl AsRef<str>) {
     assert_str_eq!(
@@ -138,6 +141,8 @@ fn check_repl(content: String) {
     let mut repl = ReplImpl::<CacheImpl>::new(std::io::sink());
     repl.load_stdlib().unwrap();
     for piece in content.split("\n\n") {
+        // We only process `piece`s starting with `>`. This way we can make the
+        // testing code ignore unknown REPL statements, e.g. `:query`.
         if let Some(piece) = piece.strip_prefix('>') {
             let (input, result) = extract_repl_piece(piece);
 

--- a/doc/manual/contracts.md
+++ b/doc/manual/contracts.md
@@ -764,9 +764,8 @@ Let us see if we indeed preserved laziness:
     "0" | doc "Some information" = true,
   }
 
-# Don't parse this in tests hide-line
-> :query config "0"
-* documentation: Some information
+> config."0"
+true
 ```
 
 Yes! Our contract doesn't unduly cause the evaluation of the field `"1"`. Does
@@ -808,17 +807,17 @@ it check anything, though?
     "0" | doc "Some information" = false,
   }
 
-# Don't parse this in tests hide-line
-> :q config."0"
-error: contract broken by a value [field name `not_a_number` is not a number].
+> config."0"
+error: contract broken by a value: field name `not_a_number` is not a number
+[...]
 
 > let config | NumberBoolDict = {
     "0" | doc "Some information" = "not a boolean",
   }
 
-# Don't parse this in tests hide-line
-> :q config."0"
-error: contract broken by a value [field `0` is not a boolean].
+> config."0"
+error: contract broken by a value: field `0` is not a boolean
+[...]
 ```
 
 It does!

--- a/doc/manual/types-vs-contracts.md
+++ b/doc/manual/types-vs-contracts.md
@@ -48,13 +48,11 @@ What to do depends on the context:
     > let foo : Number =
         let addTwo = fun x => x + 2 in
         addTwo 4
-      in {}
 
     > let foo : Number =
         let ev : ((Number -> Number) -> Number) -> Number -> Number
           = fun f x => f (std.function.const x) in
         ev (fun f => f 0) 1
-      in {}
     ```
 
 ## Data (records and arrays)


### PR DESCRIPTION
This is an enhancement of #1611 to improve testing REPL snippets. Instead of just making sure that REPL inputs parse correctly, we're now starting up a REPL session and run each command. This also enables us to compare the claimed output with what the REPL would actually produce.