### PR TITLE
Add a GitHub workflow for testing the release infrastructure

### DIFF
--- a/.github/workflows/release-infra-test.yaml
+++ b/.github/workflows/release-infra-test.yaml
@@ -1,0 +1,97 @@
+name: Test the ARM64 runner infrastructure
+on:
+  workflow_dispatch:
+
+# TODO: ideally this and `release-artifacts.yaml` should depend on a runner workflow, so that we can't have the two setups diverge. For now, this copyint is quick and good enough.
+
+permissions:
+  id-token: write
+
+jobs:
+  start-runner:
+    name: Start EC2 runner
+    runs-on: ubuntu-latest
+    outputs:
+      instance_id: ${{ steps.invoke-start.outputs.INSTANCE_ID }}
+    steps:
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.EC2_ROLE }}
+          aws-region: ${{ vars.EC2_REGION }}
+      - name: Start EC2 instance
+        id: invoke-start
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN_FOR_UPDATES }}
+          EC2_START: ${{ secrets.EC2_START }}
+        run: |
+          RUNNER_TOKEN=$(gh api -X POST -q '.token' /repos/${{ github.repository }}/actions/runners/registration-token)
+          aws lambda invoke \
+            --cli-binary-format raw-in-base64-out \
+            --function-name "$EC2_START" \
+            --payload '{"ref_name":"${{ github.ref_name }}","runner_token":"'"${RUNNER_TOKEN}"'"}' \
+            response.json
+          INSTANCE_ID=$(jq -r '.body.instance_id' < response.json)
+          echo "INSTANCE_ID=${INSTANCE_ID}" >>"$GITHUB_OUTPUT"
+          echo "Got EC2 instance ${INSTANCE_ID}"
+          echo 'Waiting for GitHub runner to start'
+          while [[ -z "$(gh api /repos/${{ github.repository }}/actions/runners | jq '.runners[] | select(.name == "ec2-spot")')" ]]; do
+            sleep 60
+          done
+          echo 'Done 🎉'
+
+  stop-runner:
+    name: Stop EC2 runner
+    runs-on: ubuntu-latest
+    # Ensure that `stop-runner` will always stop the EC2 instance, even if other jobs failed or were canceled
+    if: ${{ always() }}
+    needs:
+      - start-runner
+      - release-artifacts
+    steps:
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.EC2_ROLE }}
+          aws-region: ${{ vars.EC2_REGION }}
+      - name: Delete GitHub Runner
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN_FOR_UPDATES }}
+        run: |
+          RUNNER_ID=$(gh api /repos/${{ github.repository }}/actions/runners | jq '.runners[] | select(.name == "ec2-spot") | .id')
+          if [[ -n "${RUNNER_ID}" ]]; then
+            gh api -X DELETE /repos/${{ github.repository }}/actions/runners/${RUNNER_ID}
+          fi
+      - name: Lambda Invoke Stop
+        env:
+          EC2_STOP: ${{ secrets.EC2_STOP }}
+        run: |
+          aws lambda invoke \
+            --cli-binary-format raw-in-base64-out \
+            --function-name "$EC2_STOP" \
+            --payload '{"instance_id":"${{ needs.start-runner.outputs.instance_id }}"}' \
+            response.json
+          cat response.json
+
+  release-artifacts:
+    name: "Build hello"
+    strategy:
+      matrix:
+        os:
+          - runs-on: [EC2, ARM64, Linux]
+            architecture: arm64
+    runs-on: ${{ matrix.os.runs-on }}
+    needs:
+      - start-runner
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: master
+      - uses: cachix/install-nix-action@v25
+        name: "Installing Nix"
+        with:
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+            accept-flake-config = true
+          nix_path: "nixpkgs=channel:nixos-unstable"
+      - name: "Build hello"
+        run: |
+          nix build --log-format raw-with-logs nixpkgs#hello

--- a/.github/workflows/release-infra-test.yaml
+++ b/.github/workflows/release-infra-test.yaml
@@ -1,5 +1,6 @@
 name: Test the ARM64 runner infrastructure
 on:
+  pull_request: # TODO: make absolutely sure to remove this before merging
   workflow_dispatch:
 
 # TODO: ideally this and `release-artifacts.yaml` should depend on a runner workflow, so that we can't have the two setups diverge. For now, this copyint is quick and good enough.


### PR DESCRIPTION
The `release-infra-test.yaml` workflow can be called manually to build
`nixpkgs#hello` on the ARM64 runner. The plan is to use it as a test
while making a release to catch problems with the infrastructure early.

TODO: this doesn't work yet, because the infrastructure is only allowed to be run on release tags. I'll look into a good way to address this later.