### PR TITLE
Unsafety improvements

### DIFF
--- a/core/src/environment.rs
+++ b/core/src/environment.rs
@@ -100,7 +100,7 @@ impl<K: Hash + Eq, V: PartialEq> Environment<K, V> {
 
     /// Creates an iterator that visits all layers from the most recent one to the oldest.
     /// The element iterator type is `Rc<HashMap<K, V>>`.
-    pub fn iter_layers(&self) -> EnvLayerIter<'_, K, V> {
+    pub fn iter_layers<'slf>(&'slf self) -> EnvLayerIter<'slf, K, V> {
         EnvLayerIter {
             env: if !self.was_cloned() {
                 Some(NonNull::from(self))
@@ -121,7 +121,7 @@ impl<K: Hash + Eq, V: PartialEq> Environment<K, V> {
     /// the most recent one. It uses this order, so calling `collect` on this iterator to create a
     /// hashmap would have the same values as the Environment. The element iterator type is `(&'env
     /// K, &'env V)`, with `'env` being the lifetime of the Environment.
-    pub fn iter_elems(&self) -> EnvElemIter<'_, K, V> {
+    pub fn iter_elems<'slf>(&'slf self) -> EnvElemIter<'slf, K, V> {
         let mut env: Vec<NonNull<HashMap<K, V>>> = self
             .iter_layers()
             // SAFETY: Rc::as_ptr never returnes null

--- a/core/src/environment.rs
+++ b/core/src/environment.rs
@@ -121,6 +121,7 @@ impl<K: Hash + Eq, V: PartialEq> Environment<K, V> {
     /// the most recent one. It uses this order, so calling `collect` on this iterator to create a
     /// hashmap would have the same values as the Environment. The element iterator type is `(&'env
     /// K, &'env V)`, with `'env` being the lifetime of the Environment.
+    #[allow(clippy::needless_lifetimes)]
     pub fn iter_elems<'slf>(&'slf self) -> EnvElemIter<'slf, K, V> {
         let mut env: Vec<NonNull<HashMap<K, V>>> = self
             .iter_layers()

--- a/core/src/environment.rs
+++ b/core/src/environment.rs
@@ -121,8 +121,7 @@ impl<K: Hash + Eq, V: PartialEq> Environment<K, V> {
     /// the most recent one. It uses this order, so calling `collect` on this iterator to create a
     /// hashmap would have the same values as the Environment. The element iterator type is `(&'env
     /// K, &'env V)`, with `'env` being the lifetime of the Environment.
-    #[allow(clippy::needless_lifetimes)]
-    pub fn iter_elems<'slf>(&'slf self) -> EnvElemIter<'slf, K, V> {
+    pub fn iter_elems(&self) -> EnvElemIter<'_, K, V> {
         let mut env: Vec<NonNull<HashMap<K, V>>> = self
             .iter_layers()
             // SAFETY: Rc::as_ptr never returnes null

--- a/core/src/identifier.rs
+++ b/core/src/identifier.rs
@@ -240,9 +240,11 @@ mod interner {
     /// The interner, which serves a double purpose: it pre-allocates space
     /// so that [Ident](super::Ident) labels are created faster
     /// and it makes it so that labels are stored only once, saving space.
-    pub(crate) struct Interner<'a>(RwLock<InnerInterner<'a>>);
+    // NOTE: We set the lifetime parameter of InnerInterner to 'static since
+    // it's arbitrary, and there's no reason to expose it to users of Interner
+    pub(crate) struct Interner(RwLock<InnerInterner<'static>>);
 
-    impl<'a> Interner<'a> {
+    impl Interner {
         /// Creates an empty [Interner].
         pub(crate) fn new() -> Self {
             Self(RwLock::new(InnerInterner::new()))
@@ -258,24 +260,32 @@ mod interner {
         ///
         /// This operation cannot fails since the only way to have a [Symbol] is to have
         /// [interned](Interner::intern) the corresponding string first.
-        pub(crate) fn lookup(&self, sym: Symbol) -> &'a str {
-            self.0.read().unwrap().lookup(sym)
+        pub(crate) fn lookup<'slf>(&'slf self, sym: Symbol) -> &'slf str {
+            // SAFETY: We are making the returned &str lifetime the same as our struct,
+            // which is okay here since the InnerInterner uses a typed_arena which prevents
+            // deallocations, so the reference will be valid while the InnerInterner exists,
+            // hence while the struct exists.
+            unsafe { std::mem::transmute::<&'_ str, &'slf str>(self.0.read().unwrap().lookup(sym)) }
         }
     }
 
     /// The main part of the Interner.
-    struct InnerInterner<'a> {
+    /// 'internal should never be exposed to the outside, as it is an
+    /// implementation detail and could be set to anything. It should be treated
+    /// within the implementation of InnerInterner as the lifetime of the object
+    /// itself, since that's what it is turned into in the `lookup()` method.
+    struct InnerInterner<'internal> {
         /// Preallocates space where strings are stored.
         arena: Mutex<Arena<u8>>,
 
         /// Prevents the arena from creating different [Symbols](Symbol) for the same string.
-        map: HashMap<&'a str, Symbol>,
+        map: HashMap<&'internal str, Symbol>,
 
         /// Allows retrieving a string from a [Symbol].
-        vec: Vec<&'a str>,
+        vec: Vec<&'internal str>,
     }
 
-    impl<'a> InnerInterner<'a> {
+    impl<'internal> InnerInterner<'internal> {
         /// Creates an empty [InnerInterner].
         fn new() -> Self {
             Self {
@@ -295,10 +305,10 @@ mod interner {
             // This is okay since the lifetime of the arena is identical to the one of the struct.
             // It is also okay to use it from inside the mutex, since typed_arena does not allow
             // deallocation, so references are valid until the arena drop, which is tied to the
-            // struct drop.
-            // XXX: we have to use &'a str here, not &'self str like the comment indicates. what's going on?
+            // struct drop. Since there is no 'self lifetime, we use 'internal instead, which
+            // at least has 'internal: 'self.
             let in_string = unsafe {
-                std::mem::transmute::<&'_ str, &'a str>(
+                std::mem::transmute::<&'_ str, &'internal str>(
                     self.arena.lock().unwrap().alloc_str(string.as_ref()),
                 )
             };
@@ -311,7 +321,10 @@ mod interner {
         ///
         /// This operation cannot fails since the only way to have a [Symbol]
         /// is to have [interned](InnerInterner::intern) the corresponding string first.
-        fn lookup(&self, sym: Symbol) -> &'a str {
+        #[allow(clippy::needless_lifetimes)]
+        fn lookup<'slf>(&'slf self, sym: Symbol) -> &'slf str {
+            // The lifetime implicitly shrinks from 'internal 'slf, which
+            // prevents 'internal from leaking out.
             self.vec[sym.0 as usize]
         }
     }

--- a/core/src/identifier.rs
+++ b/core/src/identifier.rs
@@ -321,9 +321,8 @@ mod interner {
         ///
         /// This operation cannot fails since the only way to have a [Symbol]
         /// is to have [interned](InnerInterner::intern) the corresponding string first.
-        #[allow(clippy::needless_lifetimes)]
-        fn lookup<'slf>(&'slf self, sym: Symbol) -> &'slf str {
-            // The lifetime implicitly shrinks from 'internal 'slf, which
+        fn lookup(&self, sym: Symbol) -> &str {
+            // The lifetime implicitly shrinks from 'internal to 'self, which
             // prevents 'internal from leaking out.
             self.vec[sym.0 as usize]
         }

--- a/core/src/identifier.rs
+++ b/core/src/identifier.rs
@@ -258,12 +258,8 @@ mod interner {
         ///
         /// This operation cannot fails since the only way to have a [Symbol] is to have
         /// [interned](Interner::intern) the corresponding string first.
-        pub(crate) fn lookup<'slf>(&'slf self, sym: Symbol) -> &'slf str {
-            // SAFETY: We are making the returned &str lifetime the same as our struct,
-            // which is okay here since the InnerInterner uses a typed_arena which prevents
-            // deallocations, so the reference will be valid while the InnerInterner exists,
-            // hence while the struct exists.
-            unsafe { std::mem::transmute::<&'_ str, &'slf str>(self.0.read().unwrap().lookup(sym)) }
+        pub(crate) fn lookup(&self, sym: Symbol) -> &'a str {
+            self.0.read().unwrap().lookup(sym)
         }
     }
 
@@ -315,7 +311,7 @@ mod interner {
         ///
         /// This operation cannot fails since the only way to have a [Symbol]
         /// is to have [interned](InnerInterner::intern) the corresponding string first.
-        fn lookup<'slf>(&'slf self, sym: Symbol) -> &'slf str {
+        fn lookup(&self, sym: Symbol) -> &'a str {
             self.vec[sym.0 as usize]
         }
     }

--- a/core/src/term/array.rs
+++ b/core/src/term/array.rs
@@ -160,7 +160,7 @@ impl IntoIterator for Array {
         // Otherwise, we clone everything.
 
         unsafe {
-            let mut inner: Rc<[ManuallyDrop<RichTerm>]> = transmute(self.inner);
+            let mut inner = transmute::<Rc<[RichTerm]>, Rc<[ManuallyDrop<RichTerm>]>>(self.inner);
             let idx = self.start;
             let end = self.end;
 

--- a/core/src/term/array.rs
+++ b/core/src/term/array.rs
@@ -157,29 +157,50 @@ impl IntoIterator for Array {
         // to the inner slice, then we can:
         // - Drop the elements outside our inner view,
         // - Move out the elements inside out inner view.
+        // - Drop the rest of the elements when we're dropped
         // Otherwise, we clone everything.
+        //
+        // If we start as a shared reference, we could become the only reference
+        // later, but we clone everything anyways, so we don't end up in an
+        // invalid in-between state where some terms have been freed manually
+        // and others haven't.
 
-        unsafe {
-            let mut inner = transmute::<Rc<[RichTerm]>, Rc<[ManuallyDrop<RichTerm>]>>(self.inner);
-            let idx = self.start;
-            let end = self.end;
-
-            if let Some(slice) = Rc::get_mut(&mut inner) {
-                for term in &mut slice[..idx] {
+        let inner = if Rc::strong_count(&self.inner) != 1 || Rc::weak_count(&self.inner) != 0 {
+            IntoIterInner::Shared(self.inner)
+        } else {
+            unsafe {
+                let mut inner =
+                    transmute::<Rc<[RichTerm]>, Rc<[ManuallyDrop<RichTerm>]>>(self.inner);
+                let slice =
+                    Rc::get_mut(&mut inner).expect("non-unique Rc after checking for uniqueness");
+                for term in &mut slice[..self.start] {
                     ManuallyDrop::drop(term)
                 }
-                for term in &mut slice[end..] {
+                for term in &mut slice[self.end..] {
                     ManuallyDrop::drop(term)
                 }
+
+                IntoIterInner::Owned(inner)
             }
-
-            IntoIter { inner, idx, end }
+        };
+        IntoIter {
+            inner,
+            idx: self.start,
+            end: self.end,
         }
     }
 }
 
+enum IntoIterInner {
+    Shared(Rc<[RichTerm]>),
+    // This shouldn't really be an Rc. It should only ever have one reference.
+    // There may be a way to rewrite this once unsized locals are stabilized.
+    // But for now, there is no good way to repackage the inner array, so we
+    // keep it in an Rc.
+    Owned(Rc<[ManuallyDrop<RichTerm>]>),
+}
 pub struct IntoIter {
-    inner: Rc<[ManuallyDrop<RichTerm>]>,
+    inner: IntoIterInner,
     idx: usize,
     end: usize,
 }
@@ -191,18 +212,30 @@ impl Iterator for IntoIter {
         if self.idx == self.end {
             None
         } else {
-            let term = match Rc::get_mut(&mut self.inner) {
-                None => self.inner[..self.end]
-                    .get(self.idx)
-                    .cloned()
-                    .map(ManuallyDrop::into_inner),
-                Some(slice) => slice[..self.end]
-                    .get_mut(self.idx)
-                    .map(|t| unsafe { ManuallyDrop::take(t) }),
+            let term = match &mut self.inner {
+                IntoIterInner::Shared(inner) => inner.get(self.idx).cloned(),
+                IntoIterInner::Owned(inner) => unsafe {
+                    Rc::get_mut(inner)
+                        .expect("non-unique Rc after checking for uniqueness")
+                        .get_mut(self.idx)
+                        .map(|t| ManuallyDrop::take(t))
+                },
             };
 
             self.idx += 1;
             term
+        }
+    }
+}
+
+impl Drop for IntoIter {
+    fn drop(&mut self) {
+        // drop the rest of the items we haven't iterated through
+        if let IntoIterInner::Owned(inner) = &mut self.inner {
+            let inner = Rc::get_mut(inner).expect("non-unique Rc after checking for uniqueness");
+            for term in &mut inner[self.idx..self.end] {
+                unsafe { ManuallyDrop::drop(term) }
+            }
         }
     }
 }


### PR DESCRIPTION
As a followup to #1681, I've implemented a couple of the easy improvements.
- annotated `std::mem::transmute` so the types are present locally
- put lifetime annotations to disambiguate

When doing the latter, I noticed that one of the comments is wrong. I'm not sure how to interpret the lifetime that is correct, though.