### PR TITLE
Dedup diagnostics

### DIFF
--- a/lsp/nls/src/background.rs
+++ b/lsp/nls/src/background.rs
@@ -112,6 +112,8 @@ pub fn worker_main() -> anyhow::Result<()> {
             );
         }
 
+        diagnostics.sort();
+        diagnostics.dedup();
         let diagnostics = Diagnostics { path, diagnostics };
 
         // If this fails, the main process has already exited. No need for a loud error in that case.

--- a/lsp/nls/tests/inputs/diagnostics-recursion.ncl
+++ b/lsp/nls/tests/inputs/diagnostics-recursion.ncl
@@ -1,5 +1,5 @@
 ### /diagnostics-recursion.ncl
-let rec foo = { bar = foo } in
+let rec foo = { bar = foo, quux | String = 1 } in
 [
   foo,
   foo.bar.bar.bar.bar.bar.baz

--- a/lsp/nls/tests/snapshots/main__lsp__nls__tests__inputs__diagnostics-recursion.ncl.snap
+++ b/lsp/nls/tests/snapshots/main__lsp__nls__tests__inputs__diagnostics-recursion.ncl.snap
@@ -2,7 +2,10 @@
 source: lsp/nls/tests/main.rs
 expression: output
 ---
-(file:///diagnostics-recursion.ncl, 0:14-0:27: this record lacks the field `baz`)
+(file:///diagnostics-recursion.ncl, 0:14-0:46: this record lacks the field `baz`)
+(file:///diagnostics-recursion.ncl, 0:34-0:40: expected type)
+(file:///diagnostics-recursion.ncl, 0:43-0:44: applied to this expression)
+(file:///diagnostics-recursion.ncl, 0:43-0:44: contract broken by the value of `quux`)
 (file:///diagnostics-recursion.ncl, 3:2-3:29: missing field `baz`
 Did you mean `bar`?)
 (file:///diagnostics-recursion.ncl, 3:2-3:29: this requires the field `baz` to exist)


### PR DESCRIPTION
Unfortunately the `lsp_types` crate doesn't provide a lot of `Ord` impls, so I had to write some wrappers. Is there a better way? (Of course we could use hashmaps to dedup, but `lsp_types` also doesn't provide `Hash` impls)

Fixes #1882 