### PR TITLE
Avoid quadratic behavior when optimizing contracts

### DIFF
--- a/core/src/typ.rs
+++ b/core/src/typ.rs
@@ -952,21 +952,11 @@ impl Type {
         ) -> RecordRows {
             RecordRows(rrows.0.map(
                 |typ| Box::new(optimize(*typ, vars_elide.clone(), polarity)),
-                |rrows| {
-                    Box::new(optimize_rrows(
-                        *rrows,
-                        vars_elide.clone(),
-                        polarity,
-                    ))
-                },
+                |rrows| Box::new(optimize_rrows(*rrows, vars_elide.clone(), polarity)),
             ))
         }
 
-        fn optimize(
-            typ: Type,
-            mut vars_elide: VarsHashSet,
-            polarity: Polarity,
-        ) -> Type {
+        fn optimize(typ: Type, mut vars_elide: VarsHashSet, polarity: Polarity) -> Type {
             let mut pos = typ.pos;
 
             let optimized = match typ.typ {

--- a/core/src/typ.rs
+++ b/core/src/typ.rs
@@ -941,23 +941,37 @@ impl Type {
     /// - All positive occurrences of first order contracts (that is, anything but a function type)
     /// are turned to `Dyn` contracts.
     fn optimize_static(self) -> Self {
+        use crate::environment::Environment;
+        // We use this environment as a shareable HashSet
+        type VarsHashSet = Environment<Ident, ()>;
+
         fn optimize_rrows(
             rrows: RecordRows,
-            vars_elide: &HashSet<LocIdent>,
+            vars_elide: VarsHashSet,
             polarity: Polarity,
         ) -> RecordRows {
             RecordRows(rrows.0.map(
-                |typ| Box::new(optimize(*typ, vars_elide, polarity)),
-                |rrows| Box::new(optimize_rrows(*rrows, vars_elide, polarity)),
+                |typ| Box::new(optimize(*typ, vars_elide.clone(), polarity)),
+                |rrows| {
+                    Box::new(optimize_rrows(
+                        *rrows,
+                        vars_elide.clone(),
+                        polarity,
+                    ))
+                },
             ))
         }
 
-        fn optimize(typ: Type, vars_elide: &HashSet<LocIdent>, polarity: Polarity) -> Type {
+        fn optimize(
+            typ: Type,
+            mut vars_elide: VarsHashSet,
+            polarity: Polarity,
+        ) -> Type {
             let mut pos = typ.pos;
 
             let optimized = match typ.typ {
                 TypeF::Arrow(dom, codom) => TypeF::Arrow(
-                    Box::new(optimize(*dom, vars_elide, polarity.flip())),
+                    Box::new(optimize(*dom, vars_elide.clone(), polarity.flip())),
                     Box::new(optimize(*codom, vars_elide, polarity)),
                 ),
                 // TODO: don't optimize only VarKind::Type
@@ -966,9 +980,8 @@ impl Type {
                     var_kind: VarKind::Type,
                     body,
                 } if polarity == Polarity::Positive => {
-                    let mut var_owned = vars_elide.clone();
-                    var_owned.insert(var);
-                    let result = optimize(*body, &var_owned, polarity);
+                    vars_elide.insert(var.ident(), ());
+                    let result = optimize(*body, vars_elide, polarity);
                     // we keep the position of the body, not the one of the forall
                     pos = result.pos;
                     result.typ
@@ -982,7 +995,7 @@ impl Type {
                     var_kind,
                     body: Box::new(optimize(*body, vars_elide, polarity)),
                 },
-                TypeF::Var(id) if vars_elide.contains(&id) => TypeF::Dyn,
+                TypeF::Var(id) if vars_elide.get(&id).is_some() => TypeF::Dyn,
                 v @ TypeF::Var(_) => v,
                 // Any first-order type on positive position can be elided
                 _ if matches!(polarity, Polarity::Positive) => TypeF::Dyn,
@@ -999,14 +1012,13 @@ impl Type {
                 // All other types don't contain subtypes, it's a base case
                 t => t,
             };
-
             Type {
                 typ: optimized,
                 pos,
             }
         }
 
-        optimize(self, &HashSet::new(), Polarity::Positive)
+        optimize(self, VarsHashSet::new(), Polarity::Positive)
     }
 
     /// Return the contract corresponding to a type which appears in a static type annotation. Said


### PR DESCRIPTION
Follow-up of #1671. See https://github.com/tweag/nickel/pull/1671#discussion_r1350739471. I started with `Cow`, but in fact we implement a data structure that exactly fits the use-case: the environment. So I used that instead.