### PR TITLE
Update release infrastructure NixOS configuration

### DIFF
--- a/infra/github-runner.nix
+++ b/infra/github-runner.nix
@@ -1,4 +1,4 @@
-### https://nixos.org/channels/nixos-unstable nixos
+### https://nixos.org/channels/nixos-23.11 nixos
 { pkgs, lib, ... }:
 let
   runner-name = "ec2-spot";
@@ -7,10 +7,9 @@ in
   imports = [ <nixpkgs/nixos/modules/virtualisation/amazon-image.nix> ];
   ec2.hvm = true;
 
-  services.github-runner = {
+  services.github-runners."$${runner-name}" = {
     enable = true;
     replace = true;
-    name = runner-name;
     nodeRuntimes = [ "node20" ];
     extraPackages = with pkgs; [
       gh


### PR DESCRIPTION
Upstream has changed the configuration schema for GitHub runners in
NixOS. Update our configuration to follow suit.

The change is deployed and building Nickel 1.5 artifacts right now.
