### PR TITLE
Hover support without the linearizer

### DIFF
--- a/lsp/nls/src/diagnostic.rs
+++ b/lsp/nls/src/diagnostic.rs
@@ -52,6 +52,14 @@ impl LocationCompat for lsp_types::Range {
             },
         }
     }
+
+    fn from_span(span: &RawSpan, files: &Files<String>) -> Self {
+        Self::from_codespan(
+            &span.src_id,
+            &(span.start.to_usize()..span.end.to_usize()),
+            files,
+        )
+    }
 }
 
 impl LocationCompat for lsp_types::Location {

--- a/lsp/nls/src/field_walker.rs
+++ b/lsp/nls/src/field_walker.rs
@@ -236,7 +236,6 @@ impl<'a> FieldResolver<'a> {
 
                     self.resolve_def_with_path(def)
                 })
-                // FIXME: it isn't finding 'std'. Need to provide an intial env containing std...
                 .unwrap_or_else(|| {
                     log::info!("no def for {id:?}");
                     Default::default()

--- a/lsp/nls/src/field_walker.rs
+++ b/lsp/nls/src/field_walker.rs
@@ -236,7 +236,12 @@ impl<'a> FieldResolver<'a> {
 
                     self.resolve_def_with_path(def)
                 })
-                .unwrap_or_default(),
+                // FIXME: it isn't finding 'std'. Need to provide an intial env containing std...
+                .unwrap_or_else(|| {
+                    log::info!("no def for {id:?}");
+                    Default::default()
+                }),
+            //.unwrap_or_default(),
             Term::ResolvedImport(file_id) => self
                 .server
                 .cache

--- a/lsp/nls/src/files.rs
+++ b/lsp/nls/src/files.rs
@@ -111,6 +111,7 @@ pub(crate) fn typecheck(
             file_id,
             &server.initial_ctxt,
             &server.initial_env,
+            &server.initial_term_env,
             &mut server.lin_registry,
         )
         .map_err(|error| match error {

--- a/lsp/nls/src/incomplete.rs
+++ b/lsp/nls/src/incomplete.rs
@@ -164,7 +164,7 @@ pub fn parse_path_from_incomplete_input(
             server
                 .lin_registry
                 .usage_lookups
-                .insert(file_id, UsageLookup::new_with_env(&rt, env));
+                .insert(file_id, UsageLookup::new(&rt, env));
             Some(resolve_imports(rt, server))
         }
         _ => None,

--- a/lsp/nls/src/linearization/completed.rs
+++ b/lsp/nls/src/linearization/completed.rs
@@ -1,3 +1,5 @@
+#![allow(unused_imports)] // until we get rid of feature(old-completer)
+
 use std::{collections::HashMap, hash::Hash};
 
 use codespan::FileId;
@@ -76,6 +78,7 @@ impl Completed {
 
     /// Try to retrieve the item from the current linearization first, and if that fails, look into
     /// the registry if there is a linearization corresponding to the item's file id.
+    #[cfg(feature = "old-completer")]
     pub fn get_item_with_reg<'a>(
         &'a self,
         id: ItemId,
@@ -156,6 +159,7 @@ impl Completed {
     /// Retrive the type and the metadata of a linearization item. Requires a registry as this code
     /// tries to jump to the definitions of objects to find the relevant data, which might lie in a
     /// different file (and thus in a different linearization within the registry).
+    #[cfg(feature = "old-completer")]
     pub fn get_type_and_metadata(
         &self,
         item: &LinearizationItem<Resolved>,

--- a/lsp/nls/src/linearization/mod.rs
+++ b/lsp/nls/src/linearization/mod.rs
@@ -115,11 +115,13 @@ impl LinRegistry {
         linearization: Completed,
         type_lookups: CollectedTypes<Type>,
         term: &RichTerm,
+        initial_env: &crate::usage::Environment,
     ) {
         self.map.insert(file_id, linearization);
         self.position_lookups
             .insert(file_id, PositionLookup::new(term));
-        self.usage_lookups.insert(file_id, UsageLookup::new(term));
+        self.usage_lookups
+            .insert(file_id, UsageLookup::new(term, initial_env));
         self.parent_lookups.insert(file_id, ParentLookup::new(term));
         self.type_lookups.insert(file_id, type_lookups);
     }
@@ -158,6 +160,11 @@ impl LinRegistry {
             .get(&file)?
             .terms
             .get(&RichTermPtr(rt.clone()))
+    }
+
+    pub fn get_type_for_ident(&self, id: &LocIdent) -> Option<&Type> {
+        let file = id.pos.as_opt_ref()?.src_id;
+        self.type_lookups.get(&file)?.idents.get(id)
     }
 
     pub fn get_parent_chain<'a>(&'a self, rt: &'a RichTerm) -> Option<ParentChainIter<'a>> {

--- a/lsp/nls/src/requests/completion.rs
+++ b/lsp/nls/src/requests/completion.rs
@@ -745,12 +745,6 @@ fn env_completion(rt: &RichTerm, server: &Server) -> Vec<CompletionItem> {
     let resolver = FieldResolver::new(server);
     let mut items: Vec<_> = env
         .iter_elems()
-        // The name `internals` is always in scope, but let's not advertise the fact. We do want
-        // to complete `internals` if someone else uses that name, so we only filter out the
-        // `internals` that doesn't have a position -- anything user-defined should have one.
-        .filter(|(_, def_with_path)| {
-            def_with_path.ident.ident != "internals".into() || def_with_path.ident.pos.is_def()
-        })
         .map(|(_, def_with_path)| def_with_path.completion_item())
         .collect();
 

--- a/lsp/nls/src/requests/completion.rs
+++ b/lsp/nls/src/requests/completion.rs
@@ -745,6 +745,12 @@ fn env_completion(rt: &RichTerm, server: &Server) -> Vec<CompletionItem> {
     let resolver = FieldResolver::new(server);
     let mut items: Vec<_> = env
         .iter_elems()
+        // The name `internals` is always in scope, but let's not advertise the fact. We do want
+        // to complete `internals` if someone else uses that name, so we only filter out the
+        // `internals` that doesn't have a position -- anything user-defined should have one.
+        .filter(|(_, def_with_path)| {
+            def_with_path.ident.ident != "internals".into() || def_with_path.ident.pos.is_def()
+        })
         .map(|(_, def_with_path)| def_with_path.completion_item())
         .collect();
 

--- a/lsp/nls/src/requests/goto.rs
+++ b/lsp/nls/src/requests/goto.rs
@@ -79,7 +79,7 @@ pub fn handle_references(
 ) -> Result<(), ResponseError> {
     let pos = server.cache.position(&params.text_document_position)?;
 
-    // The "references" of a symbol are all the usages if its definitions,
+    // The "references" of a symbol are all the usages of its definitions,
     // so first find the definitions and then find their usages.
     let mut def_locs = server
         .lookup_term_by_position(pos)?

--- a/lsp/nls/src/requests/hover.rs
+++ b/lsp/nls/src/requests/hover.rs
@@ -1,68 +1,169 @@
-use log::debug;
 use lsp_server::{RequestId, Response, ResponseError};
 use lsp_types::{Hover, HoverContents, HoverParams, LanguageString, MarkedString, Range};
-use nickel_lang_core::position::TermPos;
+use nickel_lang_core::{
+    identifier::Ident,
+    position::RawSpan,
+    term::{record::FieldMetadata, LabeledType, RichTerm, Term, UnaryOp},
+    typ::Type,
+};
 use serde_json::Value;
 
 use crate::{
     cache::CacheExt,
     diagnostic::LocationCompat,
+    field_walker::{FieldHaver, FieldResolver},
+    identifier::LocIdent,
     server::Server,
-    trace::{Enrich, Trace},
 };
+
+#[derive(Debug)]
+struct HoverData {
+    values: Vec<RichTerm>,
+    metadata: Vec<FieldMetadata>,
+    span: RawSpan,
+    ty: Option<Type>,
+}
+
+fn annotated_contracts(rt: &RichTerm) -> &[LabeledType] {
+    match rt.as_ref() {
+        Term::Annotated(annot, _) => &annot.contracts,
+        _ => &[],
+    }
+}
+
+fn nickel_string(s: String) -> MarkedString {
+    MarkedString::LanguageString(LanguageString {
+        language: "nickel".to_owned(),
+        value: s,
+    })
+}
+
+fn values_and_metadata_from_field(
+    parents: Vec<FieldHaver>,
+    ident: Ident,
+) -> (Vec<RichTerm>, Vec<FieldMetadata>) {
+    let mut values = Vec::new();
+    let mut metadata = Vec::new();
+    for parent in parents {
+        if let FieldHaver::RecordTerm(r) = parent {
+            if let Some(field) = r.fields.get(&ident) {
+                values.extend(field.value.iter().cloned());
+                metadata.push(field.metadata.clone());
+            }
+        }
+    }
+    (values, metadata)
+}
+
+fn ident_hover(ident: LocIdent, server: &Server) -> Option<HoverData> {
+    let ty = server.lin_registry.get_type_for_ident(&ident).cloned();
+    let span = ident.pos.into_opt()?;
+    let mut ret = HoverData {
+        values: Vec::new(),
+        metadata: Vec::new(),
+        span,
+        ty,
+    };
+
+    if let Some(def) = server.lin_registry.get_def(&ident) {
+        let resolver = FieldResolver::new(server);
+        if let Some(((last, path), val)) = def.path.split_last().zip(def.value.as_ref()) {
+            let parents = resolver.resolve_term_path(val, path);
+            let (values, metadata) = values_and_metadata_from_field(parents, *last);
+            ret.values = values;
+            ret.metadata = metadata;
+        } else if def.path.is_empty() {
+            ret.values.extend(def.value.iter().cloned());
+        }
+    }
+
+    Some(ret)
+}
+
+fn term_hover(rt: &RichTerm, server: &Server) -> Option<HoverData> {
+    let ty = server.lin_registry.get_type(rt).cloned();
+    let span = rt.pos.into_opt()?;
+
+    match rt.as_ref() {
+        Term::Op1(UnaryOp::StaticAccess(id), parent) => {
+            let resolver = FieldResolver::new(server);
+            let parents = resolver.resolve_term(parent);
+            let (values, metadata) = values_and_metadata_from_field(parents, id.ident());
+            Some(HoverData {
+                values,
+                metadata,
+                span,
+                ty,
+            })
+        }
+        _ => Some(HoverData {
+            values: vec![rt.clone()],
+            metadata: vec![],
+            span,
+            ty,
+        }),
+    }
+}
 
 pub fn handle(
     params: HoverParams,
-    id: RequestId,
+    req_id: RequestId,
     server: &mut Server,
 ) -> Result<(), ResponseError> {
     let pos = server
         .cache
         .position(&params.text_document_position_params)?;
 
-    debug!("pos of hovered item: {pos:?}");
+    let hover_data = server
+        .lookup_ident_by_position(pos)?
+        .and_then(|ident| ident_hover(ident, server));
 
-    let linearization = server.lin_cache_get(&pos.src_id)?;
-    let item = linearization.item_at(pos);
+    let hover_data = match hover_data {
+        Some(h) => Some(h),
+        None => server
+            .lookup_term_by_position(pos)?
+            .and_then(|rt| term_hover(rt, server)),
+    };
 
-    Trace::enrich(&id, linearization);
+    if let Some(hover) = hover_data {
+        let mut contents = Vec::new();
 
-    if item.is_none() {
-        server.reply(Response::new_ok(id, Value::Null));
-        return Ok(());
+        if let Some(ty) = hover.ty {
+            contents.push(nickel_string(ty.to_string()));
+        } else {
+            // Unclear whether it's useful to report `Dyn` all the
+            // time, but it matches the old behavior.
+            contents.push(nickel_string("Dyn".to_string()));
+        }
+
+        let mut contracts: Vec<_> = hover
+            .metadata
+            .iter()
+            .flat_map(|m| &m.annotation.contracts)
+            .chain(hover.values.iter().flat_map(annotated_contracts))
+            .map(|contract| contract.label.typ.to_string())
+            .collect();
+
+        contracts.sort();
+        contracts.dedup();
+
+        contents.extend(contracts.into_iter().map(nickel_string));
+
+        // Not sure how to do documentation merging yet, so pick the first non-empty one.
+        let doc = hover.metadata.iter().find_map(|m| m.doc.as_ref());
+        if let Some(doc) = doc {
+            contents.push(MarkedString::String(doc.to_owned()));
+        }
+
+        server.reply(Response::new_ok(
+            req_id,
+            Hover {
+                contents: HoverContents::Array(contents),
+                range: Some(Range::from_span(&hover.span, server.cache.files())),
+            },
+        ));
+    } else {
+        server.reply(Response::new_ok(req_id, Value::Null));
     }
-
-    let item = item.unwrap().to_owned();
-
-    debug!("Found item {:?}", item);
-
-    let (ty, meta) = linearization.get_type_and_metadata(&item, &server.lin_registry);
-
-    if item.pos == TermPos::None {
-        server.reply(Response::new_ok(id, Value::Null));
-        return Ok(());
-    }
-    let pos = item.pos.unwrap();
-    let range = Range::from_codespan(
-        &pos.src_id,
-        &(pos.start.to_usize()..pos.end.to_usize()),
-        server.cache.files(),
-    );
-
-    let mut contents = Vec::new();
-    contents.push(MarkedString::LanguageString(LanguageString {
-        language: "nickel".into(),
-        value: ty.to_string(),
-    }));
-
-    contents.extend(meta.iter().cloned().map(MarkedString::String));
-
-    server.reply(Response::new_ok(
-        id,
-        Hover {
-            contents: HoverContents::Array(contents),
-            range: Some(range),
-        },
-    ));
     Ok(())
 }

--- a/lsp/nls/src/server.rs
+++ b/lsp/nls/src/server.rs
@@ -31,10 +31,13 @@ use crate::{
     cache::CacheExt,
     diagnostic::DiagnosticCompat,
     field_walker::DefWithPath,
-    linearization::{completed::Completed, Environment, ItemId, LinRegistry},
+    linearization::{Environment, ItemId, LinRegistry},
     requests::{completion, formatting, goto, hover, symbols},
     trace::Trace,
 };
+
+#[cfg(feature = "old-completer")]
+use crate::linearization::completed::Completed;
 
 pub const COMPLETIONS_TRIGGERS: &[&str] = &[".", "\"", "/"];
 
@@ -283,6 +286,7 @@ impl Server {
         Ok(())
     }
 
+    #[cfg(feature = "old-completer")]
     pub fn lin_cache_get(&self, file_id: &FileId) -> Result<&Completed, ResponseError> {
         self.lin_registry
             .map

--- a/lsp/nls/src/server.rs
+++ b/lsp/nls/src/server.rs
@@ -165,19 +165,23 @@ impl Server {
                 )
                 .unwrap();
 
-            // The term should always be populated by typecheck_with_analysis.
-            let term = cache.terms().get(&file_id).unwrap();
-            let name = module.name().into();
-            let def = DefWithPath {
-                ident: crate::identifier::LocIdent {
-                    ident: name,
-                    pos: TermPos::None,
-                },
-                value: Some(term.term.clone()),
-                path: Vec::new(),
-                metadata: None,
-            };
-            self.initial_term_env.insert(name, def);
+            // Add the std module to the environment (but not `internals`, because those symbols
+            // don't get their own namespace, and we don't want to use them for completion anyway).
+            if module == StdlibModule::Std {
+                // The term should always be populated by typecheck_with_analysis.
+                let term = cache.terms().get(&file_id).unwrap();
+                let name = module.name().into();
+                let def = DefWithPath {
+                    ident: crate::identifier::LocIdent {
+                        ident: name,
+                        pos: TermPos::None,
+                    },
+                    value: Some(term.term.clone()),
+                    path: Vec::new(),
+                    metadata: None,
+                };
+                self.initial_term_env.insert(name, def);
+            }
         }
         Ok(())
     }

--- a/lsp/nls/tests/inputs/hover-basic.ncl
+++ b/lsp/nls/tests/inputs/hover-basic.ncl
@@ -1,0 +1,20 @@
+### /main.ncl
+let record = {
+  foo | doc "middle" = {
+    bar | Number | doc "innermost" = 3
+  }
+}
+in
+record.foo.bar
+### [[request]]
+### type = "Hover"
+### textDocument.uri = "file:///main.ncl"
+### position = { line = 6, character = 2 }
+### [[request]]
+### type = "Hover"
+### textDocument.uri = "file:///main.ncl"
+### position = { line = 6, character = 8 }
+### [[request]]
+### type = "Hover"
+### textDocument.uri = "file:///main.ncl"
+### position = { line = 6, character = 12 }

--- a/lsp/nls/tests/inputs/hover-pattern.ncl
+++ b/lsp/nls/tests/inputs/hover-pattern.ncl
@@ -1,0 +1,42 @@
+### /main.ncl
+let outer@{ foo = inner@{ bar = innermost } } = {
+  foo | doc "middle" = {
+    bar | Number | doc "innermost" = 3
+  }
+}
+in
+[
+  outer,
+  outer.foo,
+  inner.bar,
+  innermost,
+]
+### [[request]] # outer
+### type = "Hover"
+### textDocument.uri = "file:///main.ncl"
+### position = { line = 7, character = 3 }
+###
+### [[request]] # the next outer
+### type = "Hover"
+### textDocument.uri = "file:///main.ncl"
+### position = { line = 8, character = 3 }
+###
+### [[request]] # the foo in outer.foo
+### type = "Hover"
+### textDocument.uri = "file:///main.ncl"
+### position = { line = 8, character = 9 }
+###
+### [[request]] # inner
+### type = "Hover"
+### textDocument.uri = "file:///main.ncl"
+### position = { line = 9, character = 3 }
+###
+### [[request]] # the bar in inner.bar
+### type = "Hover"
+### textDocument.uri = "file:///main.ncl"
+### position = { line = 9, character = 9 }
+###
+### [[request]] # innermost
+### type = "Hover"
+### textDocument.uri = "file:///main.ncl"
+### position = { line = 10, character = 3 }

--- a/lsp/nls/tests/snapshots/main__lsp__nls__tests__inputs__completion-basic.ncl.snap
+++ b/lsp/nls/tests/snapshots/main__lsp__nls__tests__inputs__completion-basic.ncl.snap
@@ -2,7 +2,7 @@
 source: lsp/nls/tests/main.rs
 expression: output
 ---
-[a, b, config]
+[a, b, config, std]
 [foo, verified, version]
 [foo, verified, version]
 [foo, verified, version]

--- a/lsp/nls/tests/snapshots/main__lsp__nls__tests__inputs__completion-incomplete.ncl.snap
+++ b/lsp/nls/tests/snapshots/main__lsp__nls__tests__inputs__completion-incomplete.ncl.snap
@@ -2,7 +2,7 @@
 source: lsp/nls/tests/main.rs
 expression: output
 ---
-[config]
+[config, std]
 [foo, verified, version]
 [foo, verified, version]
 [foo, verified, version]

--- a/lsp/nls/tests/snapshots/main__lsp__nls__tests__inputs__completion-patterns.ncl.snap
+++ b/lsp/nls/tests/snapshots/main__lsp__nls__tests__inputs__completion-patterns.ncl.snap
@@ -8,7 +8,7 @@ expression: output
 [bar, more]
 [baz, most]
 [baz, most]
-[extra, foo, inner, innermost, outer]
-[bar, extra, foo, inner, innermost, more, outer]
-[bar, baz, extra, foo, inner, innermost, more, most, outer]
+[extra, foo, inner, innermost, outer, std]
+[bar, extra, foo, inner, innermost, more, outer, std]
+[bar, baz, extra, foo, inner, innermost, more, most, outer, std]
 

--- a/lsp/nls/tests/snapshots/main__lsp__nls__tests__inputs__hover-basic.ncl.snap
+++ b/lsp/nls/tests/snapshots/main__lsp__nls__tests__inputs__hover-basic.ncl.snap
@@ -1,0 +1,16 @@
+---
+source: lsp/nls/tests/main.rs
+expression: output
+---
+<6:0-6:6>[```nickel
+Dyn
+```]
+<6:0-6:10>[```nickel
+Dyn
+```, middle]
+<6:0-6:14>[```nickel
+Dyn
+```, ```nickel
+Number
+```, innermost]
+

--- a/lsp/nls/tests/snapshots/main__lsp__nls__tests__inputs__hover-pattern.ncl.snap
+++ b/lsp/nls/tests/snapshots/main__lsp__nls__tests__inputs__hover-pattern.ncl.snap
@@ -1,0 +1,27 @@
+---
+source: lsp/nls/tests/main.rs
+expression: output
+---
+<7:2-7:7>[```nickel
+Dyn
+```]
+<8:2-8:7>[```nickel
+Dyn
+```]
+<8:2-8:11>[```nickel
+Dyn
+```, middle]
+<9:2-9:7>[```nickel
+Dyn
+```, middle]
+<9:2-9:11>[```nickel
+Dyn
+```, ```nickel
+Number
+```, innermost]
+<10:2-10:11>[```nickel
+Dyn
+```, ```nickel
+Number
+```, innermost]
+

--- a/lsp/nls/tests/snapshots/main__lsp__nls__tests__inputs__hover_field_typed_block_regression_1574.ncl.snap
+++ b/lsp/nls/tests/snapshots/main__lsp__nls__tests__inputs__hover_field_typed_block_regression_1574.ncl.snap
@@ -2,7 +2,7 @@
 source: lsp/nls/tests/main.rs
 expression: output
 ---
-<0:34-0:37>[Applies a function to every element in the given array. That is,
+<0:24-0:37>[Applies a function to every element in the given array. That is,
 `map f [ x1, x2, ..., xn ]` is `[ f x1, f x2, ..., f xn ]`.
 
 # Examples


### PR DESCRIPTION
I think this is the last piece that needs to be converted to the AST-based nls infrastructure, meaning we can get rid of the linearizer.