### PR TITLE
[Fix] Properly force enum variants

### DIFF
--- a/core/src/eval/mod.rs
+++ b/core/src/eval/mod.rs
@@ -185,6 +185,7 @@ impl<R: ImportResolver, C: Cache> VirtualMachine<R, C> {
             .map(|result| result.body)
     }
 
+    /// Same as [Self::eval_full], but takes a closure as an argument instead of a term.
     pub fn eval_full_closure(&mut self, t0: Closure) -> Result<Closure, EvalError> {
         self.eval_deep_closure_impl(t0, false)
             .map(|result| Closure {

--- a/core/tests/integration/inputs/adts/deep_seq_enum.ncl
+++ b/core/tests/integration/inputs/adts/deep_seq_enum.ncl
@@ -3,5 +3,5 @@
 # [test.metadata]
 # error = 'EvalError::BlameError'
 
-# Check that deep_eq correctly evaluate the content of an enum variant
+# Check that deep_seq correctly evaluates the content of an enum variant
 %deep_seq% ('Foo 5 | [| 'Foo String |]) null

--- a/core/tests/integration/inputs/adts/deep_seq_enum.ncl
+++ b/core/tests/integration/inputs/adts/deep_seq_enum.ncl
@@ -1,0 +1,7 @@
+# test.type = 'error'
+#
+# [test.metadata]
+# error = 'EvalError::BlameError'
+
+# Check that deep_eq correctly evaluate the content of an enum variant
+%deep_seq% ('Foo 5 | [| 'Foo String |]) null

--- a/core/tests/integration/inputs/adts/force_enum.ncl
+++ b/core/tests/integration/inputs/adts/force_enum.ncl
@@ -1,0 +1,7 @@
+# test.type = 'error'
+#
+# [test.metadata]
+# error = 'EvalError::BlameError'
+
+# Check that force correctly evaluate the content of an enum variant
+%force% ('Foo 5 | [| 'Foo String |])

--- a/core/tests/integration/inputs/adts/force_enum.ncl
+++ b/core/tests/integration/inputs/adts/force_enum.ncl
@@ -3,5 +3,5 @@
 # [test.metadata]
 # error = 'EvalError::BlameError'
 
-# Check that force correctly evaluate the content of an enum variant
+# Check that force correctly evaluates the content of an enum variant
 %force% ('Foo 5 | [| 'Foo String |])


### PR DESCRIPTION
The implementation of deep_seq and force primops haven't been properly updated to handle enum variants, letting them mostly unevaluated. This could in particular let contracts be unexpectedly unevaluated, and also shows unevaluated chunks in the REPL when inputting enum variants, which isn't ideal.

This commit properly forces enum variants.