### PR TITLE
Contract elision for static types

### DIFF
--- a/core/src/eval/mod.rs
+++ b/core/src/eval/mod.rs
@@ -705,12 +705,12 @@ impl<R: ImportResolver, C: Cache> VirtualMachine<R, C> {
                 Term::Annotated(annot, inner) => {
                     // We apply the contract coming from the static type annotation separately as
                     // it is optimized.
-                    let static_contrat = annot.static_contract();
+                    let static_contract = annot.static_contract();
                     let contracts = annot.pending_contracts()?;
                     let pos = inner.pos;
                     let inner = inner.clone();
 
-                    let inner_with_static = if let Some(static_ctr) = static_contrat {
+                    let inner_with_static = if let Some(static_ctr) = static_contract {
                         static_ctr?.apply(inner, pos)
                     } else {
                         inner

--- a/core/src/stdlib.rs
+++ b/core/src/stdlib.rs
@@ -68,7 +68,11 @@ pub mod internals {
     generate_accessor!(bool);
     generate_accessor!(string);
     generate_accessor!(array);
+    generate_accessor!(array_dyn);
     generate_accessor!(func);
+    generate_accessor!(func_dom);
+    generate_accessor!(func_codom);
+    generate_accessor!(func_dyn);
     generate_accessor!(forall_var);
     generate_accessor!(forall);
     generate_accessor!(fail);
@@ -77,6 +81,7 @@ pub mod internals {
     generate_accessor!(record);
     generate_accessor!(dict_type);
     generate_accessor!(dict_contract);
+    generate_accessor!(dict_dyn);
     generate_accessor!(record_extend);
     generate_accessor!(forall_tail);
     generate_accessor!(dyn_tail);

--- a/core/src/term/mod.rs
+++ b/core/src/term/mod.rs
@@ -287,6 +287,15 @@ impl RuntimeContract {
         RuntimeContract { contract, label }
     }
 
+    /// Generate a runtime contract from a type used as a static type annotation and a label. Use
+    /// the guarantees of the static type system to optimize and simplify the contract.
+    pub fn from_static_type(labeled_typ: LabeledType) -> Result<Self, UnboundTypeVariableError> {
+        Ok(RuntimeContract {
+            contract: labeled_typ.typ.contract_static()?,
+            label: labeled_typ.label,
+        })
+    }
+
     /// Map a function over the term representing the underlying contract.
     pub fn map_contract<F>(self, f: F) -> Self
     where
@@ -577,6 +586,15 @@ impl TypeAnnotation {
             .cloned()
             .map(RuntimeContract::try_from)
             .collect::<Result<Vec<_>, _>>()
+    }
+
+    /// Build the contract derived from the static type annotation, applying the specific
+    /// optimizations along the way.
+    pub fn static_contract(&self) -> Option<Result<RuntimeContract, UnboundTypeVariableError>> {
+        self.typ
+            .as_ref()
+            .cloned()
+            .map(RuntimeContract::from_static_type)
     }
 
     /// Convert all the contracts of this annotation, including the potential type annotation as

--- a/core/src/term/mod.rs
+++ b/core/src/term/mod.rs
@@ -1354,7 +1354,6 @@ pub enum RecordExtKind {
 /// controlled by [RecordOpKind].
 #[derive(Clone, Debug, PartialEq, Eq, Copy, Default)]
 pub enum RecordOpKind {
-    #[default]
     IgnoreEmptyOpt,
     ConsiderAllFields,
 }

--- a/core/src/term/mod.rs
+++ b/core/src/term/mod.rs
@@ -1354,6 +1354,7 @@ pub enum RecordExtKind {
 /// controlled by [RecordOpKind].
 #[derive(Clone, Debug, PartialEq, Eq, Copy, Default)]
 pub enum RecordOpKind {
+    #[default]
     IgnoreEmptyOpt,
     ConsiderAllFields,
 }

--- a/core/src/transform/gen_pending_contracts.rs
+++ b/core/src/transform/gen_pending_contracts.rs
@@ -32,7 +32,7 @@ pub fn transform_one(rt: RichTerm) -> Result<RichTerm, UnboundTypeVariableError>
             .map(|v| -> Result<RichTerm, UnboundTypeVariableError> {
                 if let Some(labeled_ty) = &field.metadata.annotation.typ {
                     let pos = v.pos;
-                    let contract = RuntimeContract::try_from(labeled_ty.clone())?;
+                    let contract = RuntimeContract::from_static_type(labeled_ty.clone())?;
                     Ok(contract.apply(v, pos))
                 } else {
                     Ok(v)

--- a/core/src/typ.rs
+++ b/core/src/typ.rs
@@ -927,6 +927,98 @@ impl Type {
         .unwrap()
     }
 
+    /// Static typing guarantees make some of the contract checks useless, assuming that blame
+    /// safety holds. This function simplifies `self` for contract generation, assuming it is part
+    /// of a static type annotation, for contract generation by removing some of these useless
+    /// checks.
+    ///
+    /// # Simplifications
+    ///
+    /// - `forall`s in positive positions are removed, and the corresponding type variable is
+    /// turned to a `Dyn` contract, with the hope of making [Self::contract()] to generate
+    /// optimized contracts in return (for example, `Array Dyn` becomes a constant-time overhead,
+    /// while `Array a` is linear in the size of the array).
+    /// - All positive occurrences of first order types are turned to `Dyn` contracts.
+    fn optimize_static_ctr(self) -> Self {
+        fn optimize_rrows(
+            rrows: RecordRows,
+            vars_elide: &HashSet<LocIdent>,
+            polarity: Polarity,
+        ) -> RecordRows {
+            RecordRows(rrows.0.map(
+                |typ| Box::new(optimize(*typ, vars_elide, polarity)),
+                |rrows| Box::new(optimize_rrows(*rrows, vars_elide, polarity)),
+            ))
+        }
+
+        fn optimize(typ: Type, vars_elide: &HashSet<LocIdent>, polarity: Polarity) -> Type {
+            let mut pos = typ.pos;
+
+            let optimized = match typ.typ {
+                TypeF::Arrow(dom, codom) => TypeF::Arrow(
+                    Box::new(optimize(*dom, vars_elide, polarity.flip())),
+                    Box::new(optimize(*codom, vars_elide, polarity)),
+                ),
+                // TODO: don't optimize only VarKind::Type
+                TypeF::Forall {
+                    var,
+                    var_kind: VarKind::Type,
+                    body,
+                } if polarity == Polarity::Positive => {
+                    let mut env = vars_elide.clone();
+                    env.insert(var);
+                    let result = optimize(*body, &env, polarity);
+                    // we keep the position of the body, not the one of the forall
+                    pos = result.pos;
+                    result.typ
+                }
+                TypeF::Forall {
+                    var,
+                    var_kind,
+                    body,
+                } => TypeF::Forall {
+                    var,
+                    var_kind,
+                    body: Box::new(optimize(*body, &vars_elide, polarity)),
+                },
+                TypeF::Var(id) if vars_elide.contains(&id) => TypeF::Dyn,
+                v @ TypeF::Var(_) => v,
+                // Any first-order type on positive position can be elided
+                _ if matches!(polarity, Polarity::Positive) => TypeF::Dyn,
+                // Otherwise, we still recurse into non-primitive types
+                TypeF::Record(rrows) => TypeF::Record(optimize_rrows(rrows, vars_elide, polarity)),
+                TypeF::Dict {
+                    type_fields,
+                    flavour,
+                } => TypeF::Dict {
+                    type_fields: Box::new(optimize(*type_fields, vars_elide, polarity)),
+                    flavour,
+                },
+                TypeF::Array(t) => TypeF::Array(Box::new(optimize(*t, vars_elide, polarity))),
+                // All other types don't contain subtypes, it's a base case
+                t => t,
+            };
+
+            Type {
+                typ: optimized,
+                pos,
+            }
+        }
+
+        optimize(self, &HashSet::new(), Polarity::Positive)
+    }
+
+    /// Return the contract corresponding to a type part of a static type annotation, either as a function or a record. Said
+    /// contract must then be applied using the `ApplyContract` primitive operation.
+    ///
+    /// [contract_static] uses the fact that the checked term has been typechecked to optimize the
+    /// generated contract.
+    pub fn contract_static(self) -> Result<RichTerm, UnboundTypeVariableError> {
+        let mut sy = 0;
+        self.optimize_static_ctr()
+            .subcontract(HashMap::new(), Polarity::Positive, &mut sy)
+    }
+
     /// Return the contract corresponding to a type, either as a function or a record. Said
     /// contract must then be applied using the `ApplyContract` primitive operation.
     pub fn contract(&self) -> Result<RichTerm, UnboundTypeVariableError> {
@@ -966,10 +1058,21 @@ impl Type {
             TypeF::Number => internals::num(),
             TypeF::Bool => internals::bool(),
             TypeF::String => internals::string(),
-            //TODO: optimization: have a specialized contract for `Array Dyn`, to avoid mapping an
-            //always successful contract on each element.
+            TypeF::Array(ref ty) if matches!(ty.typ, TypeF::Dyn) => internals::array_dyn(),
             TypeF::Array(ref ty) => mk_app!(internals::array(), ty.subcontract(vars, pol, sy)?),
             TypeF::Symbol => panic!("Are you trying to check a Sym at runtime?"),
+            TypeF::Arrow(ref s, ref t) if matches!((&s.typ, &t.typ), (TypeF::Dyn, TypeF::Dyn)) => {
+                internals::func_dyn()
+            }
+            TypeF::Arrow(ref s, ref t) if matches!(s.typ, TypeF::Dyn) => {
+                mk_app!(internals::func_codom(), t.subcontract(vars, pol, sy)?)
+            }
+            TypeF::Arrow(ref s, ref t) if matches!(t.typ, TypeF::Dyn) => {
+                mk_app!(
+                    internals::func_dom(),
+                    s.subcontract(vars.clone(), pol.flip(), sy)?
+                )
+            }
             TypeF::Arrow(ref s, ref t) => mk_app!(
                 internals::func(),
                 s.subcontract(vars.clone(), pol.flip(), sy)?,
@@ -1016,6 +1119,15 @@ impl Type {
             }
             TypeF::Enum(ref erows) => erows.subcontract()?,
             TypeF::Record(ref rrows) => rrows.subcontract(vars, pol, sy)?,
+            TypeF::Dict {
+                ref type_fields,
+                flavour: _,
+            } if matches!(type_fields.typ, TypeF::Dyn) => {
+                mk_app!(
+                    internals::dict_contract(),
+                    type_fields.subcontract(vars, pol, sy)?
+                )
+            }
             TypeF::Dict {
                 ref type_fields,
                 flavour: DictTypeFlavour::Contract,

--- a/core/src/typ.rs
+++ b/core/src/typ.rs
@@ -1015,8 +1015,10 @@ impl Type {
     /// generated contract.
     pub fn contract_static(self) -> Result<RichTerm, UnboundTypeVariableError> {
         let mut sy = 0;
-        self.optimize_static_ctr()
-            .subcontract(HashMap::new(), Polarity::Positive, &mut sy)
+        // println!("Optimizing contract: {self}");
+        // println!("Optimized: {}", self.clone().optimize_static_ctr());
+        self.optimize_static_ctr().subcontract(HashMap::new(), Polarity::Positive, &mut sy)
+        // self.subcontract(HashMap::new(), Polarity::Positive, &mut sy)
     }
 
     /// Return the contract corresponding to a type, either as a function or a record. Said
@@ -1122,12 +1124,7 @@ impl Type {
             TypeF::Dict {
                 ref type_fields,
                 flavour: _,
-            } if matches!(type_fields.typ, TypeF::Dyn) => {
-                mk_app!(
-                    internals::dict_contract(),
-                    type_fields.subcontract(vars, pol, sy)?
-                )
-            }
+            } if matches!(type_fields.typ, TypeF::Dyn) => internals::dict_dyn(),
             TypeF::Dict {
                 ref type_fields,
                 flavour: DictTypeFlavour::Contract,

--- a/core/src/typ.rs
+++ b/core/src/typ.rs
@@ -1012,8 +1012,8 @@ impl Type {
     /// Return the contract corresponding to a type which appears in a static type annotation. Said
     /// contract must then be applied using the `ApplyContract` primitive operation.
     ///
-    /// [contract_static] uses the fact that the checked term has been typechecked to optimize the
-    /// generated contract.
+    /// [Self::contract_static] uses the fact that the checked term has been typechecked to
+    /// optimize the generated contract.
     pub fn contract_static(self) -> Result<RichTerm, UnboundTypeVariableError> {
         let mut sy = 0;
         self.optimize_static()

--- a/core/src/typ.rs
+++ b/core/src/typ.rs
@@ -966,9 +966,9 @@ impl Type {
                     var_kind: VarKind::Type,
                     body,
                 } if polarity == Polarity::Positive => {
-                    let mut env = vars_elide.clone();
-                    env.insert(var);
-                    let result = optimize(*body, &env, polarity);
+                    let mut var_owned = vars_elide.clone();
+                    var_owned.insert(var);
+                    let result = optimize(*body, &var_owned, polarity);
                     // we keep the position of the body, not the one of the forall
                     pos = result.pos;
                     result.typ
@@ -980,7 +980,7 @@ impl Type {
                 } => TypeF::Forall {
                     var,
                     var_kind,
-                    body: Box::new(optimize(*body, &vars_elide, polarity)),
+                    body: Box::new(optimize(*body, vars_elide, polarity)),
                 },
                 TypeF::Var(id) if vars_elide.contains(&id) => TypeF::Dyn,
                 v @ TypeF::Var(_) => v,

--- a/core/src/typ.rs
+++ b/core/src/typ.rs
@@ -1059,7 +1059,7 @@ impl Type {
             TypeF::Number => internals::num(),
             TypeF::Bool => internals::bool(),
             TypeF::String => internals::string(),
-            // Array Dyn is specialied to array_dyn, which is constant time
+            // Array Dyn is specialized to array_dyn, which is constant time
             TypeF::Array(ref ty) if matches!(ty.typ, TypeF::Dyn) => internals::array_dyn(),
             TypeF::Array(ref ty) => mk_app!(internals::array(), ty.subcontract(vars, pol, sy)?),
             TypeF::Symbol => panic!("Are you trying to check a Sym at runtime?"),

--- a/core/stdlib/internals.ncl
+++ b/core/stdlib/internals.ncl
@@ -2,7 +2,7 @@
   # Internal operations. Can't be accessed from user code because `$` is not a
   # valid starting character for an identifier.
 
-  # Contract implementations
+  # Builtin contract implementations
   "$dyn" = fun _label value => value,
 
   "$num" = fun label value => if %typeof% value == 'Number then value else %blame% label,
@@ -19,6 +19,7 @@
     else
       %blame% label,
 
+  # A specialized version of `$array $dyn`, but which is constant time.
   "$array_dyn" = fun label value =>
     if %typeof% value == 'Array then
       value
@@ -37,6 +38,7 @@
     else
       %blame% label,
 
+  # A specialied version of `_ -> Dyn`
   "$func_dom" = fun domain label value =>
     if %typeof% value == 'Function then
       (
@@ -52,6 +54,7 @@
     else
       %blame% label,
 
+  # A specialied version of `Dyn -> _`
   "$func_codom" = fun codomain label value =>
     if %typeof% value == 'Function then
       (
@@ -64,6 +67,7 @@
     else
       %blame% label,
 
+  # A specialied version of `Dyn -> Dyn`
   "$func_dyn" = fun label value =>
     if %typeof% value == 'Function then
       value
@@ -161,6 +165,8 @@
     else
       %blame% (%label_with_message% "not a record" label),
 
+  # A specialized version of either `{_ | Dyn}` or `{_ : Dyn}` (which are
+  # equivalent), but which is constant time.
   "$dict_dyn" = fun label value =>
     if %typeof% value == 'Record then
       value

--- a/core/stdlib/internals.ncl
+++ b/core/stdlib/internals.ncl
@@ -58,7 +58,7 @@
         fun x =>
           %apply_contract%
             codomain
-            (%chng_pol% (%go_codom% label))
+            (%go_codom% label)
             (value x)
       )
     else

--- a/core/stdlib/internals.ncl
+++ b/core/stdlib/internals.ncl
@@ -19,9 +19,54 @@
     else
       %blame% label,
 
+  "$array_dyn" = fun label value =>
+    if %typeof% value == 'Array then
+      value
+    else
+      %blame% label,
+
   "$func" = fun domain codomain label value =>
     if %typeof% value == 'Function then
-      (fun x => %apply_contract% codomain (%go_codom% label) (value (%apply_contract% domain (%chng_pol% (%go_dom% label)) x)))
+      (
+        fun x =>
+          %apply_contract%
+            codomain
+            (%go_codom% label)
+            (value (%apply_contract% domain (%chng_pol% (%go_dom% label)) x))
+      )
+    else
+      %blame% label,
+
+  "$func_dom" = fun domain label value =>
+    if %typeof% value == 'Function then
+      (
+        fun x =>
+          value
+            (
+              %apply_contract%
+                domain
+                (%chng_pol% (%go_dom% label))
+                x
+            )
+      )
+    else
+      %blame% label,
+
+  "$func_codom" = fun codomain label value =>
+    if %typeof% value == 'Function then
+      (
+        fun x =>
+          %apply_contract%
+            codomain
+            (%chng_pol% (%go_codom% label))
+            (value x)
+      )
+    else
+      %blame% label,
+
+  "$func_dyn" = fun label value =>
+    if %typeof% value == 'Function then
+      value
     else
       %blame% label,
 
@@ -113,6 +158,12 @@
           fun _field field_value =>
             %apply_contract% contract (%go_dict% label) field_value
         )
+    else
+      %blame% (%label_with_message% "not a record" label),
+
+  "$dict_dyn" = fun label value =>
+    if %typeof% value == 'Record then
+      value
     else
       %blame% (%label_with_message% "not a record" label),
 

--- a/core/stdlib/std.ncl
+++ b/core/stdlib/std.ncl
@@ -1971,7 +1971,7 @@
         "%
       = fun field content r =>
         let r =
-          if %has_field_all% field r then
+          if %has_field% field r then
             %record_remove% field r
           else
             r

--- a/core/stdlib/std.ncl
+++ b/core/stdlib/std.ncl
@@ -1971,7 +1971,7 @@
         "%
       = fun field content r =>
         let r =
-          if %has_field% field r then
+          if %has_field_all% field r then
             %record_remove% field r
           else
             r

--- a/doc/manual/syntax.md
+++ b/doc/manual/syntax.md
@@ -822,7 +822,7 @@ parsed as such:
 ```nickel #repl
 > let MyDyn = fun label value => value in
     {foo = 1, bar | MyDyn = "foo"} : {foo : Number, bar : MyDyn}
-{ bar = "foo", foo = 1, }
+{ bar | MyDyn = "foo", foo = 1, }
 ```
 
 ## Metadata


### PR DESCRIPTION
## Context

As part of #1622, metrics show that the base used for benchmarks is performing an awful lot of array contract applications and their derived subcontracts, in particular polymorphic contracts. This is probably due to the usage of stdlib functions, which are all typed with a polymorphic type.

Indeed, consider `std.record.map`, whose type is `forall a b. (a -> b) -> Array a -> Array b`. If we apply it to a 5000 elements array, this will cause the execution of 20 000 small contracts: one to seal all elements of the array argument with `a`, one to unseal the same elements when `f` is applied (corresponding to `_a_ -> b`), one sealing the result of the application to `b` (the `b` in `a -> _b_`), and finally one that will map the unsealing key over the resulting array.

What's sad is that the function is statically typechecked. Thus, under the assumption that the type system is reasonably behaved (blame safety), the polymorphic contract _can never blame_. In the same spirit, it's not useful to check anything on the return value of the function: the typechecker already proves that it must be `Array b`.

I discussed contract elision rules in #285, which is a bit different, but related. This PR follows the same idea overall: use the guarantees of the static type system to elide some of the dynamic checks.

## Content

This PR applies the following rewriting when generating the contract coming from a static type annotation:

- `forall` in positive position are removed, and their bound variable is substituted for `Dyn`. That is, `forall a b. (a -> b) -> Array a -> Array b` is rewritten to `(Dyn -> Dyn) -> Array Dyn -> Array Dyn`.
- first-order contracts (anything but a function type) in positive position are substituted for `Dyn` as well. Indeed, according to blame safety, a well-typed function can never be blamed, thus positive occurrences of contracts can never fail. For map, we get after this second transformation `(Dyn -> Dyn) -> Array Dyn -> Dyn`

Those optimizations are coupled with the following specializations, which aren't restricted to static type annotations:

- `Dyn -> Dyn` is specialied to `func_dyn`, `Dyn -> T` to `func_dom T`, etc. That is, the general function contract is specialized when the domain, the codomain or both are `Dyn`, to eschew useless checks.
- Similarly, `Array Dyn` is specialized to a constant-time contract `$array_dyn` which just checks that its argument is an array (indeed, `$array $dyn` maps `$dyn` and is thus linear time - not when applied, thanks to lazy array contracts, but still when the array is finally forced)
- Similarly, `{_ : Dyn}` and `{_ | Dyn}` are specialized to `$dict_dyn`.

Those two changes combined give even better results: once the type has been rewritten, many specialized version of builtin contracts can be used. On our `map` example, the final contract becomes `$func $func_dyn ($func_dom $array_dyn)`. This contract only checks that the first argument to `map` is a function and the second is an array, all in constant time. From `4n` contract checks, we are now consistently applying 3 checks (we still check that `map` is a function, which is useless - but it's not very important and can be improved upon later).

## Result

Tested on the codebase of #1622, this gave a consistent 50% reduction in running time, which is encouraging. I will test it on kav (https://github.com/tweag/nickel/discussions/1667) as well.