### PR TITLE
[Refactor] Ease the implementation of `Display` from `Pretty`

### DIFF
--- a/core/src/pretty.rs
+++ b/core/src/pretty.rs
@@ -1079,6 +1079,18 @@ where
     }
 }
 
+/// Generate an implementation of `fmt::Display` for types that implement `Pretty`.
+#[macro_export]
+macro_rules! impl_display_from_pretty {
+    ($ty:ty) => {
+        impl std::fmt::Display for $ty {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                $crate::pretty::fmt_pretty(&self, f)
+            }
+        }
+    };
+}
+
 #[cfg(test)]
 mod tests {
     use pretty::BoxAllocator;

--- a/core/src/term/mod.rs
+++ b/core/src/term/mod.rs
@@ -23,6 +23,7 @@ use crate::{
     eval::cache::CacheIndex,
     eval::Environment,
     identifier::LocIdent,
+    impl_display_from_pretty,
     label::{Label, MergeLabel},
     match_sharedterm,
     position::TermPos,
@@ -2142,17 +2143,8 @@ impl From<Term> for RichTerm {
     }
 }
 
-impl fmt::Display for RichTerm {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        crate::pretty::fmt_pretty(&self, f)
-    }
-}
-
-impl fmt::Display for Term {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        crate::pretty::fmt_pretty(&self, f)
-    }
-}
+impl_display_from_pretty!(RichTerm);
+impl_display_from_pretty!(Term);
 
 /// Allows to match on SharedTerm without taking ownership of the matched part
 /// until the match. In the wildcard pattern, we don't take ownership, so we can

--- a/core/src/typ.rs
+++ b/core/src/typ.rs
@@ -43,6 +43,7 @@
 use crate::{
     error::{EvalError, ParseError, ParseErrors, TypecheckError},
     identifier::{Ident, LocIdent},
+    impl_display_from_pretty,
     label::Polarity,
     mk_app, mk_fun,
     position::TermPos,
@@ -55,7 +56,6 @@ use crate::{
 use std::{
     collections::{HashMap, HashSet},
     convert::Infallible,
-    fmt::{self, Display},
 };
 
 /// A record row, mapping an identifier to a type. A record type is a dictionary mapping
@@ -1318,15 +1318,8 @@ impl Traverse<RichTerm> for Type {
     }
 }
 
-impl Display for Type {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        crate::pretty::fmt_pretty(&self, f)
-    }
-}
-
-//TODO[adts]: generalize this boiler plate to a macro, and other subcomponent of types
-impl Display for EnumRow {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        crate::pretty::fmt_pretty(&self, f)
-    }
-}
+impl_display_from_pretty!(Type);
+impl_display_from_pretty!(EnumRow);
+impl_display_from_pretty!(EnumRows);
+impl_display_from_pretty!(RecordRow);
+impl_display_from_pretty!(RecordRows);


### PR DESCRIPTION
Depends on #1770

Close another TODO left from #1770: this PR adds macro to auto-generate an implementation of `Display` from the implementation of `Pretty`. This serves as a replacement of existing manual (similar) implementations, and also enables the easy addition of a few new ones for intermediate data types, such as enum/record rows or enum/record types.