### PR TITLE
Improve diagnostic location in nls

### DIFF
--- a/lsp/nls/tests/snapshots/main__lsp__nls__tests__inputs__diagnostics-array.ncl.snap
+++ b/lsp/nls/tests/snapshots/main__lsp__nls__tests__inputs__diagnostics-array.ncl.snap
@@ -3,11 +3,11 @@ source: lsp/nls/tests/main.rs
 expression: output
 ---
 (file:///diagnostics-array.ncl, 2:4-2:7: applied to this expression)
-(file:///diagnostics-array.ncl, 3:12-3:18: contract broken by a value)
+(file:///diagnostics-array.ncl, 2:4-2:7: contract broken by a value)
 (file:///diagnostics-array.ncl, 3:12-3:18: expected array element type)
 (file:///diagnostics-array.ncl, 5:12-5:17: applied to this expression)
-(file:///diagnostics-array.ncl, 6:20-6:26: contract broken by the value of `num`)
+(file:///diagnostics-array.ncl, 5:12-5:17: contract broken by the value of `num`)
 (file:///diagnostics-array.ncl, 6:20-6:26: expected type)
 (file:///diagnostics-array.ncl, 8:6-8:9: applied to this expression)
-(file:///diagnostics-array.ncl, 9:19-9:25: contract broken by a value)
+(file:///diagnostics-array.ncl, 8:6-8:9: contract broken by a value)
 (file:///diagnostics-array.ncl, 9:19-9:25: expected array element type)

--- a/lsp/nls/tests/snapshots/main__lsp__nls__tests__inputs__diagnostics-basic.ncl.snap
+++ b/lsp/nls/tests/snapshots/main__lsp__nls__tests__inputs__diagnostics-basic.ncl.snap
@@ -2,10 +2,9 @@
 source: lsp/nls/tests/main.rs
 expression: output
 ---
-(file:///diagnostics-basic.ncl, 1:8-1:14: contract broken by the value of `num`)
 (file:///diagnostics-basic.ncl, 1:8-1:14: expected type)
 (file:///diagnostics-basic.ncl, 1:17-1:20: applied to this expression)
+(file:///diagnostics-basic.ncl, 1:17-1:20: contract broken by the value of `num`)
 (file:///diagnostics-basic.ncl, 2:9-2:12: applied to this expression)
-(file:///diagnostics-basic.ncl, 3:13-3:19: contract broken by the value of `num2`)
+(file:///diagnostics-basic.ncl, 2:9-2:12: contract broken by the value of `num2`)
 (file:///diagnostics-basic.ncl, 3:13-3:19: expected type)
-


### PR DESCRIPTION
This adds a better heuristic for the "main" location of a diagnostic: we take the first label with the "primary" style, instead of just the first label.

In practice, this means that contract errors point first to the location of the value that violates the contract (whereas previously they were pointing to the contract itself).