### PR TITLE
More CI speed

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -618,9 +618,11 @@
           nickel-lang-cli
           nickel-lang-core
           rustfmt;
-        # An optimizing release build is long: eschew optimizations in checks by
-        # building a dev profile
-        nickelWasm = buildNickelWasm { profile = "dev"; };
+        # There's a tradeoff here: "release" build is in theory longer than
+        # "dev", but it hits the cache on dependencies so in practice it is
+        # shorter. Another option would be to compile a dev dependencies version
+        # of cargoArtifacts. But that almost doubles the cache space.
+        nickelWasm = buildNickelWasm { profile = "release"; };
         inherit vscodeExtension;
         pre-commit = pre-commit-builder { };
       };

--- a/flake.nix
+++ b/flake.nix
@@ -269,6 +269,12 @@
           cargoArtifacts = craneLib.buildDepsOnly {
             inherit pname src;
             cargoExtraArgs = "${cargoBuildExtraArgs} --all-features";
+            # If we build all the packages at once, feature unification takes
+            # over and we get libraries with different sets of features than
+            # we would get building them separately. Meaning that when we
+            # later build them separately, it won't hit the cache. So instead,
+            # we need to build each package separately when we are collecting
+            # dependencies.
             cargoBuildCommand = "cargoWorkspace build";
             cargoTestCommand = "cargoWorkspace test";
             cargoCheckCommand = "cargoWorkspace check";


### PR DESCRIPTION
- switch `nickelWasm` to release build so it hits the cache
- build packages separately in `cargoArtifacts` derivation, so that when we build them separately later they hit the cache correctly
  - see https://github.com/ipetkov/crane/issues/396