### PR TITLE
[Fix] Nickel doc: fix missing newline in markdown output

### DIFF
--- a/cli/tests/snapshot/snapshots/snapshot__doc_stdout_types.ncl.snap
+++ b/cli/tests/snapshot/snapshots/snapshot__doc_stdout_types.ncl.snap
@@ -6,4 +6,5 @@ expression: out
 
 - `Hello : Number`
 - `Hello | std.string.Stringable`
+
 World\!

--- a/core/src/program.rs
+++ b/core/src/program.rs
@@ -895,10 +895,22 @@ mod doc {
             tight: true,
         })));
 
-        list_item.append(arena.alloc(AstNode::from(NodeValue::Code(NodeCode {
+        // We have to wrap the content of the list item into a paragraph, otherwise the list won't
+        // be properly separated from the next block coming after it, producing invalid output (for
+        // example, the beginning of the documenantation of the current field might be merged with
+        // the last type or contract item).
+        //
+        // We probably shouldn't have to, but afer diving into comrak's rendering engine, it seems
+        // that some subtle interactions make things work correctly for parsed markdown (as opposed to
+        // this one being programmatically generated) just because list items are always parsed as
+        // paragraphs. We thus mimic this unspoken invariant here.
+        let paragraph = arena.alloc(AstNode::from(NodeValue::Paragraph));
+
+        paragraph.append(arena.alloc(AstNode::from(NodeValue::Code(NodeCode {
             literal: format!("{ident} {separator} {typ}"),
             num_backticks: 1,
         }))));
+        list_item.append(paragraph);
 
         list_item
     }


### PR DESCRIPTION
#1879  fixed `nickel doc` markdown output having spurious backslashes (#1706). However, #1879 also re-introduced a previous issue - which was why the removed hard line breaks was introduced in the first place - which is that the list of types and contracts of a field and the custom documentation might be squashed together because the renderer wouldn't properly insert a newline after the generated list (#1520).

After some investigation, it seems to be a bug in the comrak renderer. However, this bug doesn't show when the markdown is parsed from an actual source (instead of being programmatically generated). It turns out comrak correctly inserting this required newline relies on the unspoken assumption that every markdown list item content is wrapped as a paragraph. This commit thus fixes the issue by inserting the missing paragraph wrapper.