### PR TITLE
[Fix] Allow multiple underscore to start identifiers

### DIFF
--- a/core/src/parser/lexer.rs
+++ b/core/src/parser/lexer.rs
@@ -69,7 +69,7 @@ pub enum NormalToken<'input> {
     // This regex should be kept in sync with the one for RawEnumTag below.
     // Also, any change in the lexer regex must also be backported in the LSP's
     // regex for checking identifiers at ../lsp/nls/src/requests/completion.rs
-    #[regex("_?[a-zA-Z][_a-zA-Z0-9-']*")]
+    #[regex("_*[a-zA-Z][_a-zA-Z0-9-']*")]
     Identifier(&'input str),
     #[regex("[0-9]*\\.?[0-9]+([eE][+\\-]?[0-9]+)?", |lex| parse_number_sci(lex.slice()))]
     DecNumLiteral(Number),
@@ -82,7 +82,7 @@ pub enum NormalToken<'input> {
 
     // **IMPORTANT**
     // This regex should be kept in sync with the one for Identifier above.
-    #[regex("'_?[a-zA-Z][_a-zA-Z0-9-']*", |lex| lex.slice().split_at(1).1)]
+    #[regex("'_*[a-zA-Z][_a-zA-Z0-9-']*", |lex| lex.slice().split_at(1).1)]
     RawEnumTag(&'input str),
     #[token("'\"")]
     StrEnumTagBegin,

--- a/core/src/pretty.rs
+++ b/core/src/pretty.rs
@@ -58,7 +58,7 @@ fn escape(s: &str) -> String {
         .replace('\r', "\\r")
 }
 
-static QUOTING_REGEX: Lazy<Regex> = Lazy::new(|| Regex::new("^_?[a-zA-Z][_a-zA-Z0-9-]*$").unwrap());
+static QUOTING_REGEX: Lazy<Regex> = Lazy::new(|| Regex::new("^_*[a-zA-Z][_a-zA-Z0-9-]*$").unwrap());
 
 /// Return the string representation of an identifier, and add enclosing double quotes if the
 /// label isn't a valid identifier according to the parser, for example if it contains a

--- a/core/tests/integration/inputs/parsing/identifiers.ncl
+++ b/core/tests/integration/inputs/parsing/identifiers.ncl
@@ -1,0 +1,8 @@
+# test.type = 'pass'
+let {Assert, check, ..} = import "../lib/assert.ncl" in
+
+[
+  let this-isn't-invalid = true in this-isn't-invalid,
+  let ___multi_underscore_start = true in ___multi_underscore_start,
+]
+|> check

--- a/core/tests/integration/inputs/parsing/quote_in_identifier.ncl
+++ b/core/tests/integration/inputs/parsing/quote_in_identifier.ncl
@@ -1,4 +1,0 @@
-# test.type = 'pass'
-let {Assert, ..} = import "../lib/assert.ncl" in
-
-let this-isn't-invalid = true in this-isn't-invalid | Assert

--- a/doc/manual/syntax.md
+++ b/doc/manual/syntax.md
@@ -6,11 +6,11 @@ slug: syntax
 
 ## Identifiers
 
-Nickel identifiers start with an optional underscore `_` followed by an
-alphabetic character (`a` to `z` or `A` to `Z`). They are then followed by
-zero or more alphanumeric characters (alphabetic characters or digits `0` to
-`9`), `_` (underscores), `-` (dashes) or `'` (single quotes). For example,
-`_This-isn't_invalid` is a valid identifier.
+Nickel identifiers start with zero or more underscores `_`, followed by an
+alphabetic character (`a` to `z` or `A` to `Z`). They are then followed by zero
+or more alphanumeric characters (alphabetic characters or digits `0` to `9`),
+`_` (underscores), `-` (dashes) or `'` (single quotes). For example,
+`___This-isn't_invalid` is a valid identifier.
 
 ## Simple values
 


### PR DESCRIPTION
Identifiers were required to start with at most one optional underscore, followed by an alphabetic character (to avoid identifiers like _-'), and then by any identifier character. This means that identifiers like `__foo` were invalid.

There is no good reason for that, and this is mostly an oversight when writing the initial regular expression. This commit extends the lexer to allow zero or more heading underscores before the first alphabetic character.

This came up as I tried to pick ugly, mangled and hopefully non-clashing names for generated Nickel code.