### PR TITLE
Markdown documentation generation: do not insert line breaks

### DIFF
--- a/cli/tests/snapshot/snapshots/snapshot__doc_stdout_record.ncl.snap
+++ b/cli/tests/snapshot/snapshots/snapshot__doc_stdout_record.ncl.snap
@@ -4,6 +4,4 @@ expression: out
 ---
 # `Hello`
 
-\
 World\!
-

--- a/cli/tests/snapshot/snapshots/snapshot__doc_stdout_types.ncl.snap
+++ b/cli/tests/snapshot/snapshots/snapshot__doc_stdout_types.ncl.snap
@@ -6,6 +6,4 @@ expression: out
 
 - `Hello : Number`
 - `Hello | std.string.Stringable`
-\
 World\!
-

--- a/core/src/program.rs
+++ b/core/src/program.rs
@@ -789,8 +789,6 @@ mod doc {
                     ))
                 }
 
-                document.append(arena.alloc(AstNode::from(NodeValue::LineBreak)));
-
                 if let Some(ref doc) = field.documentation {
                     document.append(parse_markdown_string(header_level + 1, arena, doc, options));
                 }


### PR DESCRIPTION
Fixes #1706.

The code generating markdown documentation from a Nickel configuration used to unconditionally insert hard line breaks between a field's signature and the rest of its documentation. However, one can't insert a hard line break immediately followed by a blocks in commonmark (or put differently: it's not representable as a source), and those line breaks were just rendered as spurious backslashes at best, or sometimes interpreted differently (see #1706 for more details).

A bit of experimentation showed that what comes after this line break is always a block in the sense of commonmark (even when it's simple documentation text, it's wrapped as a Markdown paragraph). Thus this PR just removes the line break altogether, which is not useful and never legal anyway.