### PR TITLE
Sign executables after patching revision on Darwin

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -234,9 +234,12 @@
         pname = pkg.pname + "-rev-fixup";
         inherit (pkg) version meta;
         src = pkg;
-        buildInputs = [ pkgs.bbe ];
+        buildInputs = [ pkgs.bbe ]
+          ++ pkgs.lib.optionals pkgs.stdenv.isDarwin [ pkgs.darwin.autoSignDarwinBinariesHook ];
         phases = [ "fixupPhase" ];
         fixupPhase = ''
+          runHook preFixup
+
           mkdir -p $out/bin
           for srcBin in $src/bin/*; do
             outBin="$out/bin/$(basename $srcBin)"
@@ -247,6 +250,8 @@
               $srcBin > $outBin
             chmod +x $outBin
           done
+
+          runHook postFixup
         '';
       };
 


### PR DESCRIPTION
https://github.com/tweag/nickel/pull/1580 introduced patching of resulting binary in a separate derivation that ends up with bad (or missing) code signature which prevents it from running:

```
% nix run
zsh: killed     nix run
```

and Console.app revealing the reason:

```
Exception Type:        EXC_BAD_ACCESS (SIGKILL (Code Signature Invalid))
Exception Codes:       UNKNOWN_0x32 at 0x00000001054e4199
Exception Codes:       0x0000000000000032, 0x00000001054e4199
```

This change uses `autoSignDarwinBinariesHook` to sign the result that seems to fix the problem.
