### PR TITLE
Track more metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1133,6 +1133,15 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ff8ae62cd3a9102e5637afc8452c55acf3844001bd5374e0b0bd7b6616c038"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
@@ -1465,6 +1474,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "mach2"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d0d1830bcd151a6fc4aea1369af235b36c1528fe976b8ff678683c9995eade8"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "malachite"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1577,6 +1595,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "metrics-util"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4de2ed6e491ed114b40b732e4d1659a9d53992ebd87490c44a6ffe23739d973e"
+dependencies = [
+ "aho-corasick",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "hashbrown 0.13.1",
+ "indexmap 1.9.3",
+ "metrics",
+ "num_cpus",
+ "ordered-float",
+ "quanta",
+ "radix_trie",
+ "sketches-ddsketch",
+]
+
+[[package]]
 name = "minimad"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1631,6 +1668,7 @@ dependencies = [
  "git-version",
  "insta",
  "metrics",
+ "metrics-util",
  "nickel-lang-core",
  "nickel-lang-utils",
  "serde",
@@ -1827,6 +1865,15 @@ name = "opaque-debug"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
+
+[[package]]
+name = "ordered-float"
+version = "3.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a54938017eacd63036332b4ae5c8a49fc8c0c1d6d629893057e4f13609edd06"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "os_str_bytes"
@@ -2146,6 +2193,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "quanta"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a17e662a7a8291a865152364c20c7abc5e60486ab2001e8ec10b24862de0b9ab"
+dependencies = [
+ "crossbeam-utils",
+ "libc",
+ "mach2",
+ "once_cell",
+ "raw-cpuid",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+ "web-sys",
+ "winapi",
+]
+
+[[package]]
 name = "quick-xml"
 version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2230,6 +2293,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
 dependencies = [
  "rand_core",
+]
+
+[[package]]
+name = "raw-cpuid"
+version = "10.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c297679cb867470fa8c9f67dbba74a78d78e3e98d7cf2b08d6d71540f797332"
+dependencies = [
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -2604,6 +2676,12 @@ name = "siphasher"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
+
+[[package]]
+name = "sketches-ddsketch"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68a406c1882ed7f29cd5e248c9848a80e7cb6ae0fea82346d2746f2f941c07e1"
 
 [[package]]
 name = "slab"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,6 +91,7 @@ unicode-segmentation = "1.10.1"
 void = "1"
 
 metrics = "0.21"
+metrics-util = "0.15"
 
 topiary = { git = "https://github.com/tweag/topiary.git", rev = "8299a04bf83c4a2774cbbff7a036c022efa939b3" }
 topiary-queries = { git = "https://github.com/tweag/topiary.git", rev = "8299a04bf83c4a2774cbbff7a036c022efa939b3", package = "topiary-queries", default-features = false, features = ["nickel"] }

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -20,7 +20,7 @@ default = ["repl", "doc", "format"]
 repl = ["nickel-lang-core/repl"]
 doc = ["nickel-lang-core/doc"]
 format = ["nickel-lang-core/format", "dep:tempfile"]
-metrics = ["dep:metrics", "nickel-lang-core/metrics"]
+metrics = ["dep:metrics", "dep:metrics-util", "nickel-lang-core/metrics"]
 
 [dependencies]
 nickel-lang-core = { workspace = true, features = [ "markdown" ], default-features = false }
@@ -35,6 +35,7 @@ git-version = { workspace = true }
 clap_complete = { workspace = true }
 
 metrics = { workspace = true, optional = true }
+metrics-util = { workspace = true, optional = true }
 
 [dev-dependencies]
 nickel-lang-utils.workspace = true

--- a/cli/src/metrics.rs
+++ b/cli/src/metrics.rs
@@ -1,33 +1,23 @@
 use std::{
-    collections::HashMap,
-    hash::BuildHasherDefault,
-    sync::{atomic::Ordering, Arc, PoisonError, RwLock},
+    fmt::Display,
+    sync::{atomic::Ordering, Arc},
 };
 
-use metrics::{
-    atomics::AtomicU64, Counter, Gauge, Histogram, Key, KeyHasher, KeyName, SharedString, Unit,
-};
+use metrics::{Counter, Gauge, Key, KeyName, SharedString, Unit};
+use metrics_util::registry::AtomicStorage;
 
-/// The actual store for recorded metrics and their descriptions. We only need
-/// to take the write lock once when creating a new metric, in all other cases
-/// we only take a read lock. The `metrics` crate implements the necessary
-/// trait [`::metrics::CounterFn`] for `Arc<AtomicU64>` and in any case expects its
-/// counter types to be `Arc`s. For this reason, we use `Arc<AtomicU64>` as the
-/// value type of the counters `HashMap`.
-///
-/// The `metrics` crate expects to be used in a thread safe manner, so follow
-/// suit here.
-#[derive(Default)]
-pub(super) struct Registry {
-    counters: RwLock<HashMap<Key, Arc<AtomicU64>, BuildHasherDefault<KeyHasher>>>,
-    descriptions: RwLock<HashMap<KeyName, SharedString>>,
+/// A handle to the actual store for recorded metrics.
+#[derive(Clone)]
+pub(super) struct Recorder {
+    registry: Arc<metrics_util::registry::Registry<Key, AtomicStorage>>,
 }
 
-/// A metrics recorder utilizing [`Registry`] for storing metrics and their
-/// descriptions. It currently only supports [`Counter`]s and will panic if
-/// gauges or histograms are submitted.
-pub(super) struct Recorder {
-    inner: Arc<Registry>,
+impl Default for Recorder {
+    fn default() -> Recorder {
+        Recorder {
+            registry: Arc::new(metrics_util::registry::Registry::atomic()),
+        }
+    }
 }
 
 impl Recorder {
@@ -36,24 +26,17 @@ impl Recorder {
     /// retrieve the stored values later.
     ///
     /// This function should only be called once at the start of the CLI.
-    pub(super) fn install() -> Arc<Registry> {
-        let registry = Arc::<Registry>::default();
-        metrics::set_boxed_recorder(Box::new(Recorder {
-            inner: registry.clone(),
-        }))
-        .expect("registering a metrics recorder shouldn't fail");
-        registry
+    pub(super) fn install() -> Recorder {
+        let recorder = Recorder::default();
+        metrics::set_boxed_recorder(Box::new(recorder.clone()))
+            .expect("registering a metrics recorder shouldn't fail");
+        recorder
     }
 }
 
 impl metrics::Recorder for Recorder {
-    fn describe_counter(&self, key: KeyName, _unit: Option<Unit>, description: SharedString) {
-        self.inner
-            .descriptions
-            .write()
-            .unwrap_or_else(PoisonError::into_inner)
-            .entry(key)
-            .or_insert(description);
+    fn describe_counter(&self, _key: KeyName, _unit: Option<Unit>, _description: SharedString) {
+        unimplemented!()
     }
 
     fn describe_gauge(&self, _key: KeyName, _unit: Option<Unit>, _description: SharedString) {
@@ -65,67 +48,117 @@ impl metrics::Recorder for Recorder {
     }
 
     fn register_counter(&self, key: &Key) -> Counter {
-        let read = self
-            .inner
-            .counters
-            .read()
-            .unwrap_or_else(PoisonError::into_inner);
-        if let Some(counter) = read.get(key) {
-            Counter::from_arc(counter.clone())
-        } else {
-            drop(read);
-            let mut write = self
-                .inner
-                .counters
-                .write()
-                .unwrap_or_else(PoisonError::into_inner);
-            if let Some(counter) = write.get(key) {
-                Counter::from_arc(counter.clone())
-            } else {
-                let counter = Arc::new(AtomicU64::new(0));
-                write.insert(key.clone(), counter.clone());
-                Counter::from_arc(counter)
-            }
-        }
+        self.registry
+            .get_or_create_counter(key, |c| c.clone().into())
     }
 
-    fn register_gauge(&self, _key: &Key) -> Gauge {
-        unimplemented!()
+    fn register_gauge(&self, key: &Key) -> Gauge {
+        self.registry.get_or_create_gauge(key, |c| c.clone().into())
     }
 
-    fn register_histogram(&self, _key: &Key) -> Histogram {
-        unimplemented!()
+    fn register_histogram(&self, key: &Key) -> metrics::Histogram {
+        self.registry
+            .get_or_create_histogram(key, |c| c.clone().into())
     }
 }
 
-impl Registry {
+struct BucketStatistics {
+    min: f64,
+    max: f64,
+    avg: f64,
+    count: usize,
+}
+
+impl BucketStatistics {
+    fn new() -> BucketStatistics {
+        BucketStatistics {
+            min: f64::NAN,
+            max: f64::NAN,
+            avg: 0 as f64,
+            count: 0,
+        }
+    }
+
+    fn update(&mut self, data: &[f64]) {
+        let mut sum = 0 as f64;
+
+        for sample in data {
+            self.min = self.min.min(*sample);
+            self.max = self.max.max(*sample);
+            sum += *sample;
+        }
+
+        self.avg = (self.count as f64) * self.avg + sum;
+        self.count += data.len();
+        self.avg /= self.count as f64;
+    }
+}
+
+impl Default for BucketStatistics {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Display for BucketStatistics {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "min {}, max {}, avg {:.1}; samples {}",
+            self.min, self.max, self.avg, self.count
+        )
+    }
+}
+
+impl Recorder {
     /// Print out a report of all metrics that have been collected so far, with
     /// their description if available.
     ///
     /// We expect this function to be called once at the end of the CLI, but it
     /// should be safe to call it in the middle of a Nickel execution as well.
     pub(super) fn report(&self) {
-        for (key, counter) in self
-            .counters
-            .read()
-            .unwrap_or_else(PoisonError::into_inner)
-            .iter()
-        {
-            if let Some(description) = self
-                .descriptions
-                .read()
-                .unwrap_or_else(PoisonError::into_inner)
-                .get(key.name())
-            {
-                eprintln!(
-                    "{}: {}\n  {}",
-                    key.name(),
-                    description,
-                    counter.load(Ordering::Relaxed)
-                );
-            } else {
-                eprintln!("{}: {}", key.name(), counter.load(Ordering::Relaxed));
-            }
-        }
+        self.registry.visit_counters(|key, counter| {
+            eprintln!("{}: {}", key.name(), counter.load(Ordering::Relaxed))
+        });
+        self.registry.visit_histograms(|key, bucket| {
+            let mut stats = BucketStatistics::new();
+            bucket.data_with(|data| stats.update(data));
+            eprintln!("{}: {}", key.name(), stats);
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn averge_tracking() {
+        let mut overall_stats = BucketStatistics::new();
+        let mut incremental_stats = BucketStatistics::new();
+
+        let data = [3.0, 2.0, 6.0, 12.0, 56.0, 82.0, 202.0, 100.0, 29.0];
+        overall_stats.update(&data);
+
+        assert_eq!(overall_stats.count, data.len());
+        assert_eq!(
+            overall_stats.min,
+            data.iter().copied().fold(f64::NAN, f64::min)
+        );
+        assert_eq!(
+            overall_stats.max,
+            data.iter().copied().fold(f64::NAN, f64::max)
+        );
+        assert_eq!(
+            overall_stats.avg,
+            data.iter().copied().sum::<f64>() / (data.len() as f64)
+        );
+
+        incremental_stats.update(&data[0..5]);
+        incremental_stats.update(&data[5..]);
+        assert_eq!(incremental_stats.min, overall_stats.min);
+        assert_eq!(incremental_stats.max, overall_stats.max);
+        assert_eq!(incremental_stats.avg, overall_stats.avg);
+        assert_eq!(incremental_stats.count, overall_stats.count);
     }
 }

--- a/core/src/environment.rs
+++ b/core/src/environment.rs
@@ -84,7 +84,10 @@ impl<K: Hash + Eq, V: PartialEq> Environment<K, V> {
     /// Tries to find the value of a key in the Environment.
     pub fn get(&self, key: &K) -> Option<&V> {
         increment!("Environment::get");
-        self.iter_layers().find_map(|hmap| hmap.get(key))
+        self.iter_layers().find_map(|hmap| {
+            sample!("Environment.hashmap_size_get", hmap.len() as f64);
+            hmap.get(key)
+        })
     }
 
     /// Creates an iterator that visits all layers from the most recent one to the oldest.

--- a/core/src/environment.rs
+++ b/core/src/environment.rs
@@ -73,6 +73,7 @@ impl<K: Hash + Eq, V: PartialEq> Environment<K, V> {
 
     /// Inserts a key-value pair into the Environment.
     pub fn insert(&mut self, key: K, value: V) {
+        increment!("Environment::insert");
         if self.was_cloned() {
             self.current = Rc::new(HashMap::new());
         }
@@ -81,6 +82,7 @@ impl<K: Hash + Eq, V: PartialEq> Environment<K, V> {
 
     /// Tries to find the value of a key in the Environment.
     pub fn get(&self, key: &K) -> Option<&V> {
+        increment!("Environment::get");
         self.iter_layers().find_map(|hmap| hmap.get(key))
     }
 

--- a/core/src/environment.rs
+++ b/core/src/environment.rs
@@ -84,10 +84,15 @@ impl<K: Hash + Eq, V: PartialEq> Environment<K, V> {
     /// Tries to find the value of a key in the Environment.
     pub fn get(&self, key: &K) -> Option<&V> {
         increment!("Environment::get");
-        self.iter_layers().find_map(|hmap| {
+
+        let mut layer_count = 0;
+        let r = self.iter_layers().find_map(|hmap| {
             sample!("Environment.hashmap_size_get", hmap.len() as f64);
+            layer_count += 1;
             hmap.get(key)
-        })
+        });
+        sample!("Environment.get_layers_traversed", layer_count as f64);
+        r
     }
 
     /// Creates an iterator that visits all layers from the most recent one to the oldest.

--- a/core/src/environment.rs
+++ b/core/src/environment.rs
@@ -42,7 +42,10 @@ impl<K: Hash + Eq, V: PartialEq> Clone for Environment<K, V> {
     fn clone(&self) -> Self {
         increment!("Environment::clone");
         if !self.current.is_empty() && !self.was_cloned() {
-            sample!("Environment.curr_layer_size_at_clone", self.current.len() as f64);
+            sample!(
+                "Environment.curr_layer_size_at_clone",
+                self.current.len() as f64
+            );
             self.previous.replace_with(|old| {
                 Some(Rc::new(Environment {
                     current: self.current.clone(),

--- a/core/src/environment.rs
+++ b/core/src/environment.rs
@@ -42,7 +42,7 @@ impl<K: Hash + Eq, V: PartialEq> Clone for Environment<K, V> {
     fn clone(&self) -> Self {
         increment!("Environment::clone");
         if !self.current.is_empty() && !self.was_cloned() {
-            sample!("Environment.size_at_clone", self.current.len() as f64);
+            sample!("Environment.curr_layer_size_at_clone", self.current.len() as f64);
             self.previous.replace_with(|old| {
                 Some(Rc::new(Environment {
                     current: self.current.clone(),

--- a/core/src/environment.rs
+++ b/core/src/environment.rs
@@ -7,7 +7,7 @@ use std::marker::PhantomData;
 use std::ptr::NonNull;
 use std::rc::Rc;
 
-use crate::metrics::increment;
+use crate::metrics::{increment, sample};
 
 /// An environment as a linked-list of hashmaps.
 ///
@@ -42,6 +42,7 @@ impl<K: Hash + Eq, V: PartialEq> Clone for Environment<K, V> {
     fn clone(&self) -> Self {
         increment!("Environment::clone");
         if !self.current.is_empty() && !self.was_cloned() {
+            sample!("Environment.size_at_clone", self.current.len() as f64);
             self.previous.replace_with(|old| {
                 Some(Rc::new(Environment {
                     current: self.current.clone(),

--- a/core/src/eval/cache/lazy.rs
+++ b/core/src/eval/cache/lazy.rs
@@ -2,6 +2,7 @@
 use super::{BlackholedError, Cache, CacheIndex, Closure, Environment};
 use crate::{
     identifier::{Ident, LocIdent},
+    metrics::increment,
     term::{record::FieldDeps, BindingType, RichTerm, Term},
 };
 use std::cell::{Ref, RefCell, RefMut};
@@ -364,6 +365,7 @@ pub struct Thunk {
 impl Thunk {
     /// Create a new standard thunk.
     pub fn new(closure: Closure) -> Self {
+        increment!("Thunk::new");
         Thunk {
             data: Rc::new(RefCell::new(ThunkData::new(closure))),
         }
@@ -374,9 +376,12 @@ impl Thunk {
     pub fn new_rev(closure: Closure, deps: FieldDeps) -> Self {
         match deps {
             FieldDeps::Known(deps) if deps.is_empty() => Self::new(closure),
-            deps => Thunk {
-                data: Rc::new(RefCell::new(ThunkData::new_rev(closure, deps))),
-            },
+            deps => {
+                increment!("Thunk::new_rev");
+                Thunk {
+                    data: Rc::new(RefCell::new(ThunkData::new_rev(closure, deps))),
+                }
+            }
         }
     }
 

--- a/core/src/metrics.rs
+++ b/core/src/metrics.rs
@@ -16,4 +16,17 @@ macro_rules! increment {
     ( $( $args:expr ),+ ) => {};
 }
 
+#[cfg(feature = "metrics")]
+macro_rules! sample {
+    ( $counter:expr, $value:expr ) => {
+        ::metrics::histogram!($counter, $value)
+    };
+}
+
+#[cfg(not(feature = "metrics"))]
+macro_rules! sample {
+    ( $( $args:expr ),+ ) => {};
+}
+
 pub(crate) use increment;
+pub(crate) use sample;

--- a/core/src/program.rs
+++ b/core/src/program.rs
@@ -156,6 +156,7 @@ impl<EC: EvalCache> Program<EC> {
         I: IntoIterator<Item = P>,
         P: Into<OsString>,
     {
+        increment!("Program::new");
         let mut cache = Cache::new(ErrorTolerance::Strict);
 
         let merge_term = paths


### PR DESCRIPTION
Add a facility for recording numeric samples and aggregating them as a metric. Added tracked metrics:
- number of calls to `Thunk::new`
- number of calls to `Thunk::new_rev`
- number of calls to `Environment::insert`
- number of calls to `Environment::get`
- the size of an environment when it is actually cloned in `Environment:clone()`
- the size of each environment layer inspected during `Environment::get`
- the number of environment layers traversed during `Environment::get`