### PR TITLE
Implement a first solution for collecting metrics during a Nickel evaluation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1133,6 +1133,15 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ff8ae62cd3a9102e5637afc8452c55acf3844001bd5374e0b0bd7b6616c038"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
@@ -1465,6 +1474,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "mach2"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d0d1830bcd151a6fc4aea1369af235b36c1528fe976b8ff678683c9995eade8"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "malachite"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1555,6 +1573,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "metrics"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fde3af1a009ed76a778cb84fdef9e7dbbdf5775ae3e4cc1f434a6a307f6f76c5"
+dependencies = [
+ "ahash",
+ "metrics-macros",
+ "portable-atomic",
+]
+
+[[package]]
+name = "metrics-macros"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddece26afd34c31585c74a4db0630c376df271c285d682d1e55012197830b6df"
+dependencies = [
+ "proc-macro2 1.0.67",
+ "quote 1.0.33",
+ "syn 2.0.33",
+]
+
+[[package]]
+name = "metrics-util"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4de2ed6e491ed114b40b732e4d1659a9d53992ebd87490c44a6ffe23739d973e"
+dependencies = [
+ "aho-corasick",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "hashbrown 0.13.1",
+ "indexmap 1.9.3",
+ "metrics",
+ "num_cpus",
+ "ordered-float",
+ "quanta",
+ "radix_trie",
+ "sketches-ddsketch",
+]
+
+[[package]]
 name = "minimad"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1608,6 +1667,8 @@ dependencies = [
  "directories",
  "git-version",
  "insta",
+ "metrics",
+ "metrics-util",
  "nickel-lang-core",
  "nickel-lang-utils",
  "serde",
@@ -1635,6 +1696,7 @@ dependencies = [
  "malachite",
  "malachite-q",
  "md-5",
+ "metrics",
  "nickel-lang-utils",
  "once_cell",
  "pprof",
@@ -1805,6 +1867,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
+name = "ordered-float"
+version = "3.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a54938017eacd63036332b4ae5c8a49fc8c0c1d6d629893057e4f13609edd06"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "os_str_bytes"
 version = "6.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1926,6 +1997,12 @@ checksum = "38f6d39893cca0701371e3c27294f09797214b86f1fb951b89ade8ec04e2abab"
 dependencies = [
  "plotters-backend",
 ]
+
+[[package]]
+name = "portable-atomic"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31114a898e107c51bb1609ffaf55a0e011cf6a4d7f1170d0015a165082c0338b"
 
 [[package]]
 name = "pprof"
@@ -2116,6 +2193,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "quanta"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a17e662a7a8291a865152364c20c7abc5e60486ab2001e8ec10b24862de0b9ab"
+dependencies = [
+ "crossbeam-utils",
+ "libc",
+ "mach2",
+ "once_cell",
+ "raw-cpuid",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+ "web-sys",
+ "winapi",
+]
+
+[[package]]
 name = "quick-xml"
 version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2200,6 +2293,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
 dependencies = [
  "rand_core",
+]
+
+[[package]]
+name = "raw-cpuid"
+version = "10.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c297679cb867470fa8c9f67dbba74a78d78e3e98d7cf2b08d6d71540f797332"
+dependencies = [
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -2574,6 +2676,12 @@ name = "siphasher"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
+
+[[package]]
+name = "sketches-ddsketch"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68a406c1882ed7f29cd5e248c9848a80e7cb6ae0fea82346d2746f2f941c07e1"
 
 [[package]]
 name = "slab"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1133,15 +1133,6 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33ff8ae62cd3a9102e5637afc8452c55acf3844001bd5374e0b0bd7b6616c038"
-dependencies = [
- "ahash",
-]
-
-[[package]]
-name = "hashbrown"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
@@ -1474,15 +1465,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "mach2"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d0d1830bcd151a6fc4aea1369af235b36c1528fe976b8ff678683c9995eade8"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "malachite"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1595,25 +1577,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "metrics-util"
-version = "0.15.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4de2ed6e491ed114b40b732e4d1659a9d53992ebd87490c44a6ffe23739d973e"
-dependencies = [
- "aho-corasick",
- "crossbeam-epoch",
- "crossbeam-utils",
- "hashbrown 0.13.1",
- "indexmap 1.9.3",
- "metrics",
- "num_cpus",
- "ordered-float",
- "quanta",
- "radix_trie",
- "sketches-ddsketch",
-]
-
-[[package]]
 name = "minimad"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1668,7 +1631,6 @@ dependencies = [
  "git-version",
  "insta",
  "metrics",
- "metrics-util",
  "nickel-lang-core",
  "nickel-lang-utils",
  "serde",
@@ -1865,15 +1827,6 @@ name = "opaque-debug"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
-
-[[package]]
-name = "ordered-float"
-version = "3.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a54938017eacd63036332b4ae5c8a49fc8c0c1d6d629893057e4f13609edd06"
-dependencies = [
- "num-traits",
-]
 
 [[package]]
 name = "os_str_bytes"
@@ -2193,22 +2146,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "quanta"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a17e662a7a8291a865152364c20c7abc5e60486ab2001e8ec10b24862de0b9ab"
-dependencies = [
- "crossbeam-utils",
- "libc",
- "mach2",
- "once_cell",
- "raw-cpuid",
- "wasi 0.11.0+wasi-snapshot-preview1",
- "web-sys",
- "winapi",
-]
-
-[[package]]
 name = "quick-xml"
 version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2293,15 +2230,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
 dependencies = [
  "rand_core",
-]
-
-[[package]]
-name = "raw-cpuid"
-version = "10.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c297679cb867470fa8c9f67dbba74a78d78e3e98d7cf2b08d6d71540f797332"
-dependencies = [
- "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -2676,12 +2604,6 @@ name = "siphasher"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
-
-[[package]]
-name = "sketches-ddsketch"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68a406c1882ed7f29cd5e248c9848a80e7cb6ae0fea82346d2746f2f941c07e1"
 
 [[package]]
 name = "slab"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,6 +90,9 @@ typed-arena = "2.0.2"
 unicode-segmentation = "1.10.1"
 void = "1"
 
+metrics = "0.21"
+metrics-util = "0.15"
+
 topiary = { git = "https://github.com/tweag/topiary.git", rev = "8299a04bf83c4a2774cbbff7a036c022efa939b3" }
 topiary-queries = { git = "https://github.com/tweag/topiary.git", rev = "8299a04bf83c4a2774cbbff7a036c022efa939b3", package = "topiary-queries", default-features = false, features = ["nickel"] }
 # This should be kept in sync with the revision in topiary

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,7 +91,6 @@ unicode-segmentation = "1.10.1"
 void = "1"
 
 metrics = "0.21"
-metrics-util = "0.15"
 
 topiary = { git = "https://github.com/tweag/topiary.git", rev = "8299a04bf83c4a2774cbbff7a036c022efa939b3" }
 topiary-queries = { git = "https://github.com/tweag/topiary.git", rev = "8299a04bf83c4a2774cbbff7a036c022efa939b3", package = "topiary-queries", default-features = false, features = ["nickel"] }

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -20,7 +20,7 @@ default = ["repl", "doc", "format", "metrics"]
 repl = ["nickel-lang-core/repl"]
 doc = ["nickel-lang-core/doc"]
 format = ["nickel-lang-core/format", "dep:tempfile"]
-metrics = ["dep:metrics", "dep:metrics-util", "nickel-lang-core/metrics"]
+metrics = ["dep:metrics", "nickel-lang-core/metrics"]
 
 [dependencies]
 nickel-lang-core = { workspace = true, features = [ "markdown" ], default-features = false }
@@ -35,7 +35,6 @@ git-version = { workspace = true }
 clap_complete = { workspace = true }
 
 metrics = { workspace = true, optional = true }
-metrics-util = { workspace = true, optional = true }
 
 [dev-dependencies]
 nickel-lang-utils.workspace = true

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -16,7 +16,7 @@ path = "src/main.rs"
 bench = false
 
 [features]
-default = ["repl", "doc", "format", "metrics"]
+default = ["repl", "doc", "format"]
 repl = ["nickel-lang-core/repl"]
 doc = ["nickel-lang-core/doc"]
 format = ["nickel-lang-core/format", "dep:tempfile"]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -16,10 +16,11 @@ path = "src/main.rs"
 bench = false
 
 [features]
-default = ["repl", "doc", "format"]
+default = ["repl", "doc", "format", "metrics"]
 repl = ["nickel-lang-core/repl"]
 doc = ["nickel-lang-core/doc"]
-format = ["nickel-lang-core/format", "tempfile"]
+format = ["nickel-lang-core/format", "dep:tempfile"]
+metrics = ["dep:metrics", "dep:metrics-util", "nickel-lang-core/metrics"]
 
 [dependencies]
 nickel-lang-core = { workspace = true, features = [ "markdown" ], default-features = false }
@@ -32,6 +33,9 @@ tempfile = { workspace = true, optional = true }
 
 git-version = { workspace = true }
 clap_complete = { workspace = true }
+
+metrics = { workspace = true, optional = true }
+metrics-util = { workspace = true, optional = true }
 
 [dev-dependencies]
 nickel-lang-utils.workspace = true

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -46,6 +46,11 @@ pub struct GlobalOptions {
     /// Configure when to output messages in color
     #[arg(long, global = true, value_enum, default_value_t)]
     pub color: clap::ColorChoice,
+
+    #[cfg(feature = "metrics")]
+    /// Print all recorded metrics at the very end of the program
+    #[arg(long, global = true, default_value_t = false)]
+    pub metrics: bool,
 }
 
 /// Available subcommands.

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -4,6 +4,8 @@
 mod doc;
 #[cfg(feature = "format")]
 mod format;
+#[cfg(feature = "metrics")]
+mod metrics;
 #[cfg(feature = "repl")]
 mod repl;
 
@@ -23,7 +25,13 @@ use std::process::ExitCode;
 use crate::cli::{Command, Options};
 
 fn main() -> ExitCode {
+    #[cfg(feature = "metrics")]
+    let metrics = metrics::Recorder::install();
+
     let opts = <Options as clap::Parser>::parse();
+
+    #[cfg(feature = "metrics")]
+    let report_metrics = opts.global.metrics;
 
     let result = match opts.command {
         Command::Eval(eval) => eval.run(opts.global),
@@ -42,6 +50,11 @@ fn main() -> ExitCode {
         #[cfg(feature = "format")]
         Command::Format(format) => format.run(opts.global),
     };
+
+    #[cfg(feature = "metrics")]
+    if report_metrics {
+        metrics.report();
+    }
 
     if let Err(e) = result {
         e.report();

--- a/cli/src/metrics.rs
+++ b/cli/src/metrics.rs
@@ -1,0 +1,109 @@
+use std::{
+    collections::HashMap,
+    hash::BuildHasherDefault,
+    sync::{atomic::Ordering, Arc, PoisonError, RwLock},
+};
+
+use metrics::{
+    atomics::AtomicU64, Counter, Gauge, Histogram, Key, KeyHasher, KeyName, SharedString, Unit,
+};
+
+#[derive(Default)]
+pub(super) struct Registry {
+    counters: RwLock<HashMap<Key, Arc<AtomicU64>, BuildHasherDefault<KeyHasher>>>,
+    descriptions: RwLock<HashMap<KeyName, SharedString>>,
+}
+
+pub(super) struct Recorder {
+    inner: Arc<Registry>,
+}
+
+impl Recorder {
+    pub(super) fn install() -> Arc<Registry> {
+        let registry = Arc::<Registry>::default();
+        metrics::set_boxed_recorder(Box::new(Recorder {
+            inner: registry.clone(),
+        }))
+        .expect("registering a metrics recorder shouldn't fail");
+        registry
+    }
+}
+
+impl metrics::Recorder for Recorder {
+    fn describe_counter(&self, key: KeyName, _unit: Option<Unit>, description: SharedString) {
+        self.inner
+            .descriptions
+            .write()
+            .unwrap_or_else(PoisonError::into_inner)
+            .entry(key)
+            .or_insert(description);
+    }
+
+    fn describe_gauge(&self, _key: KeyName, _unit: Option<Unit>, _description: SharedString) {
+        unimplemented!()
+    }
+
+    fn describe_histogram(&self, _key: KeyName, _unit: Option<Unit>, _description: SharedString) {
+        unimplemented!()
+    }
+
+    fn register_counter(&self, key: &Key) -> Counter {
+        let read = self
+            .inner
+            .counters
+            .read()
+            .unwrap_or_else(PoisonError::into_inner);
+        if let Some(counter) = read.get(key) {
+            Counter::from_arc(counter.clone())
+        } else {
+            drop(read);
+            let mut write = self
+                .inner
+                .counters
+                .write()
+                .unwrap_or_else(PoisonError::into_inner);
+            if let Some(counter) = write.get(key) {
+                Counter::from_arc(counter.clone())
+            } else {
+                let counter = Arc::new(AtomicU64::new(0));
+                write.insert(key.clone(), counter.clone());
+                Counter::from_arc(counter)
+            }
+        }
+    }
+
+    fn register_gauge(&self, _key: &Key) -> Gauge {
+        unimplemented!()
+    }
+
+    fn register_histogram(&self, _key: &Key) -> Histogram {
+        unimplemented!()
+    }
+}
+
+impl Registry {
+    pub(super) fn report(&self) {
+        for (key, counter) in self
+            .counters
+            .read()
+            .unwrap_or_else(PoisonError::into_inner)
+            .iter()
+        {
+            if let Some(description) = self
+                .descriptions
+                .read()
+                .unwrap_or_else(PoisonError::into_inner)
+                .get(key.name())
+            {
+                println!(
+                    "{}: {}\n  {}",
+                    key.name(),
+                    description,
+                    counter.load(Ordering::Relaxed)
+                );
+            } else {
+                println!("{}: {}", key.name(), counter.load(Ordering::Relaxed));
+            }
+        }
+    }
+}

--- a/cli/src/metrics.rs
+++ b/cli/src/metrics.rs
@@ -117,14 +117,14 @@ impl Registry {
                 .unwrap_or_else(PoisonError::into_inner)
                 .get(key.name())
             {
-                println!(
+                eprintln!(
                     "{}: {}\n  {}",
                     key.name(),
                     description,
                     counter.load(Ordering::Relaxed)
                 );
             } else {
-                println!("{}: {}", key.name(), counter.load(Ordering::Relaxed));
+                eprintln!("{}: {}", key.name(), counter.load(Ordering::Relaxed));
             }
         }
     }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -14,7 +14,7 @@ readme.workspace = true
 bench = false
 
 [features]
-default = ["markdown", "repl", "doc", "format", "metrics"]
+default = ["markdown", "repl", "doc", "format"]
 markdown = ["dep:termimad"]
 repl = ["dep:rustyline", "dep:rustyline-derive", "dep:ansi_term"]
 repl-wasm = ["dep:wasm-bindgen", "dep:js-sys", "dep:serde_repr"]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -14,12 +14,13 @@ readme.workspace = true
 bench = false
 
 [features]
-default = ["markdown", "repl", "doc", "format"]
-markdown = ["termimad"]
-repl = ["rustyline", "rustyline-derive", "ansi_term"]
-repl-wasm = ["wasm-bindgen", "js-sys", "serde_repr"]
-doc = ["comrak"]
-format = ["topiary", "topiary-queries", "tree-sitter-nickel"]
+default = ["markdown", "repl", "doc", "format", "metrics"]
+markdown = ["dep:termimad"]
+repl = ["dep:rustyline", "dep:rustyline-derive", "dep:ansi_term"]
+repl-wasm = ["dep:wasm-bindgen", "dep:js-sys", "dep:serde_repr"]
+doc = ["dep:comrak"]
+format = ["dep:topiary", "dep:topiary-queries", "dep:tree-sitter-nickel"]
+metrics = ["dep:metrics"]
 
 [build-dependencies]
 lalrpop.workspace = true
@@ -66,6 +67,8 @@ strip-ansi-escapes.workspace = true
 topiary = { workspace = true, optional = true }
 topiary-queries = { workspace = true, optional = true }
 tree-sitter-nickel = { workspace = true, optional = true }
+
+metrics = { workspace = true, optional = true }
 
 [dev-dependencies]
 pretty_assertions.workspace = true

--- a/core/src/environment.rs
+++ b/core/src/environment.rs
@@ -7,6 +7,8 @@ use std::marker::PhantomData;
 use std::ptr::NonNull;
 use std::rc::Rc;
 
+use crate::metrics::increment;
+
 /// An environment as a linked-list of hashmaps.
 ///
 /// Each node of the linked-list corresponds to what is called
@@ -38,6 +40,7 @@ impl<K: Hash + Eq, V: PartialEq> Clone for Environment<K, V> {
     /// and if it wasn't, it sets the `current` has the new head of `previous`.
     /// Then a clone is an empty `current` and the clone of `self.previous`.
     fn clone(&self) -> Self {
+        increment!("Environment::clone");
         if !self.current.is_empty() && !self.was_cloned() {
             self.previous.replace_with(|old| {
                 Some(Rc::new(Environment {

--- a/core/src/identifier.rs
+++ b/core/src/identifier.rs
@@ -7,7 +7,7 @@ use std::{
     hash::Hash,
 };
 
-use crate::{position::TermPos, term::string::NickelString};
+use crate::{metrics::increment, position::TermPos, term::string::NickelString};
 
 simple_counter::generate_counter!(GeneratedCounter, usize);
 static INTERNER: Lazy<interner::Interner> = Lazy::new(interner::Interner::new);
@@ -126,6 +126,7 @@ impl LocIdent {
     /// with any identifier defined before. Generated identifiers start with a special prefix that
     /// can't be used by normal, user-defined identifiers.
     pub fn fresh() -> Self {
+        increment!("LocIdent::fresh");
         Self::new(format!("{}{}", GEN_PREFIX, GeneratedCounter::next()))
     }
 

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -19,5 +19,7 @@ pub mod transform;
 pub mod typ;
 pub mod typecheck;
 
+pub(crate) mod metrics;
+
 #[cfg(feature = "format")]
 pub mod format;

--- a/core/src/metrics.rs
+++ b/core/src/metrics.rs
@@ -1,0 +1,16 @@
+#[cfg(feature = "metrics")]
+macro_rules! increment {
+    ( $counter:expr ) => {
+        $crate::metrics::increment!($counter, 1)
+    };
+    ( $counter:expr, $count:expr ) => {
+        ::metrics::counter!($counter, $count)
+    };
+}
+
+#[cfg(not(feature = "metrics"))]
+macro_rules! increment {
+    ( $( $args:expr ),+ ) => {};
+}
+
+pub(crate) use increment;

--- a/core/src/metrics.rs
+++ b/core/src/metrics.rs
@@ -1,3 +1,6 @@
+//! This module only contains macros wrapping those of the `metrics` crate, if
+//! the `metrics` feature is enabled.
+
 #[cfg(feature = "metrics")]
 macro_rules! increment {
     ( $counter:expr ) => {

--- a/core/src/program.rs
+++ b/core/src/program.rs
@@ -27,6 +27,7 @@ use crate::{
     eval::{cache::Cache as EvalCache, VirtualMachine},
     identifier::LocIdent,
     label::Label,
+    metrics::increment,
     term::{
         make as mk_term, make::builder, record::Field, BinaryOp, MergePriority, RichTerm, Term,
     },
@@ -181,6 +182,8 @@ impl<EC: EvalCache> Program<EC> {
         path: impl Into<OsString>,
         trace: impl Write + 'static,
     ) -> std::io::Result<Self> {
+        increment!("program.new");
+
         let mut cache = Cache::new(ErrorTolerance::Strict);
         let main_id = cache.add_file(path)?;
         let vm = VirtualMachine::new(cache, trace);
@@ -202,6 +205,8 @@ impl<EC: EvalCache> Program<EC> {
         T: Read,
         S: Into<OsString> + Clone,
     {
+        increment!("program.new");
+
         let mut cache = Cache::new(ErrorTolerance::Strict);
         let path = PathBuf::from(source_name.into());
         let main_id = cache.add_source(SourcePath::Path(path), source)?;

--- a/core/src/program.rs
+++ b/core/src/program.rs
@@ -205,7 +205,7 @@ impl<EC: EvalCache> Program<EC> {
         T: Read,
         S: Into<OsString> + Clone,
     {
-        increment!("program.new");
+        increment!("Program::new");
 
         let mut cache = Cache::new(ErrorTolerance::Strict);
         let path = PathBuf::from(source_name.into());

--- a/core/src/program.rs
+++ b/core/src/program.rs
@@ -182,7 +182,7 @@ impl<EC: EvalCache> Program<EC> {
         path: impl Into<OsString>,
         trace: impl Write + 'static,
     ) -> std::io::Result<Self> {
-        increment!("program.new");
+        increment!("Program::new");
 
         let mut cache = Cache::new(ErrorTolerance::Strict);
         let main_id = cache.add_file(path)?;


### PR DESCRIPTION
Use the [`metrics`](https://docs.rs/metrics/0.21.1/metrics/) crate to collect metrics during a Nickel evaluation run. Additionally, implement a very simple metrics recorder for storing and displaying collected metrics after the CLI is finished.

For now, we only collect three metrics:
- the number of `Program`s constructed
- the number of times `Environment::clone` is called
- the number of fresh identifiers generated

Adding new metrics to track is very cheap, just use `increment!("<metric name>")` with a new metric name and everything should just work. Once we accumulate a large number of them, we will want to revisit the interface for reporting them and add some filtering functionality.