### PR TITLE
format: don't fail silently on invalid input anymore

### DIFF
--- a/core/src/format.rs
+++ b/core/src/format.rs
@@ -32,7 +32,7 @@ pub fn format(mut input: impl Read, mut output: impl Write) -> Result<(), Format
         &grammar,
         topiary::Operation::Format {
             skip_idempotence: true,
-            tolerate_parsing_errors: true,
+            tolerate_parsing_errors: false,
         },
     )
     .map_err(FormatError)


### PR DESCRIPTION
`nickel format` is silently doing nothing and exit with success code when the input file doesn't parse, which can be surprising (you think that you correctly formatted your codebase, but in fact the file doesn't even parse). This is due to using `tolerate_parsing_errors: true`, which as reported by @vkleen was a fix for a time when Topiary would simply erase some files upon parsing errors, which was of course problematic, to say the least.

This isn't the case anymore, and thus we can get rid of this option and correctly report parse errors when formatting.