### PR TITLE
Convert symbols request away from the linearizer

### DIFF
--- a/lsp/lsp-harness/src/lib.rs
+++ b/lsp/lsp-harness/src/lib.rs
@@ -4,8 +4,8 @@ mod output;
 pub use jsonrpc::Server;
 use log::error;
 use lsp_types::{
-    CompletionParams, DocumentFormattingParams, GotoDefinitionParams, HoverParams, ReferenceParams,
-    Url,
+    CompletionParams, DocumentFormattingParams, DocumentSymbolParams, GotoDefinitionParams,
+    HoverParams, ReferenceParams, Url,
 };
 pub use output::LspDebug;
 use serde::Deserialize;
@@ -35,6 +35,7 @@ pub enum Request {
     Completion(CompletionParams),
     Formatting(DocumentFormattingParams),
     Hover(HoverParams),
+    Symbols(DocumentSymbolParams),
 }
 
 #[derive(Deserialize, Debug, Default)]

--- a/lsp/lsp-harness/src/output.rs
+++ b/lsp/lsp-harness/src/output.rs
@@ -4,7 +4,7 @@
 
 use std::io::Write;
 
-use lsp_types::GotoDefinitionResponse;
+use lsp_types::{DocumentSymbolResponse, GotoDefinitionResponse};
 
 pub trait LspDebug {
     fn debug(&self, w: impl Write) -> std::io::Result<()>;
@@ -155,5 +155,36 @@ impl LspDebug for lsp_types::MarkedString {
 impl LspDebug for lsp_types::MarkupContent {
     fn debug(&self, mut w: impl Write) -> std::io::Result<()> {
         write!(w, "{}", self.value)
+    }
+}
+
+impl LspDebug for lsp_types::SymbolInformation {
+    fn debug(&self, mut w: impl Write) -> std::io::Result<()> {
+        let name = &self.name;
+        let kind = self.kind;
+        write!(w, "{name} ({kind:?})@{}", self.location.debug_str())
+    }
+}
+
+impl LspDebug for lsp_types::DocumentSymbol {
+    fn debug(&self, mut w: impl Write) -> std::io::Result<()> {
+        let name = &self.name;
+        let kind = self.kind;
+        let detail = self.detail.clone().unwrap_or_default();
+        write!(
+            w,
+            "{name} ({kind:?} / {detail:?})@{} in {}",
+            self.selection_range.debug_str(),
+            self.range.debug_str()
+        )
+    }
+}
+
+impl LspDebug for DocumentSymbolResponse {
+    fn debug(&self, w: impl Write) -> std::io::Result<()> {
+        match self {
+            DocumentSymbolResponse::Flat(xs) => xs.debug(w),
+            DocumentSymbolResponse::Nested(xs) => xs.debug(w),
+        }
     }
 }

--- a/lsp/nls/src/cache.rs
+++ b/lsp/nls/src/cache.rs
@@ -11,7 +11,7 @@ use nickel_lang_core::{
 };
 
 use crate::linearization::{building::Building, AnalysisHost, Environment, LinRegistry};
-use crate::linearization::{CombinedLinearizer, TypeCollector};
+use crate::linearization::{CollectedTypes, CombinedLinearizer, TypeCollector};
 
 pub trait CacheExt {
     fn typecheck_with_analysis(
@@ -78,7 +78,7 @@ impl CacheExt for Cache {
                 initial_ctxt.clone(),
                 self,
                 lin,
-                (building, HashMap::new()),
+                (building, CollectedTypes::default()),
             )
             .map_err(|err| vec![Error::TypecheckError(err)])?;
 

--- a/lsp/nls/test2.ncl
+++ b/lsp/nls/test2.ncl
@@ -1,0 +1,2 @@
+let x : { _ : { foo : Number | default = 1 } } = {} in
+x.PATH.foo

--- a/lsp/nls/tests/inputs/symbols-basic.ncl
+++ b/lsp/nls/tests/inputs/symbols-basic.ncl
@@ -1,0 +1,15 @@
+### /syms.ncl
+let foo = 3 in
+let func = fun x => 1 in
+{
+  name = "value",
+  other_name = {
+    inner_name = let inner_binding = 3 in "value",
+  },
+  type_checked_block = {
+    inner_name = { name = "value" },
+  } : _,
+}
+### [[request]]
+### type = "Symbols"
+### textDocument.uri = "file:///syms.ncl"

--- a/lsp/nls/tests/main.rs
+++ b/lsp/nls/tests/main.rs
@@ -2,7 +2,8 @@ use std::collections::{hash_map::Entry, HashMap};
 
 use assert_cmd::cargo::CommandCargoExt;
 use lsp_types::request::{
-    Completion, Formatting, GotoDefinition, HoverRequest, References, Request as LspRequest,
+    Completion, DocumentSymbolRequest, Formatting, GotoDefinition, HoverRequest, References,
+    Request as LspRequest,
 };
 use nickel_lang_utils::project_root::project_root;
 use test_generator::test_resources;
@@ -40,6 +41,7 @@ impl TestHarness {
             Request::Formatting(f) => self.request::<Formatting>(f),
             Request::Hover(h) => self.request::<HoverRequest>(h),
             Request::References(r) => self.request::<References>(r),
+            Request::Symbols(s) => self.request::<DocumentSymbolRequest>(s),
         }
     }
 

--- a/lsp/nls/tests/snapshots/main__lsp__nls__tests__inputs__symbols-basic.ncl.snap
+++ b/lsp/nls/tests/snapshots/main__lsp__nls__tests__inputs__symbols-basic.ncl.snap
@@ -1,0 +1,6 @@
+---
+source: lsp/nls/tests/main.rs
+expression: output
+---
+[foo (Variable / "Number")@0:4-0:7 in 0:4-0:7, func (Variable / "Dyn")@1:4-1:8 in 1:4-1:8, name (Variable / "String")@3:2-3:6 in 3:2-3:6, other_name (Variable / "Dyn")@4:2-4:12 in 4:2-4:12, inner_name (Variable / "Dyn")@5:4-5:14 in 5:4-5:14, inner_binding (Variable / "Number")@5:21-5:34 in 5:21-5:34, type_checked_block (Variable / "Dyn")@7:2-7:20 in 7:2-7:20, inner_name (Variable / "{ name : String }")@8:4-8:14 in 8:4-8:14, name (Variable / "String")@8:19-8:23 in 8:19-8:23]
+


### PR DESCRIPTION
I'm not completely sure about what should count as a symbol. Right now, let bindings and record fields create "symbols" but function arguments do not.

Returning all locally scoped symbols feels a little noisy to me right now. Maybe the best way to improve it would be to make a symbol hierarchy instead of a flat list. LSP supports this, but we aren't doing it yet.