### PR TITLE
Implement equality on ADTs

### DIFF
--- a/core/src/eval/operation.rs
+++ b/core/src/eval/operation.rs
@@ -3126,7 +3126,12 @@ fn eq<C: Cache>(
         (Term::Str(s1), Term::Str(s2)) => Ok(EqResult::Bool(s1 == s2)),
         (Term::Lbl(l1), Term::Lbl(l2)) => Ok(EqResult::Bool(l1 == l2)),
         (Term::SealingKey(s1), Term::SealingKey(s2)) => Ok(EqResult::Bool(s1 == s2)),
-        (Term::Enum(id1), Term::Enum(id2)) => Ok(EqResult::Bool(id1 == id2)),
+        (Term::Enum(id1), Term::Enum(id2)) => Ok(EqResult::Bool(id1.ident() == id2.ident())),
+        (Term::EnumVariant(id1, arg1), Term::EnumVariant(id2, arg2))
+            if id1.ident() == id2.ident() =>
+        {
+            Ok(gen_eqs(cache, std::iter::once((arg1, arg2)), env1, env2))
+        }
         (Term::Record(r1), Term::Record(r2)) => {
             let merge::split::SplitResult {
                 left,

--- a/core/tests/integration/pass/core/eq.ncl
+++ b/core/tests/integration/pass/core/eq.ncl
@@ -77,5 +77,11 @@ let {check, ..} = import "../lib/assert.ncl" in
         [[1,2,3,4], [1,2,3,4], [1,2,3,4], [1,2,3,4]]
       == false
   ),
+
+  # ADTs
+  'Left..(1+1) == 'Left..(2),
+  'Left..(1) != 'Left..(2),
+  'Left..(2) != 'Right..(2),
+  'Up..([1,2,3]) == 'Up..([0+1,1+1,2+1]),
 ]
 |> check


### PR DESCRIPTION
Small follow-up of #1770, adding the missing cases to compare enum variants.

Depends on #1770