### PR TITLE
correctly drop Array::IntoIter

### DIFF
--- a/core/src/term/array.rs
+++ b/core/src/term/array.rs
@@ -218,7 +218,7 @@ impl Iterator for IntoIter {
                     Rc::get_mut(inner)
                         .expect("non-unique Rc after checking for uniqueness")
                         .get_mut(self.idx)
-                        .map(|t| ManuallyDrop::take(t))
+                        .map(ManuallyDrop::take)
                 },
             };
 


### PR DESCRIPTION
Since #1683 has been open a while, and I'm not sure when I'm going to have the time to work out what's going on with `Interner`, I wanted to separate out the changes to Array::IntoIter.

If you called `Array::into_iter()`, you could leak elements in two circumstances:
1. If you did not iterate through all elements before dropping, since they had been converted to `ManuallyDrop`
2. If the Array had multiple references when the iterator was created, but the other references were dropped before the iterator was dropped, then the existence of the iterator would prevent those Rcs from dropping their contents, but then because the iterator is of type ManuallyDrop, it wouldn't drop those elements either
