### PR TITLE
Add `array.zip_with` and `array.imap` to the standard library

### DIFF
--- a/core/stdlib/std.ncl
+++ b/core/stdlib/std.ncl
@@ -747,6 +747,30 @@
         let last = %elem_at% array last_index in
         let rest = %array_slice% 0 last_index array in
         fold_right f last rest,
+
+    zip_with
+      : forall a b c. (a -> b -> c) -> Array a -> Array b -> Array c
+      | doc m%"
+          `zip_with f xs ys` combines the arrays `xs` and `ys` using the
+          operation `f`. The resulting array's length will be the smaller of the
+          lengths of `xs` and `ys`.
+
+          # Examples
+
+          ```nickel
+          std.array.zip_with (+) [1, 2, 3] [4, 5, 6]
+            => [5, 7, 9]
+          std.array.zip_with (*) [1, 2] [4, 5, 6]
+            => [4, 10]
+          std.array.zip_with (-) [1, 2, 3] [4, 5]
+            => [-3, -3]
+          ```
+        "%
+      = fun f xs ys =>
+        std.function.flip
+          std.array.generate
+          (std.number.min (std.array.length xs) (std.array.length ys))
+          (fun i => f (std.array.at i xs) (std.array.at i ys)),
   },
 
   contract = {

--- a/core/stdlib/std.ncl
+++ b/core/stdlib/std.ncl
@@ -771,6 +771,25 @@
           std.array.generate
           (std.number.min (std.array.length xs) (std.array.length ys))
           (fun i => f (std.array.at i xs) (std.array.at i ys)),
+
+    imap
+      : forall a b. (Number -> a -> b) -> Array a -> Array b
+      | doc m%"
+          Applies a function to every element in the given array while passing
+          its (0-based) index. That is,
+          `imap f [ x1, x2, ... ]` is `[ f 0 x1, f 1 x2, ... ]`.
+
+          # Examples
+
+          ```nickel
+          std.array.map (fun i x => i + x + 1) [ 1, 2, 3 ] =>
+            [ 2, 4, 6 ]
+          ```
+        "%
+      = fun f xs =>
+        xs
+        |> std.array.length
+        |> std.array.generate (fun i => f i (std.array.at i xs)),
   },
 
   contract = {

--- a/core/tests/integration/pass/core/arrays.ncl
+++ b/core/tests/integration/pass/core/arrays.ncl
@@ -42,5 +42,9 @@ let {check, ..} = import "../lib/assert.ncl" in
     let all = fun pred array => foldr and true (%map% array pred) in
     let isZ = fun x => x == 0 in
     all isZ [0, 0, 0, 1] == false,
+
+  std.array.zip_with (+) [1, 2, 3] [4, 5, 6] == [5, 7, 9],
+  std.array.zip_with (*) [1, 2] [4, 5, 6] == [4, 10],
+  std.array.zip_with (-) [1, 2, 3] [4, 5] == [-3, -3],
 ]
 |> check

--- a/core/tests/integration/pass/core/arrays.ncl
+++ b/core/tests/integration/pass/core/arrays.ncl
@@ -46,5 +46,7 @@ let {check, ..} = import "../lib/assert.ncl" in
   std.array.zip_with (+) [1, 2, 3] [4, 5, 6] == [5, 7, 9],
   std.array.zip_with (*) [1, 2] [4, 5, 6] == [4, 10],
   std.array.zip_with (-) [1, 2, 3] [4, 5] == [-3, -3],
+
+  std.array.imap (+) [1, 2, 3] == [1, 3, 5],
 ]
 |> check

--- a/doc/manual/merging.md
+++ b/doc/manual/merging.md
@@ -621,9 +621,9 @@ error: missing definition for `required_field2`
    8 │     & { foo.required_field1 = "here" }
      │             ------------------------ in this record
      │
-     ┌─ <stdlib/std.ncl>:2973:18
+     ┌─ <stdlib/std.ncl>:2993:18
      │
-2973 │     = fun x y => %deep_seq% x y,
+2993 │     = fun x y => %deep_seq% x y,
      │                  ------------ accessed here
 ```
 

--- a/doc/manual/merging.md
+++ b/doc/manual/merging.md
@@ -621,9 +621,9 @@ error: missing definition for `required_field2`
    8 │     & { foo.required_field1 = "here" }
      │             ------------------------ in this record
      │
-     ┌─ <stdlib/std.ncl>:2949:18
+     ┌─ <stdlib/std.ncl>:2973:18
      │
-2949 │     = fun x y => %deep_seq% x y,
+2973 │     = fun x y => %deep_seq% x y,
      │                  ------------ accessed here
 ```
 


### PR DESCRIPTION
This change adds the functions `zip_with` and`imap` to the array standard library. Both were quite useful in a recent project of mine and seem general enough to warrant inclusion.