### PR TITLE
Add cousin search to goto and hover

### DIFF
--- a/lsp/nls/src/analysis.rs
+++ b/lsp/nls/src/analysis.rs
@@ -9,7 +9,7 @@ use nickel_lang_core::{
 };
 
 use crate::{
-    field_walker::DefWithPath,
+    field_walker::Def,
     identifier::LocIdent,
     position::PositionLookup,
     term::RichTermPtr,
@@ -139,6 +139,8 @@ impl<'a> ParentChainIter<'a> {
         let is_fieldy_term = |rt: &RichTerm| {
             matches!(
                 rt.as_ref(),
+                // There is also NAryOp::MergeContract, but only at eval time so we don't
+                // expect it.
                 Term::Op2(BinaryOp::Merge(_), _, _)
                     | Term::Annotated(_, _)
                     | Term::RecRecord(..)
@@ -249,7 +251,7 @@ impl AnalysisRegistry {
         self.analysis.remove(&file_id);
     }
 
-    pub fn get_def(&self, ident: &LocIdent) -> Option<&DefWithPath> {
+    pub fn get_def(&self, ident: &LocIdent) -> Option<&Def> {
         let file = ident.pos.as_opt_ref()?.src_id;
         self.analysis.get(&file)?.usage_lookup.def(ident)
     }

--- a/lsp/nls/src/requests/goto.rs
+++ b/lsp/nls/src/requests/goto.rs
@@ -4,21 +4,27 @@ use nickel_lang_core::term::{RichTerm, Term, UnaryOp};
 use serde_json::Value;
 
 use crate::{
-    cache::CacheExt, diagnostic::LocationCompat, field_walker::FieldResolver, identifier::LocIdent,
+    cache::CacheExt,
+    diagnostic::LocationCompat,
+    field_walker::{DefWithPath, FieldResolver},
+    identifier::LocIdent,
     server::Server,
 };
 
 fn get_defs(term: &RichTerm, ident: Option<LocIdent>, server: &Server) -> Option<Vec<LocIdent>> {
+    let resolver = FieldResolver::new(server);
     let ret = match (term.as_ref(), ident) {
         (Term::Var(id), _) => {
-            let loc = server
-                .analysis
-                .get_def(&(*id).into())
-                .map(|def| def.ident)?;
-            vec![loc]
+            let id = LocIdent::from(*id);
+            let def = server.analysis.get_def(&id)?;
+            let cousins = resolver.get_cousin_defs(def);
+            if cousins.is_empty() {
+                vec![def.ident]
+            } else {
+                cousins.into_iter().map(|(loc, _)| loc).collect()
+            }
         }
         (Term::Op1(UnaryOp::StaticAccess(id), parent), _) => {
-            let resolver = FieldResolver::new(server);
             let parents = resolver.resolve_term(parent);
             parents
                 .iter()
@@ -32,7 +38,6 @@ fn get_defs(term: &RichTerm, ident: Option<LocIdent>, server: &Server) -> Option
                 .flat_map(|m| m.to_flattened_bindings())
                 .find(|(_path, bound_id, _)| bound_id.ident() == hovered_id.ident)?;
             path.reverse();
-            let resolver = FieldResolver::new(server);
             let (last, path) = path.split_last()?;
             let path: Vec<_> = path.iter().map(|id| id.ident()).collect();
             let parents = resolver.resolve_term_path(value, path.iter().copied());
@@ -100,15 +105,36 @@ pub fn handle_references(
 
     // The "references" of a symbol are all the usages of its definitions,
     // so first find the definitions and then find their usages.
-    let mut def_locs = server
-        .lookup_term_by_position(pos)?
+    let term = server.lookup_term_by_position(pos)?;
+    let mut def_locs = term
         .and_then(|term| get_defs(term, ident, server))
         .unwrap_or_default();
 
     // Maybe the position is pointing straight at the definition already.
     // In that case, def_locs won't have the definition yet; so add it.
-    def_locs.extend(server.lookup_ident_by_position(pos)?);
+    if let Some(id) = server.lookup_ident_by_position(pos)? {
+        def_locs.push(id);
+        if let Some(parent) = term {
+            // If `id` is a field name in a record, we can search through cousins
+            // to find more definitions.
+            if matches!(parent.as_ref(), Term::RecRecord(..) | Term::Record(_)) {
+                let def = DefWithPath {
+                    ident: id,
+                    value: None,
+                    path: vec![id.ident],
+                    parent_record: Some(parent.clone()),
+                    metadata: None,
+                };
+                let resolver = FieldResolver::new(server);
+                let cousins = resolver.get_cousin_defs(&def);
+                def_locs.extend(cousins.into_iter().map(|(loc, _)| loc))
+            }
+        }
+    }
 
+    // TODO: This usage map is based only on static scoping, and not on our "extended"
+    // scopes that we build up dynamically based on merges. Improving this probably
+    // requires building the extended scopes at static analysis time.
     let mut usages: Vec<_> = def_locs
         .iter()
         .flat_map(|id| server.analysis.get_usages(id))

--- a/lsp/nls/src/requests/hover.rs
+++ b/lsp/nls/src/requests/hover.rs
@@ -73,7 +73,17 @@ fn ident_hover(ident: LocIdent, server: &Server) -> Option<HoverData> {
             ret.values = values;
             ret.metadata = metadata;
         } else if def.path.is_empty() {
-            ret.values.extend(def.value.iter().cloned());
+            let cousins = resolver.get_cousin_defs(def);
+            if cousins.is_empty() {
+                ret.values.extend(def.value.iter().cloned());
+            } else {
+                for (_, cousin) in cousins {
+                    if let Some(val) = cousin.value {
+                        ret.values.push(val);
+                    }
+                    ret.metadata.push(cousin.metadata);
+                }
+            }
         }
     }
 

--- a/lsp/nls/src/requests/hover.rs
+++ b/lsp/nls/src/requests/hover.rs
@@ -67,15 +67,15 @@ fn ident_hover(ident: LocIdent, server: &Server) -> Option<HoverData> {
 
     if let Some(def) = server.analysis.get_def(&ident) {
         let resolver = FieldResolver::new(server);
-        if let Some(((last, path), val)) = def.path.split_last().zip(def.value.as_ref()) {
+        if let Some(((last, path), val)) = def.path().split_last().zip(def.value()) {
             let parents = resolver.resolve_term_path(val, path.iter().copied());
             let (values, metadata) = values_and_metadata_from_field(parents, *last);
             ret.values = values;
             ret.metadata = metadata;
-        } else if def.path.is_empty() {
+        } else if def.path().is_empty() {
             let cousins = resolver.get_cousin_defs(def);
             if cousins.is_empty() {
-                ret.values.extend(def.value.iter().cloned());
+                ret.values.extend(def.value().into_iter().cloned());
             } else {
                 for (_, cousin) in cousins {
                     if let Some(val) = cousin.value {

--- a/lsp/nls/src/server.rs
+++ b/lsp/nls/src/server.rs
@@ -30,7 +30,7 @@ use crate::{
     analysis::{Analysis, AnalysisRegistry},
     cache::CacheExt,
     diagnostic::DiagnosticCompat,
-    field_walker::DefWithPath,
+    field_walker::Def,
     requests::{completion, formatting, goto, hover, symbols},
     trace::Trace,
 };
@@ -145,15 +145,13 @@ impl Server {
                 // The term should always be populated by typecheck_with_analysis.
                 let term = cache.terms().get(&file_id).unwrap();
                 let name = module.name().into();
-                let def = DefWithPath {
+                let def = Def::Let {
                     ident: crate::identifier::LocIdent {
                         ident: name,
                         pos: TermPos::None,
                     },
-                    value: Some(term.term.clone()),
+                    value: term.term.clone(),
                     path: Vec::new(),
-                    metadata: None,
-                    parent_record: None,
                 };
                 self.initial_term_env.insert(name, def);
             }

--- a/lsp/nls/src/server.rs
+++ b/lsp/nls/src/server.rs
@@ -153,6 +153,7 @@ impl Server {
                     value: Some(term.term.clone()),
                     path: Vec::new(),
                     metadata: None,
+                    parent_record: None,
                 };
                 self.initial_term_env.insert(name, def);
             }

--- a/lsp/nls/tests/inputs/goto-recursive.ncl
+++ b/lsp/nls/tests/inputs/goto-recursive.ncl
@@ -1,0 +1,69 @@
+### /main.ncl
+({ a = { b = a } } & { a = a.b.b }).a.b
+### # Test the two definition sites of `a`.
+###
+### [[request]]
+### type = "GotoDefinition"
+### textDocument.uri = "file:///main.ncl"
+### position = { line = 0, character = 13 }
+###
+### [[request]]
+### type = "GotoDefinition"
+### textDocument.uri = "file:///main.ncl"
+### position = { line = 0, character = 27 }
+###
+### [[request]]
+### type = "GotoDefinition"
+### textDocument.uri = "file:///main.ncl"
+### position = { line = 0, character = 36 }
+###
+### # Test the two references of `a`. There are three, actually,
+### # but the last one doesn't work yet because we only track
+### # Term::Vars as usages.
+###
+### [[request]]
+### type = "References"
+### textDocument.uri = "file:///main.ncl"
+### position = { line = 0, character = 3 }
+### context = { includeDeclaration = false }
+###
+### [[request]]
+### type = "References"
+### textDocument.uri = "file:///main.ncl"
+### position = { line = 0, character = 13 }
+### context = { includeDeclaration = false }
+###
+### [[request]]
+### type = "References"
+### textDocument.uri = "file:///main.ncl"
+### position = { line = 0, character = 23 }
+### context = { includeDeclaration = false }
+###
+### [[request]]
+### type = "References"
+### textDocument.uri = "file:///main.ncl"
+### position = { line = 0, character = 27 }
+### context = { includeDeclaration = false }
+###
+### [[request]]
+### type = "References"
+### textDocument.uri = "file:///main.ncl"
+### position = { line = 0, character = 36 }
+### context = { includeDeclaration = false }
+###
+### # Test the definition of `b`.
+###
+### [[request]]
+### type = "GotoDefinition"
+### textDocument.uri = "file:///main.ncl"
+### position = { line = 0, character = 29 }
+###
+### [[request]]
+### type = "GotoDefinition"
+### textDocument.uri = "file:///main.ncl"
+### position = { line = 0, character = 31 }
+###
+### [[request]]
+### type = "GotoDefinition"
+### textDocument.uri = "file:///main.ncl"
+### position = { line = 0, character = 38 }

--- a/lsp/nls/tests/inputs/hover-cousin.ncl
+++ b/lsp/nls/tests/inputs/hover-cousin.ncl
@@ -1,0 +1,29 @@
+### /main.ncl
+{
+  foo = { bar = 2 },
+  blah = foo.bar,
+}
+| {
+  foo | doc "outer" = {
+    bar | Number | doc "inner" | default = 3
+  }
+}
+### [[request]]
+### type = "Hover"
+### textDocument.uri = "file:///main.ncl"
+### position = { line = 1, character = 3 }
+###
+### [[request]]
+### type = "Hover"
+### textDocument.uri = "file:///main.ncl"
+### position = { line = 1, character = 11 }
+###
+### [[request]]
+### type = "Hover"
+### textDocument.uri = "file:///main.ncl"
+### position = { line = 2, character = 10 }
+###
+### [[request]]
+### type = "Hover"
+### textDocument.uri = "file:///main.ncl"
+### position = { line = 2, character = 14 }

--- a/lsp/nls/tests/snapshots/main__lsp__nls__tests__inputs__goto-recursive.ncl.snap
+++ b/lsp/nls/tests/snapshots/main__lsp__nls__tests__inputs__goto-recursive.ncl.snap
@@ -1,0 +1,16 @@
+---
+source: lsp/nls/tests/main.rs
+expression: output
+---
+[file:///main.ncl:0:3-0:4, file:///main.ncl:0:23-0:24]
+[file:///main.ncl:0:3-0:4, file:///main.ncl:0:23-0:24]
+[file:///main.ncl:0:3-0:4, file:///main.ncl:0:23-0:24]
+[file:///main.ncl:0:13-0:14, file:///main.ncl:0:27-0:28]
+[file:///main.ncl:0:13-0:14, file:///main.ncl:0:27-0:28]
+[file:///main.ncl:0:13-0:14, file:///main.ncl:0:27-0:28]
+[file:///main.ncl:0:13-0:14, file:///main.ncl:0:27-0:28]
+[file:///main.ncl:0:13-0:14, file:///main.ncl:0:27-0:28]
+file:///main.ncl:0:9-0:10
+file:///main.ncl:0:9-0:10
+file:///main.ncl:0:9-0:10
+

--- a/lsp/nls/tests/snapshots/main__lsp__nls__tests__inputs__hover-cousin.ncl.snap
+++ b/lsp/nls/tests/snapshots/main__lsp__nls__tests__inputs__hover-cousin.ncl.snap
@@ -1,0 +1,21 @@
+---
+source: lsp/nls/tests/main.rs
+expression: output
+---
+<1:2-1:5>[```nickel
+Dyn
+```, outer]
+<1:10-1:13>[```nickel
+Number
+```, ```nickel
+Number
+```, inner]
+<2:9-2:12>[```nickel
+Dyn
+```, outer]
+<2:9-2:16>[```nickel
+Dyn
+```, ```nickel
+Number
+```, inner]
+


### PR DESCRIPTION
When encountering trees of merges and annotations in the AST, we've been doing some analysis to include "cousins" into the local scope when generating completions. This PR extends this analysis to hover and goto definition/references. For example, hovering over the first `foo` in the following example now correctly brings up the doc metadata.

```nickel
{
   inner = { foo = 1 }
} | { inner = { foo | doc "hello" } }
```