### PR TITLE
Add a recursion limit to background evaluation

### DIFF
--- a/lsp/nls/src/background.rs
+++ b/lsp/nls/src/background.rs
@@ -19,7 +19,7 @@ use crate::{
 };
 
 const EVAL_TIMEOUT: Duration = Duration::from_secs(1);
-const RECURSION_LIMIT: u64 = 128;
+const RECURSION_LIMIT: usize = 128;
 
 #[derive(Debug, Serialize, Deserialize)]
 enum Command {

--- a/lsp/nls/src/background.rs
+++ b/lsp/nls/src/background.rs
@@ -19,6 +19,7 @@ use crate::{
 };
 
 const EVAL_TIMEOUT: Duration = Duration::from_secs(1);
+const RECURSION_LIMIT: u64 = 128;
 
 #[derive(Debug, Serialize, Deserialize)]
 enum Command {
@@ -97,7 +98,7 @@ pub fn worker_main() -> anyhow::Result<()> {
             // We've already checked that parsing and typechecking are successful, so we
             // don't expect further errors.
             let rt = vm.prepare_eval(file_id).unwrap();
-            let errors = vm.eval_permissive(rt);
+            let errors = vm.eval_permissive(rt, RECURSION_LIMIT);
             diagnostics.extend(
                 errors
                     .into_iter()

--- a/lsp/nls/tests/inputs/diagnostics-recursion.ncl
+++ b/lsp/nls/tests/inputs/diagnostics-recursion.ncl
@@ -1,0 +1,7 @@
+### /diagnostics-recursion.ncl
+let rec foo = { bar = foo } in
+[
+  foo,
+  foo.bar.bar.bar.bar.bar.baz
+]
+### diagnostic = ["file:///diagnostics-recursion.ncl"]

--- a/lsp/nls/tests/snapshots/main__lsp__nls__tests__inputs__diagnostics-recursion.ncl.snap
+++ b/lsp/nls/tests/snapshots/main__lsp__nls__tests__inputs__diagnostics-recursion.ncl.snap
@@ -1,0 +1,8 @@
+---
+source: lsp/nls/tests/main.rs
+expression: output
+---
+(file:///diagnostics-recursion.ncl, 0:14-0:27: this record lacks the field `baz`)
+(file:///diagnostics-recursion.ncl, 3:2-3:29: missing field `baz`
+Did you mean `bar`?)
+(file:///diagnostics-recursion.ncl, 3:2-3:29: this requires the field `baz` to exist)


### PR DESCRIPTION
Adds a recursion limit (currently hardcoded to 128) to the background evaluator in nls. This limit applies to recursion in arrays or records, not to recursive function calls.

This might fix #1875 (it's hard to tell, as I can't reproduce it). But independent of that, it avoids a crash and preserves eval diagnostics.