### PR TITLE
Fix doc, example code for pipe lacks prefix

### DIFF
--- a/core/stdlib/std.ncl
+++ b/core/stdlib/std.ncl
@@ -1589,9 +1589,9 @@
         # Examples
 
         ```nickel
-        pipe 2 [ (+) 2, (+) 3 ]
+        std.function.pipe 2 [ (+) 2, (+) 3 ]
           => 7
-        pipe 'World [ std.string.from, fun s => "Hello, %{s}!" ]
+        std.function.pipe 'World [ std.string.from, fun s => "Hello, %{s}!" ]
           => "Hello, World!"
         ```
       "%%


### PR DESCRIPTION
The example code for "pipe" doesn't compile because the method "pipe" lacks prefix. Fixed by changing "pipe" to "std.function.pipe"