### PR TITLE
Assume -> ApplyContract

### DIFF
--- a/core/src/eval/merge.rs
+++ b/core/src/eval/merge.rs
@@ -207,7 +207,7 @@ pub fn merge<C: Cache>(
             // exactly the same, but can't be shadowed.
             let eq_contract = mk_app!(stdlib::internals::stdlib_contract_equal(), t1);
             let result = mk_app!(
-                mk_term::op2(BinaryOp::Assume(), eq_contract, Term::Lbl(label)),
+                mk_term::op2(BinaryOp::ApplyContract(), eq_contract, Term::Lbl(label)),
                 t2
             )
             .with_pos(pos_op);

--- a/core/src/eval/mod.rs
+++ b/core/src/eval/mod.rs
@@ -35,11 +35,6 @@
 //!   causes an [`crate::error::EvalError::InternalError`]. A resolved import, identified by a
 //!   `FileId`, is retrieved from the import resolver and evaluation proceeds.
 //!
-//! ## Contracts
-//!
-//! - **`Assume(type, label, term)`** (or `Promise(type, label, term)`): replace the current term
-//! with the contract corresponding to `types`, applied to label and term (`contract label term`).
-//!
 //! ## Operators
 //!
 //! Operators are strict by definition. To evaluate say `exp1 + exp2`, the following steps have to

--- a/core/src/label.rs
+++ b/core/src/label.rs
@@ -25,13 +25,12 @@ pub mod ty_path {
     //! Checking higher-order contracts can involve a good share of intermediate contract checking.
     //! Take the following example:
     //! ```text
-    //! Assume(
-    //!     (Number -> Number) -> Number) -> Number -> Number,
-    //!     fun ev => fun cst => ev (fun x => cst)
-    //! )
+    //! (fun ev => fun cst => ev (fun x => cst))
+    //!   | ((Number -> Number) -> Number) -> Number -> Number,
     //! ```
     //! Once called, various checks will be performed on the arguments of functions and their return
     //! values:
+    //!
     //! 1. Check that `ev` provides a `Number` to `(fun x => cst)`
     //! 2. Check that `(fun x => cst)` returns a `Number`
     //! 3. Check that `ev (fun x => cst)` return a `Number`
@@ -39,8 +38,8 @@ pub mod ty_path {
     //!
     //! Each check can be linked to a base type occurrence (here, a `Number`) in the original type:
     //! ```text
-    //! (Number -> Number) -> Number) -> Number -> Number
-    //!  ^^^^^1    ^^^^^^2    ^^^^^^3    etc.
+    //! ((Number -> Number) -> Number) -> Number -> Number
+    //!   ^^^^^1    ^^^^^^2    ^^^^^^3    etc.
     //! ```
     //!
     //! This is the information encoded by a type path: what part of the original type is currently

--- a/core/src/parser/grammar.lalrpop
+++ b/core/src/parser/grammar.lalrpop
@@ -836,9 +836,9 @@ InfixExpr: UniTerm = {
 }
 
 BOpPre: BinaryOp = {
-    "assume" => BinaryOp::Assume(),
-    "array_lazy_assume" => BinaryOp::ArrayLazyAssume(),
-    "record_lazy_assume" => BinaryOp::RecordLazyAssume(),
+    "apply_contract" => BinaryOp::ApplyContract(),
+    "array_lazy_app_ctr" => BinaryOp::ArrayLazyAppCtr(),
+    "record_lazy_app_ctr" => BinaryOp::RecordLazyAppCtr(),
     "unseal" => BinaryOp::Unseal(),
     "seal" => BinaryOp::Seal(),
     "go_field" => BinaryOp::GoField(),
@@ -1019,9 +1019,9 @@ extern {
         "Array" => Token::Normal(NormalToken::Array),
 
         "typeof" => Token::Normal(NormalToken::Typeof),
-        "assume" => Token::Normal(NormalToken::Assume),
-        "array_lazy_assume" => Token::Normal(NormalToken::ArrayLazyAssume),
-        "record_lazy_assume" => Token::Normal(NormalToken::RecordLazyAssume),
+        "apply_contract" => Token::Normal(NormalToken::ApplyContract),
+        "array_lazy_app_ctr" => Token::Normal(NormalToken::ArrayLazyAppCtr),
+        "record_lazy_app_ctr" => Token::Normal(NormalToken::RecordLazyAppCtr),
         "op force" => Token::Normal(NormalToken::OpForce),
         "blame" => Token::Normal(NormalToken::Blame),
         "chng_pol" => Token::Normal(NormalToken::ChangePol),

--- a/core/src/parser/lexer.rs
+++ b/core/src/parser/lexer.rs
@@ -184,12 +184,12 @@ pub enum NormalToken<'input> {
     #[token("%typeof%")]
     Typeof,
 
-    #[token("%assume%")]
-    Assume,
-    #[token("%array_lazy_assume%")]
-    ArrayLazyAssume,
-    #[token("%record_lazy_assume%")]
-    RecordLazyAssume,
+    #[token("%apply_contract%")]
+    ApplyContract,
+    #[token("%array_lazy_app_ctr%")]
+    ArrayLazyAppCtr,
+    #[token("%record_lazy_app_ctr%")]
+    RecordLazyAppCtr,
     #[token("%blame%")]
     Blame,
     #[token("%chng_pol%")]

--- a/core/src/term/mod.rs
+++ b/core/src/term/mod.rs
@@ -301,7 +301,12 @@ impl RuntimeContract {
         use crate::mk_app;
 
         mk_app!(
-            make::op2(BinaryOp::ApplyContract(), self.contract, Term::Lbl(self.label)).with_pos(pos),
+            make::op2(
+                BinaryOp::ApplyContract(),
+                self.contract,
+                Term::Lbl(self.label)
+            )
+            .with_pos(pos),
             rt
         )
         .with_pos(pos)
@@ -2229,7 +2234,11 @@ pub mod make {
         Term::OpN(op, args.into_iter().map(T::into).collect()).into()
     }
 
-    pub fn apply_contract<T>(typ: Type, l: Label, t: T) -> Result<RichTerm, UnboundTypeVariableError>
+    pub fn apply_contract<T>(
+        typ: Type,
+        l: Label,
+        t: T,
+    ) -> Result<RichTerm, UnboundTypeVariableError>
     where
         T: Into<RichTerm>,
     {

--- a/core/src/typ.rs
+++ b/core/src/typ.rs
@@ -923,7 +923,7 @@ impl Type {
     }
 
     /// Return the contract corresponding to a type, either as a function or a record. Said
-    /// contract must then be applied using the `Assume` primitive operation.
+    /// contract must then be applied using the `ApplyContract` primitive operation.
     pub fn contract(&self) -> Result<RichTerm, UnboundTypeVariableError> {
         let mut sy = 0;
         self.subcontract(HashMap::new(), Polarity::Positive, &mut sy)

--- a/core/src/typecheck/mod.rs
+++ b/core/src/typecheck/mod.rs
@@ -2514,7 +2514,7 @@ fn field_apparent_type(
 ///
 /// When a let-binding `let x = bound_exp in body` is processed, the type of `bound_exp` must be
 /// determined in order to be bound to the variable `x` in the typing environment.
-/// Then, future occurrences of `x` can be given this type when used in a `Promise` block.
+/// Then, future occurrences of `x` can be given this type when used in a statically typed block.
 ///
 /// The role of `apparent_type` is precisely to determine the type of `bound_exp`:
 /// - if `bound_exp` is annotated by a type or contract annotation, return the user-provided type,

--- a/core/src/typecheck/operation.rs
+++ b/core/src/typecheck/operation.rs
@@ -236,7 +236,7 @@ pub fn get_bop_type(
         BinaryOp::StrConcat() => (mk_uniftype::str(), mk_uniftype::str(), mk_uniftype::str()),
         // Ideally: Contract -> Label -> Dyn -> Dyn
         // Currently: Dyn -> Dyn -> (Dyn -> Dyn)
-        BinaryOp::Assume() => (
+        BinaryOp::ApplyContract() => (
             mk_uniftype::dynamic(),
             mk_uniftype::dynamic(),
             mk_uty_arrow!(mk_uniftype::dynamic(), mk_uniftype::dynamic()),
@@ -366,7 +366,7 @@ pub fn get_bop_type(
         ),
         // The first argument is a contract, the second is a label.
         // forall a. Dyn -> Dyn -> Array a -> Array a
-        BinaryOp::ArrayLazyAssume() => {
+        BinaryOp::ArrayLazyAppCtr() => {
             let ty_elt = state.table.fresh_type_uvar(var_level);
             let ty_array = mk_uniftype::array(ty_elt);
             (
@@ -377,7 +377,7 @@ pub fn get_bop_type(
         }
         // The first argument is a label, the third is a contract.
         // forall a. Dyn -> {_: a} -> Dyn -> {_: a}
-        BinaryOp::RecordLazyAssume() => {
+        BinaryOp::RecordLazyAppCtr() => {
             let ty_field = state.table.fresh_type_uvar(var_level);
             let ty_dict = mk_uniftype::dict(ty_field);
             (

--- a/core/stdlib/internals.ncl
+++ b/core/stdlib/internals.ncl
@@ -15,13 +15,13 @@
 
   "$array" = fun element_contract label value =>
     if %typeof% value == 'Array then
-      %array_lazy_assume% (%go_array% label) value element_contract
+      %array_lazy_app_ctr% (%go_array% label) value element_contract
     else
       %blame% label,
 
   "$func" = fun domain codomain label value =>
     if %typeof% value == 'Function then
-      (fun x => %assume% codomain (%go_codom% label) (value (%assume% domain (%chng_pol% (%go_dom% label)) x)))
+      (fun x => %apply_contract% codomain (%go_codom% label) (value (%apply_contract% domain (%chng_pol% (%go_dom% label)) x)))
     else
       %blame% label,
 
@@ -49,7 +49,7 @@
 
   "$enums" = fun case label value =>
     if %typeof% value == 'Enum then
-      %assume% case label value
+      %apply_contract% case label value
     else
       %blame% (%label_with_message% "not an enum tag" label),
 
@@ -85,7 +85,7 @@
                   let contract = field_contracts."%{field}" in
                   let label = %go_field% field label in
                   let val = value."%{field}" in
-                  %record_insert% field acc (%assume% contract label val)
+                  %record_insert% field acc (%apply_contract% contract label val)
                 else
                   acc
             )
@@ -107,7 +107,7 @@
   # Lazy dictionary contract for `{_ | T}`
   "$dict_contract" = fun contract label value =>
     if %typeof% value == 'Record then
-      %record_lazy_assume% (%go_dict% label) value (fun _field => contract)
+      %record_lazy_app_ctr% (%go_dict% label) value (fun _field => contract)
     else
       %blame% (%label_with_message% "not a record" label),
 
@@ -118,7 +118,7 @@
         value
         (
           fun _field field_value =>
-            %assume% contract (%go_dict% label) field_value
+            %apply_contract% contract (%go_dict% label) field_value
         )
     else
       %blame% (%label_with_message% "not a record" label),

--- a/core/stdlib/std.ncl
+++ b/core/stdlib/std.ncl
@@ -836,7 +836,7 @@
                 else if %length% diff.missing != 0 then
                   blame_fields_differ "missing" diff.missing ctr_label
                 else
-                  %record_lazy_assume%
+                  %record_lazy_app_ctr%
                     ctr_label
                     value
                     (
@@ -1168,7 +1168,7 @@
           using the parent contract message and note.
         "%
       = fun contract label value =>
-        %assume% contract (%label_push_diag% label) value,
+        %apply_contract% contract (%label_push_diag% label) value,
 
     unstable
       | doc m%"

--- a/notes/fixing-sealing-and-recursive-records.md
+++ b/notes/fixing-sealing-and-recursive-records.md
@@ -125,9 +125,9 @@ Op1(record_map, record); {stack..}
 record ~ RecRecord {..}
 
 RECORD{ foo |pending Num = %1, bar |pending [PosNat,Even] = %2}
-%2 := (%assume% Num label %1) + 1
+%2 := (%apply_contract% Num label %1) + 1
 
-RECORD{ foo = f (%assume% Num %1), bar = f (%assume% PosNat,Even %2) }
+RECORD{ foo = f (%apply_contract% Num %1), bar = f (%apply_contract% PosNat,Even %2) }
 
 # With a call to pending_contract.dualize()
 


### PR DESCRIPTION
At the very beginning of Nickel, the duality between a type annotation and contract annotation was reflected in their original naming, the assume construct (contract annotation) and the promise construct (a type annotation).

This terminology isn't used anymore, and isn't very telling for new contributors. This PR gets rid of old references to `Assume` and `Promise`, and rename the `Assume` primitive operation to the more boring but more explicit `ApplyContract`.