### PR TITLE
Support importing txt files as strings

### DIFF
--- a/core/src/cache.rs
+++ b/core/src/cache.rs
@@ -41,7 +41,7 @@ pub enum InputFormat {
     Toml,
     #[cfg(feature = "nix-experimental")]
     Nix,
-    String,
+    Raw,
 }
 
 impl InputFormat {
@@ -54,7 +54,7 @@ impl InputFormat {
             Some("toml") => Some(InputFormat::Toml),
             #[cfg(feature = "nix-experimental")]
             Some("nix") => Some(InputFormat::Nix),
-            Some("txt") => Some(InputFormat::String),
+            Some("txt") => Some(InputFormat::Raw),
             _ => None,
         }
     }
@@ -618,10 +618,10 @@ impl Cache {
                     .map(|t| (attach_pos(t), ParseErrors::default()))
                     .map_err(|err| ParseError::from_serde_json(err, file_id, &self.files))
             }
-            InputFormat::String => Ok((
+            InputFormat::Raw => Ok((
                 attach_pos(Term::Str(self.files.source(file_id).into()).into()),
-                ParseErrors::default()
-            ))
+                ParseErrors::default(),
+            )),
         }
     }
 

--- a/core/src/cache.rs
+++ b/core/src/cache.rs
@@ -41,6 +41,7 @@ pub enum InputFormat {
     Toml,
     #[cfg(feature = "nix-experimental")]
     Nix,
+    String,
 }
 
 impl InputFormat {
@@ -53,6 +54,7 @@ impl InputFormat {
             Some("toml") => Some(InputFormat::Toml),
             #[cfg(feature = "nix-experimental")]
             Some("nix") => Some(InputFormat::Nix),
+            Some("txt") => Some(InputFormat::String),
             _ => None,
         }
     }
@@ -616,6 +618,10 @@ impl Cache {
                     .map(|t| (attach_pos(t), ParseErrors::default()))
                     .map_err(|err| ParseError::from_serde_json(err, file_id, &self.files))
             }
+            InputFormat::String => Ok((
+                attach_pos(Term::Str(self.files.source(file_id).into()).into()),
+                ParseErrors::default()
+            ))
         }
     }
 


### PR DESCRIPTION
Files that contain raw text shouldn't be interpreted as Nickel code