### PR TITLE
Fix clippy 1.75 warnings

### DIFF
--- a/cli/src/doc.rs
+++ b/cli/src/doc.rs
@@ -102,7 +102,7 @@ impl DocCommand {
 
                     let mut has_file_name = false;
 
-                    if let Some(path) = self.input.files.get(0) {
+                    if let Some(path) = self.input.files.first() {
                         if let Some(file_stem) = path.file_stem() {
                             output_file.push(file_stem);
                             has_file_name = true;

--- a/core/src/typecheck/eq.rs
+++ b/core/src/typecheck/eq.rs
@@ -106,6 +106,10 @@ impl TermEnvironment for SimpleTermEnvironment {
     where
         F: FnOnce(Option<(&RichTerm, &SimpleTermEnvironment)>) -> T,
     {
+        // See https://github.com/rust-lang/rust-clippy/issues/11764. It's been fixed upstream, but
+        // hasn't landed in a clippy release yet. We can remove the allow(clippy) once it does
+        // land.
+        #[allow(clippy::map_identity)]
         f(env.0.get(&id).map(|(rt, env)| (rt, env)))
     }
 

--- a/core/src/typecheck/mod.rs
+++ b/core/src/typecheck/mod.rs
@@ -2106,7 +2106,7 @@ fn infer_with_annot<V: TypecheckVisitor>(
             },
             value_opt,
         ) if !contracts.is_empty() => {
-            let ctr = contracts.get(0).unwrap();
+            let ctr = contracts.first().unwrap();
             let LabeledType { typ: ty2, .. } = ctr;
 
             let uty2 = UnifType::from_type(ty2.clone(), &ctxt.term_env);


### PR DESCRIPTION
Latest clippy complains about new things.

I initially did this as part of #1733, but the latter fails on something unrelated now. So in the meantime, let's backport the fixes here.