### PR TITLE
manual/modular-configurations.md: add argument to std.string.join

### DIFF
--- a/doc/manual/modular-configurations.md
+++ b/doc/manual/modular-configurations.md
@@ -381,7 +381,7 @@ a reusable configuration module. For example:
     },
 
   some_config_option = inputs.bar + 1,
-  other_option = std.string.join ["Hello", local.computed],
+  other_option = std.string.join " " ["Hello", local.computed],
   last_option = "values are %{local.computed} and %{std.to_string inputs.bar}",
 }
 ```


### PR DESCRIPTION
This is another change related to the final example in `doc/manual/modular-configurations.md`.
The `std.string.join` function takes two arguments.

Before this change:
```
$ echo '(import "example.ncl") & {inputs = {foo = "Phooey", bar = 123}}' | nickel export
error: non serializable term
   ┌─ <stdlib/internals.ncl>:44:7
   │
44 │ ╭       (
45 │ │         fun x =>
46 │ │           value
47 │ │             (
   · │
52 │ │             )
53 │ │       )
   │ ╰───────^
   │
   = Nickel only supports serializing to and from strings, booleans, numbers, enum tags, `null` (depending on the format), as well as records and arrays of serializable values.
   = Functions and special values (such as contract labels) aren't serializable.
   = If you want serialization to ignore a specific value, please use the `not_exported` metadata.
```
After this change:
```
$ echo '(import "example.ncl") & {inputs = {foo = "Phooey", bar = 123}}' | nickel export
{
  "last_option": "values are phooey and 123",
  "other_option": "Hello phooey",
  "some_config_option": 124
}
```