### PR TITLE
manual/syntax.md: minor typo

### DIFF
--- a/doc/manual/syntax.md
+++ b/doc/manual/syntax.md
@@ -683,7 +683,7 @@ value of the corresponding shape.
 For example, `'Foo`, `'Bar x` or `'protocol {x,y}` are valid enum patterns.
 
 Two or more nested variant patterns must be parenthesized. For example, `'Ok
-'Some Stuff` isn't a valid enum pattern. On the other hand, `'Ok ('Some 'Stuff)`
+'Some 'Stuff` isn't a valid enum pattern. On the other hand, `'Ok ('Some 'Stuff)`
 or `'Foo ('Bar x)` are valid enum patterns.
 
 #### Record patterns


### PR DESCRIPTION
This PR modifies the text `'Ok 'Some Stuff` -> `'Ok 'Some 'Stuff` to be consistent with the text `'Ok ('Some 'Stuff)` that occurs later in the same sentence.