### PR TITLE
Vendor codespan, and fix character offset issues

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -409,17 +409,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "codespan-lsp"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc4159b76af02757139baf42c0c971c6dc155330999fbfd8eddb29b97fb2db68"
-dependencies = [
- "codespan-reporting",
- "lsp-types",
- "url",
-]
-
-[[package]]
 name = "codespan-reporting"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1708,7 +1697,6 @@ dependencies = [
  "assert_matches",
  "clap 4.4.18",
  "codespan",
- "codespan-lsp",
  "codespan-reporting",
  "criterion",
  "csv",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,6 @@ assert_matches = "1.5.0"
 clap = "4.3"
 clap_complete = "4.3.2"
 codespan = { version = "0.11", features = ["serialization"] }
-codespan-lsp = "0.11"
 codespan-reporting = { version = "0.11", features = ["serialization"] }
 comrak = "0.17.0"
 criterion = "0.4"

--- a/lsp/nls/Cargo.toml
+++ b/lsp/nls/Cargo.toml
@@ -30,7 +30,6 @@ lalrpop-util.workspace = true
 clap = { workspace = true, features = ["derive"] }
 codespan.workspace = true
 codespan-reporting.workspace = true
-codespan-lsp.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 regex.workspace = true

--- a/lsp/nls/src/cache.rs
+++ b/lsp/nls/src/cache.rs
@@ -124,12 +124,10 @@ impl CacheExt for Cache {
             .file_id(uri)?
             .ok_or_else(|| crate::error::Error::FileNotFound(uri.clone()))?;
         let pos = lsp_pos.position;
-        let idx =
-            codespan_lsp::position_to_byte_index(self.files(), file_id, &pos).map_err(|_| {
-                crate::error::Error::InvalidPosition {
-                    pos,
-                    file: uri.clone(),
-                }
+        let idx = crate::codespan_lsp::position_to_byte_index(self.files(), file_id, &pos)
+            .map_err(|_| crate::error::Error::InvalidPosition {
+                pos,
+                file: uri.clone(),
             })?;
 
         Ok(RawPos::new(file_id, ByteIndex(idx as u32)))

--- a/lsp/nls/src/codespan_lsp.rs
+++ b/lsp/nls/src/codespan_lsp.rs
@@ -1,0 +1,225 @@
+// Utilities for translating from codespan types into Language Server Protocol (LSP) types
+//
+// This file was copied (and modified) from the original in the codespan-lsp crate, which appears
+// to be abandoned. The latest upstream version is available at the link below, copyright Markus Westerlind,
+// released under the Apache-2.0 license.
+//
+// https://github.com/brendanzab/codespan/blob/ce6d0bb2ed29a27782acd21017d6a7524d36ebba/codespan-lsp/src/lib.rs
+
+use codespan_reporting::files::{Error, Files};
+use lsp_types::{Position as LspPosition, Range as LspRange};
+use std::ops::Range;
+
+fn location_to_position(
+    line_str: &str,
+    line: usize,
+    column: usize,
+    byte_index: usize,
+) -> Result<LspPosition, Error> {
+    if column > line_str.len() {
+        let max = line_str.len();
+        let given = column;
+
+        Err(Error::ColumnTooLarge { given, max })
+    } else if !line_str.is_char_boundary(column) {
+        let given = byte_index;
+
+        Err(Error::InvalidCharBoundary { given })
+    } else {
+        let line_utf16 = line_str[..column].encode_utf16();
+        let character = line_utf16.count() as u32;
+        let line = line as u32;
+
+        Ok(LspPosition { line, character })
+    }
+}
+
+pub fn byte_index_to_position<'a, F>(
+    files: &'a F,
+    file_id: F::FileId,
+    byte_index: usize,
+) -> Result<LspPosition, Error>
+where
+    F: Files<'a> + ?Sized,
+{
+    let source = files.source(file_id)?;
+    let source = source.as_ref();
+
+    let line_index = files.line_index(file_id, byte_index)?;
+    let line_span = files.line_range(file_id, line_index).unwrap();
+
+    // https://github.com/rust-lang/rust-clippy/issues/8522
+    #[allow(clippy::unnecessary_lazy_evaluations)]
+    let line_str = source
+        .get(line_span.clone())
+        .ok_or_else(|| Error::IndexTooLarge {
+            given: if line_span.start >= source.len() {
+                line_span.start
+            } else {
+                line_span.end
+            },
+            max: source.len() - 1,
+        })?;
+    let column = byte_index - line_span.start;
+
+    location_to_position(line_str, line_index, column, byte_index)
+}
+
+pub fn byte_span_to_range<'a, F>(
+    files: &'a F,
+    file_id: F::FileId,
+    span: Range<usize>,
+) -> Result<LspRange, Error>
+where
+    F: Files<'a> + ?Sized,
+{
+    Ok(LspRange {
+        start: byte_index_to_position(files, file_id, span.start)?,
+        end: byte_index_to_position(files, file_id, span.end)?,
+    })
+}
+
+fn character_to_line_offset(line: &str, character: u32) -> Result<usize, Error> {
+    let line_len = line.len();
+    let mut character_offset = 0;
+
+    let mut chars = line.chars();
+    while let Some(ch) = chars.next() {
+        if character_offset == character {
+            let chars_off = chars.as_str().len();
+            let ch_off = ch.len_utf8();
+
+            return Ok(line_len - chars_off - ch_off);
+        }
+
+        character_offset += ch.len_utf16() as u32;
+    }
+
+    // Handle positions after the last character on the line
+    if character_offset == character {
+        Ok(line_len)
+    } else {
+        Err(Error::ColumnTooLarge {
+            given: character_offset as usize,
+            max: line.len(),
+        })
+    }
+}
+
+pub fn position_to_byte_index<'a, F>(
+    files: &'a F,
+    file_id: F::FileId,
+    position: &LspPosition,
+) -> Result<usize, Error>
+where
+    F: Files<'a> + ?Sized,
+{
+    let source = files.source(file_id)?;
+    let source = source.as_ref();
+
+    let line_span = files.line_range(file_id, position.line as usize).unwrap();
+    let line_str = source.get(line_span.clone()).unwrap();
+
+    let byte_offset = character_to_line_offset(line_str, position.character)?;
+
+    Ok(line_span.start + byte_offset)
+}
+
+#[cfg(test)]
+mod tests {
+    use codespan_reporting::files::{Location, SimpleFiles};
+
+    use super::*;
+
+    #[test]
+    fn position() {
+        let text = r#"
+let test = 2
+let test1 = ""
+test
+"#;
+        let mut files = SimpleFiles::new();
+        let file_id = files.add("test", text);
+        let pos = position_to_byte_index(
+            &files,
+            file_id,
+            &LspPosition {
+                line: 3,
+                character: 2,
+            },
+        )
+        .unwrap();
+        assert_eq!(
+            Location {
+                // One-based
+                line_number: 3 + 1,
+                column_number: 2 + 1,
+            },
+            files.location(file_id, pos).unwrap()
+        );
+    }
+
+    // The protocol specifies that each `character` in position is a UTF-16 character.
+    // This means that `å` and `ä` here counts as 1 while `𐐀` counts as 2.
+    const UNICODE: &str = "åä t𐐀b";
+
+    #[test]
+    fn unicode_get_byte_index() {
+        let mut files = SimpleFiles::new();
+        let file_id = files.add("unicode", UNICODE);
+
+        let result = position_to_byte_index(
+            &files,
+            file_id,
+            &LspPosition {
+                line: 0,
+                character: 3,
+            },
+        );
+        assert_eq!(result.unwrap(), 5);
+
+        let result = position_to_byte_index(
+            &files,
+            file_id,
+            &LspPosition {
+                line: 0,
+                character: 6,
+            },
+        );
+        assert_eq!(result.unwrap(), 10);
+    }
+
+    #[test]
+    fn unicode_get_position() {
+        let mut files = SimpleFiles::new();
+        let file_id = files.add("unicode", UNICODE.to_string());
+        let file_id2 = files.add("unicode newline", "\n".to_string() + UNICODE);
+
+        let result = byte_index_to_position(&files, file_id, 5);
+        assert_eq!(
+            result.unwrap(),
+            LspPosition {
+                line: 0,
+                character: 3,
+            }
+        );
+
+        let result = byte_index_to_position(&files, file_id, 10);
+        assert_eq!(
+            result.unwrap(),
+            LspPosition {
+                line: 0,
+                character: 6,
+            }
+        );
+
+        let result = byte_index_to_position(&files, file_id2, 11);
+        assert_eq!(
+            result.unwrap(),
+            LspPosition {
+                line: 1,
+                character: 6,
+            }
+        );
+    }
+}

--- a/lsp/nls/src/main.rs
+++ b/lsp/nls/src/main.rs
@@ -8,6 +8,7 @@ use lsp_server::Connection;
 mod actions;
 mod analysis;
 mod cache;
+mod codespan_lsp;
 mod command;
 mod diagnostic;
 mod error;

--- a/lsp/nls/src/requests/symbols.rs
+++ b/lsp/nls/src/requests/symbols.rs
@@ -25,7 +25,8 @@ pub fn handle_document_symbols(
         .filter_map(|ident| {
             let (file_id, span) = ident.pos.into_opt()?.to_range();
             let range =
-                codespan_lsp::byte_span_to_range(server.cache.files(), file_id, span).ok()?;
+                crate::codespan_lsp::byte_span_to_range(server.cache.files(), file_id, span)
+                    .ok()?;
             let ty = type_lookups.idents.get(&ident);
 
             #[allow(deprecated)] // because the `deprecated` field is... wait for it... deprecated.

--- a/lsp/nls/tests/inputs/offsets.ncl
+++ b/lsp/nls/tests/inputs/offsets.ncl
@@ -1,0 +1,17 @@
+### /offsets.ncl
+{
+  foo = "𐑄𐐮𐑅 𐐰𐑊𐑁𐐰𐐺𐐯𐐻 𐐮𐑆 𐐿𐐭𐑊", bar = 1
+}.bar
+### # The "bar" in the first line is at lsp "character" 45--48,
+### # because lsp measures characters in UTF-16 codepoints 🤦
+###
+### [[request]]
+### type = "GotoDefinition"
+### textDocument.uri = "file:///offsets.ncl"
+### position = { line = 2, character = 3 }
+###
+### [[request]]
+### type = "References"
+### textDocument.uri = "file:///offsets.ncl"
+### position = { line = 1, character = 46 }
+### context = { includeDeclaration = true }

--- a/lsp/nls/tests/snapshots/main__lsp__nls__tests__inputs__offsets.ncl.snap
+++ b/lsp/nls/tests/snapshots/main__lsp__nls__tests__inputs__offsets.ncl.snap
@@ -1,0 +1,7 @@
+---
+source: lsp/nls/tests/main.rs
+expression: output
+---
+file:///offsets.ncl:1:45-1:48
+[file:///offsets.ncl:1:45-1:48]
+


### PR DESCRIPTION
The original motivation here was that I wanted to update `lsp_types` but was blocked by `codespan_lsp`'s dependency on an old version. `codespan_lsp` seems to be abandoned (along with the rest of codespan). Since it's only a few utility functions, the easiest thing was to vendor it.

While I was doing that, I noticed that we aren't correctly converting byte positions to lsp positions in some of our responses, so I fixed that.