### PR TITLE
Proper error message for non exhaustive match

### DIFF
--- a/cli/tests/snapshot/inputs/errors/non_exhaustive_match.ncl
+++ b/cli/tests/snapshot/inputs/errors/non_exhaustive_match.ncl
@@ -1,0 +1,13 @@
+# capture = 'stderr'
+# command = ['eval']
+
+# Ensure that a non-exhaustive pattern matching applied to a non-matching
+# argument produces a proper error message.
+let x = if true then 'a else 'b in
+let f = match {
+  'c => "hello",
+  'd => "adios",
+}
+in
+
+f x

--- a/cli/tests/snapshot/snapshots/snapshot__eval_stderr_non_exhaustive_match.ncl.snap
+++ b/cli/tests/snapshot/snapshots/snapshot__eval_stderr_non_exhaustive_match.ncl.snap
@@ -1,0 +1,20 @@
+---
+source: cli/tests/snapshot/main.rs
+expression: err
+---
+error: non-exhaustive pattern matching
+   ┌─ [INPUTS_PATH]/errors/non_exhaustive_match.ncl:7:9
+   │  
+ 6 │   let x = if true then 'a else 'b in
+   │                        -- this value doesn't match any branch
+ 7 │   let f = match {
+   │ ╭─────────^
+ 8 │ │   'c => "hello",
+ 9 │ │   'd => "adios",
+10 │ │ }
+   │ ╰─^ in this match expression
+   │  
+   = This match expression isn't exhaustive, matching only the following pattern(s): `'c, 'd`
+   = But it has been applied to an argument which doesn't match any of those patterns
+
+

--- a/core/src/eval/operation.rs
+++ b/core/src/eval/operation.rs
@@ -315,6 +315,7 @@ impl<R: ImportResolver, C: Cache> VirtualMachine<R, C> {
                     .stack
                     .pop_arg(&self.cache)
                     .expect("missing arg for match");
+
                 let default = if has_default {
                     Some(
                         self.stack
@@ -351,9 +352,11 @@ impl<R: ImportResolver, C: Cache> VirtualMachine<R, C> {
                             env: cases_env,
                         })
                         .or(default)
-                        .ok_or_else(||
-                        // ? We should have a dedicated error for unmatched pattern
-                        mk_type_error!("match", "Enum"))
+                        .ok_or_else(|| EvalError::NonExhaustiveMatch {
+                            expected: cases.keys().copied().collect(),
+                            found: RichTerm::new(Term::Enum(*en), pos),
+                            pos: pos_op_inh,
+                        })
                 } else if let Some(clos) = default {
                     Ok(clos)
                 } else {


### PR DESCRIPTION
Fixes #1771.

An argument to match expressions that wouldn't match any of the branches used to print a pretty bad error message ("expecting Enum, found Enum"). This commit creates a proper variant for non-matching expressions, and make the error reporting point to the match expression and to the value the argument evaluated to.

Currently, one position that might be lost in translation is where the match expression was applied to this argument. Here we only get the point where the match expression is defined, and what the argument evaluated to (often the application of the expression to the argument is close to the definition of the match expression, but not necessarily). The application site is a bit harder to track; for now, this PR is a trivial change and a strict improvement over the previous situation. Let's reconsider later if this proves insufficient.