### PR TITLE
Search for imports in NICKEL_PATH

### DIFF
--- a/cli/src/input.rs
+++ b/cli/src/input.rs
@@ -32,6 +32,10 @@ impl<C: clap::Args + Customize> Prepare for InputOptions<C> {
 
         program.color_opt = global.color.into();
 
+        if let Ok(nickel_path) = std::env::var("NICKEL_PATH") {
+            program.add_import_paths(nickel_path.split(':'));
+        }
+
         #[cfg(debug_assertions)]
         if self.nostdlib {
             program.set_skip_stdlib();

--- a/core/src/cache.rs
+++ b/core/src/cache.rs
@@ -324,10 +324,6 @@ pub enum SourceState {
 
 impl Cache {
     pub fn new(error_tolerance: ErrorTolerance) -> Self {
-        let import_paths = std::env::var("NICKEL_PATH")
-            .map(|paths| paths.split(':').map(PathBuf::from).collect())
-            .unwrap_or_default();
-
         Cache {
             files: Files::new(),
             file_ids: HashMap::new(),
@@ -338,12 +334,18 @@ impl Cache {
             rev_imports: HashMap::new(),
             stdlib_ids: None,
             error_tolerance,
-
-            import_paths,
+            import_paths: Vec::new(),
 
             #[cfg(debug_assertions)]
             skip_stdlib: false,
         }
+    }
+
+    pub fn add_import_paths<P>(&mut self, paths: impl Iterator<Item = P>)
+    where
+        PathBuf: From<P>,
+    {
+        self.import_paths.extend(paths.map(PathBuf::from));
     }
 
     /// Same as [Self::add_file], but assume that the path is already normalized, and take the

--- a/core/src/program.rs
+++ b/core/src/program.rs
@@ -224,6 +224,13 @@ impl<EC: EvalCache> Program<EC> {
         self.overrides.extend(overrides);
     }
 
+    pub fn add_import_paths<P>(&mut self, paths: impl Iterator<Item = P>)
+    where
+        PathBuf: From<P>,
+    {
+        self.vm.import_resolver_mut().add_import_paths(paths);
+    }
+
     /// Only parse the program, don't typecheck or evaluate. returns the [`RichTerm`] AST
     pub fn parse(&mut self) -> Result<RichTerm, Error> {
         self.vm

--- a/core/tests/integration/imports/missing-nickel-path.ncl
+++ b/core/tests/integration/imports/missing-nickel-path.ncl
@@ -1,0 +1,5 @@
+# test.type = 'error'
+#
+# [test.metadata]
+# error = 'ImportError::IoError'
+2 == (import "two.ncl")

--- a/core/tests/integration/imports/needs-nickel-path.ncl
+++ b/core/tests/integration/imports/needs-nickel-path.ncl
@@ -1,0 +1,3 @@
+# test.type = 'pass'
+# nickel_path = ['tests/integration/imports/imported']
+2 == (import "two.ncl")

--- a/core/tests/integration/main.rs
+++ b/core/tests/integration/main.rs
@@ -63,12 +63,15 @@ fn run_test(test_case: TestCase<Test>, path: String) {
     let test = test_case.annotation.test;
 
     for _ in 0..repeat {
-        let p = TestProgram::new_from_source(
+        let mut p = TestProgram::new_from_source(
             Cursor::new(program.clone()),
             path.as_str(),
             std::io::stderr(),
         )
         .expect("");
+        if let Some(imports) = &test_case.annotation.nickel_path {
+            p.add_import_paths(imports.iter());
+        }
         match test.clone() {
             Expectation::Error(expected_err) => {
                 let err = eval_strategy.eval_program_to_err(p);
@@ -92,6 +95,7 @@ struct Test {
     test: Expectation,
     repeat: Option<usize>,
     eval: Option<EvalStrategy>,
+    nickel_path: Option<Vec<String>>,
 }
 
 #[derive(Clone, Copy, Deserialize)]

--- a/core/tests/integration/main.rs
+++ b/core/tests/integration/main.rs
@@ -200,6 +200,8 @@ enum ErrorExpectation {
     ParseTypedFieldWithoutDefinition,
     #[serde(rename = "ImportError::ParseError")]
     ImportParseError,
+    #[serde(rename = "ImportError::IoError")]
+    ImportIoError,
     #[serde(rename = "ExportError::NumberOutOfRange")]
     SerializeNumberOutOfRange,
 }
@@ -233,6 +235,7 @@ impl PartialEq<Error> for ErrorExpectation {
                 Error::TypecheckError(TypecheckError::FlatTypeInTermPosition { .. }),
             )
             | (ImportParseError, Error::ImportError(ImportError::ParseErrors(..)))
+            | (ImportIoError, Error::ImportError(ImportError::IOError(..)))
             | (
                 SerializeNumberOutOfRange,
                 Error::EvalError(EvalError::SerializationError(ExportError::NumberOutOfRange {
@@ -344,6 +347,7 @@ impl std::fmt::Display for ErrorExpectation {
                 "ParseError::TypedFieldWithoutDefinition".to_owned()
             }
             ImportParseError => "ImportError::ParseError".to_owned(),
+            ImportIoError => "ImportError::IoError".to_owned(),
             EvalBlameError => "EvalError::BlameError".to_owned(),
             EvalTypeError => "EvalError::TypeError".to_owned(),
             EvalEqError => "EvalError::EqError".to_owned(),


### PR DESCRIPTION
Here is a proposal for the most basic kind of "package management": a `NICKEL_PATH` environment whose value is a comma-separated list of paths look for imports in. The idea is that if you're using `npm`, for example, then you set this up to point to `node_modules` and then nickel can find all your imported packages.

It works reasonably well with nix also, as long as there are no recursive dependencies. For example, I'm using the following flake to get nickel validation for helix configurations:

```nix
{
  description = "Helix and nickel";

  inputs = {
    helix-nickel.url = "github:jneem/helix-nickel";
    nickel.url = "github:tweag/nickel/nickel-path";
  };

  outputs = { self, nixpkgs, helix-nickel, nickel }:
  let pkgs = import nixpkgs {
      system = "x86_64-linux";
    };
  in
  {
    devShell.x86_64-linux = pkgs.mkShell {
      NICKEL_PATH = helix-nickel.packages.x86_64-linux.default;

      nativeBuildInputs = [
        nickel.packages.x86_64-linux.default
      ];
    };
  };
}
```

I didn't have a good idea for how to test this, given that it requires setting up an environment variable...