### PR TITLE
Add --error-format flag to serialize err diagnostics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -405,6 +405,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3362992a0d9f1dd7c3d0e89e0ab2bb540b7a95fea8cd798090e758fda2899b5e"
 dependencies = [
  "codespan-reporting",
+ "serde",
 ]
 
 [[package]]
@@ -424,6 +425,7 @@ version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
 dependencies = [
+ "serde",
  "termcolor",
  "unicode-width",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,9 +39,9 @@ assert_cmd = "2.0.11"
 assert_matches = "1.5.0"
 clap = "4.3"
 clap_complete = "4.3.2"
-codespan = "0.11"
+codespan = { version = "0.11", features = ["serialization"] }
 codespan-lsp = "0.11"
-codespan-reporting = "0.11"
+codespan-reporting = { version = "0.11", features = ["serialization"] }
 comrak = "0.17.0"
 criterion = "0.4"
 csv = "1"

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -7,6 +7,8 @@ use crate::{
     pprint_ast::PprintAstCommand, query::QueryCommand, typecheck::TypecheckCommand,
 };
 
+use nickel_lang_core::error::report::ErrorFormat;
+
 #[cfg(feature = "repl")]
 use crate::repl::ReplCommand;
 
@@ -46,6 +48,10 @@ pub struct GlobalOptions {
     /// Configure when to output messages in color
     #[arg(long, global = true, value_enum, default_value_t)]
     pub color: clap::ColorChoice,
+
+    /// Output error messages in a specific format.
+    #[arg(long, global = true, value_enum, default_value_t)]
+    pub error_format: ErrorFormat,
 
     #[cfg(feature = "metrics")]
     /// Print all recorded metrics at the very end of the program

--- a/cli/src/error.rs
+++ b/cli/src/error.rs
@@ -1,7 +1,7 @@
 //! Error handling for the CLI.
 
 use nickel_lang_core::{
-    error::{Diagnostic, FileId, Files, IntoDiagnostics, ParseError},
+    error::{report::ErrorFormat, Diagnostic, FileId, Files, IntoDiagnostics, ParseError},
     eval::cache::lazy::CBNCache,
     program::{FieldOverride, FieldPath, Program},
 };
@@ -215,9 +215,10 @@ impl<T> ResultErrorExt<T> for Result<T, nickel_lang_core::error::Error> {
 }
 
 impl Error {
-    pub fn report(self) {
+    /// Report this error on the standard error stream.
+    pub fn report(self, format: ErrorFormat) {
         match self {
-            Error::Program { mut program, error } => program.report(error),
+            Error::Program { mut program, error } => program.report(error, format),
             Error::Io { error } => {
                 eprintln!("{error}")
             }
@@ -233,7 +234,7 @@ impl Error {
             }
             #[cfg(feature = "format")]
             Error::Format { error } => eprintln!("{error}"),
-            Error::CliUsage { error, mut program } => program.report(error),
+            Error::CliUsage { error, mut program } => program.report(error, format),
             Error::CustomizeInfoPrinted => {
                 // Nothing to do, the caller should simply exit.
             }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -30,6 +30,7 @@ fn main() -> ExitCode {
 
     let opts = <Options as clap::Parser>::parse();
 
+    let error_format = opts.global.error_format;
     #[cfg(feature = "metrics")]
     let report_metrics = opts.global.metrics;
 
@@ -61,7 +62,7 @@ fn main() -> ExitCode {
         // user's point of view.
         Ok(()) | Err(error::Error::CustomizeInfoPrinted) => ExitCode::SUCCESS,
         Err(error) => {
-            error.report();
+            error.report(error_format);
             ExitCode::FAILURE
         }
     }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -31,6 +31,7 @@ fn main() -> ExitCode {
     let opts = <Options as clap::Parser>::parse();
 
     let error_format = opts.global.error_format;
+    let color = opts.global.color;
     #[cfg(feature = "metrics")]
     let report_metrics = opts.global.metrics;
 
@@ -62,7 +63,7 @@ fn main() -> ExitCode {
         // user's point of view.
         Ok(()) | Err(error::Error::CustomizeInfoPrinted) => ExitCode::SUCCESS,
         Err(error) => {
-            error.report(error_format);
+            error.report(error_format, color.into());
             ExitCode::FAILURE
         }
     }

--- a/cli/src/query.rs
+++ b/cli/src/query.rs
@@ -52,7 +52,7 @@ impl QueryCommand {
         let mut program = self.inputs.prepare(&global)?;
 
         if self.inputs.customize_mode.field().is_none() {
-            program.report(Warning::EmptyQueryPath)
+            program.report(Warning::EmptyQueryPath, global.error_format);
         }
 
         let found = program

--- a/core/src/error/mod.rs
+++ b/core/src/error/mod.rs
@@ -32,6 +32,7 @@ use crate::{
     typ::{Type, TypeF, VarKindDiscriminant},
 };
 
+pub mod report;
 pub mod suggest;
 
 /// A general error occurring during either parsing or evaluation.
@@ -2281,73 +2282,4 @@ impl IntoDiagnostics<FileId> for ReplError {
             }
         }
     }
-}
-
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
-pub struct ColorOpt(pub(crate) clap::ColorChoice);
-
-impl From<clap::ColorChoice> for ColorOpt {
-    fn from(color_choice: clap::ColorChoice) -> Self {
-        Self(color_choice)
-    }
-}
-
-impl From<ColorOpt> for ColorChoice {
-    fn from(c: ColorOpt) -> Self {
-        use std::io::{stdout, IsTerminal};
-
-        match c.0 {
-            clap::ColorChoice::Auto => {
-                if stdout().is_terminal() {
-                    ColorChoice::Auto
-                } else {
-                    ColorChoice::Never
-                }
-            }
-            clap::ColorChoice::Always => ColorChoice::Always,
-            clap::ColorChoice::Never => ColorChoice::Never,
-        }
-    }
-}
-
-impl Default for ColorOpt {
-    fn default() -> Self {
-        Self(clap::ColorChoice::Auto)
-    }
-}
-
-/// Pretty-print an error on stderr.
-///
-/// # Arguments
-///
-/// - `cache` is the file cache used during the evaluation, which is required by the reporting
-/// infrastructure to point at specific locations and print snippets when needed.
-pub fn report<E: IntoDiagnostics<FileId>>(cache: &mut Cache, error: E, color_opt: ColorOpt) {
-    let stdlib_ids = cache.get_all_stdlib_modules_file_id();
-    report_with(
-        &mut StandardStream::stderr(color_opt.into()).lock(),
-        cache.files_mut(),
-        stdlib_ids.as_ref(),
-        error,
-    )
-}
-
-/// Report an error on `stderr`, provided a file database and a list of stdlib file ids.
-pub fn report_with<E: IntoDiagnostics<FileId>>(
-    writer: &mut dyn WriteColor,
-    files: &mut Files<String>,
-    stdlib_ids: Option<&Vec<FileId>>,
-    error: E,
-) {
-    let config = codespan_reporting::term::Config::default();
-    let diagnostics = error.into_diagnostics(files, stdlib_ids);
-
-    let result = diagnostics
-        .iter()
-        .try_for_each(|d| codespan_reporting::term::emit(writer, &config, files, d));
-
-    match result {
-        Ok(()) => (),
-        Err(err) => panic!("error::report_with(): could not print an error on stderr: {err}"),
-    };
 }

--- a/core/src/error/mod.rs
+++ b/core/src/error/mod.rs
@@ -821,6 +821,17 @@ pub trait IntoDiagnostics<FileId> {
     ) -> Vec<Diagnostic<FileId>>;
 }
 
+// Allow the use of a single `Diagnostic` directly as an error that can be reported by Nickel.
+impl<FileId> IntoDiagnostics<FileId> for Diagnostic<FileId> {
+    fn into_diagnostics(
+        self,
+        _files: &mut Files<String>,
+        _stdlib_ids: Option<&Vec<FileId>>,
+    ) -> Vec<Diagnostic<FileId>> {
+        vec![self]
+    }
+}
+
 // Helpers for the creation of codespan `Label`s
 
 /// Create a primary label from a span.

--- a/core/src/error/report.rs
+++ b/core/src/error/report.rs
@@ -95,10 +95,7 @@ pub fn report_with<E: IntoDiagnostics<FileId>>(
             codespan_reporting::term::emit(writer, &config, files, d).map_err(|err| err.to_string())
         }),
         ErrorFormat::Json => serde_json::to_writer(stderr, &DiagnosticsWrapper::from(diagnostics))
-            .and_then(|_| {
-                eprintln!();
-                Ok(())
-            })
+            .map(|_| eprintln!())
             .map_err(|err| err.to_string()),
         ErrorFormat::Yaml => serde_yaml::to_writer(stderr, &DiagnosticsWrapper::from(diagnostics))
             .map_err(|err| err.to_string()),

--- a/core/src/error/report.rs
+++ b/core/src/error/report.rs
@@ -1,0 +1,114 @@
+//! Error diagnostics reporting and serialization.
+use super::*;
+
+/// Serializable wrapper type to export diagnostics with a top-level attribute.
+#[derive(serde::Serialize)]
+pub struct DiagnosticsWrapper {
+    pub diagnostics: Vec<Diagnostic<FileId>>,
+}
+
+impl From<Vec<Diagnostic<FileId>>> for DiagnosticsWrapper {
+    fn from(diagnostics: Vec<Diagnostic<FileId>>) -> Self {
+        Self { diagnostics }
+    }
+}
+
+/// Available export formats for error diagnostics.
+#[derive(Copy, Clone, Eq, PartialEq, Debug, Default, clap::ValueEnum)]
+pub enum ErrorFormat {
+    #[default]
+    Text,
+    Json,
+    Yaml,
+    Toml,
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct ColorOpt(pub(crate) clap::ColorChoice);
+
+impl From<clap::ColorChoice> for ColorOpt {
+    fn from(color_choice: clap::ColorChoice) -> Self {
+        Self(color_choice)
+    }
+}
+
+impl From<ColorOpt> for ColorChoice {
+    fn from(c: ColorOpt) -> Self {
+        use std::io::{stdout, IsTerminal};
+
+        match c.0 {
+            clap::ColorChoice::Auto => {
+                if stdout().is_terminal() {
+                    ColorChoice::Auto
+                } else {
+                    ColorChoice::Never
+                }
+            }
+            clap::ColorChoice::Always => ColorChoice::Always,
+            clap::ColorChoice::Never => ColorChoice::Never,
+        }
+    }
+}
+
+impl Default for ColorOpt {
+    fn default() -> Self {
+        Self(clap::ColorChoice::Auto)
+    }
+}
+
+/// Pretty-print an error on stderr.
+///
+/// # Arguments
+///
+/// - `cache` is the file cache used during the evaluation, which is required by the reporting
+/// infrastructure to point at specific locations and print snippets when needed.
+pub fn report<E: IntoDiagnostics<FileId>>(
+    cache: &mut Cache,
+    error: E,
+    format: ErrorFormat,
+    color_opt: ColorOpt,
+) {
+    let stdlib_ids = cache.get_all_stdlib_modules_file_id();
+    report_with(
+        &mut StandardStream::stderr(color_opt.into()).lock(),
+        cache.files_mut(),
+        stdlib_ids.as_ref(),
+        error,
+        format,
+    )
+}
+
+/// Report an error on `stderr`, provided a file database and a list of stdlib file ids.
+pub fn report_with<E: IntoDiagnostics<FileId>>(
+    writer: &mut dyn WriteColor,
+    files: &mut Files<String>,
+    stdlib_ids: Option<&Vec<FileId>>,
+    error: E,
+    format: ErrorFormat,
+) {
+    let config = codespan_reporting::term::Config::default();
+    let diagnostics = error.into_diagnostics(files, stdlib_ids);
+    let stderr = std::io::stderr();
+
+    let result = match format {
+        ErrorFormat::Text => diagnostics.iter().try_for_each(|d| {
+            codespan_reporting::term::emit(writer, &config, files, d).map_err(|err| err.to_string())
+        }),
+        ErrorFormat::Json => serde_json::to_writer(stderr, &DiagnosticsWrapper::from(diagnostics))
+            .and_then(|_| {
+                eprintln!();
+                Ok(())
+            })
+            .map_err(|err| err.to_string()),
+        ErrorFormat::Yaml => serde_yaml::to_writer(stderr, &DiagnosticsWrapper::from(diagnostics))
+            .map_err(|err| err.to_string()),
+        ErrorFormat::Toml => toml::to_string(&DiagnosticsWrapper::from(diagnostics))
+            .map(|repr| eprint!("{}", repr))
+            .map_err(|err| err.to_string()),
+    };
+
+    match result {
+        Ok(()) => (),
+        Err(err) => panic!("error::report_with(): could not print an error on stderr: {err}"),
+    };
+}

--- a/core/src/program.rs
+++ b/core/src/program.rs
@@ -22,7 +22,10 @@
 //! Each such value is added to the initial environment before the evaluation of the program.
 use crate::{
     cache::*,
-    error::{report, ColorOpt, Error, EvalError, IOError, IntoDiagnostics, ParseError},
+    error::{
+        report::{report, ColorOpt, ErrorFormat},
+        Error, EvalError, IOError, IntoDiagnostics, ParseError,
+    },
     eval::{cache::Cache as EvalCache, Closure, VirtualMachine},
     identifier::LocIdent,
     label::Label,
@@ -454,11 +457,11 @@ impl<EC: EvalCache> Program<EC> {
     }
 
     /// Wrapper for [`report`].
-    pub fn report<E>(&mut self, error: E)
+    pub fn report<E>(&mut self, error: E, format: ErrorFormat)
     where
         E: IntoDiagnostics<FileId>,
     {
-        report(self.vm.import_resolver_mut(), error, self.color_opt)
+        report(self.vm.import_resolver_mut(), error, format, self.color_opt)
     }
 
     /// Build an error report as a string and return it.

--- a/core/src/repl/mod.rs
+++ b/core/src/repl/mod.rs
@@ -7,7 +7,10 @@
 //! jupyter-kernel (which is not exactly user-facing, but still manages input/output and
 //! formatting), etc.
 use crate::cache::{Cache, Envs, ErrorTolerance, SourcePath};
-use crate::error::{Error, EvalError, IOError, ParseError, ParseErrors, ReplError};
+use crate::error::{
+    report::{self, ColorOpt, ErrorFormat},
+    Error, EvalError, IOError, IntoDiagnostics, ParseError, ParseErrors, ReplError,
+};
 use crate::eval::cache::Cache as EvalCache;
 use crate::eval::{Closure, VirtualMachine};
 use crate::identifier::LocIdent;
@@ -207,6 +210,10 @@ impl<EC: EvalCache> ReplImpl<EC> {
                 Ok(EvalResult::Bound(id))
             }
         }
+    }
+
+    fn report(&mut self, err: impl IntoDiagnostics<FileId>, color_opt: ColorOpt) {
+        report::report(self.cache_mut(), err, ErrorFormat::Text, color_opt);
     }
 }
 

--- a/core/src/serialize.rs
+++ b/core/src/serialize.rs
@@ -1,7 +1,4 @@
 //! Serialization of an evaluated program to various data format.
-use malachite::{num::conversion::traits::RoundingFrom, rounding_modes::RoundingMode};
-use once_cell::sync::Lazy;
-
 use crate::{
     error::ExportError,
     identifier::LocIdent,
@@ -17,7 +14,11 @@ use serde::{
     ser::{Serialize, SerializeMap, SerializeSeq, Serializer},
 };
 
-use malachite::num::conversion::traits::IsInteger;
+use malachite::{
+    num::conversion::traits::{IsInteger, RoundingFrom},
+    rounding_modes::RoundingMode,
+};
+use once_cell::sync::Lazy;
 
 use std::{fmt, io, rc::Rc};
 

--- a/core/src/term/mod.rs
+++ b/core/src/term/mod.rs
@@ -60,7 +60,6 @@ use std::{
 ///
 /// Parsed terms also need to store their position in the source for error reporting.  This is why
 /// this type is nested with [`RichTerm`].
-///
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum Term {

--- a/core/tests/manual/main.rs
+++ b/core/tests/manual/main.rs
@@ -138,6 +138,8 @@ fn check_error_report(actual: impl AsRef<str>, expected: MessageExpectation) {
 }
 
 fn check_repl(content: String) {
+    use error::report::{report_with, ErrorFormat};
+
     let mut repl = ReplImpl::<CacheImpl>::new(std::io::sink());
     repl.load_stdlib().unwrap();
     for piece in content.split("\n\n") {
@@ -156,7 +158,7 @@ fn check_repl(content: String) {
                     let mut error = NoColor::new(Vec::<u8>::new());
                     let stdlib_ids = repl.cache_mut().get_all_stdlib_modules_file_id();
                     let files = repl.cache_mut().files_mut();
-                    error::report_with(&mut error, files, stdlib_ids.as_ref(), e);
+                    report_with(&mut error, files, stdlib_ids.as_ref(), e, ErrorFormat::Text);
 
                     check_error_report(String::from_utf8(error.into_inner()).unwrap(), expected);
                 }

--- a/utils/src/bench.rs
+++ b/utils/src/bench.rs
@@ -174,6 +174,7 @@ macro_rules! ncl_bench_group {
                 cache::{Envs, Cache, ErrorTolerance, ImportResolver},
                 eval::{VirtualMachine, cache::{CacheImpl, Cache as EvalCache}},
                 transform::import_resolution::strict::resolve_imports,
+                error::report::{report, ColorOpt, ErrorFormat},
             };
 
             let mut c: criterion::Criterion<_> = $config
@@ -212,10 +213,11 @@ macro_rules! ncl_bench_group {
                                 .with_initial_env(eval_env.clone());
 
                                 if let Err(e) = vm.eval(t) {
-                                    nickel_lang_core::error::report(
+                                    report(
                                         vm.import_resolver_mut(),
                                         e,
-                                        nickel_lang_core::error::ColorOpt::default()
+                                        ErrorFormat::Text,
+                                        ColorOpt::default(),
                                     );
                                     panic!("Error during bench evaluation");
                                 }


### PR DESCRIPTION
Closes #1738.

This PR adds an `--error-format` global flag (copied over from Rust, after benchmarking what a few other compilers are donig, this seemed to be the better tradeoff between being intuitive and not conflicting with other meaning of "format as JSON", which we have a lot in Nickel - export format, input format, etc.).

The user can choose between JSON, TOML or YAML - I believe JSON is the most common one, but it's virtually free to support more formats with `serde` (at the least the format that we export Nickel configurations to), hence I don't see an obvious reason to not support them.

Incidentally, this PR formats more CLI errors using codespan diagnostics (they were just printed as text before), so that the flag really affects all error messages. As a bonus, those error messages are now nicely colored like the others.