### PR TITLE
fixed std.array.split_at behavior at right boundary.

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -66,7 +66,7 @@ nickel-lang-lsp 0.1.0
 
 To only build the main crate `nickel-lang-core`, run:
 
-```console
+```shell
 cargo build -p nickel-lang-core
 ```
 

--- a/cli/tests/snapshot/snapshots/snapshot__eval_stderr_array_at_empty_array.ncl.snap
+++ b/cli/tests/snapshot/snapshots/snapshot__eval_stderr_array_at_empty_array.ncl.snap
@@ -6,8 +6,8 @@ error: contract broken by the caller of `at`
        invalid array indexing
     ┌─ <stdlib/std.ncl>:162:9
     │
-162 │       | std.contract.unstable.IndexedArrayFun
-    │         ------------------------------------- expected type
+162 │       | std.contract.unstable.IndexedArrayFun 'Index
+    │         -------------------------------------------- expected type
     │
     ┌─ [INPUTS_PATH]/errors/array_at_empty_array.ncl:3:16
     │

--- a/cli/tests/snapshot/snapshots/snapshot__eval_stderr_array_at_out_of_bound.ncl.snap
+++ b/cli/tests/snapshot/snapshots/snapshot__eval_stderr_array_at_out_of_bound.ncl.snap
@@ -6,8 +6,8 @@ error: contract broken by the caller of `at`
        invalid array indexing
     ┌─ <stdlib/std.ncl>:162:9
     │
-162 │       | std.contract.unstable.IndexedArrayFun
-    │         ------------------------------------- expected type
+162 │       | std.contract.unstable.IndexedArrayFun 'Index
+    │         -------------------------------------------- expected type
     │
     ┌─ [INPUTS_PATH]/errors/array_at_out_of_bound.ncl:3:16
     │

--- a/core/stdlib/std.ncl
+++ b/core/stdlib/std.ncl
@@ -578,7 +578,7 @@
 
           # Preconditions
 
-          In `split_at inded value`, `index` must be a positive integer such
+          In `split_at index value`, `index` must be a positive integer such
           that `0 <= index <= std.array.length value`.
 
           # Examples

--- a/core/stdlib/std.ncl
+++ b/core/stdlib/std.ncl
@@ -1325,6 +1325,7 @@
                 (fun start => RangeSecond start -> Codomain),
 
         IndexedArrayFun
+          | [| 'Index, 'Split |] -> Dyn -> Dyn
           | doc m%"
               **Warning**: this is an unstable item. It might be renamed,
               modified or deleted in any subsequent minor Nickel version.
@@ -1379,15 +1380,13 @@
               else
                 value
             in
-            let contract
-              | [| 'Index, 'Split |] -> Dyn -> Dyn
-              = fun type label function =>
-                DependentFun
-                  ArrayIndexFirst
-                  (fun index => ArrayIndexSecond type index -> Dyn)
-                  label
-                  function
-              in contract,
+            let contract = fun type label function =>
+              DependentFun
+                ArrayIndexFirst
+                (fun index => ArrayIndexSecond type index -> Dyn)
+                label
+                function
+            in contract,
 
         ArraySliceFun
           | doc m%"

--- a/core/stdlib/std.ncl
+++ b/core/stdlib/std.ncl
@@ -1362,7 +1362,7 @@
               if %typeof% min_size == 'Number && %typeof% value == 'Array then
                 if min_size >= %length% value then
                   let index_as_str = %to_str% min_size in
-                  let max_as_str = %to_str% (%length% value - 1) in
+                  let max_as_str = %to_str% (%length% value) in
                   let note =
                     if %length% value == 0 then
                       "Can't index into an empty array"

--- a/core/stdlib/std.ncl
+++ b/core/stdlib/std.ncl
@@ -159,7 +159,7 @@
 
     at
       : forall a. Number -> Array a -> a
-      | std.contract.unstable.IndexedArrayFun
+      | std.contract.unstable.IndexedArrayFun 'Index
       | doc m%"
           Retrieves the n-th element from an array, with indices starting at 0.
 
@@ -570,7 +570,7 @@
 
     split_at
       : forall a. Number -> Array a -> { left : Array a, right : Array a }
-      | std.contract.unstable.IndexedArrayFun
+      | std.contract.unstable.IndexedArrayFun 'Split
       | doc m%"
           Splits an array in two at a given index and puts all the elements
           to the left of the element at the given index (excluded) in the
@@ -1358,11 +1358,12 @@
                 value
             in
 
-            let ArrayIndexSecond = fun min_size label value =>
+            let ArrayIndexSecond = fun type min_size label value =>
               if %typeof% min_size == 'Number && %typeof% value == 'Array then
-                if min_size >= %length% value then
+                let max_idx = type |> match { 'Index => %length% value - 1, 'Split => %length% value } in
+                if min_size > max_idx then
                   let index_as_str = %to_str% min_size in
-                  let max_as_str = %to_str% (%length% value) in
+                  let max_as_str = %to_str% max_idx in
                   let note =
                     if %length% value == 0 then
                       "Can't index into an empty array"
@@ -1378,9 +1379,15 @@
               else
                 value
             in
-            DependentFun
-              ArrayIndexFirst
-              (fun index => ArrayIndexSecond index -> Dyn),
+            let contract
+              | [| 'Index, 'Split |] -> Dyn -> Dyn
+              = fun type label function =>
+                DependentFun
+                  ArrayIndexFirst
+                  (fun index => ArrayIndexSecond type index -> Dyn)
+                  label
+                  function
+              in contract,
 
         ArraySliceFun
           | doc m%"

--- a/doc/manual/merging.md
+++ b/doc/manual/merging.md
@@ -621,9 +621,9 @@ error: missing definition for `required_field2`
    8 │     & { foo.required_field1 = "here" }
      │             ------------------------ in this record
      │
-     ┌─ <stdlib/std.ncl>:2991:18
+     ┌─ <stdlib/std.ncl>:2997:18
      │
-2991 │     = fun x y => %deep_seq% x y,
+2997 │     = fun x y => %deep_seq% x y,
      │                  ------------ accessed here
 ```
 


### PR DESCRIPTION
fixes #1802 .
