### PR TITLE
Add a cli param to specify the search path

### DIFF
--- a/cli/src/input.rs
+++ b/cli/src/input.rs
@@ -14,6 +14,15 @@ pub struct InputOptions<Customize: clap::Args> {
     #[arg(long, global = true)]
     pub nostdlib: bool,
 
+    /// Specifies a (comma-separated) list of paths to search for imports in.
+    ///
+    /// When importing a file, nickel searches for it relative to the file doing the
+    /// import. If not found, it searches in the paths specified by `--nickel-path`.
+    /// If not found there, it searches in the (colon-separated) list of paths contained
+    /// in the environment variable `NICKEL_PATH`.
+    #[arg(long, global = true, value_delimiter = ',', num_args = 1..)]
+    pub nickel_path: Option<Vec<PathBuf>>,
+
     #[command(flatten)]
     pub customize_mode: Customize,
 }
@@ -31,6 +40,10 @@ impl<C: clap::Args + Customize> Prepare for InputOptions<C> {
         }?;
 
         program.color_opt = global.color.into();
+
+        if let Some(nickel_path) = &self.nickel_path {
+            program.add_import_paths(nickel_path.iter());
+        }
 
         if let Ok(nickel_path) = std::env::var("NICKEL_PATH") {
             program.add_import_paths(nickel_path.split(':'));

--- a/cli/src/input.rs
+++ b/cli/src/input.rs
@@ -14,14 +14,14 @@ pub struct InputOptions<Customize: clap::Args> {
     #[arg(long, global = true)]
     pub nostdlib: bool,
 
-    /// Specifies a (comma-separated) list of paths to search for imports in.
+    /// Adds a directory to the list of paths to search for imports in.
     ///
     /// When importing a file, nickel searches for it relative to the file doing the
-    /// import. If not found, it searches in the paths specified by `--nickel-path`.
+    /// import. If not found, it searches in the paths specified by `--import-path`.
     /// If not found there, it searches in the (colon-separated) list of paths contained
-    /// in the environment variable `NICKEL_PATH`.
-    #[arg(long, global = true, value_delimiter = ',', num_args = 1..)]
-    pub nickel_path: Option<Vec<PathBuf>>,
+    /// in the environment variable `NICKEL_IMPORT_PATH`.
+    #[arg(long, short = 'I', global = true)]
+    pub import_path: Vec<PathBuf>,
 
     #[command(flatten)]
     pub customize_mode: Customize,
@@ -41,11 +41,9 @@ impl<C: clap::Args + Customize> Prepare for InputOptions<C> {
 
         program.color_opt = global.color.into();
 
-        if let Some(nickel_path) = &self.nickel_path {
-            program.add_import_paths(nickel_path.iter());
-        }
+        program.add_import_paths(self.import_path.iter());
 
-        if let Ok(nickel_path) = std::env::var("NICKEL_PATH") {
+        if let Ok(nickel_path) = std::env::var("NICKEL_IMPORT_PATH") {
             program.add_import_paths(nickel_path.split(':'));
         }
 

--- a/core/src/program.rs
+++ b/core/src/program.rs
@@ -297,6 +297,7 @@ impl<EC: EvalCache> Program<EC> {
         self.overrides.extend(overrides);
     }
 
+    /// Adds import paths to the end of the list.
     pub fn add_import_paths<P>(&mut self, paths: impl Iterator<Item = P>)
     where
         PathBuf: From<P>,


### PR DESCRIPTION
This adds the cli argument version of the `NICKEL_PATH` environment variable. A couple points that could be bike-shedded:

- comma-separated vs colon-separated. I feel like comma-separated is "traditional" in arguments while colon-separated is "traditional" in environment variables, but I have no other justification for this choice.
- the name of the cli arg. Maybe the `nickel` prefix is unnecessary? I think it's justified for the env var because it lives in a global namespace.