### PR TITLE
Enum tag destructuring

### DIFF
--- a/core/src/eval/operation.rs
+++ b/core/src/eval/operation.rs
@@ -230,7 +230,7 @@ impl<R: ImportResolver, C: Cache> VirtualMachine<R, C> {
                     Term::Num(_) => "Number",
                     Term::Bool(_) => "Bool",
                     Term::Str(_) => "String",
-                    Term::Enum(_) => "Enum",
+                    Term::Enum(_) | Term::EnumVariant { .. } => "Enum",
                     Term::Fun(..) | Term::Match { .. } => "Function",
                     Term::Array(..) => "Array",
                     Term::Record(..) | Term::RecRecord(..) => "Record",

--- a/core/src/parser/grammar.lalrpop
+++ b/core/src/parser/grammar.lalrpop
@@ -533,7 +533,7 @@ Pattern: Pattern = {
 #[inline]
 PatternData: PatternData = {
     RecordPattern => PatternData::Record(<>),
-    EnumVariantPattern => PatternData::EnumVariant(<>),
+    EnumPattern => PatternData::Enum(<>),
     Ident => PatternData::Any(<>),
 };
 
@@ -560,13 +560,18 @@ RecordPattern: RecordPattern = {
     },
 };
 
-EnumVariantPattern: EnumVariantPattern =
-    <start: @L> <tag: EnumTag> ".." "(" <pattern: Pattern> ")" <end: @R> =>
-        EnumVariantPattern {
-            tag,
-            pattern: Box::new(pattern),
-            span: mk_span(src_id, start, end),
-        };
+EnumPattern: EnumPattern = {
+    <start: @L> <tag: EnumTag> <end: @R> => EnumPattern {
+        tag,
+        pattern: None,
+        span: mk_span(src_id, start, end),
+    },
+    <start: @L> <tag: EnumTag> ".." "(" <pattern: Pattern> ")" <end: @R> => EnumPattern {
+        tag,
+        pattern: Some(Box::new(pattern)),
+        span: mk_span(src_id, start, end),
+    },
+};
 
 // A binding `ident = <pattern>` inside a record pattern.
 FieldPattern: FieldPattern = {

--- a/core/src/pretty.rs
+++ b/core/src/pretty.rs
@@ -2,9 +2,7 @@ use std::fmt;
 
 use crate::identifier::LocIdent;
 use crate::parser::lexer::KEYWORDS;
-use crate::term::pattern::{
-    EnumVariantPattern, Pattern, PatternData, RecordPattern, RecordPatternTail,
-};
+use crate::term::pattern::{EnumPattern, Pattern, PatternData, RecordPattern, RecordPatternTail};
 use crate::term::record::RecordData;
 use crate::term::{
     record::{Field, FieldMetadata},
@@ -574,12 +572,12 @@ where
         match self {
             PatternData::Any(id) => allocator.as_string(id),
             PatternData::Record(rp) => rp.pretty(allocator),
-            PatternData::EnumVariant(evp) => evp.pretty(allocator),
+            PatternData::Enum(evp) => evp.pretty(allocator),
         }
     }
 }
 
-impl<'a, D, A> Pretty<'a, D, A> for &EnumVariantPattern
+impl<'a, D, A> Pretty<'a, D, A> for &EnumPattern
 where
     D: NickelAllocatorExt<'a, A>,
     D::Doc: Clone,
@@ -590,9 +588,11 @@ where
             allocator,
             "'",
             ident_quoted(&self.tag),
-            "..(",
-            &*self.pattern,
-            ")"
+            if let Some(ref arg_pat) = self.pattern {
+                docs![allocator, "..(", &**arg_pat, ")"]
+            } else {
+                allocator.nil()
+            }
         ]
     }
 }

--- a/core/src/transform/free_vars.rs
+++ b/core/src/transform/free_vars.rs
@@ -243,7 +243,7 @@ impl RemoveBindings for PatternData {
             PatternData::Record(record_pat) => {
                 record_pat.remove_bindings(working_set);
             }
-            PatternData::EnumVariant(enum_variant_pat) => {
+            PatternData::Enum(enum_variant_pat) => {
                 enum_variant_pat.remove_bindings(working_set);
             }
         }
@@ -278,8 +278,10 @@ impl RemoveBindings for RecordPattern {
     }
 }
 
