### PR TITLE
Honor `nostdlib` in customize mode as well

### DIFF
--- a/cli/src/doc.rs
+++ b/cli/src/doc.rs
@@ -11,9 +11,9 @@ use nickel_lang_core::{
 
 use crate::{
     cli::GlobalOptions,
+    customize::NoCustomizeMode,
     error::{CliResult, ResultErrorExt},
-    eval::EvalCommand,
-    input::Prepare,
+    input::{InputOptions, Prepare},
 };
 
 #[derive(Copy, Clone, Eq, PartialEq, Debug, Default, clap::ValueEnum)]
@@ -56,12 +56,12 @@ pub struct DocCommand {
     pub format: crate::doc::DocFormat,
 
     #[command(flatten)]
-    pub evaluation: EvalCommand,
+    pub input: InputOptions<NoCustomizeMode>,
 }
 
 impl DocCommand {
     pub fn run(self, global: GlobalOptions) -> CliResult<()> {
-        let mut program = self.evaluation.prepare(&global)?;
+        let mut program = self.input.prepare(&global)?;
         self.export_doc(&mut program).report_with_program(program)
     }
 
@@ -95,7 +95,7 @@ impl DocCommand {
 
                         let mut has_file_name = false;
 
-                        if let Some(path) = self.evaluation.input.files.get(0) {
+                        if let Some(path) = self.input.files.get(0) {
                             if let Some(file_stem) = path.file_stem() {
                                 output_file.push(file_stem);
                                 has_file_name = true;

--- a/cli/src/eval.rs
+++ b/cli/src/eval.rs
@@ -1,5 +1,3 @@
-use nickel_lang_core::{eval::cache::lazy::CBNCache, program::Program};
-
 use crate::{
     cli::GlobalOptions,
     customize::CustomizeMode,
@@ -9,37 +7,16 @@ use crate::{
 
 #[derive(clap::Parser, Debug)]
 pub struct EvalCommand {
-    #[cfg(debug_assertions)]
-    /// Skips the standard library import. For debugging only
-    #[arg(long, global = true)]
-    pub nostdlib: bool,
-
     #[command(flatten)]
     pub input: InputOptions<CustomizeMode>,
 }
 
 impl EvalCommand {
     pub fn run(self, global: GlobalOptions) -> CliResult<()> {
-        let mut program = self.prepare(&global)?;
+        let mut program = self.input.prepare(&global)?;
         program
             .eval_full()
             .map(|t| println!("{t}"))
             .report_with_program(program)
-    }
-}
-
-impl Prepare for EvalCommand {
-    fn prepare(&self, global: &GlobalOptions) -> CliResult<Program<CBNCache>> {
-        // Rust warns about `program` not needing to be mutable if
-        // `debug_assertions` are off
-        #![allow(unused_mut)]
-        let mut program = self.input.prepare(global)?;
-
-        #[cfg(debug_assertions)]
-        if self.nostdlib {
-            program.set_skip_stdlib();
-        }
-
-        Ok(program)
     }
 }

--- a/cli/src/export.rs
+++ b/cli/src/export.rs
@@ -9,9 +9,9 @@ use nickel_lang_core::{
 
 use crate::{
     cli::GlobalOptions,
+    customize::CustomizeMode,
     error::{CliResult, ResultErrorExt},
-    eval::EvalCommand,
-    input::Prepare,
+    input::{InputOptions, Prepare},
 };
 
 #[derive(clap::Parser, Debug)]
@@ -24,12 +24,12 @@ pub struct ExportCommand {
     pub output: Option<PathBuf>,
 
     #[command(flatten)]
-    pub evaluation: EvalCommand,
+    pub input: InputOptions<CustomizeMode>,
 }
 
 impl ExportCommand {
     pub fn run(self, global: GlobalOptions) -> CliResult<()> {
-        let mut program = self.evaluation.prepare(&global)?;
+        let mut program = self.input.prepare(&global)?;
 
         self.export(&mut program).report_with_program(program)
     }

--- a/cli/src/input.rs
+++ b/cli/src/input.rs
@@ -9,6 +9,11 @@ pub struct InputOptions<Customize: clap::Args> {
     /// Input files, omit to read from stdin
     pub files: Vec<PathBuf>,
 
+    #[cfg(debug_assertions)]
+    /// Skips the standard library import. For debugging only
+    #[arg(long, global = true)]
+    pub nostdlib: bool,
+
     #[command(flatten)]
     pub customize_mode: Customize,
 }
@@ -26,6 +31,11 @@ impl<C: clap::Args + Customize> Prepare for InputOptions<C> {
         }?;
 
         program.color_opt = global.color.into();
+
+        #[cfg(debug_assertions)]
+        if self.nostdlib {
+            program.set_skip_stdlib();
+        }
 
         self.customize_mode.customize(program)
     }


### PR DESCRIPTION
Because of an oversight when refactoring the CLI, `--nostdlib` was ignored for the record spine evaluation in customize mode.