### PR TITLE
modular-configurations.md: to_lower -> lowercase

### DIFF
--- a/doc/manual/modular-configurations.md
+++ b/doc/manual/modular-configurations.md
@@ -377,7 +377,7 @@ a reusable configuration module. For example:
         | optional,
     },
   local | not_exported = {
-      computed = std.string.to_lower inputs.foo,
+      computed = std.string.lowercase inputs.foo,
     },
 
   some_config_option = inputs.bar + 1,


### PR DESCRIPTION
I tried running the example from the "Toward modules" section of `doc/manual/modular-configurations.md`, and I got the following error message:
```
error: missing field `to_lower`
     ┌─ /home/homestar/tmp/machines.ncl:14:18
     │
  14 │       computed = std.string.to_lower inputs.foo,
     │                  ^^^^^^^^^^^^^^^^^^^ this requires the field `to_lower` to exist
     │
     ┌─ <stdlib/std.ncl>:2295:12
     │
2295 │     string = {
     │ ╭────────────'
2296 │ │     BoolLiteral
2297 │ │       | doc m%"
2298 │ │         Contract for a string representation of a boolean, namely `true` or
     · │
2872 │ │       = fun s => %enum_from_str% s,
2873 │ │   },
     │ ╰───' this record lacks the field `to_lower`
```
Looking at nickel's standard library docs, I concluded that `std.string.to_lower` should probably be replaced with `std.string.lowercase`.