### PR TITLE
Improve the description of identifier syntax in the manual

### DIFF
--- a/doc/manual/syntax.md
+++ b/doc/manual/syntax.md
@@ -6,9 +6,11 @@ slug: syntax
 
 ## Identifiers
 
-Nickel identifiers start with an alphabetic character, followed by zero or more
-alphanumeric characters, `_` (underscores) or `'` (single quotes). For example,
-`this-isn't-invalid` is a valid identifier.
+Nickel identifiers start with an optional underscore `_` followed by an
+alphabetic character (`a` to `z` or `A` to `Z`). They are then followed by
+zero or more alphanumeric characters (alphabetic characters or digits `0` to
+`9`), `_` (underscores), `-` (dashes) or `'` (single quotes). For example,
+`_This-isn't_invalid` is a valid identifier.
 
 ## Simple values
 


### PR DESCRIPTION
Explicitly mention the validity of dashes and leading underscores.

Fixes #1837