### PR TITLE
Stop using spot instances for release builds

### DIFF
--- a/infra/spot_lambdas/start.py
+++ b/infra/spot_lambdas/start.py
@@ -22,13 +22,6 @@ def lambda_handler(event, context):
             "LaunchTemplateId": launch_template_id,
             "Version": "$Latest"
         },
-        InstanceMarketOptions={
-            "MarketType": "spot",
-            "SpotOptions": {
-                "SpotInstanceType": "one-time",
-                "InstanceInterruptionBehavior": "terminate",
-            },
-        },
         TagSpecifications=[
             {
                 "ResourceType": "instance",


### PR DESCRIPTION
We now had a failure to build release binaries due to a spot instance getting canceled early for the second time. For now, I propose not using a spot instance. While this will increase the cost, with it only getting run once per release, I don't think there's cause for concern.

This change is change is already deployed to the AWS account to build the 1.4 release artifacts.