### PR TITLE
Fix typecheck bench workflow

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -82,4 +82,4 @@ jobs:
           exit $errcode
 
     - name: Typecheck benchmarks
-      run: find benches -type f -name "*.ncl" -print0 | xargs -0 -I file nix run . -- -f file typecheck
+      run: find core/benches -type f -name "*.ncl" -print0 | xargs -0 -I file nix run . -- typecheck file


### PR DESCRIPTION
The workflow was still pointing to the old file hierarchy, before we split the monolithic crate in several ones, which means that `find` wasn't finding anything and the workflow didn't actually check anything.