### PR TITLE
ADT destructuring

### DIFF
--- a/core/src/eval/operation.rs
+++ b/core/src/eval/operation.rs
@@ -1136,6 +1136,13 @@ impl<R: ImportResolver, C: Cache> VirtualMachine<R, C> {
                     ))
                 }
             }
+            UnaryOp::EnumUnwrapVariant() => {
+                if let Term::EnumVariant { arg, ..} = &*t {
+                    Ok(Closure { body: arg.clone(), env })
+                } else {
+                    Err(mk_type_error!("enum_unwrap_variant", "Enum variant"))
+                }
+            }
         }
     }
 

--- a/core/src/eval/operation.rs
+++ b/core/src/eval/operation.rs
@@ -1137,11 +1137,31 @@ impl<R: ImportResolver, C: Cache> VirtualMachine<R, C> {
                 }
             }
             UnaryOp::EnumUnwrapVariant() => {
-                if let Term::EnumVariant { arg, ..} = &*t {
-                    Ok(Closure { body: arg.clone(), env })
+                if let Term::EnumVariant { arg, .. } = &*t {
+                    Ok(Closure {
+                        body: arg.clone(),
+                        env,
+                    })
                 } else {
                     Err(mk_type_error!("enum_unwrap_variant", "Enum variant"))
                 }
+            }
+            UnaryOp::EnumGetTag() => {
+                if let Term::EnumVariant { tag, .. } = &*t {
+                    Ok(Closure {
+                        body: RichTerm::new(Term::Enum(*tag), pos_op_inh),
+                        env,
+                    })
+                } else {
+                    Err(mk_type_error!("enum_get_tag", "Enum variant"))
+                }
+            }
+            UnaryOp::EnumIsVariant() => {
+                let result = matches!(&*t, Term::EnumVariant { .. });
+                Ok(Closure::atomic_closure(RichTerm::new(
+                    Term::Bool(result),
+                    pos_op_inh,
+                )))
             }
         }
     }

--- a/core/src/eval/operation.rs
+++ b/core/src/eval/operation.rs
@@ -1146,16 +1146,12 @@ impl<R: ImportResolver, C: Cache> VirtualMachine<R, C> {
                     Err(mk_type_error!("enum_unwrap_variant", "Enum variant"))
                 }
             }
