### PR TITLE
Update Nickel IM channel from Matrix to Discord

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,7 +59,7 @@ documentation is relevant as well:
 Nickel is maintained by [Tweag][tweag]. The current lead maintainer is Yann
 Hamdaoui (@yannham).
 
-You can find some of us on our [matrix channel][matrix-nickel] (and in
+You can find some of us on our [discord channel][nickel-chat] (and in
 particular the Devs room), or fire an email at `nickel-lang@tweag.io`.
 
 ## Set up a development environment
@@ -123,4 +123,4 @@ minimizes back-and-forths with trusted authors.
 [doc-notes]: notes/
 [tweag]: https://www.tweag.io
 [rfcs]: ./rfcs/
-[matrix-nickel]: https://matrix.to/#/#nickel-lang:matrix.org
+[nickel-chat]: https://discord.gg/vYDnJYBmax


### PR DESCRIPTION
Tweag decided to make all communication channels related to FOSS projects public, instead of hosting them internally on Slack, which wasn't contributor-friendly. We also settled on a common instant messaging platform, and for a number of reasons, Discord was picked.

Thus the Nickel instant messaging channel has been moved from Matrix to Discord. The Matrix channel is still there and is bridged with the Discord one, but we want to redirect new users directly to the Discord one.

This PR removes a mention to Matrix and updates it with the Discord's channel link.