### PR TITLE
build lalrpop in a separate derivation

### DIFF
--- a/core/src/typ.rs
+++ b/core/src/typ.rs
@@ -126,8 +126,8 @@ pub enum EnumRowsF<ERows> {
 /// type variables are introduced, that is, on forall quantifiers.
 #[derive(Clone, PartialEq, Eq, Debug, Default)]
 pub enum VarKind {
-    Type,
     #[default]
+    Type,
     EnumRows,
     /// `excluded` keeps track of which rows appear somewhere alongside the tail, and therefore
     /// cannot appear in the tail. For instance `forall r. { ; r } -> { x : Number ; r }` assumes

--- a/core/src/typ.rs
+++ b/core/src/typ.rs
@@ -126,8 +126,8 @@ pub enum EnumRowsF<ERows> {
 /// type variables are introduced, that is, on forall quantifiers.
 #[derive(Clone, PartialEq, Eq, Debug, Default)]
 pub enum VarKind {
-    #[default]
     Type,
+    #[default]
     EnumRows,
     /// `excluded` keeps track of which rows appear somewhere alongside the tail, and therefore
     /// cannot appear in the tail. For instance `forall r. { ; r } -> { x : Number ; r }` assumes

--- a/flake.nix
+++ b/flake.nix
@@ -322,9 +322,9 @@
             pnameSuffix = "-core-lalrpop";
             cargoPackage = "${pname}-core";
             extraArgs = {
+              cargoArtifacts = cargoArtifactsDeps;
               src = craneLib.mkDummySrc {
                 inherit src;
-                cargoArtifacts = cargoArtifactsDeps;
 
                 # after stubbing out, reset things back just enough for lalrpop build
                 extraDummyScript = ''

--- a/flake.nix
+++ b/flake.nix
@@ -408,7 +408,7 @@
           # Check that documentation builds without warnings or errors
           checkRustDoc = craneLib.cargoDoc {
             inherit pname src version cargoArtifacts env;
-            inherit (cargoArtifacts) buildInputs;
+            inherit (cargoArtifactsDeps) buildInputs;
 
             RUSTDOCFLAGS = "-D warnings";
 
@@ -429,7 +429,7 @@
 
           clippy = craneLib.cargoClippy {
             inherit pname src cargoArtifacts env;
-            inherit (cargoArtifacts) buildInputs;
+            inherit (cargoArtifactsDeps) buildInputs;
 
             cargoExtraArgs = cargoBuildExtraArgs;
             cargoClippyExtraArgs = "--all-features --all-targets --workspace -- --deny warnings --allow clippy::new-without-default --allow clippy::match_like_matches_macro";

--- a/flake.nix
+++ b/flake.nix
@@ -345,7 +345,7 @@
           };
         in
         rec {
-          inherit cargoArtifacts;
+          inherit cargoArtifacts cargoArtifactsDeps;
           nickel-lang-core = buildPackage { pnameSuffix = "-core"; };
           nickel-lang-cli = fixupGitRevision (buildPackage {
             pnameSuffix = "-cli";
@@ -437,12 +437,10 @@
         };
 
       makeDevShell = { rust }: pkgs.mkShell {
-        # Trick found in Crane's examples to get a nice dev shell
-        # See https://github.com/ipetkov/crane/blob/master/examples/quick-start/flake.nix
-        # XXX: this is weird. why are we sticking all the cargoArtifacts in
-        # the devShell? we're not going to use them anyways. This is a problem
-        # because we don't want to build lalrpop for the devShell
-        inputsFrom = builtins.attrValues (mkCraneArtifacts { inherit rust; });
+        # Get deps needed to build. Get them from cargoArtifactsDeps so we build
+        # the minimal amount possible to get there. It is a waste of time to
+        # build the cargoArtifacts, because cargo won't use them anyways.
+        inputsFrom = [ (mkCraneArtifacts { inherit rust; }).cargoArtifactsDeps ];
 
         buildInputs = [
           pkgs.rust-analyzer


### PR DESCRIPTION
lalrpop takes a significant amount of the build time of nickel-lang-core (1:30 / 4:30 on my machine). It's even worse than that in CI because pretty much every package depends on nickel-lang-core and rebuilds it separately.

The good news is that the lalrpop file doesn't change very often, so most of the time we can cache it. I made it into its own package that gets used as the cargoArtifacts of all the downstream packages.