-            UnaryOp::EnumGetTag() => {
-                if let Term::EnumVariant { tag, .. } = &*t {
-                    Ok(Closure {
-                        body: RichTerm::new(Term::Enum(*tag), pos_op_inh),
-                        env,
-                    })
-                } else {
-                    Err(mk_type_error!("enum_get_tag", "Enum variant"))
-                }
-            }
+            UnaryOp::EnumGetTag() => match &*t {
+                Term::EnumVariant { tag, .. } | Term::Enum(tag) => Ok(Closure::atomic_closure(
+                    RichTerm::new(Term::Enum(*tag), pos_op_inh),
+                )),
+                _ => Err(mk_type_error!("enum_get_tag", "Enum")),
+            },
             UnaryOp::EnumIsVariant() => {
                 let result = matches!(&*t, Term::EnumVariant { .. });
                 Ok(Closure::atomic_closure(RichTerm::new(

--- a/core/src/parser/grammar.lalrpop
+++ b/core/src/parser/grammar.lalrpop
@@ -793,7 +793,8 @@ UOp: UnaryOp = {
                 }
             })
         }
-    }
+    },
+    "enum_unwrap_variant" => UnaryOp::EnumUnwrapVariant(),
 }
 
 MatchCase: MatchCase = {
@@ -1258,6 +1259,7 @@ extern {
         "label_push_diag" => Token::Normal(NormalToken::LabelPushDiag),
         "array_slice" => Token::Normal(NormalToken::ArraySlice),
         "eval_nix" => Token::Normal(NormalToken::EvalNix),
+        "enum_unwrap_variant" => Token::Normal(NormalToken::EnumUnwrapVariant),
 
         "{" => Token::Normal(NormalToken::LBrace),
         "}" => Token::Normal(NormalToken::RBrace),

--- a/core/src/parser/grammar.lalrpop
+++ b/core/src/parser/grammar.lalrpop
@@ -795,6 +795,8 @@ UOp: UnaryOp = {
         }
     },
     "enum_unwrap_variant" => UnaryOp::EnumUnwrapVariant(),
+    "enum_is_variant" => UnaryOp::EnumIsVariant(),
+    "enum_get_tag" => UnaryOp::EnumGetTag(),
 }
 
 MatchCase: MatchCase = {
@@ -1260,6 +1262,8 @@ extern {
         "array_slice" => Token::Normal(NormalToken::ArraySlice),
         "eval_nix" => Token::Normal(NormalToken::EvalNix),
         "enum_unwrap_variant" => Token::Normal(NormalToken::EnumUnwrapVariant),
+        "enum_is_variant" => Token::Normal(NormalToken::EnumIsVariant),
+        "enum_get_tag" => Token::Normal(NormalToken::EnumGetTag),
 
         "{" => Token::Normal(NormalToken::LBrace),
         "}" => Token::Normal(NormalToken::RBrace),

--- a/core/src/parser/grammar.lalrpop
+++ b/core/src/parser/grammar.lalrpop
@@ -521,21 +521,22 @@ LastFieldPat: LastPattern<FieldPattern> = {
 // The right hand side of an `=` inside a destructuring pattern.
 #[inline]
 Pattern: Pattern = {
-    <l: @L> <alias:(<Ident> "@")?> <record_pat: RecordPattern> <r: @R> => {
+    <l: @L> <alias:(<Ident> "@")?> <data: PatternData> <r: @R> => {
         Pattern {
            alias,
-           data: PatternData::Record(record_pat),
+           data,
            span: mk_span(src_id, l, r),
         }
     },
-    Ident => {
-        let span = <>.pos.unwrap();
-
-        Pattern { data: PatternData::Any(<>), alias: None, span }
-    },
 };
 
-// A full pattern at the left-hand side of a destructuring let.
+#[inline]
+PatternData: PatternData = {
+    RecordPattern => PatternData::Record(<>),
+    EnumVariantPattern => PatternData::EnumVariant(<>),
+    Ident => PatternData::Any(<>),
+};
+
 RecordPattern: RecordPattern = {
     <start: @L> "{" <mut field_pats: (<FieldPattern> ",")*> <last: LastFieldPat?> "}" <end: @R> =>? {
         let tail = match last {
@@ -559,7 +560,15 @@ RecordPattern: RecordPattern = {
     },
 };
 
-// A binding `ident = <pattern>` inside a destructuring pattern.
+EnumVariantPattern: EnumVariantPattern =
+    <start: @L> <tag: EnumTag> ".." "(" <pattern: Pattern> ")" <end: @R> =>
+        EnumVariantPattern {
+            tag,
+            pattern: Box::new(pattern),
+            span: mk_span(src_id, start, end),
+        };
+
+// A binding `ident = <pattern>` inside a record pattern.
 FieldPattern: FieldPattern = {
     <l: @L> <matched_id:Ident> <anns: SimpleFieldAnnot<FixedType>?> <default: DefaultAnnot?>
       "=" <pattern: Pattern> <r: @R> => {

--- a/core/src/parser/lexer.rs
+++ b/core/src/parser/lexer.rs
@@ -322,6 +322,8 @@ pub enum NormalToken<'input> {
     NumFromStr,
     #[token("%enum_from_str%")]
     EnumFromStr,
+    #[token("%enum_unwrap_variant%")]
+    EnumUnwrapVariant,
     #[token("%label_with_message%")]
     LabelWithMessage,
     #[token("%label_with_notes%")]

--- a/core/src/parser/lexer.rs
+++ b/core/src/parser/lexer.rs
@@ -324,6 +324,11 @@ pub enum NormalToken<'input> {
     EnumFromStr,
     #[token("%enum_unwrap_variant%")]
     EnumUnwrapVariant,
+    #[token("%enum_is_variant%")]
+    EnumIsVariant,
+    #[token("%enum_get_tag%")]
+    EnumGetTag,
+
     #[token("%label_with_message%")]
     LabelWithMessage,
     #[token("%label_with_notes%")]

--- a/core/src/pretty.rs
+++ b/core/src/pretty.rs
@@ -2,7 +2,9 @@ use std::fmt;
 
 use crate::identifier::LocIdent;
 use crate::parser::lexer::KEYWORDS;
-use crate::term::pattern::{Pattern, PatternData, RecordPattern, RecordPatternTail};
+use crate::term::pattern::{
+    EnumVariantPattern, Pattern, PatternData, RecordPattern, RecordPatternTail,
+};
 use crate::term::record::RecordData;
 use crate::term::{
     record::{Field, FieldMetadata},
@@ -572,7 +574,27 @@ where
         match self {
             PatternData::Any(id) => allocator.as_string(id),
             PatternData::Record(rp) => rp.pretty(allocator),
+            PatternData::EnumVariant(evp) => evp.pretty(allocator),
         }
+    }
+}
+
+impl<'a, D, A> Pretty<'a, D, A> for &EnumVariantPattern
+where
+    D: NickelAllocatorExt<'a, A>,
+    D::Doc: Clone,
+    A: Clone + 'a,
+{
+    fn pretty(self, allocator: &'a D) -> DocBuilder<'a, D, A> {
+        docs![
+            allocator,
+            "'",
+            ident_quoted(&self.tag),
+            //TODO[adts]: replace this with a space once we have a proper syntax
+            "..(",
+            &*self.pattern,
+            ")"
+        ]
     }
 }
 

--- a/core/src/pretty.rs
+++ b/core/src/pretty.rs
@@ -590,7 +590,6 @@ where
             allocator,
             "'",
             ident_quoted(&self.tag),
-            //TODO[adts]: replace this with a space once we have a proper syntax
             "..(",
             &*self.pattern,
             ")"

--- a/core/src/stdlib.rs
+++ b/core/src/stdlib.rs
@@ -86,6 +86,7 @@ pub mod internals {
     generate_accessor!(forall_tail);
     generate_accessor!(dyn_tail);
     generate_accessor!(empty_tail);
+    generate_accessor!(enum_variant);
     generate_accessor!(stdlib_contract_equal);
 
     generate_accessor!(rec_default);

--- a/core/src/term/mod.rs
+++ b/core/src/term/mod.rs
@@ -1363,6 +1363,9 @@ pub enum UnaryOp {
     /// Evaluate a string of nix code into a resulting nickel value. Currently completely (strictly) evaluates the nix code, and must result in a value serializable into JSON.
     #[cfg(feature = "nix-experimental")]
     EvalNix(),
+
+    /// Unwrap the variant from an enum: `%unwrap_enum_variant% ('Foo t) := t`
+    EnumUnwrapVariant(),
 }
 
 impl fmt::Display for UnaryOp {
@@ -1411,8 +1414,11 @@ impl fmt::Display for UnaryOp {
             RecordEmptyWithTail() => write!(f, "record_empty_with_tail"),
             Trace() => write!(f, "trace"),
             LabelPushDiag() => write!(f, "label_push_diag"),
+
             #[cfg(feature = "nix-experimental")]
             EvalNix() => write!(f, "eval_nix"),
+
+            EnumUnwrapVariant() => write!(f, "unwrap_enum_variant"),
         }
     }
 }

--- a/core/src/term/mod.rs
+++ b/core/src/term/mod.rs
@@ -1366,6 +1366,10 @@ pub enum UnaryOp {
 
     /// Unwrap the variant from an enum: `%unwrap_enum_variant% ('Foo t) := t`
     EnumUnwrapVariant(),
+    /// Return true if the given parameter is an enum variant.
+    EnumIsVariant(),
+    /// Extract the tag from an enum tag or an enum variant.
+    EnumGetTag(),
 }
 
 impl fmt::Display for UnaryOp {
@@ -1419,6 +1423,8 @@ impl fmt::Display for UnaryOp {
             EvalNix() => write!(f, "eval_nix"),
 
             EnumUnwrapVariant() => write!(f, "unwrap_enum_variant"),
+            EnumIsVariant() => write!(f, "enum_is_variant"),
+            EnumGetTag() => write!(f, "enum_get_tag"),
         }
     }
 }

--- a/core/src/term/mod.rs
+++ b/core/src/term/mod.rs
@@ -1422,7 +1422,7 @@ impl fmt::Display for UnaryOp {
             #[cfg(feature = "nix-experimental")]
             EvalNix() => write!(f, "eval_nix"),
 
-            EnumUnwrapVariant() => write!(f, "unwrap_enum_variant"),
+            EnumUnwrapVariant() => write!(f, "enum_unwrap_variant"),
             EnumIsVariant() => write!(f, "enum_is_variant"),
             EnumGetTag() => write!(f, "enum_get_tag"),
         }

--- a/core/src/transform/free_vars.rs
+++ b/core/src/transform/free_vars.rs
@@ -243,6 +243,9 @@ impl RemoveBindings for PatternData {
             PatternData::Record(record_pat) => {
                 record_pat.remove_bindings(working_set);
             }
+            PatternData::EnumVariant(enum_variant_pat) => {
+                enum_variant_pat.remove_bindings(working_set);
+            }
         }
     }
 }
@@ -272,5 +275,11 @@ impl RemoveBindings for RecordPattern {
         if let RecordPatternTail::Capture(rest) = self.tail {
             working_set.remove(&rest.ident());
         }
+    }
+}
+
+impl RemoveBindings for EnumVariantPattern {
+    fn remove_bindings(&self, working_set: &mut HashSet<Ident>) {
+        self.pattern.remove_bindings(working_set);
     }
 }

--- a/core/src/typecheck/mod.rs
+++ b/core/src/typecheck/mod.rs
@@ -1892,9 +1892,8 @@ fn check<V: TypecheckVisitor>(
             // The inferred type of the expr being bound
             let ty_let = binding_type(state, re.as_ref(), &ctxt, true);
 
-            ty_let
-                .clone()
-                .unify(pat_ty, state, &ctxt)
+            pat_ty
+                .unify(ty_let.clone(), state, &ctxt)
                 .map_err(|e| e.into_typecheck_err(state, re.pos))?;
 
             check(state, ctxt.clone(), visitor, re, ty_let.clone())?;

--- a/core/src/typecheck/operation.rs
+++ b/core/src/typecheck/operation.rs
@@ -211,10 +211,14 @@ pub fn get_uop_type(
         #[cfg(feature = "nix-experimental")]
         UnaryOp::EvalNix() => (mk_uniftype::str(), mk_uniftype::dynamic()),
         // Because the tag isn't fixed, we can't really provide a proper static type for this
-        // primop (morally, it's `forall 'tag a. [| 'tag a |] -> a`).
+        // primop.
         // This isn't a problem, as this operator is mostly internal and pattern matching should be
         // used to destructure enum variants.
         UnaryOp::EnumUnwrapVariant() => (mk_uniftype::dynamic(), mk_uniftype::dynamic()),
+        // Same as `EnumUnwrapVariant` just above.
+        UnaryOp::EnumGetTag() => (mk_uniftype::dynamic(), mk_uniftype::dynamic()),
+        // forall a. a -> Bool
+        UnaryOp::EnumIsVariant() => (state.table.fresh_type_uvar(var_level), mk_uniftype::bool()),
     })
 }
 

--- a/core/src/typecheck/operation.rs
+++ b/core/src/typecheck/operation.rs
@@ -210,6 +210,11 @@ pub fn get_uop_type(
         // Str -> Dyn
         #[cfg(feature = "nix-experimental")]
         UnaryOp::EvalNix() => (mk_uniftype::str(), mk_uniftype::dynamic()),
+        // Because the tag isn't fixed, we can't really provide a proper static type for this
+        // primop (morally, it's `forall 'tag a. [| 'tag a |] -> a`).
+        // This isn't a problem, as this operator is mostly internal and pattern matching should be
+        // used to destructure enum variants.
+        UnaryOp::EnumUnwrapVariant() => (mk_uniftype::dynamic(), mk_uniftype::dynamic()),
     })
 }
 

--- a/core/src/typecheck/operation.rs
+++ b/core/src/typecheck/operation.rs
@@ -217,8 +217,9 @@ pub fn get_uop_type(
         UnaryOp::EnumUnwrapVariant() => (mk_uniftype::dynamic(), mk_uniftype::dynamic()),
         // Same as `EnumUnwrapVariant` just above.
         UnaryOp::EnumGetTag() => (mk_uniftype::dynamic(), mk_uniftype::dynamic()),
-        // forall a. a -> Bool
-        UnaryOp::EnumIsVariant() => (state.table.fresh_type_uvar(var_level), mk_uniftype::bool()),
+        // Note that is_variant breaks parametricity, so it can't get a polymorphic type.
+        // Dyn -> Bool
+        UnaryOp::EnumIsVariant() => (mk_uniftype::dynamic(), mk_uniftype::bool()),
     })
 }
 

