### PR TITLE
Add "goto definition" support for the import term

### DIFF
--- a/lsp/nls/src/analysis.rs
+++ b/lsp/nls/src/analysis.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 
 use codespan::FileId;
 use nickel_lang_core::{
+    position::RawSpan,
     term::{BinaryOp, RichTerm, Term, Traverse, TraverseControl},
     typ::{Type, TypeF},
     typecheck::{reporting::NameReg, TypeTables, TypecheckVisitor, UnifType},
@@ -272,15 +273,15 @@ impl AnalysisRegistry {
         self.analysis.get(&file)?.usage_lookup.def(ident)
     }
 
-    pub fn get_usages(&self, ident: &LocIdent) -> impl Iterator<Item = &LocIdent> {
+    pub fn get_usages(&self, span: &RawSpan) -> impl Iterator<Item = &LocIdent> {
         fn inner<'a>(
             slf: &'a AnalysisRegistry,
-            ident: &LocIdent,
+            span: &RawSpan,
         ) -> Option<impl Iterator<Item = &'a LocIdent>> {
-            let file = ident.pos.as_opt_ref()?.src_id;
-            Some(slf.analysis.get(&file)?.usage_lookup.usages(ident))
+            let file = span.src_id;
+            Some(slf.analysis.get(&file)?.usage_lookup.usages(span))
         }
-        inner(self, ident).into_iter().flatten()
+        inner(self, span).into_iter().flatten()
     }
 
     pub fn get_env(&self, rt: &RichTerm) -> Option<&crate::usage::Environment> {

--- a/lsp/nls/tests/inputs/goto-cross-file.ncl
+++ b/lsp/nls/tests/inputs/goto-cross-file.ncl
@@ -8,6 +8,11 @@ in
 ### [[request]]
 ### type = "GotoDefinition"
 ### textDocument.uri = "file:///goto.ncl"
+### position = { line = 1, character = 16 }
+###
+### [[request]]
+### type = "GotoDefinition"
+### textDocument.uri = "file:///goto.ncl"
 ### position = { line = 3, character = 2 }
 ###
 ### [[request]]

--- a/lsp/nls/tests/snapshots/main__lsp__nls__tests__inputs__goto-cross-file.ncl.snap
+++ b/lsp/nls/tests/snapshots/main__lsp__nls__tests__inputs__goto-cross-file.ncl.snap
@@ -2,6 +2,7 @@
 source: lsp/nls/tests/main.rs
 expression: output
 ---
+file:///dep.ncl:0:0-0:15
 file:///goto.ncl:1:2-1:8
 file:///dep.ncl:0:2-0:5
 


### PR DESCRIPTION
After this PR, asking for "goto definition" on an import term will go to that file.

Most of this PR is relaxing a previous assumption that the "definition" is always an identifier (because in the case of an import, the definition is an arbitrary term). Instead, the answer for a definition query is now an arbitrary `RawSpan`.

Fixes #1754