### PR TITLE
Rename LSP action

### DIFF
--- a/lsp/lsp-harness/src/lib.rs
+++ b/lsp/lsp-harness/src/lib.rs
@@ -10,10 +10,10 @@ use lsp_types::{
     notification::{Notification, PublishDiagnostics},
     request::{
         Completion, DocumentSymbolRequest, Formatting, GotoDefinition, HoverRequest, References,
-        Request as LspRequest,
+        Rename, Request as LspRequest,
     },
     CompletionParams, DocumentFormattingParams, DocumentSymbolParams, GotoDefinitionParams,
-    HoverParams, PublishDiagnosticsParams, ReferenceParams, Url,
+    HoverParams, PublishDiagnosticsParams, ReferenceParams, RenameParams, Url,
 };
 pub use output::LspDebug;
 use serde::Deserialize;
@@ -43,6 +43,7 @@ pub enum Request {
     Completion(CompletionParams),
     Formatting(DocumentFormattingParams),
     Hover(HoverParams),
+    Rename(RenameParams),
     Symbols(DocumentSymbolParams),
 }
 
@@ -142,6 +143,7 @@ impl TestHarness {
             Request::Formatting(f) => self.request::<Formatting>(f),
             Request::Hover(h) => self.request::<HoverRequest>(h),
             Request::References(r) => self.request::<References>(r),
+            Request::Rename(r) => self.request::<Rename>(r),
             Request::Symbols(s) => self.request::<DocumentSymbolRequest>(s),
         }
     }

--- a/lsp/lsp-harness/src/output.rs
+++ b/lsp/lsp-harness/src/output.rs
@@ -4,7 +4,7 @@
 
 use std::io::Write;
 
-use lsp_types::{DocumentSymbolResponse, GotoDefinitionResponse};
+use lsp_types::{DocumentSymbolResponse, GotoDefinitionResponse, WorkspaceEdit};
 
 pub trait LspDebug {
     fn debug(&self, w: impl Write) -> std::io::Result<()>;
@@ -54,6 +54,12 @@ impl<T: LspDebug> LspDebug for Vec<T> {
     }
 }
 
+impl<S: LspDebug, T: LspDebug> LspDebug for (S, T) {
+    fn debug(&self, mut w: impl Write) -> std::io::Result<()> {
+        write!(w, "({}, {})", self.0.debug_str(), self.1.debug_str())
+    }
+}
+
 impl LspDebug for lsp_types::Range {
     fn debug(&self, mut w: impl Write) -> std::io::Result<()> {
         write!(
@@ -61,6 +67,12 @@ impl LspDebug for lsp_types::Range {
             "{}:{}-{}:{}",
             self.start.line, self.start.character, self.end.line, self.end.character
         )
+    }
+}
+
+impl LspDebug for lsp_types::Url {
+    fn debug(&self, mut w: impl Write) -> std::io::Result<()> {
+        write!(w, "{}", self.as_str())
     }
 }
 
@@ -186,5 +198,13 @@ impl LspDebug for DocumentSymbolResponse {
             DocumentSymbolResponse::Flat(xs) => xs.debug(w),
             DocumentSymbolResponse::Nested(xs) => xs.debug(w),
         }
+    }
+}
+
+impl LspDebug for WorkspaceEdit {
+    fn debug(&self, w: impl Write) -> std::io::Result<()> {
+        let changes = self.changes.clone();
+        let changes = changes.into_iter().flatten().collect::<Vec<_>>();
+        changes.debug(w)
     }
 }