--- a/core/stdlib/internals.ncl
+++ b/core/stdlib/internals.ncl
@@ -251,5 +251,4 @@
   # in an internal value prefixed with `$` makes it accessible from the initial
   # environment and prevents it from being shadowed.
   "$stdlib_contract_equal" = std.contract.Equal,
-
 }

--- a/core/stdlib/internals.ncl
+++ b/core/stdlib/internals.ncl
@@ -226,6 +226,20 @@
             label
         ),
 
+  # Contract for an enum variant with tag `'tag`, that is any value of the form
+  # `'tag exp`.
+  "$enum_variant" = fun tag label value =>
+    if %enum_is_variant% value then
+      let value_tag = %enum_get_tag% value in
+
+      if value_tag == tag then
+        value
+      else
+        let msg = "expected `'%{%to_str% tag}`, got `'%{%to_str% value_tag}`" in
+        %blame% (%label_with_message% "tag mismatch: %{msg}" label)
+    else
+      %blame% (%label_with_message% "expected an enum variant" label),
+
   # Recursive priorities operators
 
   "$rec_force" = fun value => %rec_force% (%force% value),
@@ -237,4 +251,5 @@
   # in an internal value prefixed with `$` makes it accessible from the initial
   # environment and prevents it from being shadowed.
   "$stdlib_contract_equal" = std.contract.Equal,
