### PR TITLE
Fix hover on assignments to subrecords

### DIFF
--- a/lsp/nls/src/usage.rs
+++ b/lsp/nls/src/usage.rs
@@ -164,7 +164,7 @@ impl UsageLookup {
                         }
                         TraverseControl::ContinueWithScope(new_env)
                     }
-                    Term::RecRecord(data, _interp_fields, _deps) => {
+                    Term::RecRecord(data, ..) | Term::Record(data) => {
                         let mut new_env = env.clone();
 
                         // Records are recursive and the order of fields is unimportant, so define

--- a/lsp/nls/tests/inputs/hover-cousin.ncl
+++ b/lsp/nls/tests/inputs/hover-cousin.ncl
@@ -2,11 +2,13 @@
 {
   foo = { bar = 2 },
   blah = foo.bar,
+  baz.path.path = 2,
 }
 | {
   foo | doc "outer" = {
     bar | Number | doc "inner" | default = 3
-  }
+  },
+  baz.path | doc "longer path"
 }
 ### [[request]]
 ### type = "Hover"
@@ -27,3 +29,8 @@
 ### type = "Hover"
 ### textDocument.uri = "file:///main.ncl"
 ### position = { line = 2, character = 14 }
+###
+### [[request]]
+### type = "Hover"
+### textDocument.uri = "file:///main.ncl"
+### position = { line = 3, character = 6 }

--- a/lsp/nls/tests/snapshots/main__lsp__nls__tests__inputs__completion-nested.ncl.snap
+++ b/lsp/nls/tests/snapshots/main__lsp__nls__tests__inputs__completion-nested.ncl.snap
@@ -4,5 +4,5 @@ expression: output
 ---
 [bar, baz, foo, one, std]
 [bar, baz, foo, std, two]
-[bar, baz, foo, std, three]
+[bar, baz, foo, quux, std, three]
 

--- a/lsp/nls/tests/snapshots/main__lsp__nls__tests__inputs__hover-cousin.ncl.snap
+++ b/lsp/nls/tests/snapshots/main__lsp__nls__tests__inputs__hover-cousin.ncl.snap
@@ -18,4 +18,7 @@ Dyn
 ```, ```nickel
 Number
 ```, inner]
+<3:6-3:10>[```nickel
+Dyn
+```, longer path]
 


### PR DESCRIPTION
A subrecord assignment like `{ foo.bar = 1 }` gets desugared into a `Record`, not a `RecRecord`. Since we forgot to handle `Record`, we were missing out on some definitions.

In particular, hovering over the first `bar` in `{ foo.bar = 1 } | { foo.bar | doc "hi" }` now works.