--- a/lsp/lsp-harness/src/output.rs
+++ b/lsp/lsp-harness/src/output.rs
@@ -204,7 +204,9 @@ impl LspDebug for DocumentSymbolResponse {
 impl LspDebug for WorkspaceEdit {
     fn debug(&self, w: impl Write) -> std::io::Result<()> {
         let changes = self.changes.clone();
-        let changes = changes.into_iter().flatten().collect::<Vec<_>>();
+        let mut changes = changes.into_iter().flatten().collect::<Vec<_>>();
+        // Sort the keys, for determinism
+        changes.sort_by_key(|(url, _)| url.clone());
         changes.debug(w)
     }
 }

--- a/lsp/nls/src/requests/mod.rs
+++ b/lsp/nls/src/requests/mod.rs
@@ -1,6 +1,7 @@
 pub mod completion;
 pub mod goto;
 pub mod hover;
+pub mod rename;
 pub mod symbols;
 
 #[cfg(feature = "format")]

--- a/lsp/nls/src/requests/rename.rs
+++ b/lsp/nls/src/requests/rename.rs
@@ -1,0 +1,59 @@
+use std::collections::HashMap;
+
+use lsp_server::{RequestId, Response, ResponseError};
+use lsp_types::{Range, RenameParams, TextEdit, Url, WorkspaceEdit};
+use nickel_lang_core::term::{RichTerm, Term, UnaryOp};
+
+use crate::cache::CacheExt as _;
+use crate::diagnostic::LocationCompat;
+use crate::requests::goto::get_defs;
+use crate::server::Server;
+
+pub fn handle_rename(
+    params: RenameParams,
+    id: RequestId,
+    server: &mut Server,
+) -> Result<(), ResponseError> {
+    let pos = server.cache.position(&params.text_document_position)?;
+
+    let ident = server.lookup_ident_by_position(pos)?;
+    let term = server.lookup_term_by_position(pos)?;
+    let mut def_locs = term
+        .and_then(|term| get_defs(term, ident, server))
+        .unwrap_or_default();
+    def_locs.extend(ident.and_then(|id| id.pos.into_opt()));
+    if let Some(Term::Op1(UnaryOp::StaticAccess(id), _)) = term.map(RichTerm::as_ref) {
+        def_locs.extend(id.pos.into_opt());
+    }
+
+    let mut all_positions: Vec<_> = def_locs
+        .iter()
+        .flat_map(|id| server.analysis.get_usages(id))
+        .filter_map(|id| id.pos.into_opt())
+        .chain(def_locs.iter().copied())
+        .collect();
+
+    // Sort in some arbitrary order, for determinism and deduplication.
+    all_positions.sort_by_key(|span| (span.src_id, span.start, span.end));
+    all_positions.dedup();
+
+    // Group edits by file
+    let mut changes = HashMap::<Url, Vec<TextEdit>>::new();
+    for pos in all_positions {
+        let url = Url::from_file_path(server.cache.files().name(pos.src_id)).unwrap();
+        changes.entry(url).or_default().push(TextEdit {
+            range: Range::from_span(&pos, server.cache.files()),
+            new_text: params.new_name.clone(),
+        });
+    }
+
+    server.reply(Response::new_ok(
+        id,
+        WorkspaceEdit {
+            changes: Some(changes),
+            document_changes: None,
+            change_annotations: None,
+        },
+    ));
+    Ok(())
+}

--- a/lsp/nls/src/server.rs
+++ b/lsp/nls/src/server.rs
@@ -17,7 +17,7 @@ use lsp_types::{
     CodeActionParams, CompletionOptions, CompletionParams, DidChangeTextDocumentParams,
     DidOpenTextDocumentParams, DocumentFormattingParams, DocumentSymbolParams,
     ExecuteCommandParams, GotoDefinitionParams, HoverOptions, HoverParams, HoverProviderCapability,
-    OneOf, PublishDiagnosticsParams, ReferenceParams, ServerCapabilities,
+    OneOf, PublishDiagnosticsParams, ReferenceParams, RenameParams, ServerCapabilities,
     TextDocumentSyncCapability, TextDocumentSyncKind, TextDocumentSyncOptions, Url,
     WorkDoneProgressOptions,
 };
@@ -39,7 +39,7 @@ use crate::{
     field_walker::{Def, FieldResolver},
     identifier::LocIdent,
     pattern::Bindings,
-    requests::{completion, formatting, goto, hover, symbols},
+    requests::{completion, formatting, goto, hover, rename, symbols},
     trace::Trace,
 };
 
@@ -93,6 +93,7 @@ impl Server {
                 commands: vec!["eval".to_owned()],
                 ..Default::default()
             }),
+            rename_provider: Some(OneOf::Left(true)),
             ..ServerCapabilities::default()
         }
     }
@@ -286,6 +287,12 @@ impl Server {
                 debug!("command");
                 let params: ExecuteCommandParams = serde_json::from_value(req.params).unwrap();
                 command::handle_command(params, req.id.clone(), self)
+            }
+
+            Rename::METHOD => {
+                debug!("rename");
+                let params: RenameParams = serde_json::from_value(req.params).unwrap();
+                rename::handle_rename(params, req.id.clone(), self)
             }
 
             _ => Ok(()),

