### PR TITLE
Update/refresh examples using latest Nickel idioms

### DIFF
--- a/examples/arrays/arrays.ncl
+++ b/examples/arrays/arrays.ncl
@@ -11,15 +11,16 @@ let my_array_lib = {
         let tail = std.array.drop_first arr in
         [f head] @ map f tail,
 
-  fold : forall a b. (a -> b -> b) -> Array a -> b -> b = fun f arr first =>
+  fold : forall a b. (a -> b -> b) -> b -> Array a -> b = fun f first arr =>
       if arr == [] then
         first
       else
         let head = std.array.first arr in
         let tail = std.array.drop_first arr in
-        f head (fold f tail first),
+        f head (fold f first tail),
 }
 in
 # Compute `7!`
-let l = my_array_lib.map (fun x => x + 1) [1, 2, 3, 4, 5, 6] in
-my_array_lib.fold (fun x acc => x * acc) l 1
+[1, 2, 3, 4, 5, 6]
+|> my_array_lib.map ((+) 1)
+|> my_array_lib.fold (*) 1

--- a/examples/config-gcc/config-gcc.ncl
+++ b/examples/config-gcc/config-gcc.ncl
@@ -6,25 +6,27 @@ let GccFlag =
   # We only allow the following flags
   let available = ["W", "c", "S", "e", "o"] in
   fun label value =>
-    if std.is_string value then
-      if std.string.length value > 0
-      && std.array.any (fun x => x == std.string.substring 0 1 value) available then
-        value
-      else
-        std.contract.blame_with_message "unknown flag %{value}" label
-    else if std.is_record value then
-      if std.record.has_field "flag" value && std.record.has_field "arg" value then
-        if std.array.any (fun x => x == value.flag) available then
-          #Normalize the tag to a string
-          value.flag ++ value.arg
+    std.typeof value
+    |> match {
+      'String =>
+        if std.string.length value > 0
+        && std.array.any ((==) (std.string.substring 0 1 value)) available then
+          value
         else
-          std.contract.blame_with_message "unknown flag %{value.flag}" label
-      else
-        std.contract.blame_with_message
-          "bad record structure: missing field `flag` or `arg`"
-          label
-    else
-      std.contract.blame_with_message "expected record or string" label
+          std.contract.blame_with_message "unknown flag %{value}" label,
+      'Record =>
+        if std.record.has_field "flag" value && std.record.has_field "arg" value then
+          if std.array.any ((==) value.flag) available then
+            #Normalize the tag to a string
+            value.flag ++ value.arg
+          else
+            std.contract.blame_with_message "unknown flag %{value.flag}" label
+        else
+          std.contract.blame_with_message
+            "bad record structure: missing field `flag` or `arg`"
+            label,
+      _ => std.contract.blame_with_message "expected record or string" label,
+    }
 in
 
 let Path =
@@ -87,7 +89,9 @@ let Contract = {
 }
 in
 
-{
-  flags = ["Wextra", { flag = "o", arg = "stuff.o" }],
-  optimization_level = 2,
-} | Contract
+(
+  {
+    flags = ["Wextra", { flag = "o", arg = "stuff.o" }],
+    optimization_level = 2,
+  } | Contract
+)

--- a/examples/foreach-pattern/foreach-pattern-on-import.ncl
+++ b/examples/foreach-pattern/foreach-pattern-on-import.ncl
@@ -1,16 +1,13 @@
 # test = 'ignore'
-let users =
-  (import "data_users.yml").users
-  |> std.array.map
-    (
-      fun name =>
-        {
-          username = name,
-          email = "%{name}@nickel-lang.org"
-        }
-    )
-in
-
 {
-  posix_users = users
+  posix_users =
+    (import "data_users.yml").users
+    |> std.array.map
+      (
+        fun name =>
+          {
+            username = name,
+            email = "%{name}@nickel-lang.org"
+          }
+      )
 }

--- a/examples/foreach-pattern/foreach-pattern.ncl
+++ b/examples/foreach-pattern/foreach-pattern.ncl
@@ -1,16 +1,13 @@
 # test = 'pass'
-let users =
-  ["jane", "pete", "richie"]
-  |> std.array.map
-    (
-      fun name =>
-        {
-          username = name,
-          email = "%{name}@nickel-lang.org"
-        }
-    )
-in
-
 {
-  usernames = users
+  user =
+    ["jane", "pete", "richie"]
+    |> std.array.map
+      (
+        fun name =>
+          {
+            username = name,
+            email = "%{name}@nickel-lang.org",
+          }
+      )
 }

--- a/examples/merge-priorities/security.ncl
+++ b/examples/merge-priorities/security.ncl
@@ -3,7 +3,9 @@
   server.host.options | priority 10 = "TLS",
 
   # force make it impossible to override this value with false
-  firewall.enabled | force = true,
-  firewall.type | default = "iptables",
-  firewall.open_ports | priority 5 = [21, 80, 443],
+  firewall = {
+    enabled | force = true,
+    type | default = "iptables",
+    open_ports | priority 5 = [21, 80, 443],
+  },
 }

--- a/examples/merge-priorities/server.ncl
+++ b/examples/merge-priorities/server.ncl
@@ -1,6 +1,8 @@
 # test = 'ignore'
 {
-  server.host.ip | default = "182.168.1.1",
-  server.host.port | default = 80,
-  server.host.name | default = "hello-world.net",
+  server.host = {
+    ip | default = "182.168.1.1",
+    port | default = 80,
+    name | default = "hello-world.net",
+  },
 }

--- a/examples/merge/server.ncl
+++ b/examples/merge/server.ncl
@@ -1,6 +1,8 @@
 # test = 'ignore'
 {
-  server.host.ip = "182.168.1.1",
-  server.host.port = 80,
-  server.host.name = "hello-world.net",
+  server.host = {
+    ip = "182.168.1.1",
+    port = 80,
+    name = "hello-world.net",
+  },
 }

--- a/examples/record-contract/record-contract.ncl
+++ b/examples/record-contract/record-contract.ncl
@@ -39,25 +39,28 @@ let KubernetesConfig = {
 
   apiVersion | String,
 
-  metadata = {
-    name | String,
-    labels.app | String,
-  },
-
-  spec = {
-    replicas
-      | std.number.PosNat
-      | doc "The number of replicas"
-      | default
-      = 1,
-
-    selector.matchLabels.app | String,
-
-    template = {
-      metadata.labels.app | String,
-      spec.containers | Array Container,
+  metadata
+    | {
+      name | String,
+      labels.app | String,
     },
-  },
+
+  spec
+    | {
+      replicas
+        | std.number.PosNat
+        | doc "The number of replicas"
+        | default
+        = 1,
+
+      selector.matchLabels.app | String,
+
+      template
+        | {
+          metadata.labels.app | String,
+          spec.containers | Array Container,
+        },
+    },
 }
 in
 


### PR DESCRIPTION
The initial motivation for this small PR was to fix an inconsistency between examples and the user manual: the "Warning `=` vs `|`" paragraph advises to use `|` as much as possible, but the record-contract example uses `=` inside contracts.

Doing so, I also took a tour of the existing examples to update them to use latest niceties whenever it made the code simple/more idiomatic/more readable (at least IMHO, but please challenge it if you don't think alike!)