### PR TITLE
Add a `--field` argument to subcommands whenever it makes sense

### DIFF
--- a/cli/src/customize/mod.rs
+++ b/cli/src/customize/mod.rs
@@ -252,13 +252,13 @@ impl CustomizeOptions {
         customizable_fields: CustomizableFields,
         mut program: Program<CBNCache>,
     ) -> CliResult<Program<CBNCache>> {
-        let assignment_overrides: Result<Vec<_>, super::error::CliUsageError> = self
+        let assignment_overrides: Result<Vec<_>, CliUsageError> = self
             .assignment
             .into_iter()
             .map(|assignment| {
                 let ovd = program
                     .parse_override(assignment, MergePriority::default())
-                    .map_err(|error| super::error::CliUsageError::AssignmentParseError { error })?;
+                    .map_err(|error| CliUsageError::AssignmentParseError { error })?;
 
                 if !customizable_fields.inputs.contains_key(&ovd.path) {
                     if customizable_fields.overrides.contains_key(&ovd.path) {
@@ -386,8 +386,6 @@ fn program_with_field(
     mut program: Program<CBNCache>,
     field: Option<String>,
 ) -> CliResult<Program<CBNCache>> {
-    use super::error::{CliUsageError, Error};
-
     if let Some(field) = field {
         match program.parse_field_path(field) {
             Ok(field_path) => program.field = field_path,

--- a/cli/src/customize/mod.rs
+++ b/cli/src/customize/mod.rs
@@ -29,21 +29,23 @@ use interface::{FieldInterface, TermInterface};
 const ASSIGNMENT_SYNTAX: &str = "FIELD_PATH=NICKEL_EXPRESSION";
 
 const EXPERIMENTAL_MSG: &str =
-    "[WARNING] Customize mode is experimental. Its interface is subject to breaking changes.";
+    "WARNING: Customize mode is experimental. Its interface is subject to breaking changes.";
 
 /// For commands where full customization is allowed, combining extracting a target field and
 /// overriding arbitrary values of the configuration.
 #[derive(clap::Parser, Debug)]
 pub struct CustomizeMode {
-    /// Query a specific field of the configuration. If omitted, the top-level value is queried
-    #[arg(long, short, value_name = "FIELD_PATH")]
+    /// Only query or act on a specific field of the configuration. For example,
+    /// `nickel export config.ncl --field machines.servers.remote_builder` will only evaluate and
+    /// export the content of the `remote_builder` field.
+    #[arg(long, value_name = "FIELD_PATH")]
     pub field: Option<String>,
 
-    /// \[WARNING\] Customize mode is experimental. Its interface is subject to breaking changes.
+    /// WARNING: Customize mode is experimental. Its interface is subject to breaking changes.
     ///
     /// Customize mode turns the nickel invocation into a new CLI based on the configuration to be
     /// exported, where the value of fields can be set directly through CLI arguments. Print the
-    /// corresponding help (`nickel export <file.ncl> -- --help`) to see available options.
+    /// corresponding help (`nickel [COMMAND] <file.ncl> -- --help`) to see available options.
     #[arg(last = true)]
     pub customize_mode: Vec<OsString>,
 }
@@ -233,10 +235,18 @@ impl CustomizableFields {
 }
 
 pub trait Customize {
+    /// Customize the program with the given options.
     fn customize(&self, program: Program<CBNCache>) -> CliResult<Program<CBNCache>>;
+    /// Return the value of the `field` argument, if specified and if supported by the current
+    /// customize variant.
+    fn field(&self) -> Option<&String> {
+        None
+    }
 }
 
 impl CustomizeOptions {
+    // Actually parse assignments and overrides from the command line and add them accordingly to
+    // `program`, given an interface of customizable fields.
     fn do_customize(
         self,
         customizable_fields: CustomizableFields,
@@ -301,11 +311,10 @@ impl CustomizeOptions {
     }
 }
 
-impl Customize for CustomizeMode {
-    // XXX: we should give a nice error message when someone tries to evaluate some
-    //      expression that has unset values, telling them they can set them using
-    //      this method
-    fn customize(&self, mut program: Program<CBNCache>) -> CliResult<Program<CBNCache>> {
+impl CustomizeMode {
+    // Contains most of the actual implementation of the customizing logic for overriding, but
+    // doesn't set the extracted field.
+    fn customize_impl(&self, mut program: Program<CBNCache>) -> CliResult<Program<CBNCache>> {
         if self.customize_mode.is_empty() {
             return Ok(program);
         }
@@ -320,10 +329,7 @@ impl Customize for CustomizeMode {
         let opts = CustomizeOptions::parse_from(self.customize_mode.iter());
 
         match opts.command {
-            None => {
-                let program = opts.do_customize(customizable_fields, program)?;
-                program_with_field(program, self.field.clone())
-            }
+            None => opts.do_customize(customizable_fields, program),
             Some(CustomizeCommand::List(list_command)) => {
                 list_command.run(&customizable_fields)?;
                 Err(Error::CustomizeInfoPrinted)
@@ -332,18 +338,37 @@ impl Customize for CustomizeMode {
     }
 }
 
+impl Customize for CustomizeMode {
+    // XXX: we should give a nice error message when someone tries to evaluate some
+    //      expression that has unset values, telling them they can set them using
+    //      this method
+    fn customize(&self, program: Program<CBNCache>) -> CliResult<Program<CBNCache>> {
+        program_with_field(self.customize_impl(program)?, self.field.clone())
+    }
+
+    fn field(&self) -> Option<&String> {
+        self.field.as_ref()
+    }
+}
+
 /// For commands when no overriding is allowed, but a target field can still be specified, such as
 /// `nickel query` or `nickel doc`.
 #[derive(clap::Parser, Debug)]
 pub struct ExtractFieldOnly {
-    /// Query a specific field of the configuration. If omitted, the top-level value is queried
-    #[arg(long, short, value_name = "FIELD_PATH")]
+    /// Only query or act on a specific field of the configuration. For example,
+    /// `nickel export config.ncl --field machines.servers.remote_builder` will only evaluate and
+    /// export the content of the `remote_builder` field.
+    #[arg(long, value_name = "FIELD_PATH")]
     pub field: Option<String>,
 }
 
 impl Customize for ExtractFieldOnly {
     fn customize(&self, program: Program<CBNCache>) -> CliResult<Program<CBNCache>> {
         program_with_field(program, self.field.clone())
+    }
+
+    fn field(&self) -> Option<&String> {
+        self.field.as_ref()
     }
 }
 

--- a/cli/src/customize/mod.rs
+++ b/cli/src/customize/mod.rs
@@ -35,11 +35,8 @@ const EXPERIMENTAL_MSG: &str =
 /// overriding arbitrary values of the configuration.
 #[derive(clap::Parser, Debug)]
 pub struct CustomizeMode {
-    /// Only query or act on a specific field of the configuration. For example,
-    /// `nickel export config.ncl --field machines.servers.remote_builder` will only evaluate and
-    /// export the content of the `remote_builder` field.
-    #[arg(long, value_name = "FIELD_PATH")]
-    pub field: Option<String>,
+    #[command(flatten)]
+    extract_field: ExtractFieldOnly,
 
     /// WARNING: Customize mode is experimental. Its interface is subject to breaking changes.
     ///
@@ -343,11 +340,14 @@ impl Customize for CustomizeMode {
     //      expression that has unset values, telling them they can set them using
     //      this method
     fn customize(&self, program: Program<CBNCache>) -> CliResult<Program<CBNCache>> {
-        program_with_field(self.customize_impl(program)?, self.field.clone())
+        program_with_field(
+            self.customize_impl(program)?,
+            self.extract_field.field.clone(),
+        )
     }
 
     fn field(&self) -> Option<&String> {
-        self.field.as_ref()
+        self.extract_field.field.as_ref()
     }
 }
 

--- a/cli/src/doc.rs
+++ b/cli/src/doc.rs
@@ -11,7 +11,7 @@ use nickel_lang_core::{
 
 use crate::{
     cli::GlobalOptions,
-    customize::NoCustomizeMode,
+    customize::ExtractFieldOnly,
     error::{CliResult, ResultErrorExt},
     input::{InputOptions, Prepare},
 };
@@ -56,7 +56,7 @@ pub struct DocCommand {
     pub format: crate::doc::DocFormat,
 
     #[command(flatten)]
-    pub input: InputOptions<NoCustomizeMode>,
+    pub input: InputOptions<ExtractFieldOnly>,
 }
 
 impl DocCommand {

--- a/cli/src/error.rs
+++ b/cli/src/error.rs
@@ -176,7 +176,7 @@ impl<FileId> IntoDiagnostics<FileId> for Warning {
                 "For example, instead of querying the expression \
             `(import \"config.ncl\").module.input` with an empty path, query \
             `config.ncl` with the `module.input` path: \
-            \n`nickel query module.input -f config.ncl`"
+            \n`nickel query config.ncl --field module.input"
                     .into(),
             ])]
     }

--- a/cli/src/error.rs
+++ b/cli/src/error.rs
@@ -15,14 +15,11 @@ pub struct UnknownFieldData {
 }
 
 /// Errors related to mishandling the CLI.
-#[allow(dead_code)]
 pub enum CliUsageError {
     /// Tried to override a field which doesn't exist.
     UnknownFieldOverride(UnknownFieldData),
     /// Tried to assign a field which doesn't exist.
     UnknownFieldAssignment(UnknownFieldData),
-    /// Tried to show information about a field which doesn't exist.
-    UnknownField(UnknownFieldData),
     /// Tried to override an defined field without the `--override` argument.
     CantAssignNonInput { ovd: FieldOverride },
     /// A parse error occurred when trying to parse an assignment.
@@ -102,7 +99,6 @@ impl IntoDiagnostics<FileId> for CliUsageError {
         match self {
             CliUsageError::UnknownFieldOverride(data) => mk_unknown_diags(data, "override"),
             CliUsageError::UnknownFieldAssignment(data) => mk_unknown_diags(data, "assignment"),
-            CliUsageError::UnknownField(data) => mk_unknown_diags(data, "query"),
             CliUsageError::CantAssignNonInput {
                 ovd: FieldOverride { path, value, .. },
             } => {
@@ -140,10 +136,14 @@ impl IntoDiagnostics<FileId> for CliUsageError {
                     Diagnostic::note()
                         .with_message("when parsing a field path on the command line")
                         .with_notes(vec![
-                            "A field path must be a dot-separated list of fields. Fields \
-                            with spaces or special characters must be properly quoted."
+                            "A field path must be a dot-separated list of fields. Special \
+                            characters must be properly escaped, both for Nickel and for the \
+                            shell."
                                 .to_owned(),
-                            "For example: `config.database.\"$port\"`".to_owned(),
+                            "For example: a field path `config.\"$port\"` in Nickel source code \
+                            must be written `config.\\\"\\$port\\\"` or `'config.\"$port\"'` on \
+                            a POSIX shell"
+                                .to_owned(),
                         ]),
                 );
                 diags

--- a/cli/src/eval.rs
+++ b/cli/src/eval.rs
@@ -7,6 +7,10 @@ use crate::{
 
 #[derive(clap::Parser, Debug)]
 pub struct EvalCommand {
+    /// Evaluate a specific field of the configuration
+    #[arg(long, short, value_name = "FIELD_PATH")]
+    pub field: Option<String>,
+
     #[command(flatten)]
     pub input: InputOptions<CustomizeMode>,
 }

--- a/cli/src/eval.rs
+++ b/cli/src/eval.rs
@@ -7,10 +7,6 @@ use crate::{
 
 #[derive(clap::Parser, Debug)]
 pub struct EvalCommand {
-    /// Evaluate a specific field of the configuration
-    #[arg(long, short, value_name = "FIELD_PATH")]
-    pub field: Option<String>,
-
     #[command(flatten)]
     pub input: InputOptions<CustomizeMode>,
 }

--- a/cli/src/eval.rs
+++ b/cli/src/eval.rs
@@ -18,6 +18,7 @@ pub struct EvalCommand {
 impl EvalCommand {
     pub fn run(self, global: GlobalOptions) -> CliResult<()> {
         let mut program = self.input.prepare(&global)?;
+
         program
             .eval_full()
             .map(|t| println!("{t}"))

--- a/cli/src/export.rs
+++ b/cli/src/export.rs
@@ -19,10 +19,6 @@ pub struct ExportCommand {
     #[arg(long, short, value_enum, default_value_t)]
     pub format: ExportFormat,
 
-    /// Export a specific field of the configuration
-    #[arg(long, short, value_name = "FIELD_PATH")]
-    pub field: Option<String>,
-
     /// Output file. Standard output by default
     #[arg(short, long)]
     pub output: Option<PathBuf>,

--- a/cli/src/export.rs
+++ b/cli/src/export.rs
@@ -19,6 +19,10 @@ pub struct ExportCommand {
     #[arg(long, short, value_enum, default_value_t)]
     pub format: ExportFormat,
 
+    /// Export a specific field of the configuration
+    #[arg(long, short, value_name = "FIELD_PATH")]
+    pub field: Option<String>,
+
     /// Output file. Standard output by default
     #[arg(short, long)]
     pub output: Option<PathBuf>,

--- a/cli/src/query.rs
+++ b/cli/src/query.rs
@@ -2,17 +2,13 @@ use nickel_lang_core::repl::query_print;
 
 use crate::{
     cli::GlobalOptions,
-    customize::ExtractFieldOnly,
+    customize::{ExtractFieldOnly, Customize},
     error::{CliResult, ResultErrorExt, Warning},
     input::{InputOptions, Prepare},
 };
 
 #[derive(clap::Parser, Debug)]
 pub struct QueryCommand {
-    /// Query a specific field of the configuration. If omitted, the top-level value is queried
-    #[arg(long, short, value_name = "FIELD_PATH")]
-    pub field: Option<String>,
-
     #[arg(long)]
     pub doc: bool,
 
@@ -55,7 +51,7 @@ impl QueryCommand {
     pub fn run(self, global: GlobalOptions) -> CliResult<()> {
         let mut program = self.inputs.prepare(&global)?;
 
-        if self.field.is_none() {
+        if self.inputs.customize_mode.field().is_none() {
             program.report(Warning::EmptyQueryPath)
         }
 

--- a/cli/src/query.rs
+++ b/cli/src/query.rs
@@ -2,7 +2,7 @@ use nickel_lang_core::repl::query_print;
 
 use crate::{
     cli::GlobalOptions,
-    customize::NoCustomizeMode,
+    customize::ExtractFieldOnly,
     error::{CliResult, ResultErrorExt, Warning},
     input::{InputOptions, Prepare},
 };
@@ -29,7 +29,7 @@ pub struct QueryCommand {
     pub value: bool,
 
     #[command(flatten)]
-    pub inputs: InputOptions<NoCustomizeMode>,
+    pub inputs: InputOptions<ExtractFieldOnly>,
 }
 
 impl QueryCommand {
@@ -52,7 +52,7 @@ impl QueryCommand {
         }
     }
 
-    pub fn run(mut self, global: GlobalOptions) -> CliResult<()> {
+    pub fn run(self, global: GlobalOptions) -> CliResult<()> {
         let mut program = self.inputs.prepare(&global)?;
 
         if self.field.is_none() {
@@ -60,7 +60,7 @@ impl QueryCommand {
         }
 
         let found = program
-            .query(self.field.take())
+            .query()
             .map(|field| {
                 query_print::write_query_result(
                     &mut std::io::stdout(),

--- a/cli/src/query.rs
+++ b/cli/src/query.rs
@@ -2,7 +2,7 @@ use nickel_lang_core::repl::query_print;
 
 use crate::{
     cli::GlobalOptions,
-    customize::{ExtractFieldOnly, Customize},
+    customize::{Customize, ExtractFieldOnly},
     error::{CliResult, ResultErrorExt, Warning},
     input::{InputOptions, Prepare},
 };

--- a/cli/src/query.rs
+++ b/cli/src/query.rs
@@ -9,9 +9,9 @@ use crate::{
 
 #[derive(clap::Parser, Debug)]
 pub struct QueryCommand {
-    /// A field path to inspect. If omitted, we query the top level value.
-    #[arg(long, short)]
-    pub path: Option<String>,
+    /// Query a specific field of the configuration. If omitted, the top-level value is queried
+    #[arg(long, short, value_name = "FIELD_PATH")]
+    pub field: Option<String>,
 
     #[arg(long)]
     pub doc: bool,
@@ -55,12 +55,12 @@ impl QueryCommand {
     pub fn run(mut self, global: GlobalOptions) -> CliResult<()> {
         let mut program = self.inputs.prepare(&global)?;
 
-        if self.path.is_none() {
+        if self.field.is_none() {
             program.report(Warning::EmptyQueryPath)
         }
 
         let found = program
-            .query(std::mem::take(&mut self.path))
+            .query(self.field.take())
             .map(|field| {
                 query_print::write_query_result(
                     &mut std::io::stdout(),

--- a/cli/tests/snapshot/inputs/customize-mode/field_path_syntax_error.ncl
+++ b/cli/tests/snapshot/inputs/customize-mode/field_path_syntax_error.ncl
@@ -1,7 +1,7 @@
 # capture = 'stderr'
 # command = ['query']
 # extra_args = [
-#  '--path',
+#  '--field',
 #  'input.+foo.baz',
 # ]
 {

--- a/cli/tests/snapshot/inputs/customize-mode/unknown_field_path.ncl
+++ b/cli/tests/snapshot/inputs/customize-mode/unknown_field_path.ncl
@@ -1,7 +1,7 @@
 # capture = 'stderr'
 # command = ['query']
 # extra_args = [
-#  '--path',
+#  '--field',
 #  'unknown.field.path',
 # ]
 {

--- a/cli/tests/snapshot/inputs/errors/query_non_record.ncl
+++ b/cli/tests/snapshot/inputs/errors/query_non_record.ncl
@@ -1,3 +1,3 @@
 # capture = 'stderr'
-# command = [ 'query', '--path', 'value' ]
+# command = [ 'query', '--field', 'value' ]
 1

--- a/cli/tests/snapshot/snapshots/snapshot__export_stdout_help.ncl.snap
+++ b/cli/tests/snapshot/snapshots/snapshot__export_stdout_help.ncl.snap
@@ -37,5 +37,5 @@ Options:
   -h, --help
           Print help (see a summary with '-h')
 
-[WARNING] Customize mode is experimental. Its interface is subject to breaking changes.
+WARNING: Customize mode is experimental. Its interface is subject to breaking changes.
 

--- a/cli/tests/snapshot/snapshots/snapshot__query_stderr_field_path_syntax_error.ncl.snap
+++ b/cli/tests/snapshot/snapshots/snapshot__query_stderr_field_path_syntax_error.ncl.snap
@@ -8,4 +8,8 @@ error: unexpected token
 1 │ input.+foo.baz
   │       ^
 
+note: when parsing a field path on the command line
+ = A field path must be a dot-separated list of fields. Special characters must be properly escaped, both for Nickel and for the shell.
+ = For example: a field path `config."$port"` in Nickel source code must be written `config.\"\$port\"` or `'config."$port"'` on a POSIX shell
+
 

--- a/cli/tests/snapshot/snapshots/snapshot__query_stdout_show.ncl.snap
+++ b/cli/tests/snapshot/snapshots/snapshot__query_stdout_show.ncl.snap
@@ -2,8 +2,4 @@
 source: cli/tests/snapshot/main.rs
 expression: out
 ---
-[38;5;240m•[39m [1mcontract[0m: [3mstd.number.Integer[0m
-[38;5;240m•[39m [1mdefault[0m: [3m2[0m
-[38;5;240m•[39m [1mdocumentation[0m: Some documentation
-
 

--- a/core/src/eval/mod.rs
+++ b/core/src/eval/mod.rs
@@ -325,7 +325,6 @@ impl<R: ImportResolver, C: Cache> VirtualMachine<R, C> {
                 body: curr_value_with_ctr,
                 env,
             })?;
-
             env = current_evaled.env;
 
             match current_evaled.body.term.into_owned() {

--- a/core/src/eval/mod.rs
+++ b/core/src/eval/mod.rs
@@ -378,7 +378,7 @@ impl<R: ImportResolver, C: Cache> VirtualMachine<R, C> {
     ) -> Result<Field, EvalError> {
         // extract_field does almost what we want, but for querying, we evaluate the content of the
         // field as well in order to print a potential default value.
-        let (mut field, env) = self.extract_field(closure.body, &path)?;
+        let (mut field, env) = self.extract_field(closure.body, path)?;
 
         if let Some(value) = field.value.take() {
             let pos = value.pos;

--- a/core/src/repl/mod.rs
+++ b/core/src/repl/mod.rs
@@ -312,9 +312,9 @@ impl<EC: EvalCache> Repl for ReplImpl<EC> {
 
         let mut query_path = FieldPath::parse(self.vm.import_resolver_mut(), path)?;
 
-        // remove(): this is safe because there is no such thing as an empty field path. If `path`
-        // is empty, the parser will error out. Hence, `QueryPath::parse` always returns a non-empty
-        // vector.
+        // remove(): this is safe because there is no such thing as an empty field path, at least
+        // when it comes out of the parser. If `path` is empty, the parser will error out. Hence,
+        // `FieldPath::parse` always returns a non-empty vector.
         let target = query_path.0.remove(0);
 
         let file_id = self
@@ -331,7 +331,7 @@ impl<EC: EvalCache> Repl for ReplImpl<EC> {
                 body: self.vm.import_resolver().get_owned(file_id).unwrap(),
                 env: self.env.eval_env.clone(),
             },
-            query_path,
+            &query_path,
         )?)
     }
 


### PR DESCRIPTION
Depends on #1709
Closes #1408

This PR is the last step toward closing #1408. It adds a `--field <FIELD_PATH>` parameter to several subcommands, to allow to act or to query only a specific subfield of the configuration. One of the usual motivating use case is to generate several configurations from the same Nickel file:

```console
$ nickel export all_machines.ncl --field machines.pikachu -o pikachu.json
$ nickel export all_machines.ncl --field machines.taupiqueur -o taupiqueur.json
$ nickel export all_machines.ncl --field machines.grolem -o grolem.json
```

This also subsumes the path provided as an argument to `nickel query`, which was the default positional argument in prior versions (<= 1.2) and was temporarily set as `--path` after the CLI rework on master (#1502). It's thus not a breaking change, because `nickel query --path` hasn't made in a release yet. `field` seemed to be more explicit and less confusing than `path` to me.

## Implementation

To avoid code duplication, this PR uses the same trick as for customize mode, which is to ship common options (but not global options) as extra parameter to main commands using clap's `#[command(flatten)]` inclusion mechanism. In particular, although it's part of the customize mode per se - the part after the `--` -- it was just handy to pack the `--field` argument description and implementation there (after all, it can be seen as a form of customization, and adding it as part of the customize mode CLI has been discussed before).

For the field extraction logic, this was mostly already implemented by `VirtualMachnine::query`, so the code has been repurposed as a more general `extract_field` function, which is then used by `program` directly before proceeding further with any operation.