### PR TITLE
[Fix] Fix enum contract stripping unwrapping variant argument

### DIFF
--- a/core/src/typ.rs
+++ b/core/src/typ.rs
@@ -976,7 +976,7 @@ impl Subcontract for EnumRows {
         //   x |> match {
         //     'foo => x,
         //     'bar => x,
-        //     'Baz variant_arg => %apply_contract% T label_arg variant_arg,
+        //     'Baz variant_arg => 'Baz (%apply_contract% T label_arg variant_arg),
         //     _ => $enum_fail l
         //   }
         // ```
@@ -992,15 +992,22 @@ impl Subcontract for EnumRows {
                     });
 
                     let body = if let Some(ty) = row.typ.as_ref() {
-                        // %apply_contract% T label_arg variant_arg
-                        mk_app!(
+                        // 'Tag (%apply_contract% T label_arg variant_arg)
+                        let arg = mk_app!(
                             mk_term::op2(
                                 BinaryOp::ApplyContract(),
                                 ty.subcontract(vars.clone(), pol, sy)?,
                                 mk_term::var(label_arg)
                             ),
                             mk_term::var(variant_arg)
-                        )
+                        );
+
+                        Term::EnumVariant {
+                            tag: row.id,
+                            arg,
+                            attrs: Default::default(),
+                        }
+                        .into()
                     } else {
                         mk_term::var(value_arg)
                     };

--- a/core/tests/integration/inputs/contracts/enum_variant_fail.ncl
+++ b/core/tests/integration/inputs/contracts/enum_variant_fail.ncl
@@ -2,4 +2,4 @@
 #
 # [test.metadata]
 # error = 'EvalError::BlameError'
-'Foo 5 | [| 'Foo String, 'Bar Number, 'Barg |]
+%force% ('Foo 5 | [| 'Foo String, 'Bar Number, 'Barg |])


### PR DESCRIPTION
Depends on #1835

Fix a bug introduced with enum variant contracts, which would cause a contract such as `[| 'Foo Number |]` to unwrap the numeric argument of a matching value, that is `'Foo 5 | [| 'Foo Number |]` would evaluate to `5` instead of `'Foo 5`.