### PR TITLE
Propagate pending array contracts in permissive_eval

### DIFF
--- a/core/src/eval/mod.rs
+++ b/core/src/eval/mod.rs
@@ -956,12 +956,17 @@ impl<R: ImportResolver, C: Cache> VirtualMachine<R, C> {
                     slf.reset();
                 }
                 Ok(t) => match t.as_ref() {
-                    Term::Array(ts, _) => {
+                    Term::Array(ts, attrs) => {
                         for t in ts.iter() {
                             // After eval_closure, all the array elements  are
                             // closurized already, so we don't need to do any tracking
                             // of the env.
-                            inner(slf, acc, t.clone());
+                            let value_with_ctr = RuntimeContract::apply_all(
+                                t.clone(),
+                                attrs.pending_contracts.iter().cloned(),
+                                t.pos,
+                            );
+                            inner(slf, acc, value_with_ctr);
                         }
                     }
                     Term::Record(data) => {

--- a/lsp/nls/tests/inputs/diagnostics-array.ncl
+++ b/lsp/nls/tests/inputs/diagnostics-array.ncl
@@ -1,0 +1,13 @@
+### /diagnostics-array.ncl
+[
+  [
+    "a",
+  ] | Array Number,
+  [
+    { num = "str" }
+  ] | Array { num | Number },
+  [
+    [ "a" ]
+  ] | Array (Array Number),
+]
+### diagnostic = ["file:///diagnostics-array.ncl"]

--- a/lsp/nls/tests/snapshots/main__lsp__nls__tests__inputs__diagnostics-array.ncl.snap
+++ b/lsp/nls/tests/snapshots/main__lsp__nls__tests__inputs__diagnostics-array.ncl.snap
@@ -1,0 +1,13 @@
+---
+source: lsp/nls/tests/main.rs
+expression: output
+---
+(file:///diagnostics-array.ncl, 2:4-2:7: applied to this expression)
+(file:///diagnostics-array.ncl, 3:12-3:18: contract broken by a value)
+(file:///diagnostics-array.ncl, 3:12-3:18: expected array element type)
+(file:///diagnostics-array.ncl, 5:12-5:17: applied to this expression)
+(file:///diagnostics-array.ncl, 6:20-6:26: contract broken by the value of `num`)
+(file:///diagnostics-array.ncl, 6:20-6:26: expected type)
+(file:///diagnostics-array.ncl, 8:6-8:9: applied to this expression)
+(file:///diagnostics-array.ncl, 9:19-9:25: contract broken by a value)
+(file:///diagnostics-array.ncl, 9:19-9:25: expected array element type)


### PR DESCRIPTION
I don't think this had an issue, but it was mentioned in the discord...