### PR TITLE
Implement contract deduplication optimization

### DIFF
--- a/core/src/eval/merge.rs
+++ b/core/src/eval/merge.rs
@@ -418,9 +418,9 @@ fn merge_fields<'a, C: Cache, I: DoubleEndedIterator<Item = &'a LocIdent> + Clon
         RuntimeContract::push_dedup(
             initial_env,
             &mut pending_contracts,
-            &env_final,
+            env_final,
             ctr2,
-            &env_final,
+            env_final,
         );
     }
 

--- a/core/src/eval/merge.rs
+++ b/core/src/eval/merge.rs
@@ -67,6 +67,7 @@ impl From<MergeMode> for MergeLabel {
 #[allow(clippy::too_many_arguments)] // TODO: Is it worth to pack the inputs in an ad-hoc struct?
 pub fn merge<C: Cache>(
     cache: &mut C,
+    initial_env: &Environment,
     t1: RichTerm,
     env1: Environment,
     t2: RichTerm,
@@ -307,6 +308,7 @@ pub fn merge<C: Cache>(
                     id,
                     merge_fields(
                         cache,
+                        initial_env,
                         merge_label,
                         field1,
                         env1.clone(),
@@ -357,6 +359,7 @@ pub fn merge<C: Cache>(
 #[allow(clippy::too_many_arguments)]
 fn merge_fields<'a, C: Cache, I: DoubleEndedIterator<Item = &'a LocIdent> + Clone>(
     cache: &mut C,
+    initial_env: &Environment,
     merge_label: MergeLabel,
     field1: Field,
     env1: Environment,
@@ -412,7 +415,7 @@ fn merge_fields<'a, C: Cache, I: DoubleEndedIterator<Item = &'a LocIdent> + Clon
     let mut pending_contracts = pending_contracts1.revert_closurize(cache, env_final, env1.clone());
 
     for ctr2 in pending_contracts2.revert_closurize(cache, env_final, env2.clone()) {
-        RuntimeContract::push_elide(&mut pending_contracts, ctr2, &env1, &env2);
+        RuntimeContract::push_elide(initial_env, &mut pending_contracts, &env_final, ctr2, &env_final);
     }
 
     Ok(Field {

--- a/core/src/eval/merge.rs
+++ b/core/src/eval/merge.rs
@@ -415,7 +415,7 @@ fn merge_fields<'a, C: Cache, I: DoubleEndedIterator<Item = &'a LocIdent> + Clon
     let mut pending_contracts = pending_contracts1.revert_closurize(cache, env_final, env1.clone());
 
     for ctr2 in pending_contracts2.revert_closurize(cache, env_final, env2.clone()) {
-        RuntimeContract::push_elide(
+        RuntimeContract::push_dedup(
             initial_env,
             &mut pending_contracts,
             &env_final,
@@ -427,7 +427,7 @@ fn merge_fields<'a, C: Cache, I: DoubleEndedIterator<Item = &'a LocIdent> + Clon
     Ok(Field {
         metadata: FieldMetadata {
             doc: merge_doc(metadata1.doc, metadata2.doc),
-            annotation: TypeAnnotation::combine_elide(metadata1.annotation, metadata2.annotation),
+            annotation: TypeAnnotation::combine_dedup(metadata1.annotation, metadata2.annotation),
             // If one of the record requires this field, then it musn't be optional. The
             // resulting field is optional iff both are.
             opt: metadata1.opt && metadata2.opt,

--- a/core/src/eval/merge.rs
+++ b/core/src/eval/merge.rs
@@ -32,7 +32,7 @@ use crate::label::{Label, MergeLabel};
 use crate::position::TermPos;
 use crate::term::{
     record::{self, Field, FieldDeps, FieldMetadata, RecordAttrs, RecordData},
-    BinaryOp, IndexMap, RichTerm, Term,
+    BinaryOp, IndexMap, RichTerm, Term, TypeAnnotation,
 };
 use crate::transform::Closurizable;
 
@@ -415,13 +415,19 @@ fn merge_fields<'a, C: Cache, I: DoubleEndedIterator<Item = &'a LocIdent> + Clon
     let mut pending_contracts = pending_contracts1.revert_closurize(cache, env_final, env1.clone());
 
     for ctr2 in pending_contracts2.revert_closurize(cache, env_final, env2.clone()) {
-        RuntimeContract::push_elide(initial_env, &mut pending_contracts, &env_final, ctr2, &env_final);
+        RuntimeContract::push_elide(
+            initial_env,
+            &mut pending_contracts,
+            &env_final,
+            ctr2,
+            &env_final,
+        );
     }
 
     Ok(Field {
         metadata: FieldMetadata {
             doc: merge_doc(metadata1.doc, metadata2.doc),
-            annotation: Combine::combine(metadata1.annotation, metadata2.annotation),
+            annotation: TypeAnnotation::combine_elide(metadata1.annotation, metadata2.annotation),
             // If one of the record requires this field, then it musn't be optional. The
             // resulting field is optional iff both are.
             opt: metadata1.opt && metadata2.opt,

--- a/core/src/eval/merge.rs
+++ b/core/src/eval/merge.rs
@@ -410,7 +410,10 @@ fn merge_fields<'a, C: Cache, I: DoubleEndedIterator<Item = &'a LocIdent> + Clon
     };
 
     let mut pending_contracts = pending_contracts1.revert_closurize(cache, env_final, env1.clone());
-    pending_contracts.extend(pending_contracts2.revert_closurize(cache, env_final, env2.clone()));
+
+    for ctr2 in pending_contracts2.revert_closurize(cache, env_final, env2.clone()) {
+        RuntimeContract::push_elide(&mut pending_contracts, ctr2, &env1, &env2);
+    }
 
     Ok(Field {
         metadata: FieldMetadata {

--- a/core/src/eval/mod.rs
+++ b/core/src/eval/mod.rs
@@ -122,6 +122,8 @@ pub struct VirtualMachine<R: ImportResolver, C: Cache> {
     import_resolver: R,
     // The evaluation cache.
     pub cache: C,
+    // The initial environment containing stdlib and builtin functions accessible from anywhere
+    initial_env: Environment,
     // The stream for writing trace output.
     trace: Box<dyn Write>,
 }
@@ -133,6 +135,7 @@ impl<R: ImportResolver, C: Cache> VirtualMachine<R, C> {
             call_stack: Default::default(),
             stack: Stack::new(),
             cache: Cache::new(),
+            initial_env: Environment::new(),
             trace: Box::new(trace),
         }
     }
@@ -144,6 +147,7 @@ impl<R: ImportResolver, C: Cache> VirtualMachine<R, C> {
             stack: Stack::new(),
             cache,
             trace: Box::new(trace),
+            initial_env: Environment::new(),
         }
     }
 
@@ -164,8 +168,8 @@ impl<R: ImportResolver, C: Cache> VirtualMachine<R, C> {
 
     /// Evaluate a Nickel term. Wrapper around [VirtualMachine::eval_closure] that starts from an
     /// empty local environment and drops the final environment.
-    pub fn eval(&mut self, t0: RichTerm, initial_env: &Environment) -> Result<RichTerm, EvalError> {
-        self.eval_closure(Closure::atomic_closure(t0), initial_env)
+    pub fn eval(&mut self, t: RichTerm) -> Result<RichTerm, EvalError> {
+        self.eval_closure(Closure::atomic_closure(t))
             .map(|(term, _)| term)
     }
 
@@ -174,45 +178,50 @@ impl<R: ImportResolver, C: Cache> VirtualMachine<R, C> {
     pub fn eval_full(
         &mut self,
         t0: RichTerm,
-        initial_env: &Environment,
     ) -> Result<RichTerm, EvalError> {
-        self.eval_deep_closure(t0, initial_env, false)
-            .map(|(term, env)| subst(&self.cache, term, initial_env, &env))
+        self.eval_full_closure(Closure::atomic_closure(t0)).map(|(term, _)| term)
+    }
+
+    pub fn eval_full_closure(
+        &mut self,
+        t0: Closure,
+    ) -> Result<(RichTerm, Environment), EvalError> {
+        self.eval_deep_closure(t0, false)
+            .map(|(term, env)| (subst(&self.cache, term, &self.initial_env, &env), env))
     }
 
     /// Like `eval_full`, but skips evaluating record fields marked `not_exported`.
     pub fn eval_full_for_export(
         &mut self,
         t0: RichTerm,
-        initial_env: &Environment,
     ) -> Result<RichTerm, EvalError> {
-        self.eval_deep_closure(t0, initial_env, true)
-            .map(|(term, env)| subst(&self.cache, term, initial_env, &env))
+        self.eval_deep_closure(Closure::atomic_closure(t0), true)
+            .map(|(term, env)| subst(&self.cache, term, &self.initial_env, &env))
     }
 
     /// Fully evaluates a Nickel term like `eval_full`, but does not substitute all variables.
     pub fn eval_deep(
         &mut self,
         t0: RichTerm,
-        initial_env: &Environment,
     ) -> Result<RichTerm, EvalError> {
-        self.eval_deep_closure(t0, initial_env, false)
+        self.eval_deep_closure(Closure::atomic_closure(t0), false)
             .map(|(term, _)| term)
     }
 
     fn eval_deep_closure(
         &mut self,
-        rt: RichTerm,
-        initial_env: &Environment,
+        mut closure: Closure,
         for_export: bool,
     ) -> Result<(RichTerm, Environment), EvalError> {
-        let wrapper = mk_term::op1(
+
+        closure.body = mk_term::op1(
             UnaryOp::Force {
                 ignore_not_exported: for_export,
             },
-            rt,
+            closure.body,
         );
-        self.eval_closure(Closure::atomic_closure(wrapper), initial_env)
+
+        self.eval_closure(closure)
     }
 
     /// Query the value and the metadata of a record field in an expression.
@@ -228,7 +237,7 @@ impl<R: ImportResolver, C: Cache> VirtualMachine<R, C> {
         initial_env: &Environment,
     ) -> Result<Field, EvalError> {
         let mut prev_pos = t.pos;
-        let (rt, mut env) = self.eval_closure(Closure::atomic_closure(t), initial_env)?;
+        let (rt, mut env) = self.eval_closure(Closure::atomic_closure(t))?;
 
         let mut field: Field = rt.into();
 
@@ -272,8 +281,7 @@ impl<R: ImportResolver, C: Cache> VirtualMachine<R, C> {
                                     Closure {
                                         body: value_with_ctr,
                                         env: env.clone(),
-                                    },
-                                    initial_env,
+                                    }
                                 )?;
                                 env = new_env;
 
@@ -329,7 +337,6 @@ impl<R: ImportResolver, C: Cache> VirtualMachine<R, C> {
     pub fn eval_closure(
         &mut self,
         mut clos: Closure,
-        initial_env: &Environment,
     ) -> Result<(RichTerm, Environment), EvalError> {
         loop {
             let Closure {
@@ -383,7 +390,7 @@ impl<R: ImportResolver, C: Cache> VirtualMachine<R, C> {
                 Term::Var(x) => {
                     let mut idx = env
                         .get(&x.ident())
-                        .or_else(|| initial_env.get(&x.ident()))
+                        .or_else(|| self.initial_env.get(&x.ident()))
                         .cloned()
                         .ok_or(EvalError::UnboundIdentifier(*x, pos))?;
                     std::mem::drop(env); // idx may be a 1RC pointer
@@ -820,13 +827,14 @@ impl<R: ImportResolver, C: Cache> VirtualMachine<R, C> {
 }
 
 impl<C: Cache> VirtualMachine<ImportCache, C> {
-    pub fn prepare_eval(&mut self, main_id: FileId) -> Result<(RichTerm, Environment), Error> {
+    pub fn prepare_eval(&mut self, main_id: FileId) -> Result<RichTerm, Error> {
         let Envs {
             eval_env,
             type_ctxt,
         }: Envs = self.import_resolver.prepare_stdlib(&mut self.cache)?;
         self.import_resolver.prepare(main_id, &type_ctxt)?;
-        Ok((self.import_resolver().get(main_id).unwrap(), eval_env))
+        self.initial_env = eval_env;
+        Ok(self.import_resolver().get(main_id).unwrap())
     }
 
     pub fn prepare_stdlib(&mut self) -> Result<Envs, Error> {

--- a/core/src/eval/mod.rs
+++ b/core/src/eval/mod.rs
@@ -175,37 +175,36 @@ impl<R: ImportResolver, C: Cache> VirtualMachine<R, C> {
 
     /// Fully evaluate a Nickel term: the result is not a WHNF but to a value with all variables
     /// substituted.
-    pub fn eval_full(
-        &mut self,
-        t0: RichTerm,
-    ) -> Result<RichTerm, EvalError> {
-        self.eval_full_closure(Closure::atomic_closure(t0)).map(|(term, _)| term)
+    pub fn eval_full(&mut self, t0: RichTerm) -> Result<RichTerm, EvalError> {
+        self.eval_full_closure(Closure::atomic_closure(t0))
+            .map(|(term, _)| term)
     }
 
-    pub fn eval_full_closure(
-        &mut self,
-        t0: Closure,
-    ) -> Result<(RichTerm, Environment), EvalError> {
+    pub fn eval_full_closure(&mut self, t0: Closure) -> Result<(RichTerm, Environment), EvalError> {
         self.eval_deep_closure(t0, false)
             .map(|(term, env)| (subst(&self.cache, term, &self.initial_env, &env), env))
     }
 
     /// Like `eval_full`, but skips evaluating record fields marked `not_exported`.
-    pub fn eval_full_for_export(
-        &mut self,
-        t0: RichTerm,
-    ) -> Result<RichTerm, EvalError> {
+    pub fn eval_full_for_export(&mut self, t0: RichTerm) -> Result<RichTerm, EvalError> {
         self.eval_deep_closure(Closure::atomic_closure(t0), true)
             .map(|(term, env)| subst(&self.cache, term, &self.initial_env, &env))
     }
 
     /// Fully evaluates a Nickel term like `eval_full`, but does not substitute all variables.
-    pub fn eval_deep(
-        &mut self,
-        t0: RichTerm,
-    ) -> Result<RichTerm, EvalError> {
+    pub fn eval_deep(&mut self, t0: RichTerm) -> Result<RichTerm, EvalError> {
         self.eval_deep_closure(Closure::atomic_closure(t0), false)
             .map(|(term, _)| term)
+    }
+
+    /// Use a specific initial environment for evaluation. Usually, [VirtualMachine::prepare_eval]
+    /// is populating the initial environment. But in some cases, such as testing or benchmarks, we
+    /// might want to use a different one.
+    ///
+    /// Return the new virtual machine with the updated initial environment.
+    pub fn with_initial_env(mut self, env: Environment) -> Self {
+        self.initial_env = env;
+        self
     }
 
     fn eval_deep_closure(
@@ -213,7 +212,6 @@ impl<R: ImportResolver, C: Cache> VirtualMachine<R, C> {
         mut closure: Closure,
         for_export: bool,
     ) -> Result<(RichTerm, Environment), EvalError> {
-
         closure.body = mk_term::op1(
             UnaryOp::Force {
                 ignore_not_exported: for_export,
@@ -230,14 +228,15 @@ impl<R: ImportResolver, C: Cache> VirtualMachine<R, C> {
     /// `baz`. The content of `baz` is evaluated as well, and variables are substituted, in order
     /// to obtain a value that can be printed. The metadata and the evaluated value are returned as
     /// a new field.
-    pub fn query(
-        &mut self,
-        t: RichTerm,
-        path: QueryPath,
-        initial_env: &Environment,
-    ) -> Result<Field, EvalError> {
-        let mut prev_pos = t.pos;
-        let (rt, mut env) = self.eval_closure(Closure::atomic_closure(t))?;
+    pub fn query(&mut self, t: RichTerm, path: QueryPath) -> Result<Field, EvalError> {
+        self.query_closure(Closure::atomic_closure(t), path)
+    }
+
+    /// Same as [VirtualMachine::query], but starts from a closure instead of a term in an empty
+    /// environment.
+    pub fn query_closure(&mut self, closure: Closure, path: QueryPath) -> Result<Field, EvalError> {
+        let mut prev_pos = closure.body.pos;
+        let (rt, mut env) = self.eval_closure(closure)?;
 
         let mut field: Field = rt.into();
 
@@ -277,12 +276,10 @@ impl<R: ImportResolver, C: Cache> VirtualMachine<R, C> {
                                     pending_contracts.into_iter(),
                                     prev_pos,
                                 );
-                                let (new_value, new_env) = self.eval_closure(
-                                    Closure {
-                                        body: value_with_ctr,
-                                        env: env.clone(),
-                                    }
-                                )?;
+                                let (new_value, new_env) = self.eval_closure(Closure {
+                                    body: value_with_ctr,
+                                    env: env.clone(),
+                                })?;
                                 env = new_env;
 
                                 Ok(new_value)
@@ -827,18 +824,29 @@ impl<R: ImportResolver, C: Cache> VirtualMachine<R, C> {
 }
 
 impl<C: Cache> VirtualMachine<ImportCache, C> {
+    /// Prepare the underlying program for evaluation (load the stdlib, typecheck, transform,
+    /// etc.). Sets the initial environment of the virtual machine.
     pub fn prepare_eval(&mut self, main_id: FileId) -> Result<RichTerm, Error> {
         let Envs {
             eval_env,
             type_ctxt,
-        }: Envs = self.import_resolver.prepare_stdlib(&mut self.cache)?;
+        } = self.import_resolver.prepare_stdlib(&mut self.cache)?;
         self.import_resolver.prepare(main_id, &type_ctxt)?;
         self.initial_env = eval_env;
         Ok(self.import_resolver().get(main_id).unwrap())
     }
 
+    /// Prepare the stdlib for evaluation. Sets the initial environment of the virtual machine. As
+    /// opposed to [VirtualMachine::prepare_eval], [VirtualMachine::prepare_stdlib] doesn't prepare
+    /// the main program yet (typechecking, transformations, etc.).
+    ///
+    /// # Returns
+    ///
+    /// The initial evaluation and typing environments, containing the stdlib items.
     pub fn prepare_stdlib(&mut self) -> Result<Envs, Error> {
-        self.import_resolver.prepare_stdlib(&mut self.cache)
+        let envs = self.import_resolver.prepare_stdlib(&mut self.cache)?;
+        self.initial_env = envs.eval_env.clone();
+        Ok(envs)
     }
 }
 

--- a/core/src/eval/operation.rs
+++ b/core/src/eval/operation.rs
@@ -2113,6 +2113,7 @@ impl<R: ImportResolver, C: Cache> VirtualMachine<R, C> {
                             // due to a limitation of `match_sharedterm`: see the macro's
                             // documentation
                             let mut record_data = record_data;
+                            let term_original_env = env2.clone();
 
                             let mut contract_at_field = |id: LocIdent| {
                                 let pos = contract_term.pos;
@@ -2125,10 +2126,17 @@ impl<R: ImportResolver, C: Cache> VirtualMachine<R, C> {
                             };
 
                             for (id, field) in record_data.fields.iter_mut() {
-                                field.pending_contracts.push(RuntimeContract {
-                                    contract: contract_at_field(*id),
-                                    label: label.clone(),
-                                });
+                                let runtime_ctr = RuntimeContract {
+                                        contract: contract_at_field(*id),
+                                        label: label.clone(),
+                                    };
+
+                                crate::term::RuntimeContract::push_elide(
+                                    &mut field.pending_contracts,
+                                    runtime_ctr,
+                                    &term_original_env,
+                                    &contract_env,
+                                );
                             }
 
                             // IMPORTANT: here, we revert the record back to a `RecRecord`. The

--- a/core/src/eval/operation.rs
+++ b/core/src/eval/operation.rs
@@ -1881,6 +1881,7 @@ impl<R: ImportResolver, C: Cache> VirtualMachine<R, C> {
             },
             BinaryOp::Merge(merge_label) => merge::merge(
                 &mut self.cache,
+                &self.initial_env,
                 RichTerm {
                     term: t1,
                     pos: pos1,
@@ -2132,9 +2133,10 @@ impl<R: ImportResolver, C: Cache> VirtualMachine<R, C> {
                                     };
 
                                 crate::term::RuntimeContract::push_elide(
+                                    &self.initial_env,
                                     &mut field.pending_contracts,
-                                    runtime_ctr,
                                     &term_original_env,
+                                    runtime_ctr,
                                     &contract_env,
                                 );
                             }
@@ -2471,6 +2473,7 @@ impl<R: ImportResolver, C: Cache> VirtualMachine<R, C> {
                         Term::Lbl(lbl) => {
                             merge::merge(
                                 &mut self.cache,
+                                &self.initial_env,
                                 RichTerm {
                                     term: t2,
                                     pos: pos2,

--- a/core/src/eval/operation.rs
+++ b/core/src/eval/operation.rs
@@ -2132,7 +2132,7 @@ impl<R: ImportResolver, C: Cache> VirtualMachine<R, C> {
                                         label: label.clone(),
                                     };
 
-                                crate::term::RuntimeContract::push_elide(
+                                crate::term::RuntimeContract::push_dedup(
                                     &self.initial_env,
                                     &mut field.pending_contracts,
                                     &term_original_env,

--- a/core/src/eval/tests.rs
+++ b/core/src/eval/tests.rs
@@ -14,7 +14,7 @@ use codespan::Files;
 /// Evaluate a term without import support.
 fn eval_no_import(t: RichTerm) -> Result<Term, EvalError> {
     VirtualMachine::<_, CacheImpl>::new(DummyResolver {}, std::io::sink())
-        .eval(t, &Environment::new())
+        .eval(t)
         .map(Term::from)
 }
 
@@ -169,9 +169,7 @@ fn imports() {
     let mk_import_two = mk_import("x", "two", mk_term::var("x"), &mut vm).unwrap();
     vm.reset();
     assert_eq!(
-        vm.eval(mk_import_two, &Environment::new(),)
-            .map(RichTerm::without_pos)
-            .unwrap(),
+        vm.eval(mk_import_two).map(RichTerm::without_pos).unwrap(),
         mk_term::integer(2)
     );
 
@@ -187,9 +185,7 @@ fn imports() {
     );
     vm.reset();
     assert_eq!(
-        vm.eval(mk_import_lib.unwrap(), &Environment::new(),)
-            .map(Term::from)
-            .unwrap(),
+        vm.eval(mk_import_lib.unwrap()).map(Term::from).unwrap(),
         Term::Bool(true)
     );
 }
@@ -269,7 +265,8 @@ fn initial_env() {
     let t = mk_term::let_in("x", mk_term::integer(2), mk_term::var("x"));
     assert_eq!(
         VirtualMachine::new_with_cache(DummyResolver {}, eval_cache.clone(), std::io::sink())
-            .eval(t, &initial_env)
+            .with_initial_env(initial_env.clone())
+            .eval(t)
             .map(RichTerm::without_pos),
         Ok(mk_term::integer(2))
     );
@@ -277,7 +274,8 @@ fn initial_env() {
     let t = mk_term::let_in("x", mk_term::integer(2), mk_term::var("g"));
     assert_eq!(
         VirtualMachine::new_with_cache(DummyResolver {}, eval_cache.clone(), std::io::sink())
-            .eval(t, &initial_env)
+            .with_initial_env(initial_env.clone())
+            .eval(t)
             .map(RichTerm::without_pos),
         Ok(mk_term::integer(1))
     );
@@ -286,7 +284,8 @@ fn initial_env() {
     let t = mk_term::let_in("g", mk_term::integer(2), mk_term::var("g"));
     assert_eq!(
         VirtualMachine::new_with_cache(DummyResolver {}, eval_cache.clone(), std::io::sink())
-            .eval(t, &initial_env)
+            .with_initial_env(initial_env.clone())
+            .eval(t)
             .map(RichTerm::without_pos),
         Ok(mk_term::integer(2))
     );

--- a/core/src/program.rs
+++ b/core/src/program.rs
@@ -234,8 +234,7 @@ impl<EC: EvalCache> Program<EC> {
             .clone())
     }
 
-    /// Retrieve the parsed term, typecheck it, and generate a fresh initial environment. Return
-    /// both.
+    /// Retrieve the parsed term, typecheck it, and generate a fresh initial environment.
     fn prepare_eval(&mut self) -> Result<RichTerm, Error> {
         // If there are no overrides, we avoid the boilerplate of creating an empty record and
         // merging it with the current program

--- a/core/src/program.rs
+++ b/core/src/program.rs
@@ -309,7 +309,7 @@ impl<EC: EvalCache> Program<EC> {
         self.vm.eval_deep(t).map_err(|e| e.into())
     }
 
-    /// Wrapper for [`query`].
+    /// Prepare for evaluation, then query the program for a field.
     pub fn query(&mut self, path: Option<String>) -> Result<Field, Error> {
         let rt = self.prepare_eval()?;
         let query_path = QueryPath::parse_opt(self.vm.import_resolver_mut(), path)?;

--- a/core/src/program.rs
+++ b/core/src/program.rs
@@ -22,7 +22,7 @@
 //! Each such value is added to the initial environment before the evaluation of the program.
 use crate::{
     cache::*,
-    error::{report, ColorOpt, Error, IntoDiagnostics, ParseError, EvalError, IOError},
+    error::{report, ColorOpt, Error, EvalError, IOError, IntoDiagnostics, ParseError},
     eval::{cache::Cache as EvalCache, VirtualMachine},
     identifier::LocIdent,
     label::Label,
@@ -266,7 +266,11 @@ impl<EC: EvalCache> Program<EC> {
         // generate a dummy file id).
         // We'll have to adapt `Label` and `MergeLabel` to be generated programmatically,
         // without referring to any source position.
-        Ok(mk_term::op2(BinaryOp::Merge(Label::default().into()), t, built_record))
+        Ok(mk_term::op2(
+            BinaryOp::Merge(Label::default().into()),
+            t,
+            built_record,
+        ))
     }
 
     /// Parse if necessary, typecheck and then evaluate the program.

--- a/core/src/repl/mod.rs
+++ b/core/src/repl/mod.rs
@@ -167,6 +167,7 @@ impl<EC: EvalCache> ReplImpl<EC> {
 
     fn eval_(&mut self, exp: &str, eval_full: bool) -> Result<EvalResult, Error> {
         self.vm.reset();
+
         let eval_function = if eval_full {
             eval::VirtualMachine::eval_full_closure
         } else {
@@ -304,6 +305,8 @@ impl<EC: EvalCache> Repl for ReplImpl<EC> {
     }
 
     fn query(&mut self, path: String) -> Result<Field, Error> {
+        self.vm.reset();
+
         let mut query_path = QueryPath::parse(self.vm.import_resolver_mut(), path)?;
 
         // remove(): this is safe because there is no such thing as an empty field path. If `path`
@@ -315,6 +318,10 @@ impl<EC: EvalCache> Repl for ReplImpl<EC> {
             .vm
             .import_resolver_mut()
             .replace_string(SourcePath::ReplQuery, target.label().into());
+
+        self.vm
+            .import_resolver_mut()
+            .prepare(file_id, &self.env.type_ctxt)?;
 
         Ok(self.vm.query_closure(
             Closure {

--- a/core/src/serialize.rs
+++ b/core/src/serialize.rs
@@ -281,7 +281,7 @@ mod tests {
     use super::*;
     use crate::cache::resolvers::DummyResolver;
     use crate::eval::cache::CacheImpl;
-    use crate::eval::{Environment, VirtualMachine};
+    use crate::eval::VirtualMachine;
     use crate::program::Program;
     use crate::term::{make as mk_term, BinaryOp};
     use serde_json::json;
@@ -306,10 +306,7 @@ mod tests {
     fn assert_nickel_eq(term: RichTerm, expected: RichTerm) {
         assert_eq!(
             VirtualMachine::<_, CacheImpl>::new(DummyResolver {}, std::io::stderr())
-                .eval(
-                    mk_term::op2(BinaryOp::Eq(), term, expected),
-                    &Environment::new(),
-                )
+                .eval(mk_term::op2(BinaryOp::Eq(), term, expected))
                 .map(Term::from),
             Ok(Term::Bool(true))
         )

--- a/core/src/term/mod.rs
+++ b/core/src/term/mod.rs
@@ -319,6 +319,21 @@ impl RuntimeContract {
     {
         contracts.fold(rt, |acc, ctr| ctr.apply(acc, pos))
     }
+
+    pub fn push_elide(
+        contracts: &mut Vec<RuntimeContract>,
+        ctr: Self,
+        env1: &crate::eval::Environment,
+        env2: &crate::eval::Environment,
+    ) {
+        for c in contracts.iter() {
+            if crate::typecheck::eq::contract_eq(0, &c.contract, env1, &ctr.contract, env2) {
+                return;
+            }
+        }
+
+        contracts.push(ctr);
+    }
 }
 
 impl Traverse<RichTerm> for RuntimeContract {

--- a/core/src/term/mod.rs
+++ b/core/src/term/mod.rs
@@ -26,7 +26,7 @@ use crate::{
     match_sharedterm,
     position::TermPos,
     typ::{Type, UnboundTypeVariableError},
-    typecheck::eq::{contract_eq, type_eq_noenv, EvalEnvs},
+    typecheck::eq::{contract_eq, type_eq_noenv, EvalEnvsRef},
 };
 
 use codespan::FileId;
@@ -332,17 +332,18 @@ impl RuntimeContract {
         ctr: Self,
         env2: &Environment,
     ) {
-        let envs1 = EvalEnvs {
+        let envs1 = EvalEnvsRef {
             eval_env: env1,
             initial_env,
         };
 
         for c in contracts.iter() {
-            let envs = EvalEnvs {
+            let envs = EvalEnvsRef {
                 eval_env: env2,
                 initial_env,
             };
-            if contract_eq::<EvalEnvs>(0, &c.contract, envs1, &ctr.contract, envs) {
+
+            if contract_eq::<EvalEnvsRef>(0, &c.contract, envs1, &ctr.contract, envs) {
                 return;
             }
         }

--- a/core/src/term/mod.rs
+++ b/core/src/term/mod.rs
@@ -612,9 +612,9 @@ impl TypeAnnotation {
     /// could equate contracts that are actually totally distinct), but we use it only to trim
     /// accumulated contracts before pretty-printing. Do not use prior to any form of evaluation.
     ///
-    /// Same as [`Combine::combine`], but eliminate duplicate contracts. As there's no notion of
-    /// environment when considering mere annotations, we use an unsound contract equality checking
-    /// which correspond to compares contracts syntactically.
+    /// Same as [`crate::combine::Combine`], but eliminate duplicate contracts. As there's no
+    /// notion of environment when considering mere annotations, we use an unsound contract
+    /// equality checking which correspond to compares contracts syntactically.
     pub fn combine_dedup(left: Self, right: Self) -> Self {
         let mut contracts = left.contracts;
 

--- a/core/src/typecheck/eq.rs
+++ b/core/src/typecheck/eq.rs
@@ -49,6 +49,8 @@ use crate::{
     term::{self, record::Field, IndexMap, UnaryOp},
 };
 
+use std::fmt::Debug;
+
 /// The maximal number of variable links we want to unfold before abandoning the check. It should
 /// stay low, but has been fixed arbitrarily: feel fee to increase reasonably if it turns out
 /// legitimate type equalities between simple contracts are unduly rejected in practice.
@@ -63,9 +65,15 @@ pub const MAX_GAS: u8 = 20;
 /// `TermEnvironment::get_then` has to take a closure representing the continuation of the task to
 /// do with the result instead of merely returning it.
 pub trait TermEnvironment: Clone {
-    fn get_then<F, T>(&self, id: Ident, f: F) -> T
+    type Owned : Clone + PartialEq + Debug;
+    type Ref<'a> : Copy;
+
+    fn get_then<F, T>(env: Self::Ref<'_>, id: Ident, f: F) -> T
     where
-        F: FnOnce(Option<(&RichTerm, &Self)>) -> T;
+        F: FnOnce(Option<(&RichTerm, Self::Ref<'_>)>) -> T;
+
+    fn owned_to_ref(&self) -> Self::Ref<'_>;
+    fn ref_to_owned(env: Self::Ref<'_>) -> Self::Owned;
 }
 
 /// A simple term environment, as a mapping from identifiers to a tuple of a term and an
@@ -86,11 +94,28 @@ impl Default for SimpleTermEnvironment {
 }
 
 impl TermEnvironment for SimpleTermEnvironment {
-    fn get_then<F, T>(&self, id: Ident, f: F) -> T
+    type Owned = Self;
+    type Ref<'a> = &'a Self;
+
+    fn get_then<F, T>(env: &Self, id: Ident, f: F) -> T
     where
         F: FnOnce(Option<(&RichTerm, &SimpleTermEnvironment)>) -> T,
     {
-        f(self.0.get(&id).map(|(rt, env)| (rt, env)))
+        f(env.0.get(&id).map(|(rt, env)| (rt, env)))
+    }
+
+    fn owned_to_ref(&self) -> Self::Ref<'_> {
+        self
+    }
+
+    fn ref_to_owned(env: &Self) -> Self::Owned {
+        env.clone()
+    }
+}
+
+impl<'a> AsRef<SimpleTermEnvironment> for &'a SimpleTermEnvironment {
+    fn as_ref(&self) -> &SimpleTermEnvironment {
+        self
     }
 }
 
@@ -105,14 +130,45 @@ impl std::iter::FromIterator<(Ident, (RichTerm, SimpleTermEnvironment))> for Sim
     }
 }
 
-impl TermEnvironment for eval::Environment {
-    fn get_then<F, T>(&self, id: Ident, f: F) -> T
+#[derive(Clone, Copy)]
+pub struct EvalEnvs<'a> {
+    pub eval_env: &'a eval::Environment,
+    pub initial_env:  &'a eval::Environment,
+}
+
+#[derive(Clone, PartialEq, Debug)]
+pub struct EvalEnvsOwned {
+    pub eval_env: eval::Environment,
+    pub initial_env:  eval::Environment,
+}
+
+impl<'a> TermEnvironment for EvalEnvs<'a> {
+    type Ref<'b> = EvalEnvs<'b>;
+    type Owned = EvalEnvsOwned;
+
+    fn get_then<F, T>(env: EvalEnvs<'_>, id: Ident, f: F) -> T
     where
-        F: FnOnce(Option<(&RichTerm, &eval::Environment)>) -> T,
+        F: FnOnce(Option<(&RichTerm, EvalEnvs<'_>)>) -> T,
     {
-        match self.get(&id).map(eval::cache::lazy::Thunk::borrow) {
-            Some(closure_ref) => f(Some((&closure_ref.body, &closure_ref.env))),
+        debug_assert!(env.eval_env.get(&id).or(env.initial_env.get(&id)).is_some(), "unbound variable `{}`", id);
+
+        match env.eval_env.get(&id).or(env.initial_env.get(&id)).map(eval::cache::lazy::Thunk::borrow) {
+            Some(closure_ref) => f(Some((&closure_ref.body, EvalEnvs { eval_env: &closure_ref.env, initial_env: env.initial_env }))),
             None => f(None),
+        }
+    }
+
+    fn owned_to_ref(&self) -> Self::Ref<'_> {
+        EvalEnvs {
+            eval_env: self.eval_env,
+            initial_env: self.initial_env,
+        }
+    }
+
+    fn ref_to_owned(env: EvalEnvs) -> Self::Owned {
+        EvalEnvsOwned {
+            eval_env: env.eval_env.clone(),
+            initial_env: env.initial_env.clone(),
         }
     }
 }
@@ -185,24 +241,24 @@ impl State {
 ///
 /// - `env`: an environment mapping variables to their definition (the second placeholder in a
 ///   `let _ = _ in _`)
-pub fn contract_eq<E: TermEnvironment>(
+pub fn contract_eq<'env, 'a: 'env, E: TermEnvironment>(
     var_uid: usize,
-    t1: &RichTerm,
-    env1: &E,
-    t2: &RichTerm,
-    env2: &E,
+    t1: &'a RichTerm,
+    env1: E::Ref<'env>,
+    t2: &'a RichTerm,
+    env2: E::Ref<'env>,
 ) -> bool {
-    contract_eq_bounded(&mut State::new(var_uid), t1, env1, t2, env2)
+    contract_eq_bounded::<E>(&mut State::new(var_uid), t1, env1, t2, env2)
 }
 
 /// Decide type equality on contracts in their respective environment and given the remaining gas
 /// `gas`.
-fn contract_eq_bounded<E: TermEnvironment>(
+fn contract_eq_bounded<'env, 'a: 'env, E: TermEnvironment>(
     state: &mut State,
-    t1: &RichTerm,
-    env1: &E,
-    t2: &RichTerm,
-    env2: &E,
+    t1: &'a RichTerm,
+    env1: E::Ref<'env>,
+    t2: &'a RichTerm,
+    env2: E::Ref<'env>,
 ) -> bool {
     use Term::*;
 
@@ -221,7 +277,7 @@ fn contract_eq_bounded<E: TermEnvironment>(
         (Enum(id1), Enum(id2)) => id1 == id2,
         (SealingKey(s1), SealingKey(s2)) => s1 == s2,
         (Sealed(key1, inner1, _), Sealed(key2, inner2, _)) => {
-            key1 == key2 && contract_eq_bounded(state, inner1, env1, inner2, env2)
+            key1 == key2 && contract_eq_bounded::<E>(state, inner1, env1, inner2, env2)
         }
         // We only compare string chunks when they represent a plain string (they don't contain any
         // interpolated expression), as static string may be currently parsed as such. We return
@@ -237,8 +293,8 @@ fn contract_eq_bounded<E: TermEnvironment>(
                     })
         }
         (App(head1, arg1), App(head2, arg2)) => {
-            contract_eq_bounded(state, head1, env1, head2, env2)
-                && contract_eq_bounded(state, arg1, env1, arg2, env2)
+            contract_eq_bounded::<E>(state, head1, env1, head2, env2)
+                && contract_eq_bounded::<E>(state, arg1, env1, arg2, env2)
         }
         // All variables must be bound at this stage. This is checked by the typechecker when
         // walking annotations. However, we may assume that `env` is a local environment (that it
@@ -246,8 +302,8 @@ fn contract_eq_bounded<E: TermEnvironment>(
         // if they have the same identifier: whatever global environment the term will be put in,
         // free variables are not redefined locally and will be bound to the same value in any case.
         (Var(id1), Var(id2)) => {
-            env1.get_then(id1.ident(), |binding1| {
-                env2.get_then(id2.ident(), |binding2| {
+            <E as TermEnvironment>::get_then(env1, id1.ident(), |binding1| {
+                <E as TermEnvironment>::get_then(env2, id2.ident(), |binding2| {
                     match (binding1, binding2) {
                         (None, None) => id1 == id2,
                         (Some((t1, env1)), Some((t2, env2))) => {
@@ -256,7 +312,7 @@ fn contract_eq_bounded<E: TermEnvironment>(
                             // still return false if gas was already at zero.
                             let had_gas = state.use_gas();
                             state.use_gas();
-                            had_gas && contract_eq_bounded(state, t1, env1, t2, env2)
+                            had_gas && contract_eq_bounded::<E>(state, t1, env1, t2, env2)
                         }
                         _ => false,
                     }
@@ -265,23 +321,23 @@ fn contract_eq_bounded<E: TermEnvironment>(
         }
         (Var(id), _) => {
             state.use_gas()
-                && env1.get_then(id.ident(), |binding| {
+                && <E as TermEnvironment>::get_then(env1, id.ident(), |binding| {
                     binding
-                        .map(|(t1, env1)| contract_eq_bounded(state, t1, env1, t2, env2))
+                        .map(|(t1, env1)| contract_eq_bounded::<E>(state, t1, env1, t2, env2))
                         .unwrap_or(false)
                 })
         }
         (_, Var(id)) => {
             state.use_gas()
-                && env2.get_then(id.ident(), |binding| {
+                && <E as TermEnvironment>::get_then(env2, id.ident(), |binding| {
                     binding
-                        .map(|(t2, env2)| contract_eq_bounded(state, t1, env1, t2, env2))
+                        .map(|(t2, env2)| contract_eq_bounded::<E>(state, t1, env1, t2, env2))
                         .unwrap_or(false)
                 })
         }
         (Record(r1), Record(r2)) => {
-            map_eq(
-                contract_eq_fields,
+            map_eq::<_, _, E>(
+                contract_eq_fields::<E>,
                 state,
                 &r1.fields,
                 env1,
@@ -295,8 +351,8 @@ fn contract_eq_bounded<E: TermEnvironment>(
         {
             dyn_fields1.is_empty()
                 && dyn_fields2.is_empty()
-                && map_eq(
-                    contract_eq_fields,
+                && map_eq::<_, _, E>(
+                    contract_eq_fields::<E>,
                     state,
                     &r1.fields,
                     env1,
@@ -310,13 +366,13 @@ fn contract_eq_bounded<E: TermEnvironment>(
                 && ts1
                     .iter()
                     .zip(ts2.iter())
-                    .all(|(t1, t2)| contract_eq_bounded(state, t1, env1, t2, env2))
+                    .all(|(t1, t2)| contract_eq_bounded::<E>(state, t1, env1, t2, env2))
                 && attrs1 == attrs2
         }
         // We must compare the inner values as well as the corresponding contracts or type
         // annotations.
         (Annotated(annot1, t1), Annotated(annot2, t2)) => {
-            let value_eq = contract_eq_bounded(state, t1, env1, t2, env2);
+            let value_eq = contract_eq_bounded::<E>(state, t1, env1, t2, env2);
 
             // TODO:
             // - does it really make sense to compare the annotations?
@@ -335,9 +391,9 @@ fn contract_eq_bounded<E: TermEnvironment>(
                 (None, None) => true,
                 (Some(ctr1), Some(ctr2)) => type_eq_bounded(
                     state,
-                    &GenericUnifType::from_type(ctr1.typ.clone(), env1),
+                    &GenericUnifType::<E>::from_type(ctr1.typ.clone(), env1),
                     env1,
-                    &GenericUnifType::from_type(ctr2.typ.clone(), env2),
+                    &GenericUnifType::<E>::from_type(ctr2.typ.clone(), env2),
                     env2,
                 ),
                 _ => false,
@@ -346,7 +402,7 @@ fn contract_eq_bounded<E: TermEnvironment>(
             value_eq && ty_eq
         }
         (Op1(UnaryOp::StaticAccess(id1), t1), Op1(UnaryOp::StaticAccess(id2), t2)) => {
-            id1 == id2 && contract_eq_bounded(state, t1, env1, t2, env2)
+            id1 == id2 && contract_eq_bounded::<E>(state, t1, env1, t2, env2)
         }
         // We don't treat imports, parse errors, nor pairs of terms that don't have the same shape
         _ => false,
@@ -354,16 +410,16 @@ fn contract_eq_bounded<E: TermEnvironment>(
 }
 
 /// Compute the equality between two hashmaps holding either types or terms.
-fn map_eq<V, F, E>(
+fn map_eq<'env, 'a: 'env, V, F, E: TermEnvironment>(
     mut f: F,
     state: &mut State,
-    map1: &IndexMap<LocIdent, V>,
-    env1: &E,
-    map2: &IndexMap<LocIdent, V>,
-    env2: &E,
+    map1: &'a IndexMap<LocIdent, V>,
+    env1: E::Ref<'env>,
+    map2: &'a IndexMap<LocIdent, V>,
+    env2: E::Ref<'env>,
 ) -> bool
 where
-    F: FnMut(&mut State, &V, &E, &V, &E) -> bool,
+    F: FnMut(&mut State, &'a V, E::Ref<'env>, &'a V, E::Ref<'env>) -> bool,
 {
     map1.len() == map2.len()
         && map1.iter().all(|(id, v1)| {
@@ -412,16 +468,16 @@ fn rows_as_set(erows: &UnifEnumRows) -> Option<HashSet<LocIdent>> {
 
 /// Check for contract equality between record fields. Fields are equal if they are both without a
 /// definition, or are both defined and their values are equal.
-fn contract_eq_fields<E: TermEnvironment>(
+fn contract_eq_fields<'env, 'a: 'env, E: TermEnvironment>(
     state: &mut State,
-    field1: &Field,
-    env1: &E,
-    field2: &Field,
-    env2: &E,
+    field1: &'a Field,
+    env1: E::Ref<'env>,
+    field2: &'a Field,
+    env2: E::Ref<'env>,
 ) -> bool {
     match (&field1.value, &field2.value) {
         (Some(ref value1), Some(ref value2)) => {
-            contract_eq_bounded(state, value1, env1, value2, env2)
+            contract_eq_bounded::<E>(state, value1, env1, value2, env2)
         }
         (None, None) => true,
         _ => false,
@@ -438,12 +494,12 @@ fn contract_eq_fields<E: TermEnvironment>(
 /// the rigid type variables encountered have been introduced by `type_eq_bounded` itself. This is
 /// why we don't need unique identifiers that are distinct from the one used during typechecking,
 /// and we can just start from `0`.
-fn type_eq_bounded<E: TermEnvironment>(
+fn type_eq_bounded<'env, 'a: 'env, E: TermEnvironment>(
     state: &mut State,
-    ty1: &GenericUnifType<E>,
-    env1: &E,
-    ty2: &GenericUnifType<E>,
-    env2: &E,
+    ty1: &'a GenericUnifType<E>,
+    env1: E::Ref<'env>,
+    ty2: &'a GenericUnifType<E>,
+    env2: E::Ref<'env>,
 ) -> bool {
     match (ty1, ty2) {
         (GenericUnifType::Concrete { typ: s1, .. }, GenericUnifType::Concrete { typ: s2, .. }) => {
@@ -477,12 +533,12 @@ fn type_eq_bounded<E: TermEnvironment>(
                     rows1.is_some() && rows2.is_some() && rows1 == rows2
                 }
                 (TypeF::Record(uty1), TypeF::Record(uty2)) => {
-                    fn type_eq_bounded_wrapper<E: TermEnvironment>(
+                    fn type_eq_bounded_wrapper<'env, 'a: 'env, E: TermEnvironment>(
                         state: &mut State,
-                        uty1: &&GenericUnifType<E>,
-                        env1: &E,
-                        uty2: &&GenericUnifType<E>,
-                        env2: &E,
+                        uty1: &'a &'a GenericUnifType<E>,
+                        env1: E::Ref<'env>,
+                        uty2: &'a &'a GenericUnifType<E>,
+                        env2: E::Ref<'env>,
                     ) -> bool {
                         type_eq_bounded(state, *uty1, env1, *uty2, env2)
                     }
@@ -492,12 +548,12 @@ fn type_eq_bounded<E: TermEnvironment>(
 
                     map1.zip(map2)
                         .map(|(m1, m2)| {
-                            map_eq(type_eq_bounded_wrapper, state, &m1, env1, &m2, env2)
+                            map_eq::<_, _, E>(type_eq_bounded_wrapper, state, &m1, env1, &m2, env2)
                         })
                         .unwrap_or(false)
                 }
                 (TypeF::Flat(t1), TypeF::Flat(t2)) => {
-                    contract_eq_bounded(state, t1, env1, t2, env2)
+                    contract_eq_bounded::<E>(state, t1, env1, t2, env2)
                 }
                 (
                     TypeF::Forall {

--- a/core/src/typecheck/eq.rs
+++ b/core/src/typecheck/eq.rs
@@ -122,7 +122,7 @@ impl TermEnvironment for SimpleTermEnvironment {
 }
 
 impl<'a> AsRef<SimpleTermEnvironment> for &'a SimpleTermEnvironment {
-    fn as_ref(&self) -> &SimpleTermEnvironment {
+    fn as_ref(&self) -> &Self {
         self
     }
 }

--- a/core/src/typecheck/eq.rs
+++ b/core/src/typecheck/eq.rs
@@ -52,7 +52,7 @@ use crate::{
 /// The maximal number of variable links we want to unfold before abandoning the check. It should
 /// stay low, but has been fixed arbitrarily: feel fee to increase reasonably if it turns out
 /// legitimate type equalities between simple contracts are unduly rejected in practice.
-pub const MAX_GAS: u8 = 8;
+pub const MAX_GAS: u8 = 20;
 
 /// Abstract over the term environment, which is represented differently in the typechecker and
 /// during evaluation.
@@ -105,19 +105,17 @@ impl std::iter::FromIterator<(Ident, (RichTerm, SimpleTermEnvironment))> for Sim
     }
 }
 
-/*
-impl<C: Cache> TermEnvironment for eval::Environment {
-    fn get_then<F, T>(&self, id: &Ident, f: F) -> T
+impl TermEnvironment for eval::Environment {
+    fn get_then<F, T>(&self, id: Ident, f: F) -> T
     where
         F: FnOnce(Option<(&RichTerm, &eval::Environment)>) -> T,
     {
-        match self.get(id).map(eval::lazy::Thunk::borrow) {
+        match self.get(&id).map(eval::cache::lazy::Thunk::borrow) {
             Some(closure_ref) => f(Some((&closure_ref.body, &closure_ref.env))),
             None => f(None),
         }
     }
 }
-*/
 
 pub trait FromEnv<C: Cache> {
     fn from_env(eval_env: eval::Environment, cache: &C) -> Self;

--- a/core/src/typecheck/eq.rs
+++ b/core/src/typecheck/eq.rs
@@ -327,7 +327,7 @@ pub fn type_eq_noenv(var_uid: usize, t1: &Type, t2: &Type) -> bool {
 }
 
 /// Decide type equality on contracts in their respective environment and given the remaining gas
-/// `gas`.
+/// in `state`.
 fn contract_eq_bounded<E: TermEnvironment>(
     state: &mut State,
     var_eq: VarEq,

--- a/core/src/typecheck/eq.rs
+++ b/core/src/typecheck/eq.rs
@@ -122,7 +122,7 @@ impl TermEnvironment for SimpleTermEnvironment {
 }
 
 impl<'a> AsRef<SimpleTermEnvironment> for &'a SimpleTermEnvironment {
-    fn as_ref(&self) -> &Self {
+    fn as_ref(&self) -> Self {
         self
     }
 }

--- a/core/src/typecheck/eq.rs
+++ b/core/src/typecheck/eq.rs
@@ -274,7 +274,7 @@ impl State {
 
 /// Different possible behavior for variables comparison variables.
 #[derive(Copy, Clone, PartialEq, Eq)]
-enum VarEq {
+pub enum VarEq {
     /// Use the environment to fetch the content of variables and compare them.
     Environment,
     /// Don't use an environment and simply compare variables by name. This is unsound, and should

--- a/core/src/typecheck/mod.rs
+++ b/core/src/typecheck/mod.rs
@@ -89,7 +89,7 @@ pub mod mk_uniftype;
 pub mod eq;
 pub mod unif;
 
-use eq::{SimpleTermEnvironment, TermEnvironment};
+use eq::{SimpleTermEnvironment, TermEnvironment, ToOwnedEnv};
 use error::*;
 use indexmap::IndexMap;
 use operation::{get_bop_type, get_nop_type, get_uop_type};
@@ -822,7 +822,7 @@ impl<E: TermEnvironment + Clone> GenericUnifType<E> {
     /// checking type equality involving contracts.
     pub fn from_type(ty: Type, env: E::Ref<'_>) -> Self {
         match ty.typ {
-            TypeF::Flat(t) => GenericUnifType::Contract(t, <E as TermEnvironment>::ref_to_owned(env)),
+            TypeF::Flat(t) => GenericUnifType::Contract(t, env.to_owned_env()),
             ty => GenericUnifType::concrete(ty.map(
                 |ty_| Box::new(GenericUnifType::from_type(*ty_, env)),
                 |rrows| GenericUnifRecordRows::from_record_rows(rrows, env),

--- a/core/src/typecheck/unif.rs
+++ b/core/src/typecheck/unif.rs
@@ -1124,7 +1124,7 @@ impl Unify for UnifType {
                 Err(UnifError::WithConst(VarKindDiscriminant::Type, i, ty))
             }
             (UnifType::Contract(t1, env1), UnifType::Contract(t2, env2))
-                if eq::contract_eq(state.table.max_uvars_count(), &t1, &env1, &t2, &env2) =>
+                if eq::contract_eq::<SimpleTermEnvironment>(state.table.max_uvars_count(), &t1, &env1, &t2, &env2) =>
             {
                 Ok(())
             }

--- a/core/src/typecheck/unif.rs
+++ b/core/src/typecheck/unif.rs
@@ -1124,7 +1124,13 @@ impl Unify for UnifType {
                 Err(UnifError::WithConst(VarKindDiscriminant::Type, i, ty))
             }
             (UnifType::Contract(t1, env1), UnifType::Contract(t2, env2))
-                if eq::contract_eq::<SimpleTermEnvironment>(state.table.max_uvars_count(), &t1, &env1, &t2, &env2) =>
+                if eq::contract_eq::<SimpleTermEnvironment>(
+                    state.table.max_uvars_count(),
+                    &t1,
+                    &env1,
+                    &t2,
+                    &env2,
+                ) =>
             {
                 Ok(())
             }

--- a/doc/manual/contracts.md
+++ b/doc/manual/contracts.md
@@ -58,6 +58,29 @@ are available. `Dyn` is a contract that never fails.
 
 ## User-defined contracts
 
+### Preamble: idempotency
+
+As you will see in this section, Nickel contracts are more than mere boolean
+validators. They can sometimes modify the checked value for valid reasons
+exposed below. However, it's hard (if not impossible) to rightfully limit the
+expressive power of contracts to be *reasonable* with respect to modifications.
+
+For Nickel, the notion of reasonable modification is practically defined by
+idempotency. An idempotent contract is a contract which gives the same result if
+applied once or many times to the same value. That is, for any value,
+`MyContract` is idempotent if `value | MyContract` and `value | MyContract |
+MyContract` gives the same result. Idempotency sounds like a reasonable property
+for a contract, even if it can perform some normalization.
+
+**Nickel makes the assumption that all contracts - including user-defined
+contracts - are idempotent**, because the converse would be surprising for
+consumers of the contract and because this assumption enables important
+optimizations such as contract deduplication. **While non-idempotent contracts
+shouldn't wreak havoc on your program, they might lead to surprising results**,
+such as a change in behavior e.g. when refactoring a program to a new version
+that should be identical, typically because the deduplication optimization
+doesn't fire anymore.
+
 ### By hand
 
 The ability to check arbitrary properties is where run-time contracts really

--- a/utils/src/bench.rs
+++ b/utils/src/bench.rs
@@ -121,12 +121,14 @@ pub fn bench_terms<'r>(rts: Vec<Bench<'r>>) -> Box<dyn Fn(&mut Criterion) + 'r> 
                             c_local.typecheck(id, &type_ctxt).unwrap();
                         } else {
                             c_local.prepare(id, &type_ctxt).unwrap();
+
                             VirtualMachine::new_with_cache(
                                 c_local,
                                 eval_cache.clone(),
                                 std::io::sink(),
                             )
-                            .eval(t, &eval_env)
+                            .with_initial_env(eval_env.clone())
+                            .eval(t)
                             .unwrap();
                         }
                     },
@@ -201,12 +203,14 @@ macro_rules! ncl_bench_group {
                                 c_local.typecheck(id, &type_ctxt).unwrap();
                             } else {
                                 c_local.prepare(id, &type_ctxt).unwrap();
+
                                 VirtualMachine::new_with_cache(
                                     c_local,
                                     eval_cache.clone(),
                                     std::io::sink()
                                 )
-                                .eval(t, &eval_env)
+                                .with_initial_env(eval_env.clone())
+                                .eval(t)
                                 .unwrap();
                             }
                         },


### PR DESCRIPTION
Partially fixes #1622. Related to #1484.

Implement the contract deduplication optimization, which avoid applying many times the same contract to a field value. This optimization requires that contracts are idempotent, or it could change the meaning of programs.

## Content

- Add `push_dedup` method on `RuntimeContract`, which conditionally pushes a contract to an existing list of pending contracts, given that it's not already in the list. Theoretically, this makes the complexity of merging two pending contract lists `size(left)*size(right)`. In practice, we expect pending contracts list to be very small (< 10), and in fact the deduplication optimization typically participate in keeping the size small.
- Add a `combine_dedup` method to combine contract annotation and deduplicate them based on an unsound, "syntax equality" like check. This is to avoid accumulating and printing many copies of the same initial contract when showing the result of evaluation.
- Fix the contract equality check for the eval environment. In particular, the contract equality checker actually needs to access to the initial environment, which comes with a few techcal complications as to how to properly define the signature in the `TermEnvironment` trait.
- Add a unsound mode to contract equality checking, corresponding to comparing them syntactically, used by |
- The previous point required to thread the initial environment into me functions, to make it accessible when deduplicating contracts. In the end, I put the initial environment into the virtual machine, because it looks like it shouldn't change much over the course of any Nickel subcommands - it's always the environment populated with the stdlib - and got rid of a lot of environment threading, a bit of simplification around the `query` subcommand as well.

## Results

On the codebase mentioned in #1622, this got the runtime down by roughly 50%, equivalently across `nickel export` or the normal evaluation.

## Future work

- [ ] Apply the same optimization to lazy array contracts