### PR TITLE
Fix contract equality on revertible thunks

### DIFF
--- a/core/src/closurize.rs
+++ b/core/src/closurize.rs
@@ -295,6 +295,8 @@ pub fn should_share(t: &Term) -> bool {
     }
 }
 
+/// Closurize all the inner terms of a recursive record, including pending contracts and
+/// dynamically defined fields.
 pub fn closurize_rec_record<C: Cache>(
     cache: &mut C,
     data: RecordData,

--- a/core/src/eval/cache/lazy.rs
+++ b/core/src/eval/cache/lazy.rs
@@ -249,9 +249,11 @@ impl ThunkData {
     pub fn closure_(&self) -> &Closure {
         match self.inner {
             InnerThunkData::Standard(ref closure) => closure,
-            InnerThunkData::Revertible { ref cached, ref orig, .. } => {
-                cached.as_ref().unwrap_or(orig)
-            }
+            InnerThunkData::Revertible {
+                ref cached,
+                ref orig,
+                ..
+            } => cached.as_ref().unwrap_or(orig),
         }
     }
 
@@ -439,7 +441,6 @@ impl Thunk {
     pub fn borrow_(&self) -> Ref<'_, Closure> {
         Ref::map(self.data.borrow(), ThunkData::closure_)
     }
-
 
     /// Mutably borrow the inner closure. Panic if there is any other active borrow.
     pub fn borrow_mut(&mut self) -> RefMut<'_, Closure> {

--- a/core/src/eval/merge.rs
+++ b/core/src/eval/merge.rs
@@ -67,7 +67,6 @@ impl From<MergeMode> for MergeLabel {
 #[allow(clippy::too_many_arguments)] // TODO: Is it worth to pack the inputs in an ad-hoc struct?
 pub fn merge<C: Cache>(
     cache: &mut C,
-    initial_env: &Environment,
     t1: RichTerm,
     env1: Environment,
     t2: RichTerm,
@@ -307,14 +306,7 @@ pub fn merge<C: Cache>(
             for (id, (field1, field2)) in center.into_iter() {
                 m.insert(
                     id,
-                    merge_fields(
-                        cache,
-                        initial_env,
-                        merge_label,
-                        field1,
-                        field2,
-                        field_names.iter(),
-                    )?,
+                    merge_fields(cache, merge_label, field1, field2, field_names.iter())?,
                 );
             }
 
@@ -358,7 +350,6 @@ pub fn merge<C: Cache>(
 #[allow(clippy::too_many_arguments)]
 fn merge_fields<'a, C: Cache, I: DoubleEndedIterator<Item = &'a LocIdent> + Clone>(
     cache: &mut C,
-    initial_env: &Environment,
     merge_label: MergeLabel,
     field1: Field,
     field2: Field,
@@ -400,7 +391,7 @@ fn merge_fields<'a, C: Cache, I: DoubleEndedIterator<Item = &'a LocIdent> + Clon
     let empty = Environment::new();
 
     for ctr2 in pending_contracts2.revert_closurize(cache) {
-        RuntimeContract::push_dedup(initial_env, &mut pending_contracts, &empty, ctr2, &empty);
+        RuntimeContract::push_dedup(&mut pending_contracts, &empty, ctr2, &empty);
     }
 
     Ok(Field {

--- a/core/src/eval/operation.rs
+++ b/core/src/eval/operation.rs
@@ -1892,7 +1892,6 @@ impl<R: ImportResolver, C: Cache> VirtualMachine<R, C> {
             },
             BinaryOp::Merge(merge_label) => merge::merge(
                 &mut self.cache,
-                &self.initial_env,
                 RichTerm {
                     term: t1,
                     pos: pos1,
@@ -2087,7 +2086,6 @@ impl<R: ImportResolver, C: Cache> VirtualMachine<R, C> {
                         // Preserve the environment of the contract in the resulting array.
                         let contract = rt3.closurize(&mut self.cache, env3);
                         RuntimeContract::push_dedup(
-                            &self.initial_env,
                             &mut attrs.pending_contracts,
                             &final_env,
                             RuntimeContract::new(contract, lbl),
@@ -2145,7 +2143,6 @@ impl<R: ImportResolver, C: Cache> VirtualMachine<R, C> {
                             };
 
                             RuntimeContract::push_dedup(
-                                &self.initial_env,
                                 &mut field.pending_contracts,
                                 &env2,
                                 runtime_ctr,
@@ -2479,7 +2476,6 @@ impl<R: ImportResolver, C: Cache> VirtualMachine<R, C> {
                     Term::Lbl(lbl) => {
                         merge::merge(
                             &mut self.cache,
-                            &self.initial_env,
                             RichTerm {
                                 term: t2,
                                 pos: pos2,

--- a/core/src/eval/operation.rs
+++ b/core/src/eval/operation.rs
@@ -33,7 +33,7 @@ use crate::{
         string::NickelString,
         *,
     },
-    typecheck::eq::{contract_eq, EvalEnvsRef},
+    typecheck::eq::contract_eq,
 };
 
 use malachite::{
@@ -1788,27 +1788,17 @@ impl<R: ImportResolver, C: Cache> VirtualMachine<R, C> {
                                     return true;
                                 }
 
-                                let envs_left = EvalEnvsRef {
-                                    eval_env: &env1,
-                                    initial_env: &self.initial_env,
-                                };
-
                                 // We check if there is a remaining contract in
                                 // `ctrs_right_sieve` which matches `ctr`: in this case,
                                 // `twin_index` will hold its index.
                                 let twin_index = ctrs_right_sieve.iter().position(|other_ctr| {
                                     other_ctr.as_ref().map_or(false, |other_ctr| {
-                                        let envs_right = EvalEnvsRef {
-                                            eval_env: &env2,
-                                            initial_env: &self.initial_env,
-                                        };
-
-                                        contract_eq::<EvalEnvsRef>(
+                                        contract_eq(
                                             0,
                                             &ctr.contract,
-                                            envs_left,
+                                            &env1,
                                             &other_ctr.contract,
-                                            envs_right,
+                                            &env2,
                                         )
                                     })
                                 });

--- a/core/src/program.rs
+++ b/core/src/program.rs
@@ -544,11 +544,10 @@ impl<EC: EvalCache> Program<EC> {
         } else {
             rt
         };
-        let doc: DocBuilder<_, ()> = rt.clone().pretty(&allocator);
+        let doc: DocBuilder<_, ()> = rt.pretty(&allocator);
         doc.render(80, out).map_err(IOError::from)?;
         writeln!(out).map_err(IOError::from)?;
 
-        println!("\n\n{rt:#?}");
         Ok(())
     }
 }

--- a/core/src/program.rs
+++ b/core/src/program.rs
@@ -544,9 +544,11 @@ impl<EC: EvalCache> Program<EC> {
         } else {
             rt
         };
-        let doc: DocBuilder<_, ()> = rt.pretty(&allocator);
+        let doc: DocBuilder<_, ()> = rt.clone().pretty(&allocator);
         doc.render(80, out).map_err(IOError::from)?;
         writeln!(out).map_err(IOError::from)?;
+
+        println!("\n\n{rt:#?}");
         Ok(())
     }
 }

--- a/core/src/term/mod.rs
+++ b/core/src/term/mod.rs
@@ -27,7 +27,7 @@ use crate::{
     match_sharedterm,
     position::TermPos,
     typ::{Type, UnboundTypeVariableError},
-    typecheck::eq::{contract_eq, type_eq_noenv, EvalEnvsRef},
+    typecheck::eq::{contract_eq, type_eq_noenv},
 };
 
 use codespan::FileId;
@@ -425,18 +425,8 @@ impl RuntimeContract {
         ctr: Self,
         env2: &Environment,
     ) {
-        let envs1 = EvalEnvsRef {
-            eval_env: env1,
-            initial_env,
-        };
-
         for c in contracts.iter() {
-            let envs = EvalEnvsRef {
-                eval_env: env2,
-                initial_env,
-            };
-
-            if contract_eq::<EvalEnvsRef>(0, &c.contract, envs1, &ctr.contract, envs) {
+            if contract_eq(0, &c.contract, env1, &ctr.contract, env2) {
                 return;
             }
         }

--- a/core/src/term/mod.rs
+++ b/core/src/term/mod.rs
@@ -419,7 +419,6 @@ impl RuntimeContract {
     /// present in the vector, according to the notion of contract equality defined in
     /// [crate::typecheck::eq].
     pub fn push_dedup(
-        initial_env: &Environment,
         contracts: &mut Vec<RuntimeContract>,
         env1: &Environment,
         ctr: Self,

--- a/core/src/typecheck/eq.rs
+++ b/core/src/typecheck/eq.rs
@@ -168,26 +168,6 @@ impl<C: Cache> FromEnv<C> for SimpleTermEnvironment {
     }
 }
 
-/// Dummy environment used when we only want to compare variables by name.
-#[derive(Copy, Clone, Debug, PartialEq)]
-pub struct NoEnvironment;
-
-impl TermEnvironment for NoEnvironment {
-    fn get_then<F, T>(_env: &Self, _id: Ident, f: F) -> T
-    where
-        F: FnOnce(Option<(&RichTerm, &NoEnvironment)>) -> T,
-    {
-        f(None)
-    }
-
-    fn get_idx_then<F, T>(_env: &Self, _idx: &CacheIndex, f: F) -> T
-    where
-        F: FnOnce(Option<(&RichTerm, &NoEnvironment)>) -> T,
-    {
-        f(None)
-    }
-}
-
 /// State threaded through the type equality computation.
 #[derive(Copy, Clone, Default)]
 struct State {
@@ -252,15 +232,17 @@ pub fn contract_eq<E: TermEnvironment>(
 /// pretty-printing, where there is no notion of environment and the only thing that matters is
 /// that they are printed the same or not.
 ///
-/// Compute equality between two contracts, considering that two variables with the same name are
-/// equal.
+/// Compute equality between two contracts in an empty environment. This means that two variables
+/// with the same name are considered equal.
 pub fn type_eq_noenv(var_uid: usize, t1: &Type, t2: &Type) -> bool {
-    type_eq_bounded::<NoEnvironment>(
+    let empty = eval::Environment::new();
+
+    type_eq_bounded(
         &mut State::new(var_uid),
-        &GenericUnifType::<NoEnvironment>::from_type(t1.clone(), &NoEnvironment),
-        &NoEnvironment,
-        &GenericUnifType::<NoEnvironment>::from_type(t2.clone(), &NoEnvironment),
-        &NoEnvironment,
+        &GenericUnifType::from_type(t1.clone(), &empty),
+        &empty,
+        &GenericUnifType::from_type(t2.clone(), &empty),
+        &empty,
     )
 }
 

--- a/core/src/typecheck/eq.rs
+++ b/core/src/typecheck/eq.rs
@@ -133,8 +133,6 @@ impl TermEnvironment for eval::Environment {
     where
         F: FnOnce(Option<(&RichTerm, &eval::Environment)>) -> T,
     {
-        debug_assert!(env.get(&id).is_some(), "unbound variable `{}`", id);
-
         match env.get(&id).map(eval::cache::lazy::Thunk::borrow) {
             Some(closure_ref) => f(Some((&closure_ref.body, &closure_ref.env))),
             None => f(None),
@@ -666,7 +664,7 @@ fn type_eq_bounded<E: TermEnvironment>(
         }
         (GenericUnifType::Constant(i1), GenericUnifType::Constant(i2)) => i1 == i2,
         (GenericUnifType::Contract(t1, env2), GenericUnifType::Contract(t2, env1)) => {
-            contract_eq_bounded::<E>(state, t1, &env1, t2, &env2)
+            contract_eq_bounded::<E>(state, t1, env1, t2, env2)
         }
         _ => false,
     }

--- a/core/src/typecheck/eq.rs
+++ b/core/src/typecheck/eq.rs
@@ -143,7 +143,7 @@ impl TermEnvironment for eval::Environment {
     where
         F: FnOnce(Option<(&RichTerm, &eval::Environment)>) -> T,
     {
-        let closure_ref = idx.borrow_();
+        let closure_ref = idx.borrow_orig();
 
         f(Some((&closure_ref.body, &closure_ref.env)))
     }

--- a/core/src/typecheck/unif.rs
+++ b/core/src/typecheck/unif.rs
@@ -1124,13 +1124,7 @@ impl Unify for UnifType {
                 Err(UnifError::WithConst(VarKindDiscriminant::Type, i, ty))
             }
             (UnifType::Contract(t1, env1), UnifType::Contract(t2, env2))
-                if eq::contract_eq::<SimpleTermEnvironment>(
-                    state.table.max_uvars_count(),
-                    &t1,
-                    &env1,
-                    &t2,
-                    &env2,
-                ) =>
+                if eq::contract_eq(state.table.max_uvars_count(), &t1, &env1, &t2, &env2) =>
             {
                 Ok(())
             }


### PR DESCRIPTION
Closes #1664. Depends on #1698.

## Context

The introduction of contract deduplication led to a panic reported in #1664. Merging two records produces a new `RecRecord`, that is, a fixpoint. Every part of the previous records that could depend recursively on other fields are reverted to their original expression. This is a form of intermediate state that isn't supposed to be observed: after `merge` returns, the eval loop kicks in again, and will finish to build the reverted thunks by creating and injecting the recursive environment, practically "applying" the fixpoint to get a concrete record.

However, contract deduplication acts at the end of merging, before the fixpoint is recomputed at the next evaluation tick. Thus, it can observe those partially-built values and an `assert` complains somewhere in the implementation of thunks.

The issue is that, morally, we must use the new fixpoint, but we don't have access to it yet. One possibility is to built it as part of merging, but this is annoying, because this would duplicate in part the code already present inside `eval_closure`, even if we may factor out some of it. Secondly, we need to compute the fixpoint before merging the pending contracts, then perform deduplication, and finally combine the (deduplicated, fixpointed) pending contracts. Nothing impossible, but a bit clumsy.

## Content

### Fix the issue

This PR instead relies of the already existing but not really exploited behavior of contract equality check, which is that free variables (alternatively, unbound variables) are considered equal if they have the same name. That is, contract equality considers _open terms_, and thus check their equality _assuming they are living in the same environment_. As long as we can ensure there's no unbound variable in practice - which is verified as part of typechecking, this stays sound.

We introduced the `borrow_orig` method to get the cached value of a thunk or its original expression if it's an unitialized revertible thunk. This function is intended to be used only for contract equality check, and is somehow unsatisfying as a leaky abstraction - but it's such a small and simple change, which is appealing. 

### Embrace free variables

Now that we rely on the behavior of contract equality checking on free variables, we might as well bite the bullet and get rid of `NoEnvironment` and the threading of the initial environment through contract equality check. Those were a way to avoid to rely on simple name comparison for variables, but at the cost of more complexity.

Now, contract equality checks simply compares variable by name when encountering symbols from the standard library or the internal module, which is equivalent. This get rids of a lot of complexity, turbofish operators and abstractions (`EnvRefs/EnvOwned`) around contract equality checking.

Passing by, we've updated/reworded some old documentation.