+
 }

--- a/core/tests/integration/inputs/adts/enum_primops.ncl
+++ b/core/tests/integration/inputs/adts/enum_primops.ncl
@@ -2,10 +2,10 @@
 let {check, ..} = import "../lib/assert.ncl" in
 
 [
-  %enum_unwrap_variant% 'Left..(1+1) == 2,
+  %enum_unwrap_variant% ('Left..(1+1)) == 2,
   !(%enum_is_variant% 'Right),
-  %enum_is_variant% 'Right..(1),
+  %enum_is_variant% ('Right..(1)),
   %enum_get_tag% 'Right == 'Right,
-  %enum_get_tag% 'Right "stuff" == 'Right,
+  %enum_get_tag% ('Right..("stuff")) == 'Right,
 ]
 |> check

--- a/core/tests/integration/inputs/adts/enum_primops.ncl
+++ b/core/tests/integration/inputs/adts/enum_primops.ncl
@@ -1,0 +1,11 @@
+# test.type = 'pass'
+let {check, ..} = import "../lib/assert.ncl" in
+
+[
+  %enum_unwrap_variant% 'Left..(1+1) == 2,
+  !(%enum_is_variant% 'Right),
+  %enum_is_variant% 'Right..(1),
+  %enum_get_tag% 'Right == 'Right,
+  %enum_get_tag% 'Right "stuff" == 'Right,
+]
+|> check

--- a/core/tests/integration/inputs/destructuring/adt_missing_arg_contract_fail.ncl
+++ b/core/tests/integration/inputs/destructuring/adt_missing_arg_contract_fail.ncl
@@ -1,0 +1,6 @@
+# test.type = 'error'
+#
+# [test.metadata]
+# error = 'EvalError::BlameError'
+let 'Foo..(x) = 'Foo in
+x

--- a/core/tests/integration/inputs/destructuring/adt_type_matches.ncl
+++ b/core/tests/integration/inputs/destructuring/adt_type_matches.ncl
@@ -1,0 +1,6 @@
+# test.type = 'pass'
+(
+  let y = 'Foo..(1 + 1) in
+  let 'Foo..(x) = y in
+  x + 1 == 3
+) : _

--- a/core/tests/integration/inputs/destructuring/adt_type_mismatch_extra_row.ncl
+++ b/core/tests/integration/inputs/destructuring/adt_type_mismatch_extra_row.ncl
@@ -1,0 +1,8 @@
+# test.type = 'error'
+#
+# [test.metadata]
+# error = 'TypecheckError::ExtraRow'
+#
+# [test.metadata.expectation]
+# ident = 'Bar'
+(let y : [| 'Foo Number, 'Bar String |] = 'Foo..(5) in let 'Foo..(x) = y in x) : _

--- a/core/tests/integration/inputs/destructuring/adt_type_mismatch_tag.ncl
+++ b/core/tests/integration/inputs/destructuring/adt_type_mismatch_tag.ncl
@@ -1,0 +1,8 @@
+# test.type = 'error'
+#
+# [test.metadata]
+# error = 'TypecheckError::ExtraRow'
+#
+# [test.metadata.expectation]
+# ident = 'Bar'
+(let 'Foo..(x) = 'Bar..(5) in x) : _

--- a/core/tests/integration/inputs/destructuring/adt_wrong_tag_contract_fail.ncl
+++ b/core/tests/integration/inputs/destructuring/adt_wrong_tag_contract_fail.ncl
@@ -1,0 +1,6 @@
+# test.type = 'error'
+#
+# [test.metadata]
+# error = 'EvalError::BlameError'
+let 'Foo..(x) = 'Bar..(5)  in
+x

--- a/core/tests/integration/inputs/destructuring/adt_wrong_type_contract_fail.ncl
+++ b/core/tests/integration/inputs/destructuring/adt_wrong_type_contract_fail.ncl
@@ -1,0 +1,6 @@
+# test.type = 'error'
+#
+# [test.metadata]
+# error = 'EvalError::BlameError'
+let 'Foo..(x) = {bar = 1}  in
+x

--- a/lsp/nls/src/pattern.rs
+++ b/lsp/nls/src/pattern.rs
@@ -85,6 +85,9 @@ impl InjectBindings for PatternData {
             PatternData::Record(record_pat) => {
                 record_pat.inject_bindings(bindings, path, parent_deco)
             }
+            PatternData::EnumVariant(evariant_pat) => {
+                evariant_pat.inject_bindings(bindings, path, parent_deco)
+            }
         }
     }
 }
@@ -114,5 +117,18 @@ impl InjectBindings for FieldPattern {
         path.push(self.matched_id);
         self.pattern
             .inject_bindings(bindings, path, Some(&self.extra));
+    }
+}
+
+impl InjectBindings for EnumVariantPattern {
+    fn inject_bindings(
+        &self,
+        bindings: &mut Vec<(Vec<LocIdent>, LocIdent, Field)>,
+        path: Vec<LocIdent>,
+        _parent_extra: Option<&Field>,
+    ) {
+        //TODO: I'm not sure we should just transparently forward to the variant's argument. Maybe
+        //we need a more complex notion of path here, that knows when we enter an enum variant?
+        self.pattern.inject_bindings(bindings, path, None);
     }
 }


### PR DESCRIPTION
Depends on #1799

This PR adds support for ADTs (enum variants) in patterns. Patterns can currently only be used in destructuring, which isn't very useful for ADTs: you have to know the tag in advance to be able to actually destructure them. However, it's a first way to inspect enum variants, and a stepping stone toward full pattern matching as we will use the same notion (and the same Rust type in practice) for patterns in a match expression, and common implementations for type elaboration as well as the extraction code.

## Content

- introduces three new primops to be able to desugar the new enum variant pattern (`%enum_unwrap_variant%`, `%enum_is_variant%`, `%enum_get_tag%`) as well as a new internal contract `$enum_variant`
- adds a pattern type for enum variants
- implements type elaboration for this new pattern
- implements desugaring of this new pattern to normal (non-destructuring) let bindings
- add tests

## Follow-ups

- [ ] Add a pattern for enum tags (enum variants without argument). The reason it's not been done is that currently enum tags are probably better described as constant of the language, and that we can add constants all at once, to be able to match on numers, boolean and strings as well (it might become false if we introduce the `Unit` type and the `()` value)