--- a/lsp/nls/tests/inputs/rename.ncl
+++ b/lsp/nls/tests/inputs/rename.ncl
@@ -1,0 +1,55 @@
+### /base.ncl
+let foo = import "dep.ncl" in
+{
+    x = foo.included,
+    y = { foo = x },
+}
+### /dep.ncl
+{
+  included = 5
+}
+### # Rename foo to a bar (but not the "foo" in "foo = x")
+### [[request]]
+### type = "Rename"
+### textDocument.uri = "file:///base.ncl"
+### position = { line = 0, character = 5 }
+### newName = "bar"
+###
+### [[request]]
+### type = "Rename"
+### textDocument.uri = "file:///base.ncl"
+### position = { line = 2, character = 9 }
+### newName = "bar"
+###
+### # Rename "foo" in "foo = x" (shouldn't rename the others)
+### [[request]]
+### type = "Rename"
+### textDocument.uri = "file:///base.ncl"
+### position = { line = 3, character = 11 }
+### newName = "baz"
+###
+### # Rename x to y
+### [[request]]
+### type = "Rename"
+### textDocument.uri = "file:///base.ncl"
+### position = { line = 2, character = 4 }
+### newName = "y"
+###
+### [[request]]
+### type = "Rename"
+### textDocument.uri = "file:///base.ncl"
+### position = { line = 3, character = 16 }
+### newName = "y"
+###
+### # Cross-file rename
+### [[request]]
+### type = "Rename"
+### textDocument.uri = "file:///base.ncl"
+### position = { line = 2, character = 15 }
+### newName = "dependency"
+###
+### [[request]]
+### type = "Rename"
+### textDocument.uri = "file:///dep.ncl"
+### position = { line = 1, character = 5 }
+### newName = "dependency"

--- a/lsp/nls/tests/snapshots/main__lsp__nls__tests__inputs__rename.ncl.snap
+++ b/lsp/nls/tests/snapshots/main__lsp__nls__tests__inputs__rename.ncl.snap
@@ -7,6 +7,6 @@ expression: output
 [(file:///base.ncl, [<3:10-3:13> baz])]
 [(file:///base.ncl, [<2:4-2:5> y, <3:16-3:17> y])]
 [(file:///base.ncl, [<2:4-2:5> y, <3:16-3:17> y])]
-[(file:///dep.ncl, [<1:2-1:10> dependency]), (file:///base.ncl, [<2:12-2:20> dependency])]
-[(file:///dep.ncl, [<1:2-1:10> dependency]), (file:///base.ncl, [<2:12-2:20> dependency])]
+[(file:///base.ncl, [<2:12-2:20> dependency]), (file:///dep.ncl, [<1:2-1:10> dependency])]
+[(file:///base.ncl, [<2:12-2:20> dependency]), (file:///dep.ncl, [<1:2-1:10> dependency])]
 

--- a/lsp/nls/tests/snapshots/main__lsp__nls__tests__inputs__rename.ncl.snap
+++ b/lsp/nls/tests/snapshots/main__lsp__nls__tests__inputs__rename.ncl.snap
@@ -1,0 +1,12 @@
+---
+source: lsp/nls/tests/main.rs
+expression: output
+---
+[(file:///base.ncl, [<0:4-0:7> bar, <2:8-2:11> bar])]
+[(file:///base.ncl, [<0:4-0:7> bar, <2:8-2:11> bar])]
+[(file:///base.ncl, [<3:10-3:13> baz])]
+[(file:///base.ncl, [<2:4-2:5> y, <3:16-3:17> y])]
+[(file:///base.ncl, [<2:4-2:5> y, <3:16-3:17> y])]
+[(file:///dep.ncl, [<1:2-1:10> dependency]), (file:///base.ncl, [<2:12-2:20> dependency])]
+[(file:///dep.ncl, [<1:2-1:10> dependency]), (file:///base.ncl, [<2:12-2:20> dependency])]
+


### PR DESCRIPTION
Adds a "rename" action for the LSP. The current behavior is that it renames exactly the same locations that are returned by "references"; I think this is probably the most predictable behavior, but we can tweak it if it turns out not to be.

Fixes #1776 