### PR TITLE
Reword impl of partial_cmp for Ident, LocIdent

### DIFF
--- a/core/src/identifier.rs
+++ b/core/src/identifier.rs
@@ -59,7 +59,7 @@ impl From<Ident> for LocIdent {
 
 impl PartialOrd for Ident {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        self.label().partial_cmp(other.label())
+        Some(self.cmp(other))
     }
 }
 
@@ -151,7 +151,7 @@ pub const GEN_PREFIX: char = '%';
 
 impl PartialOrd for LocIdent {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        self.label().partial_cmp(other.label())
+        Some(self.cmp(other))
     }
 }
 


### PR DESCRIPTION
This rewords the implementation of `partial_cmp` for `Ident` and `LocalIdent` in a way that pleases clippy.

Note that the implementation was correct and that this does not change its behavior.

Of course another way to get rid of the lint error would be `#[allow(clippy::incorrect_partial_ord_impl_on_ord_type)]`, but I think (more as a matter of principle than for any practical reason in this specific case) following clippy's advice and have `partial_cmp` call `cmp` is preferable to repeating the implementation, and... I also thing the annotation would be ugly :smiley:.

Anyway, in case they help clarify, here's  clippy complains about `Ident`:

```
error: incorrect implementation of `partial_cmp` on an `Ord` type
  --> core/src/identifier.rs:60:1
   |
60 | /  impl PartialOrd for Ident {
61 | |      fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
   | | _______________________________________________________________________-
62 | ||         self.label().partial_cmp(other.label())
63 | ||     }
   | ||_____- help: change this to: `{ Some(self.cmp(other)) }`
64 | |  }
   | |__^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#incorrect_partial_ord_impl_on_ord_type
```

and `LocIdent`:

```
error: incorrect implementation of `partial_cmp` on an `Ord` type
   --> core/src/identifier.rs:152:1
    |
152 | /  impl PartialOrd for LocIdent {
153 | |      fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
    | | _______________________________________________________________________-
154 | ||         self.label().partial_cmp(other.label())
155 | ||     }
    | ||_____- help: change this to: `{ Some(self.cmp(other)) }`
156 | |  }
    | |__^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#incorrect_partial_ord_impl_on_ord_type
```