### PR TITLE
Remove some spurious diagnostics from background eval

### DIFF
--- a/core/src/eval/mod.rs
+++ b/core/src/eval/mod.rs
@@ -953,7 +953,7 @@ impl<R: ImportResolver, C: Cache> VirtualMachine<R, C> {
             match slf.eval(rt) {
                 Err(e) => {
                     acc.push(e);
-                    slf.stack.reset(&mut slf.cache);
+                    slf.reset();
                 }
                 Ok(t) => match t.as_ref() {
                     Term::Array(ts, _) => {

--- a/lsp/nls/src/background.rs
+++ b/lsp/nls/src/background.rs
@@ -125,6 +125,12 @@ fn worker(cmd_rx: IpcReceiver<Command>, response_tx: IpcSender<Response>) -> Opt
                     diagnostics.extend(
                         errors
                             .into_iter()
+                            .filter(|e| {
+                                !matches!(
+                                    e,
+                                    nickel_lang_core::error::EvalError::MissingFieldDef { .. }
+                                )
+                            })
                             .flat_map(|e| world.lsp_diagnostics(file_id, e)),
                     );
                 }

--- a/lsp/nls/tests/inputs/diagnostics-undefined-fields.ncl
+++ b/lsp/nls/tests/inputs/diagnostics-undefined-fields.ncl
@@ -1,0 +1,9 @@
+### /diagnostics-undefined-fields.ncl
+{
+  x | Number,
+  y = x,
+  z = x, # Second reference to the same field, to check that the thunk is reset on the first error.
+}
+### # We don't issue diagnostics on undefined fields, because they're expected for partial configurations.
+### # Even if undefined fields are referenced, that isn't an error.
+### diagnostic = ["file:///diagnostics-undefined-fields.ncl"]

--- a/lsp/nls/tests/snapshots/main__lsp__nls__tests__inputs__diagnostics-undefined-fields.ncl.snap
+++ b/lsp/nls/tests/snapshots/main__lsp__nls__tests__inputs__diagnostics-undefined-fields.ncl.snap
@@ -1,0 +1,5 @@
+---
+source: lsp/nls/tests/main.rs
+expression: output
+---
+


### PR DESCRIPTION
The first pass at background eval intended to ignore missing field errors, but it didn't do a thorough job. Specifically, it ignored missing field errors that came from forcing undefined fields. But it kept missing field errors coming from anything that evaluated those undefined fields. This PR removes those errors, and also some spurious "infinite recursion" errors coming from not resetting the thunks on error.

I decided to make `eval_permissive` return all the errors it finds, and filter out the missing field errors in nls. This is a little less efficient than filtering them out in `eval_permissive`, but it felt more principled. (Also, if we ever figure out a way to guess when a record is intended for export, maybe we won't always filter them out.)