### PR TITLE
Fix a flaky test (and refresh diagnostics correctly)

### DIFF
--- a/lsp/nls/src/files.rs
+++ b/lsp/nls/src/files.rs
@@ -46,7 +46,7 @@ pub fn handle_open(server: &mut Server, params: DidOpenTextDocumentParams) -> Re
 
     for rev_dep in &invalid {
         let diags = server.world.parse_and_typecheck(*rev_dep);
-        server.issue_diagnostics(file_id, diags);
+        server.issue_diagnostics(*rev_dep, diags);
     }
     Trace::reply(id);
     Ok(())

--- a/lsp/nls/tests/main.rs
+++ b/lsp/nls/tests/main.rs
@@ -35,6 +35,11 @@ fn refresh_missing_imports() {
     assert_eq!(2, diags.len());
     assert!(diags[0].message.contains("import of dep.ncl failed"));
 
+    // We expect another copy of the diagnostics (coming from background eval).
+    let diags = harness.wait_for_diagnostics().diagnostics;
+    assert_eq!(2, diags.len());
+    assert!(diags[0].message.contains("import of dep.ncl failed"));
+
     // Now provide the import.
     harness.send_file(url("/dep.ncl"), "42");
 


### PR DESCRIPTION
This fixes a test that was flaky in macOS ci, because it depended on a race condition between the background task sending its diagnostics and the test harness sending the next file.

There was an actual bug here too, with some diagnostics coming back for the wrong file.