### PR TITLE
Add goto support for pattern bindings

### DIFF
--- a/lsp/nls/src/requests/goto.rs
+++ b/lsp/nls/src/requests/goto.rs
@@ -35,7 +35,7 @@ fn get_defs(term: &RichTerm, ident: Option<LocIdent>, server: &Server) -> Option
             let resolver = FieldResolver::new(server);
             let (last, path) = path.split_last()?;
             let path: Vec<_> = path.iter().map(|id| id.ident()).collect();
-            let parents = resolver.resolve_term_path(value, &path);
+            let parents = resolver.resolve_term_path(value, path.iter().copied());
             parents
                 .iter()
                 .filter_map(|parent| parent.get_definition_pos(last.ident()))

--- a/lsp/nls/tests/inputs/goto-pattern.ncl
+++ b/lsp/nls/tests/inputs/goto-pattern.ncl
@@ -1,0 +1,53 @@
+### /goto.ncl
+let
+  foo = {
+    inner = { bar = 1 },
+  }
+in
+let
+  { inner } = foo
+in
+let
+  { inner = blah@{ bar } } = foo
+in
+  [
+    inner.bar,
+    bar
+  ]
+### [[request]] # the `inner` in `let { inner } = foo`
+### type = "GotoDefinition"
+### textDocument.uri = "file:///goto.ncl"
+### position = { line = 6, character = 7 }
+###
+### # the `inner` in `let { inner = blah@{ bar } } = foo`
+### # Note that this `inner` is not a binding, so we don't expect
+### # it to goto anything.
+### [[request]]
+### type = "GotoDefinition"
+### textDocument.uri = "file:///goto.ncl"
+### position = { line = 9, character = 7 }
+###
+### [[request]] # the `blah` in `let { inner = blah@{ bar } } = foo`
+### type = "GotoDefinition"
+### textDocument.uri = "file:///goto.ncl"
+### position = { line = 9, character = 14 }
+###
+### [[request]] # the `bar` in `let { inner = blah@{ bar } } = foo`
+### type = "GotoDefinition"
+### textDocument.uri = "file:///goto.ncl"
+### position = { line = 9, character = 20 }
+###
+### [[request]] # the `inner` in `inner.bar`
+### type = "GotoDefinition"
+### textDocument.uri = "file:///goto.ncl"
+### position = { line = 12, character = 7 }
+###
+### [[request]] # the `bar` in `inner.bar`
+### type = "GotoDefinition"
+### textDocument.uri = "file:///goto.ncl"
+### position = { line = 12, character = 11 }
+###
+### [[request]] # the `bar` in `bar`
+### type = "GotoDefinition"
+### textDocument.uri = "file:///goto.ncl"
+### position = { line = 13, character = 5 }

--- a/lsp/nls/tests/snapshots/main__lsp__nls__tests__inputs__goto-pattern.ncl.snap
+++ b/lsp/nls/tests/snapshots/main__lsp__nls__tests__inputs__goto-pattern.ncl.snap
@@ -1,0 +1,12 @@
+---
+source: lsp/nls/tests/main.rs
+expression: output
+---
+file:///goto.ncl:2:4-2:9
+None
+file:///goto.ncl:2:4-2:9
+file:///goto.ncl:2:14-2:17
+file:///goto.ncl:6:4-6:9
+file:///goto.ncl:2:14-2:17
+file:///goto.ncl:9:19-9:22
+


### PR DESCRIPTION
Adds support for going to the "definition" of bindings in a let pattern. For example, in

```nickel
let { foo } = bar in ...
```

a "goto definition" request for `foo` will jump to wherever the "foo" field of `bar` is defined.