### PR TITLE
Mention unstability of error schema for --error-format

### DIFF
--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -49,7 +49,8 @@ pub struct GlobalOptions {
     #[arg(long, global = true, value_enum, default_value_t)]
     pub color: clap::ColorChoice,
 
-    /// Output error messages in a specific format.
+    /// Output error messages in a specific format. The schema of serialized errors reflects the
+    /// way they are currently rendered. This schema is not guaranteed to be stable yet.
     #[arg(long, global = true, value_enum, default_value_t)]
     pub error_format: ErrorFormat,
 


### PR DESCRIPTION
Following https://github.com/tweag/nickel/pull/1740#pullrequestreview-1789156375, mention that the schema of serialized error messages isn't stable (yet).