### PR TITLE
[WIP] Lazy Imports

### DIFF
--- a/core/benches/stdlib.rs
+++ b/core/benches/stdlib.rs
@@ -1,7 +1,7 @@
 use criterion::{criterion_group, criterion_main, Criterion};
 use pprof::criterion::{Output, PProfProfiler};
 
-use nickel_lang_core::cache::{Cache, ErrorTolerance};
+use nickel_lang_core::cache::{Cache, ErrorTolerance, SourceCache};
 
 pub fn typecheck_stdlib(c: &mut Criterion) {
     let mut cache = Cache::new(ErrorTolerance::Strict);

--- a/core/benches/stdlib.rs
+++ b/core/benches/stdlib.rs
@@ -6,7 +6,7 @@ use nickel_lang_core::cache::{Cache, ErrorTolerance};
 pub fn typecheck_stdlib(c: &mut Criterion) {
     let mut cache = Cache::new(ErrorTolerance::Strict);
     cache.load_stdlib().unwrap();
-    let type_env = cache.mk_type_ctxt().unwrap();
+    let type_env = cache.initial_type_ctxt().unwrap();
     c.bench_function("typecheck stdlib", |b| {
         b.iter_batched(
             || cache.clone(),

--- a/core/src/cache.rs
+++ b/core/src/cache.rs
@@ -247,8 +247,8 @@ impl<E> CacheError<E> {
 /// lots of cases where we want to synthesize other kinds of inputs.
 ///
 /// Note that a `SourcePath` does not uniquely identify a cached input:
-/// - Some functions (like [`Cache::add_file`]) add a new cached input unconditionally.
-/// - [`Cache::get_or_add_file`] will add a new cached input at the same `SourcePath` if
+/// - Some functions (like [`SourceCacheExt::add_file`]) add a new cached input unconditionally.
+/// - [`SourceCacheExt::get_or_add_file`] will add a new cached input at the same `SourcePath` if
 ///   the file on disk was updated.
 ///
 /// The equality checking of `SourcePath` only affects [`Cache::replace_string`], which
@@ -1116,7 +1116,7 @@ pub trait SourceCache {
 
     /// Retrieve the id of a source given a name.
     ///
-    /// Note that files added via [Self::add_file] are indexed by their full normalized path (cf
+    /// Note that files added via [SourceCacheExt::add_file] are indexed by their full normalized path (cf
     /// [normalize_path]).
     fn id_of(&self, path: &SourcePath) -> Option<FileId>;
 

--- a/core/src/cache.rs
+++ b/core/src/cache.rs
@@ -1093,7 +1093,7 @@ impl Cache {
 ///    cache, and queued somewhere so that it can undergo the standard
 ///    [transformations](crate::transform) (including import resolution) later.
 /// 2. When it is finally processed, the term cache is updated with the transformed term.
-pub trait ImportCache {
+pub trait SourceCache {
     /// Add a file to the name-id table, given a *normalized* path and an explicit timestamp.
     /// In general, prefer using `FileCacheExt::add_file`.
     fn add_file_(&mut self, path: PathBuf, timestamp: SystemTime) -> io::Result<FileId>;
@@ -1159,7 +1159,7 @@ pub trait ImportCache {
     ) -> Result<CacheOp<()>, Error>;
 }
 
-pub trait ImportCacheExt {
+pub trait SourceCacheExt {
     /// Add a file to the name-id table.
     ///
     /// Uses the normalized path and the *modified at* timestamp as the name-id table entry.
@@ -1180,7 +1180,7 @@ pub trait ImportCacheExt {
     fn get_or_add_file(&mut self, path: impl Into<OsString>) -> io::Result<CacheOp<FileId>>;
 }
 
-impl<C: ImportCache> ImportCacheExt for C {
+impl<C: SourceCache> SourceCacheExt for C {
     fn add_file(&mut self, path: impl Into<OsString>) -> io::Result<FileId> {
         let path = path.into();
         let timestamp = timestamp(&path)?;
@@ -1209,7 +1209,7 @@ impl<C: ImportCache> ImportCacheExt for C {
     }
 }
 
-impl ImportCache for Cache {
+impl SourceCache for Cache {
     fn add_file_(&mut self, path: PathBuf, timestamp: SystemTime) -> io::Result<FileId> {
         let contents = std::fs::read_to_string(&path)?;
         let file_id = self.files.add(&path, contents);
@@ -1467,7 +1467,7 @@ pub mod resolvers {
     /// import.
     pub struct DummyResolver {}
 
-    impl ImportCache for DummyResolver {
+    impl SourceCache for DummyResolver {
         fn add_file_(&mut self, _path: PathBuf, _timestamp: SystemTime) -> io::Result<FileId> {
             unimplemented!("cache::resolvers: dummy resolver should not have been invoked");
         }
@@ -1534,7 +1534,7 @@ pub mod resolvers {
         }
     }
 
-    impl ImportCache for SimpleResolver {
+    impl SourceCache for SimpleResolver {
         fn add_file_(&mut self, _path: PathBuf, _timestamp: SystemTime) -> io::Result<FileId> {
             unimplemented!("cache::resolvers::SimpleResolver cannot access the filesystem")
         }

--- a/core/src/error/mod.rs
+++ b/core/src/error/mod.rs
@@ -146,7 +146,10 @@ pub enum EvalError {
         call_stack: CallStack,
     },
     /// A non-equatable term was compared for equality.
-    EqError { eq_pos: TermPos, term: RichTerm },
+    EqError {
+        eq_pos: TermPos,
+        term: RichTerm,
+    },
     /// A value didn't match any branch of a `match` expression at runtime.
     NonExhaustiveMatch {
         /// The list of expected patterns. Currently, those are just enum tags.
@@ -165,6 +168,7 @@ pub enum EvalError {
         /// Evaluated expression
         value: RichTerm,
     },
+    ImportError(ImportError),
     /// An unexpected internal error.
     InternalError(String, TermPos),
     /// Errors occurring rarely enough to not deserve a dedicated variant.
@@ -1364,6 +1368,7 @@ impl IntoDiagnostics<FileId> for EvalError {
                     .with_message("tried to query field of a non-record")
                     .with_labels(vec![label])]
             }
+            EvalError::ImportError(err) => err.into_diagnostics(files, stdlib_ids),
         }
     }
 }

--- a/core/src/eval/mod.rs
+++ b/core/src/eval/mod.rs
@@ -786,7 +786,17 @@ impl<R: SourceCache, C: Cache> VirtualMachine<R, C> {
                 Term::LazyImport { path, parent } => {
                     match self.import_resolver.resolve(&path, parent, &pos) {
                         Ok(file_id) => {
-                            todo!();
+                            let initial_ctxt = self.import_resolver.initial_type_ctxt().expect(
+                                "the stdlib should have been loaded before ever getting here",
+                            );
+                            // TODO(vkleen): This is nonsense, the eval loop now needs to be able to return any error
+                            self.import_resolver
+                                .prepare(file_id, &initial_ctxt)
+                                .unwrap();
+                            Closure::atomic_closure(RichTerm::new(
+                                Term::ResolvedImport(file_id),
+                                pos,
+                            ))
                         }
                         Err(err) => return Err(EvalError::ImportError(err)),
                     }

--- a/core/src/eval/mod.rs
+++ b/core/src/eval/mod.rs
@@ -783,7 +783,7 @@ impl<R: ImportResolver, C: Cache> VirtualMachine<R, C> {
                         ));
                     }
                 }
-                Term::Import(path) => {
+                Term::Import { path, .. } => {
                     return Err(EvalError::InternalError(
                         format!("Unresolved import ({})", path.to_string_lossy()),
                         pos,
@@ -1120,7 +1120,7 @@ pub fn subst<C: Cache>(
         | v @ Term::Lbl(_)
         | v @ Term::SealingKey(_)
         | v @ Term::Enum(_)
-        | v @ Term::Import(_)
+        | v @ Term::Import { .. }
         | v @ Term::ResolvedImport(_)
         // We could recurse here, because types can contain terms which would then be subject to
         // substitution. Not recursing should be fine, though, because a type in term position

--- a/core/src/eval/mod.rs
+++ b/core/src/eval/mod.rs
@@ -77,7 +77,7 @@
 use crate::identifier::Ident;
 use crate::term::string::NickelString;
 use crate::{
-    cache::{Cache as FullImportCache, Envs, ImportCache},
+    cache::{Cache as ImportCache, Envs, SourceCache},
     closurize::{closurize_rec_record, Closurize},
     environment::Environment as GenericEnvironment,
     error::{Error, EvalError},
@@ -117,7 +117,7 @@ impl AsRef<Vec<StackElem>> for CallStack {
 }
 
 // The current state of the Nickel virtual machine.
-pub struct VirtualMachine<R: ImportCache, C: Cache> {
+pub struct VirtualMachine<R: SourceCache, C: Cache> {
     // The main stack, storing arguments, cache indices and pending computations.
     stack: Stack<C>,
     // The call stack, for error reporting.
@@ -132,7 +132,7 @@ pub struct VirtualMachine<R: ImportCache, C: Cache> {
     trace: Box<dyn Write>,
 }
 
-impl<R: ImportCache, C: Cache> VirtualMachine<R, C> {
+impl<R: SourceCache, C: Cache> VirtualMachine<R, C> {
     pub fn new(import_resolver: R, trace: impl Write + 'static) -> Self {
         VirtualMachine {
             import_resolver,
@@ -974,7 +974,7 @@ impl<R: ImportCache, C: Cache> VirtualMachine<R, C> {
     }
 }
 
-impl<C: Cache> VirtualMachine<FullImportCache, C> {
+impl<C: Cache> VirtualMachine<ImportCache, C> {
     /// Prepare the underlying program for evaluation (load the stdlib, typecheck, transform,
     /// etc.). Sets the initial environment of the virtual machine.
     pub fn prepare_eval(&mut self, main_id: FileId) -> Result<RichTerm, Error> {

--- a/core/src/eval/mod.rs
+++ b/core/src/eval/mod.rs
@@ -783,7 +783,10 @@ impl<R: ImportResolver, C: Cache> VirtualMachine<R, C> {
                         ));
                     }
                 }
-                Term::Import { path, .. } => {
+                Term::LazyImport { path, parent } => {
+                    todo!()
+                }
+                Term::Import { path } => {
                     return Err(EvalError::InternalError(
                         format!("Unresolved import ({})", path.to_string_lossy()),
                         pos,
@@ -1121,6 +1124,7 @@ pub fn subst<C: Cache>(
         | v @ Term::SealingKey(_)
         | v @ Term::Enum(_)
         | v @ Term::Import { .. }
+        | v @ Term::LazyImport { .. }
         | v @ Term::ResolvedImport(_)
         // We could recurse here, because types can contain terms which would then be subject to
         // substitution. Not recursing should be fine, though, because a type in term position

--- a/core/src/eval/mod.rs
+++ b/core/src/eval/mod.rs
@@ -784,7 +784,12 @@ impl<R: ImportResolver, C: Cache> VirtualMachine<R, C> {
                     }
                 }
                 Term::LazyImport { path, parent } => {
-                    todo!()
+                    match self.import_resolver.resolve(&path, parent, &pos) {
+                        Ok((_, file_id)) => {
+                            todo!();
+                        }
+                        Err(err) => return Err(EvalError::ImportError(err)),
+                    }
                 }
                 Term::Import { path } => {
                     return Err(EvalError::InternalError(

--- a/core/src/eval/operation.rs
+++ b/core/src/eval/operation.rs
@@ -9,7 +9,7 @@
 use super::{
     merge::{self, MergeMode},
     stack::StrAccData,
-    subst, Cache, Closure, Environment, ImportResolver, VirtualMachine,
+    subst, Cache, Closure, Environment, ImportCache, VirtualMachine,
 };
 
 #[cfg(feature = "nix-experimental")]
@@ -108,7 +108,7 @@ impl std::fmt::Debug for OperationCont {
     }
 }
 
-impl<R: ImportResolver, C: Cache> VirtualMachine<R, C> {
+impl<R: ImportCache, C: Cache> VirtualMachine<R, C> {
     /// Process to the next step of the evaluation of an operation.
     ///
     /// Depending on the content of the stack, it either starts the evaluation of the first

--- a/core/src/eval/operation.rs
+++ b/core/src/eval/operation.rs
@@ -9,7 +9,7 @@
 use super::{
     merge::{self, MergeMode},
     stack::StrAccData,
-    subst, Cache, Closure, Environment, ImportCache, VirtualMachine,
+    subst, Cache, Closure, Environment, SourceCache, VirtualMachine,
 };
 
 #[cfg(feature = "nix-experimental")]
@@ -108,7 +108,7 @@ impl std::fmt::Debug for OperationCont {
     }
 }
 
-impl<R: ImportCache, C: Cache> VirtualMachine<R, C> {
+impl<R: SourceCache, C: Cache> VirtualMachine<R, C> {
     /// Process to the next step of the evaluation of an operation.
     ///
     /// Depending on the content of the stack, it either starts the evaluation of the first

--- a/core/src/eval/tests.rs
+++ b/core/src/eval/tests.rs
@@ -1,7 +1,7 @@
 use super::cache::CacheImpl;
 use super::*;
 use crate::cache::resolvers::{DummyResolver, SimpleResolver};
-use crate::cache::{ImportCache, SourcePath};
+use crate::cache::{SourceCache, SourcePath};
 use crate::error::ImportError;
 use crate::label::Label;
 use crate::parser::{grammar, lexer, ErrorTolerantParser};
@@ -147,7 +147,7 @@ fn imports() {
         vm: &mut VirtualMachine<R, CacheImpl>,
     ) -> Result<RichTerm, ImportError>
     where
-        R: ImportCache,
+        R: SourceCache,
     {
         resolve_imports(
             mk_term::let_in(var, mk_term::import(import), body),

--- a/core/src/parser/grammar.lalrpop
+++ b/core/src/parser/grammar.lalrpop
@@ -249,7 +249,14 @@ UniTerm: UniTerm = {
     <err: Error> => {
         UniTerm::from(err)
     },
-    "import" <s: StandardStaticString> => UniTerm::from(Term::Import(OsString::from(s))),
+    "import" <s: StandardStaticString> => UniTerm::from(Term::Import {
+        path: OsString::from(s),
+        strict: true,
+    }),
+    "import" "lazy" <s: StandardStaticString> => UniTerm::from(Term::Import {
+        path: OsString::from(s),
+        strict: false,
+    }),
 };
 
 AnnotatedInfixExpr: UniTerm = {
@@ -1139,6 +1146,7 @@ extern {
 
         "fun" => Token::Normal(NormalToken::Fun),
         "import" => Token::Normal(NormalToken::Import),
+        "lazy" => Token::Normal(NormalToken::LazyImport),
         "|" => Token::Normal(NormalToken::Pipe),
         "|>" => Token::Normal(NormalToken::RightPipe),
         "->" => Token::Normal(NormalToken::SimpleArrow),

--- a/core/src/parser/grammar.lalrpop
+++ b/core/src/parser/grammar.lalrpop
@@ -251,11 +251,10 @@ UniTerm: UniTerm = {
     },
     "import" <s: StandardStaticString> => UniTerm::from(Term::Import {
         path: OsString::from(s),
-        strict: true,
     }),
-    "import" "lazy" <s: StandardStaticString> => UniTerm::from(Term::Import {
+    "import" "lazy" <s: StandardStaticString> => UniTerm::from(Term::LazyImport {
         path: OsString::from(s),
-        strict: false,
+        parent: None,
     }),
 };
 

--- a/core/src/parser/lexer.rs
+++ b/core/src/parser/lexer.rs
@@ -172,6 +172,8 @@ pub enum NormalToken<'input> {
     Fun,
     #[token("import")]
     Import,
+    #[token("%lazy%")]
+    LazyImport,
     #[token("|")]
     Pipe,
     #[token("|>")]

--- a/core/src/pretty.rs
+++ b/core/src/pretty.rs
@@ -924,9 +924,16 @@ where
             SealingKey(sym) => allocator.text(format!("%<sealing key: {sym}>")),
             Sealed(_i, _rt, _lbl) => allocator.text("%<sealed>"),
             Annotated(annot, rt) => allocator.atom(rt).append(annot.pretty(allocator)),
-            Import(f) => allocator
-                .text("import ")
-                .append(allocator.as_string(f.to_string_lossy()).double_quotes()),
+            Import { path, strict } => docs![
+                allocator,
+                "import ",
+                if *strict {
+                    allocator.nil()
+                } else {
+                    allocator.text("%lazy% ")
+                },
+                allocator.as_string(path.to_string_lossy()).double_quotes()
+            ],
             ResolvedImport(id) => allocator.text(format!("import <file_id: {id:?}>")),
             // This type is in term position, so we don't need to add parentheses.
             Type(ty) => ty.pretty(allocator),

--- a/core/src/pretty.rs
+++ b/core/src/pretty.rs
@@ -143,7 +143,7 @@ fn needs_parens_in_type_pos(typ: &Type) -> bool {
                 | Term::Let(..)
                 | Term::LetPattern(..)
                 | Term::Op1(UnaryOp::Ite(), _)
-                | Term::Import(..)
+                | Term::Import { .. }
                 | Term::ResolvedImport(..)
         )
     } else {

--- a/core/src/pretty.rs
+++ b/core/src/pretty.rs
@@ -924,14 +924,14 @@ where
             SealingKey(sym) => allocator.text(format!("%<sealing key: {sym}>")),
             Sealed(_i, _rt, _lbl) => allocator.text("%<sealed>"),
             Annotated(annot, rt) => allocator.atom(rt).append(annot.pretty(allocator)),
-            Import { path, strict } => docs![
+            Import { path } => docs![
                 allocator,
                 "import ",
-                if *strict {
-                    allocator.nil()
-                } else {
-                    allocator.text("%lazy% ")
-                },
+                allocator.as_string(path.to_string_lossy()).double_quotes()
+            ],
+            LazyImport { path, parent: _ } => docs![
+                allocator,
+                "import %lazy% ",
                 allocator.as_string(path.to_string_lossy()).double_quotes()
             ],
             ResolvedImport(id) => allocator.text(format!("import <file_id: {id:?}>")),

--- a/core/src/program.rs
+++ b/core/src/program.rs
@@ -212,12 +212,7 @@ impl<EC: EvalCache> Program<EC> {
         // The top-level files will always be evaluated, so strict imports are appropriate
         let merge_term = paths
             .into_iter()
-            .map(|f| {
-                RichTerm::from(Term::Import {
-                    path: f.into(),
-                    strict: true,
-                })
-            })
+            .map(|f| RichTerm::from(Term::Import { path: f.into() }))
             .reduce(|acc, f| mk_term::op2(BinaryOp::Merge(Label::default().into()), acc, f))
             .unwrap();
         let main_id = cache.add_string(

--- a/core/src/program.rs
+++ b/core/src/program.rs
@@ -438,7 +438,7 @@ impl<EC: EvalCache> Program<EC> {
     pub fn typecheck(&mut self) -> Result<(), Error> {
         self.vm.import_resolver_mut().parse(self.main_id)?;
         self.vm.import_resolver_mut().load_stdlib()?;
-        let initial_env = self.vm.import_resolver().mk_type_ctxt().expect(
+        let initial_env = self.vm.import_resolver().initial_type_ctxt().expect(
             "program::typecheck(): \
             stdlib has been loaded but was not found in cache on mk_type_ctxt()",
         );

--- a/core/src/program.rs
+++ b/core/src/program.rs
@@ -209,9 +209,15 @@ impl<EC: EvalCache> Program<EC> {
         increment!("Program::new");
         let mut cache = Cache::new(ErrorTolerance::Strict);
 
+        // The top-level files will always be evaluated, so strict imports are appropriate
         let merge_term = paths
             .into_iter()
-            .map(|f| RichTerm::from(Term::Import(f.into())))
+            .map(|f| {
+                RichTerm::from(Term::Import {
+                    path: f.into(),
+                    strict: true,
+                })
+            })
             .reduce(|acc, f| mk_term::op2(BinaryOp::Merge(Label::default().into()), acc, f))
             .unwrap();
         let main_id = cache.add_string(

--- a/core/src/repl/mod.rs
+++ b/core/src/repl/mod.rs
@@ -6,7 +6,7 @@
 //! Dually, the frontend is the user-facing part, which may be a CLI, a web application, a
 //! jupyter-kernel (which is not exactly user-facing, but still manages input/output and
 //! formatting), etc.
-use crate::cache::{Cache, Envs, ErrorTolerance, SourcePath};
+use crate::cache::{Cache, Envs, ErrorTolerance, ImportCache, ImportCacheExt, SourcePath};
 use crate::error::{
     report::{self, ColorOpt, ErrorFormat},
     Error, EvalError, IOError, IntoDiagnostics, ParseError, ParseErrors, ReplError,

--- a/core/src/repl/mod.rs
+++ b/core/src/repl/mod.rs
@@ -6,7 +6,7 @@
 //! Dually, the frontend is the user-facing part, which may be a CLI, a web application, a
 //! jupyter-kernel (which is not exactly user-facing, but still manages input/output and
 //! formatting), etc.
-use crate::cache::{Cache, Envs, ErrorTolerance, ImportCache, ImportCacheExt, SourcePath};
+use crate::cache::{Cache, Envs, ErrorTolerance, SourceCache, SourceCacheExt, SourcePath};
 use crate::error::{
     report::{self, ColorOpt, ErrorFormat},
     Error, EvalError, IOError, IntoDiagnostics, ParseError, ParseErrors, ReplError,

--- a/core/src/repl/rustyline_frontend.rs
+++ b/core/src/repl/rustyline_frontend.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 
 use super::{command::Command, *};
 
-use crate::{cache::ImportCache, error::report::ColorOpt, eval::cache::CacheImpl};
+use crate::{cache::SourceCache, error::report::ColorOpt, eval::cache::CacheImpl};
 
 use ansi_term::Style;
 use rustyline::{error::ReadlineError, Config, EditMode, Editor};

--- a/core/src/repl/rustyline_frontend.rs
+++ b/core/src/repl/rustyline_frontend.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 
 use super::{command::Command, *};
 
-use crate::{error::report::ColorOpt, eval::cache::CacheImpl};
+use crate::{cache::ImportCache, error::report::ColorOpt, eval::cache::CacheImpl};
 
 use ansi_term::Style;
 use rustyline::{error::ReadlineError, Config, EditMode, Editor};

--- a/core/src/term/mod.rs
+++ b/core/src/term/mod.rs
@@ -205,7 +205,7 @@ pub enum Term {
 
     /// An unresolved import.
     #[serde(skip)]
-    Import(OsString),
+    Import { path: OsString, strict: bool },
 
     /// A resolved import (which has already been loaded and parsed).
     #[serde(skip)]
@@ -316,7 +316,16 @@ impl PartialEq for Term {
                 l0 == r0 && l1 == r1 && l2 == r2
             }
             (Self::Annotated(l0, l1), Self::Annotated(r0, r1)) => l0 == r0 && l1 == r1,
-            (Self::Import(l0), Self::Import(r0)) => l0 == r0,
+            (
+                Self::Import {
+                    path: p0,
+                    strict: s0,
+                },
+                Self::Import {
+                    path: p1,
+                    strict: s1,
+                },
+            ) => p0 == p1 && s0 == s1,
             (Self::ResolvedImport(l0), Self::ResolvedImport(r0)) => l0 == r0,
             (Self::Type(l0), Self::Type(r0)) => l0 == r0,
             (Self::ParseError(l0), Self::ParseError(r0)) => l0 == r0,
@@ -866,7 +875,7 @@ impl Term {
             | Term::Op1(_, _)
             | Term::Op2(_, _, _)
             | Term::OpN(..)
-            | Term::Import(_)
+            | Term::Import { .. }
             | Term::ResolvedImport(_)
             | Term::StrChunks(_)
             | Term::Type(_)
@@ -916,7 +925,7 @@ impl Term {
             | Term::OpN(..)
             | Term::Sealed(..)
             | Term::Annotated(..)
-            | Term::Import(_)
+            | Term::Import { .. }
             | Term::ResolvedImport(_)
             | Term::StrChunks(_)
             | Term::RecRecord(..)
@@ -977,7 +986,7 @@ impl Term {
             | Term::OpN(..)
             | Term::Sealed(..)
             | Term::Annotated(..)
-            | Term::Import(_)
+            | Term::Import { .. }
             | Term::ResolvedImport(_)
             | Term::StrChunks(_)
             | Term::RecRecord(..)
@@ -1030,7 +1039,7 @@ impl Term {
             | Term::OpN(..)
             | Term::Sealed(..)
             | Term::Annotated(..)
-            | Term::Import(..)
+            | Term::Import { .. }
             | Term::ResolvedImport(..)
             | Term::Type(_)
             | Term::Closure(_)
@@ -2105,7 +2114,7 @@ impl Traverse<RichTerm> for RichTerm {
             | Term::Var(_)
             | Term::Closure(_)
             | Term::Enum(_)
-            | Term::Import(_)
+            | Term::Import { .. }
             | Term::ResolvedImport(_)
             | Term::SealingKey(_)
             | Term::ParseError(_)
@@ -2549,7 +2558,11 @@ pub mod make {
     where
         S: Into<OsString>,
     {
-        Term::Import(path.into()).into()
+        Term::Import {
+            path: path.into(),
+            strict: true,
+        }
+        .into()
     }
 
     pub fn integer(n: impl Into<i64>) -> RichTerm {

--- a/core/src/transform/free_vars.rs
+++ b/core/src/transform/free_vars.rs
@@ -41,7 +41,7 @@ impl CollectFreeVars for RichTerm {
             | Term::Lbl(_)
             | Term::SealingKey(_)
             | Term::Enum(_)
-            | Term::Import(_)
+            | Term::Import { .. }
             | Term::ResolvedImport(_) => (),
             Term::Fun(id, t) => {
                 let mut fresh = HashSet::new();

--- a/core/src/transform/free_vars.rs
+++ b/core/src/transform/free_vars.rs
@@ -42,6 +42,7 @@ impl CollectFreeVars for RichTerm {
             | Term::SealingKey(_)
             | Term::Enum(_)
             | Term::Import { .. }
+            | Term::LazyImport { .. }
             | Term::ResolvedImport(_) => (),
             Term::Fun(id, t) => {
                 let mut fresh = HashSet::new();

--- a/core/src/transform/import_resolution.rs
+++ b/core/src/transform/import_resolution.rs
@@ -144,7 +144,8 @@ pub mod tolerant {
     {
         let term = rt.as_ref();
         match term {
-            Term::Import(path) => match resolver.resolve(path, parent, &rt.pos) {
+            // TODO(vkleen): actually implement laziness
+            Term::Import { path, strict: _ } => match resolver.resolve(path, parent, &rt.pos) {
                 Ok((_, file_id)) => (RichTerm::new(Term::ResolvedImport(file_id), rt.pos), None),
                 Err(err) => (rt, Some(err)),
             },

--- a/core/src/transform/import_resolution.rs
+++ b/core/src/transform/import_resolution.rs
@@ -1,11 +1,11 @@
 //! Import resolution. Search for imports in the AST, load the corresponding file in the cache, and
 //! replace the original import node by a resolved import one, which stores the corresponding file
 //! identifier directly.
-use super::ImportCache;
+use super::SourceCache;
 
 /// Performs import resolution, but return an error if any import terms cannot be resolved.
 pub mod strict {
-    use super::{tolerant, ImportCache};
+    use super::{tolerant, SourceCache};
     use crate::error::ImportError;
     use crate::term::RichTerm;
     use codespan::FileId;
@@ -45,7 +45,7 @@ pub mod strict {
     /// transformations (including import resolution) on the resolved terms, if needed.
     pub fn resolve_imports<R>(rt: RichTerm, resolver: &mut R) -> Result<ResolveResult, ImportError>
     where
-        R: ImportCache,
+        R: SourceCache,
     {
         let tolerant_result = super::tolerant::resolve_imports(rt, resolver);
         match tolerant_result.import_errors.first() {
@@ -63,7 +63,7 @@ pub mod strict {
         parent: Option<FileId>,
     ) -> Result<RichTerm, ImportError>
     where
-        R: ImportCache,
+        R: SourceCache,
     {
         let (rt, error) = super::tolerant::transform_one(rt, resolver, parent);
         match error {
@@ -76,7 +76,7 @@ pub mod strict {
 /// Performs import resolution that cannot fail: it accumulates all errors and returns them
 /// together with a (partially) resolved term.
 pub mod tolerant {
-    use super::ImportCache;
+    use super::SourceCache;
     use crate::error::ImportError;
     use crate::term::{RichTerm, Term, Traverse, TraverseOrder};
     use codespan::FileId;
@@ -96,7 +96,7 @@ pub mod tolerant {
     /// Performs imports resolution in an error tolerant way.
     pub fn resolve_imports<R>(rt: RichTerm, resolver: &mut R) -> ResolveResult
     where
-        R: ImportCache,
+        R: SourceCache,
     {
         let mut stack = Vec::new();
         let mut import_errors = Vec::new();
@@ -140,7 +140,7 @@ pub mod tolerant {
         parent: Option<FileId>,
     ) -> (RichTerm, Option<ImportError>)
     where
-        R: ImportCache,
+        R: SourceCache,
     {
         let term = rt.as_ref();
         match term {

--- a/core/src/transform/mod.rs
+++ b/core/src/transform/mod.rs
@@ -1,6 +1,6 @@
 //! Various post transformations of nickel code.
 use crate::{
-    cache::ImportResolver,
+    cache::ImportCache,
     term::{RichTerm, Traverse, TraverseOrder},
     typ::UnboundTypeVariableError,
     typecheck::Wildcards,

--- a/core/src/transform/mod.rs
+++ b/core/src/transform/mod.rs
@@ -1,6 +1,6 @@
 //! Various post transformations of nickel code.
 use crate::{
-    cache::ImportCache,
+    cache::SourceCache,
     term::{RichTerm, Traverse, TraverseOrder},
     typ::UnboundTypeVariableError,
     typecheck::Wildcards,

--- a/core/src/typecheck/mod.rs
+++ b/core/src/typecheck/mod.rs
@@ -1442,7 +1442,7 @@ fn walk<V: TypecheckVisitor>(
         | Term::SealingKey(_)
         // This function doesn't recursively typecheck imports: this is the responsibility of the
         // caller.
-        | Term::Import(_)
+        | Term::Import { .. }
         | Term::ResolvedImport(_) => Ok(()),
         Term::Var(x) => ctxt.type_env
             .get(&x.ident())
@@ -2092,7 +2092,7 @@ fn check<V: TypecheckVisitor>(
             .unify(mk_uniftype::sym(), state, &ctxt)
             .map_err(|err| err.into_typecheck_err(state, rt.pos)),
         Term::Sealed(_, t, _) => check(state, ctxt, visitor, t, ty),
-        Term::Import(_) => ty
+        Term::Import { .. } => ty
             .unify(mk_uniftype::dynamic(), state, &ctxt)
             .map_err(|err| err.into_typecheck_err(state, rt.pos)),
         // We use the apparent type of the import for checking. This function doesn't recursively

--- a/core/src/typecheck/mod.rs
+++ b/core/src/typecheck/mod.rs
@@ -1443,6 +1443,7 @@ fn walk<V: TypecheckVisitor>(
         // This function doesn't recursively typecheck imports: this is the responsibility of the
         // caller.
         | Term::Import { .. }
+        | Term::LazyImport { .. }
         | Term::ResolvedImport(_) => Ok(()),
         Term::Var(x) => ctxt.type_env
             .get(&x.ident())
@@ -2093,6 +2094,9 @@ fn check<V: TypecheckVisitor>(
             .map_err(|err| err.into_typecheck_err(state, rt.pos)),
         Term::Sealed(_, t, _) => check(state, ctxt, visitor, t, ty),
         Term::Import { .. } => ty
+            .unify(mk_uniftype::dynamic(), state, &ctxt)
+            .map_err(|err| err.into_typecheck_err(state, rt.pos)),
+        Term::LazyImport { .. } => ty
             .unify(mk_uniftype::dynamic(), state, &ctxt)
             .map_err(|err| err.into_typecheck_err(state, rt.pos)),
         // We use the apparent type of the import for checking. This function doesn't recursively

--- a/core/src/typecheck/mod.rs
+++ b/core/src/typecheck/mod.rs
@@ -54,7 +54,7 @@
 //! In walk mode, the type of let-bound expressions is inferred in a shallow way (see
 //! [`apparent_type`]).
 use crate::{
-    cache::ImportCache,
+    cache::SourceCache,
     environment::Environment as GenericEnvironment,
     error::TypecheckError,
     identifier::{Ident, LocIdent},
@@ -1300,7 +1300,7 @@ pub fn env_add_term(
     env: &mut Environment,
     rt: &RichTerm,
     term_env: &SimpleTermEnvironment,
-    resolver: &dyn ImportCache,
+    resolver: &dyn SourceCache,
 ) -> Result<(), EnvBuildError> {
     let RichTerm { term, pos } = rt;
 
@@ -1326,7 +1326,7 @@ pub fn env_add(
     id: LocIdent,
     rt: &RichTerm,
     term_env: &SimpleTermEnvironment,
-    resolver: &dyn ImportCache,
+    resolver: &dyn SourceCache,
 ) {
     env.insert(
         id.ident(),
@@ -1340,7 +1340,7 @@ pub fn env_add(
 /// The shared state of unification.
 pub struct State<'a> {
     /// The import resolver, to retrieve and typecheck imports.
-    resolver: &'a dyn ImportCache,
+    resolver: &'a dyn SourceCache,
     /// The unification table.
     table: &'a mut UnifTable,
     /// Row constraints.
@@ -1375,7 +1375,7 @@ pub struct TypeTables {
 pub fn type_check(
     t: &RichTerm,
     initial_ctxt: Context,
-    resolver: &impl ImportCache,
+    resolver: &impl SourceCache,
 ) -> Result<Wildcards, TypecheckError> {
     type_check_with_visitor(t, initial_ctxt, resolver, &mut ()).map(|tables| tables.wildcards)
 }
@@ -1384,7 +1384,7 @@ pub fn type_check(
 pub fn type_check_with_visitor<V>(
     t: &RichTerm,
     initial_ctxt: Context,
-    resolver: &impl ImportCache,
+    resolver: &impl SourceCache,
     visitor: &mut V,
 ) -> Result<TypeTables, TypecheckError>
 where
@@ -2525,7 +2525,7 @@ impl From<ApparentType> for Type {
 fn field_apparent_type(
     field: &Field,
     env: Option<&Environment>,
-    resolver: Option<&dyn ImportCache>,
+    resolver: Option<&dyn SourceCache>,
 ) -> ApparentType {
     field
         .metadata
@@ -2561,7 +2561,7 @@ fn field_apparent_type(
 pub fn apparent_type(
     t: &Term,
     env: Option<&Environment>,
-    resolver: Option<&dyn ImportCache>,
+    resolver: Option<&dyn SourceCache>,
 ) -> ApparentType {
     use codespan::FileId;
 
@@ -2579,7 +2579,7 @@ pub fn apparent_type(
     fn apparent_type_check_cycle(
         t: &Term,
         env: Option<&Environment>,
-        resolver: Option<&dyn ImportCache>,
+        resolver: Option<&dyn SourceCache>,
         mut imports_seen: HashSet<FileId>,
     ) -> ApparentType {
         match t {

--- a/core/src/typecheck/mod.rs
+++ b/core/src/typecheck/mod.rs
@@ -54,7 +54,7 @@
 //! In walk mode, the type of let-bound expressions is inferred in a shallow way (see
 //! [`apparent_type`]).
 use crate::{
-    cache::ImportResolver,
+    cache::ImportCache,
     environment::Environment as GenericEnvironment,
     error::TypecheckError,
     identifier::{Ident, LocIdent},
@@ -1300,7 +1300,7 @@ pub fn env_add_term(
     env: &mut Environment,
     rt: &RichTerm,
     term_env: &SimpleTermEnvironment,
-    resolver: &dyn ImportResolver,
+    resolver: &dyn ImportCache,
 ) -> Result<(), EnvBuildError> {
     let RichTerm { term, pos } = rt;
 
@@ -1326,7 +1326,7 @@ pub fn env_add(
     id: LocIdent,
     rt: &RichTerm,
     term_env: &SimpleTermEnvironment,
-    resolver: &dyn ImportResolver,
+    resolver: &dyn ImportCache,
 ) {
     env.insert(
         id.ident(),
@@ -1340,7 +1340,7 @@ pub fn env_add(
 /// The shared state of unification.
 pub struct State<'a> {
     /// The import resolver, to retrieve and typecheck imports.
-    resolver: &'a dyn ImportResolver,
+    resolver: &'a dyn ImportCache,
     /// The unification table.
     table: &'a mut UnifTable,
     /// Row constraints.
@@ -1375,7 +1375,7 @@ pub struct TypeTables {
 pub fn type_check(
     t: &RichTerm,
     initial_ctxt: Context,
-    resolver: &impl ImportResolver,
+    resolver: &impl ImportCache,
 ) -> Result<Wildcards, TypecheckError> {
     type_check_with_visitor(t, initial_ctxt, resolver, &mut ()).map(|tables| tables.wildcards)
 }
@@ -1384,7 +1384,7 @@ pub fn type_check(
 pub fn type_check_with_visitor<V>(
     t: &RichTerm,
     initial_ctxt: Context,
-    resolver: &impl ImportResolver,
+    resolver: &impl ImportCache,
     visitor: &mut V,
 ) -> Result<TypeTables, TypecheckError>
 where
@@ -2525,7 +2525,7 @@ impl From<ApparentType> for Type {
 fn field_apparent_type(
     field: &Field,
     env: Option<&Environment>,
-    resolver: Option<&dyn ImportResolver>,
+    resolver: Option<&dyn ImportCache>,
 ) -> ApparentType {
     field
         .metadata
@@ -2561,7 +2561,7 @@ fn field_apparent_type(
 pub fn apparent_type(
     t: &Term,
     env: Option<&Environment>,
-    resolver: Option<&dyn ImportResolver>,
+    resolver: Option<&dyn ImportCache>,
 ) -> ApparentType {
     use codespan::FileId;
 
@@ -2579,7 +2579,7 @@ pub fn apparent_type(
     fn apparent_type_check_cycle(
         t: &Term,
         env: Option<&Environment>,
-        resolver: Option<&dyn ImportResolver>,
+        resolver: Option<&dyn ImportCache>,
         mut imports_seen: HashSet<FileId>,
     ) -> ApparentType {
         match t {

--- a/core/tests/integration/inputs/imports/lazy_import.ncl
+++ b/core/tests/integration/inputs/imports/lazy_import.ncl
@@ -1,0 +1,7 @@
+# test.type = 'pass'
+
+let {check, ..} = import "../pass/lib/assert.ncl" in
+[
+  (import %lazy% "imported/empty.yaml") == null,
+]
+|> check

--- a/core/tests/integration/inputs/imports/lazy_import.ncl
+++ b/core/tests/integration/inputs/imports/lazy_import.ncl
@@ -1,6 +1,6 @@
 # test.type = 'pass'
 
-let {check, ..} = import "../pass/lib/assert.ncl" in
+let {check, ..} = import "../lib/assert.ncl" in
 [
   (import %lazy% "imported/empty.yaml") == null,
 ]

--- a/core/tests/integration/main.rs
+++ b/core/tests/integration/main.rs
@@ -246,7 +246,7 @@ impl PartialEq<Error> for ErrorExpectation {
                 Error::TypecheckError(TypecheckError::FlatTypeInTermPosition { .. }),
             )
             | (ImportParseError, Error::ImportError(ImportError::ParseErrors(..)))
-            | (ImportIoError, Error::ImportError(ImportError::IOError(..)))
+            | (ImportIoError, Error::ImportError(ImportError::IOError { .. }))
             | (
                 SerializeNumberOutOfRange,
                 Error::EvalError(EvalError::SerializationError(ExportError::NumberOutOfRange {

--- a/lsp/nls/src/cache.rs
+++ b/lsp/nls/src/cache.rs
@@ -2,7 +2,7 @@ use codespan::{ByteIndex, FileId};
 use lsp_types::{TextDocumentPositionParams, Url};
 use nickel_lang_core::term::{RichTerm, Term, Traverse};
 use nickel_lang_core::{
-    cache::{Cache, CacheError, CacheOp, EntryState, SourcePath, TermEntry},
+    cache::{Cache, CacheError, CacheOp, EntryState, ImportCache, SourcePath, TermEntry},
     error::{Error, ImportError},
     position::RawPos,
     typecheck::{self},
@@ -97,8 +97,11 @@ impl CacheExt for Cache {
                         _ => None,
                     })
                     .unwrap_or_default();
-                let name: String = self.name(id).to_str().unwrap().into();
-                ImportError::IOError(name, String::from(message), pos)
+                ImportError::IOError {
+                    path: self.name(id).to_owned(),
+                    message: String::from(message),
+                    pos,
+                }
             });
             import_errors.extend(typecheck_import_diagnostics);
 

--- a/lsp/nls/src/cache.rs
+++ b/lsp/nls/src/cache.rs
@@ -2,7 +2,7 @@ use codespan::{ByteIndex, FileId};
 use lsp_types::{TextDocumentPositionParams, Url};
 use nickel_lang_core::term::{RichTerm, Term, Traverse};
 use nickel_lang_core::{
-    cache::{Cache, CacheError, CacheOp, EntryState, ImportCache, SourcePath, TermEntry},
+    cache::{Cache, CacheError, CacheOp, EntryState, SourceCache, SourcePath, TermEntry},
     error::{Error, ImportError},
     position::RawPos,
     typecheck::{self},

--- a/lsp/nls/src/files.rs
+++ b/lsp/nls/src/files.rs
@@ -10,7 +10,7 @@ use lsp_types::{
     DidChangeTextDocumentParams, DidOpenTextDocumentParams, Url,
 };
 use nickel_lang_core::{
-    cache::{CacheError, CacheOp, ImportCache, SourcePath},
+    cache::{CacheError, CacheOp, SourceCache, SourcePath},
     error::{ImportError, IntoDiagnostics},
 };
 

--- a/lsp/nls/src/files.rs
+++ b/lsp/nls/src/files.rs
@@ -10,7 +10,7 @@ use lsp_types::{
     DidChangeTextDocumentParams, DidOpenTextDocumentParams, Url,
 };
 use nickel_lang_core::{
-    cache::{CacheError, CacheOp, SourcePath},
+    cache::{CacheError, CacheOp, ImportCache, SourcePath},
     error::{ImportError, IntoDiagnostics},
 };
 
@@ -127,8 +127,10 @@ pub fn handle_save(server: &mut Server, params: DidChangeTextDocumentParams) -> 
 
 // Make a record of I/O errors in imports so that we can retry them when appropriate.
 fn associate_failed_import(server: &mut Server, err: &nickel_lang_core::error::Error) {
-    if let nickel_lang_core::error::Error::ImportError(ImportError::IOError(name, _, pos)) = &err {
-        if let Some((filename, pos)) = PathBuf::from(name).file_name().zip(pos.into_opt()) {
+    if let nickel_lang_core::error::Error::ImportError(ImportError::IOError { path, pos, .. }) =
+        &err
+    {
+        if let Some((filename, pos)) = PathBuf::from(path).file_name().zip(pos.into_opt()) {
             server
                 .failed_imports
                 .entry(filename.to_owned())

--- a/lsp/nls/src/incomplete.rs
+++ b/lsp/nls/src/incomplete.rs
@@ -8,7 +8,7 @@
 use std::path::PathBuf;
 
 use nickel_lang_core::{
-    cache::SourcePath,
+    cache::{ImportCache, SourcePath},
     parser::lexer::{self, NormalToken, SpannedToken, Token},
     position::RawSpan,
     term::{RichTerm, Term},

--- a/lsp/nls/src/incomplete.rs
+++ b/lsp/nls/src/incomplete.rs
@@ -8,7 +8,7 @@
 use std::path::PathBuf;
 
 use nickel_lang_core::{
-    cache::{ImportCache, SourcePath},
+    cache::{SourceCache, SourcePath},
     parser::lexer::{self, NormalToken, SpannedToken, Token},
     position::RawSpan,
     term::{RichTerm, Term},

--- a/lsp/nls/src/requests/completion.rs
+++ b/lsp/nls/src/requests/completion.rs
@@ -172,11 +172,12 @@ pub fn handle_completion(
 
     let term = server.lookup_term_by_position(pos)?.cloned();
 
-    if let Some(Term::Import(import)) = term.as_ref().map(|t| t.term.as_ref()) {
+    // TODO(vkleen): we need to decide if laziness of imports will be respected by the LSP
+    if let Some(Term::Import { path, strict: _ }) = term.as_ref().map(|t| t.term.as_ref()) {
         // Don't respond with anything if trigger is a `.`, as that may be the
         // start of a relative file path `./`, or the start of a file extension
         if !matches!(trigger, Some(".")) {
-            let completions = handle_import_completion(import, &params, server).unwrap_or_default();
+            let completions = handle_import_completion(path, &params, server).unwrap_or_default();
             server.reply(Response::new_ok(id.clone(), completions));
         }
         return Ok(());

--- a/lsp/nls/src/requests/completion.rs
+++ b/lsp/nls/src/requests/completion.rs
@@ -173,7 +173,9 @@ pub fn handle_completion(
     let term = server.lookup_term_by_position(pos)?.cloned();
 
     // TODO(vkleen): we need to decide if laziness of imports will be respected by the LSP
-    if let Some(Term::Import { path, strict: _ }) = term.as_ref().map(|t| t.term.as_ref()) {
+    if let Some(Term::Import { path } | Term::LazyImport { path, .. }) =
+        term.as_ref().map(|t| t.term.as_ref())
+    {
         // Don't respond with anything if trigger is a `.`, as that may be the
         // start of a relative file path `./`, or the start of a file extension
         if !matches!(trigger, Some(".")) {

--- a/lsp/nls/src/requests/formatting.rs
+++ b/lsp/nls/src/requests/formatting.rs
@@ -1,6 +1,6 @@
 use lsp_server::{RequestId, Response, ResponseError};
 use lsp_types::{DocumentFormattingParams, Position, Range, TextEdit};
-use nickel_lang_core::cache::{ImportCache, SourcePath};
+use nickel_lang_core::cache::{SourceCache, SourcePath};
 
 use crate::{error::Error, files::uri_to_path, server::Server};
 

--- a/lsp/nls/src/requests/formatting.rs
+++ b/lsp/nls/src/requests/formatting.rs
@@ -1,6 +1,6 @@
 use lsp_server::{RequestId, Response, ResponseError};
 use lsp_types::{DocumentFormattingParams, Position, Range, TextEdit};
-use nickel_lang_core::cache::SourcePath;
+use nickel_lang_core::cache::{ImportCache, SourcePath};
 
 use crate::{error::Error, files::uri_to_path, server::Server};
 

--- a/lsp/nls/src/requests/symbols.rs
+++ b/lsp/nls/src/requests/symbols.rs
@@ -1,6 +1,6 @@
 use lsp_server::{RequestId, Response, ResponseError};
 use lsp_types::{DocumentSymbol, DocumentSymbolParams, SymbolKind};
-use nickel_lang_core::cache::SourcePath;
+use nickel_lang_core::cache::{ImportCache, SourcePath};
 use nickel_lang_core::typ::Type;
 
 use crate::server::Server;

--- a/lsp/nls/src/requests/symbols.rs
+++ b/lsp/nls/src/requests/symbols.rs
@@ -1,6 +1,6 @@
 use lsp_server::{RequestId, Response, ResponseError};
 use lsp_types::{DocumentSymbol, DocumentSymbolParams, SymbolKind};
-use nickel_lang_core::cache::{ImportCache, SourcePath};
+use nickel_lang_core::cache::{SourceCache, SourcePath};
 use nickel_lang_core::typ::Type;
 
 use crate::server::Server;

--- a/lsp/nls/src/server.rs
+++ b/lsp/nls/src/server.rs
@@ -23,7 +23,7 @@ use lsp_types::{
 };
 
 use nickel_lang_core::{
-    cache::{Cache, ErrorTolerance},
+    cache::{Cache, ErrorTolerance, SourceCache},
     position::{RawPos, RawSpan, TermPos},
     stdlib::StdlibModule,
     term::{record::FieldMetadata, RichTerm, Term, UnaryOp},
@@ -105,7 +105,7 @@ impl Server {
 
         // We don't recover from failing to load the stdlib for now.
         cache.load_stdlib().unwrap();
-        let initial_ctxt = cache.mk_type_ctxt().unwrap();
+        let initial_ctxt = cache.initial_type_ctxt().unwrap();
         Server {
             connection,
             cache,

--- a/utils/src/bench.rs
+++ b/utils/src/bench.rs
@@ -1,6 +1,6 @@
 use criterion::Criterion;
 use nickel_lang_core::{
-    cache::{Cache, Envs, ErrorTolerance},
+    cache::{Cache, Envs, ErrorTolerance, ImportCache, ImportCacheExt},
     eval::{
         cache::{Cache as EvalCache, CacheImpl},
         VirtualMachine,
@@ -171,7 +171,7 @@ macro_rules! ncl_bench_group {
     (name = $group_name:ident; config = $config:expr; $($b:tt),+ $(,)*) => {
         pub fn $group_name() {
             use nickel_lang_core::{
-                cache::{Envs, Cache, ErrorTolerance, ImportResolver},
+                cache::{Envs, Cache, ErrorTolerance, ImportCache, ImportCacheExt},
                 eval::{VirtualMachine, cache::{CacheImpl, Cache as EvalCache}},
                 transform::import_resolution::strict::resolve_imports,
                 error::report::{report, ColorOpt, ErrorFormat},

--- a/utils/src/bench.rs
+++ b/utils/src/bench.rs
@@ -1,6 +1,6 @@
 use criterion::Criterion;
 use nickel_lang_core::{
-    cache::{Cache, Envs, ErrorTolerance, ImportCache, ImportCacheExt},
+    cache::{Cache, Envs, ErrorTolerance, SourceCache, SourceCacheExt},
     eval::{
         cache::{Cache as EvalCache, CacheImpl},
         VirtualMachine,
@@ -171,7 +171,7 @@ macro_rules! ncl_bench_group {
     (name = $group_name:ident; config = $config:expr; $($b:tt),+ $(,)*) => {
         pub fn $group_name() {
             use nickel_lang_core::{
-                cache::{Envs, Cache, ErrorTolerance, ImportCache, ImportCacheExt},
+                cache::{Envs, Cache, ErrorTolerance, SourceCache, SourceCacheExt},
                 eval::{VirtualMachine, cache::{CacheImpl, Cache as EvalCache}},
                 transform::import_resolution::strict::resolve_imports,
                 error::report::{report, ColorOpt, ErrorFormat},


### PR DESCRIPTION
Implement a prototype solution for lazy imports. This feature can, for now,
be accessed via the intentionally annoying syntax `import %lazy% "..."`.
Semantically, the intention is to delay any filesystem actions for the import
until evaluation actually demands its value. In particular, the exitence of the
imported file is not checked. For typechecking purposes, a lazy import always
gets assigned type `Dyn`. Apart from these two differences, lazy imports are
supposed to act exctly like normal imports when they get evaluated.

## To be done

- [x] Actually support lazy imports during evaluation
- [ ] Actually support lazy imports during evaluation without panicing on errors
- [ ] Make the import cache abstraction more modular