-impl RemoveBindings for EnumVariantPattern {
+impl RemoveBindings for EnumPattern {
     fn remove_bindings(&self, working_set: &mut HashSet<Ident>) {
-        self.pattern.remove_bindings(working_set);
+        if let Some(ref arg_pat) = self.pattern {
+            arg_pat.remove_bindings(working_set);
+        }
     }
 }

--- a/core/stdlib/std.ncl
+++ b/core/stdlib/std.ncl
@@ -855,7 +855,22 @@
           let constant_type = %typeof% constant in
           let check_typeof_eq = fun ctr_label value =>
             let value_type = %typeof% value in
-            if value_type == constant_type then
+            if value_type == constant_type && value_type == 'Enum then
+              if %enum_is_variant% value != %enum_is_variant% constant then
+                let enum_kind = fun x =>
+                  if %enum_is_variant% x then
+                    "enum variant"
+                  else
+                    "enum tag"
+                in
+
+                ctr_label
+                |> label.with_message "expected an %{enum_kind constant}, got an %{enum_kind value}"
+                |> label.append_note "`std.contract.Equal some_enum` requires that the checked value is equal to the enum `some_enum`, but they are different variants."
+                |> blame
+              else
+                value
+            else if value_type == constant_type then
               value
             else
               ctr_label

--- a/core/tests/integration/inputs/destructuring/adt_enum_tag.ncl
+++ b/core/tests/integration/inputs/destructuring/adt_enum_tag.ncl
@@ -1,0 +1,4 @@
+# test.type = 'pass'
+let x = 'Foo in
+let 'Foo = x in
+true

--- a/core/tests/integration/inputs/destructuring/adt_enum_tag_tag_mismatch.ncl
+++ b/core/tests/integration/inputs/destructuring/adt_enum_tag_tag_mismatch.ncl
@@ -1,0 +1,6 @@
+# test.type = 'error'
+#
+# [test.metadata]
+# error = 'EvalError::BlameError'
+let 'Foo = 'Bar in
+true

--- a/core/tests/integration/inputs/destructuring/adt_extra_arg_contract_fail.ncl
+++ b/core/tests/integration/inputs/destructuring/adt_extra_arg_contract_fail.ncl
@@ -1,0 +1,6 @@
+# test.type = 'error'
+#
+# [test.metadata]
+# error = 'EvalError::BlameError'
+let 'Foo = 'Foo..(5) in
+true

--- a/doc/manual/merging.md
+++ b/doc/manual/merging.md
@@ -608,7 +608,7 @@ argument), we do get a contract violation error:
     { foo | FooContract }
     & { foo.required_field1 = "here" }
   in
-  
+ 
   intermediate
   & { foo.required_field2 = "here" }
   |> std.deep_seq intermediate
@@ -621,9 +621,9 @@ error: missing definition for `required_field2`
    8 │     & { foo.required_field1 = "here" }
      │             ------------------------ in this record
      │
-     ┌─ <stdlib/std.ncl>:2997:18
+     ┌─ <stdlib/std.ncl>:3012:18
      │
-2997 │     = fun x y => %deep_seq% x y,
+3012 │     = fun x y => %deep_seq% x y,
      │                  ------------ accessed here
 ```
 

--- a/lsp/nls/src/pattern.rs
+++ b/lsp/nls/src/pattern.rs
@@ -85,7 +85,7 @@ impl InjectBindings for PatternData {
             PatternData::Record(record_pat) => {
                 record_pat.inject_bindings(bindings, path, parent_deco)
             }
-            PatternData::EnumVariant(evariant_pat) => {
+            PatternData::Enum(evariant_pat) => {
                 evariant_pat.inject_bindings(bindings, path, parent_deco)
             }
         }
@@ -120,7 +120,7 @@ impl InjectBindings for FieldPattern {
     }
 }
 
-impl InjectBindings for EnumVariantPattern {
+impl InjectBindings for EnumPattern {
     fn inject_bindings(
         &self,
         bindings: &mut Vec<(Vec<LocIdent>, LocIdent, Field)>,
@@ -129,6 +129,8 @@ impl InjectBindings for EnumVariantPattern {
     ) {
         //TODO: I'm not sure we should just transparently forward to the variant's argument. Maybe
         //we need a more complex notion of path here, that knows when we enter an enum variant?
-        self.pattern.inject_bindings(bindings, path, None);
+        if let Some(ref arg_pat) = self.pattern {
+            arg_pat.inject_bindings(bindings, path, None);
+        }
     }
 }


### PR DESCRIPTION
Follow-up of #1812. Prior to extending match expressions with full pattern matching, this PR adds support for bare enum tags, which will be needed to be able to handle the existing enum tags match expressions.

In the end, I tend to agree with [@vkleen 's comment](https://github.com/tweag/nickel/pull/1812#pullrequestreview-1872407311), and contrary to what the original description of #1812 said, enum tags shouldn't in fact be treated as constants but rather as special cases of enum variants. It'll also make the transition easier, if we decide to go with an explicit `Unit` type and really have them be the same thing.

There is a bit of fuss around lazyness for patterns. Right now, `let 'Foo x = <exp> in <body>` doesn't fire any check if `<body>` doesn't use `x`, which is in line with lazy contracts, but might be surprising. Then what should do a pattern that doesn't bind any variable? In this PR, I went with the answer that we should add an artificial dependency (basically, `seq`), otherwise `let 'Foo = x in <body>` would always succeed, whatever `x` is, which is unreasonable.

Thinking ahead toward pattern in match expression, patterns _will_ have to evaluate arguments up to a point to decide which branch to take (and hence be more eager than current destructuring patterns). Although it's technically backward-incompatible, I think we should do the same with destructuring. Some programs that use to evaluate might suddenly break, but it's arguably a "should have broke earlier" case - adding eagerly error reporting isn't the same as breaking entirely fine programs. If we do so, we can just get rid of those lazyness shenanigans.

But we can discuss this question further.