### PR TITLE
Add InvalidContractError

### DIFF
--- a/cli/tests/snapshot/inputs/errors/invalid_contract_expression.ncl
+++ b/cli/tests/snapshot/inputs/errors/invalid_contract_expression.ncl
@@ -1,0 +1,3 @@
+# capture = 'stderr'
+# command = ['eval']
+{ foo | Number -> [| 'Foo 5 |] = null }

--- a/cli/tests/snapshot/snapshots/snapshot__eval_stderr_invalid_contract_expression.ncl.snap
+++ b/cli/tests/snapshot/snapshots/snapshot__eval_stderr_invalid_contract_expression.ncl.snap
@@ -1,0 +1,14 @@
+---
+source: cli/tests/snapshot/main.rs
+expression: err
+---
+error: invalid contract expression
+  ┌─ [INPUTS_PATH]/errors/invalid_contract_expression.ncl:3:27
+  │
+3 │ { foo | Number -> [| 'Foo 5 |] = null }
+  │                           ^ this can't be used as a contract
+  │
+  = This expression is used as a contract as part of an annotation or a type expression.
+  = Only functions and records might be valid contracts
+
+

--- a/core/src/parser/error.rs
+++ b/core/src/parser/error.rs
@@ -106,17 +106,14 @@ pub enum ParseError {
         /// The previous instance of the duplicated identifier.
         prev_ident: LocIdent,
     },
-    /// A type variable is used in ways that imply it has muiltiple different kinds.
+    /// A type variable is used in ways that imply it has multiple different kinds.
     ///
     /// This can happen in several situations, for example:
     /// - a variable is used as both a type variable and a row type variable,
     ///   e.g. in the signature `forall r. { ; r } -> r`,
     /// - a variable is used as both a record and enum row variable, e.g. in the
     ///   signature `forall r. [| ; r |] -> { ; r }`.
-    TypeVariableKindMismatch {
-        ty_var: LocIdent,
-        span: RawSpan,
-    },
+    TypeVariableKindMismatch { ty_var: LocIdent, span: RawSpan },
     /// A record literal, which isn't a record type, has a field with a type annotation but without
     /// a definition. While we could technically handle this situation, this is most probably an
     /// error from the user, because this type annotation is useless and, maybe non-intuitively,
@@ -139,11 +136,12 @@ pub enum ParseError {
     },
     /// The user provided a field path on the CLI, which is expected to be only composed of
     /// literals, but the parsed field path contains string interpolation.
-    InterpolationInStaticPath {
-        path_elem_span: RawSpan,
-    },
-    DisabledFeature {
-        feature: String,
-        span: RawSpan,
-    },
+    InterpolationInStaticPath { path_elem_span: RawSpan },
+    /// There was an attempt to use a feature that hasn't been enabled.
+    DisabledFeature { feature: String, span: RawSpan },
+    /// A term was used as a contract in type position, but this term has no chance to make any
+    /// sense as a contract. What terms make sense might evolve with time, but any given point in
+    /// time, there are a set of expressions that can be excluded syntactically. Currently, it's
+    /// mostly constants.
+    InvalidContract(RawSpan),
 }

--- a/core/tests/integration/inputs/typecheck/type_in_term_position.ncl
+++ b/core/tests/integration/inputs/typecheck/type_in_term_position.ncl
@@ -3,4 +3,4 @@
 # 
 # [test.metadata]
 # error = 'TypecheckError::FlatTypeInTermPosition'
-(let c = Number -> 5 in 3): _
+(let c = Number -> (4 + 1) in 3): _

--- a/doc/manual/merging.md
+++ b/doc/manual/merging.md
@@ -513,7 +513,7 @@ This evaluates to:
   },
   server = {
     host = {
-      "options": "TLS"
+      "options" = "TLS",
     }
   }
 }


### PR DESCRIPTION
Closes #1818

This PR adds a specific parse error which detects upfront nonsensical contract annotations. More precisely, when a bare constant (null, boolean, string, number) or a bare array is used as a contract in a type expression or in an annotation. This will hopefully catch common typo like using `:` instead of `=` when coming from JSON-like languages.

The initial design tried to include a bit of context, to print a special note such as "Did you mean to use `=` instead of `:` as in ...." when the error happen in the annotation of a record field definition. However, this wasn't trivial to do, because the error is currently a parsing error which is raised as soon as such an invalid contract appears in a type position. Not doing that and "catching" the error only later for record fields requires to annoyingly change several rule of the grammar (or rather to have specialized ad-hoc version of them just for record fields, which don't raise the error right away but bubble it up).

For now this PR is already a good improvement. If we really want to include more context, we can do so at the price of a bit of complexity, or we can also raise the error later in the pipeline, for example during walking/typechecking.