### PR TITLE
Leverage function contract information

### DIFF
--- a/core/src/parser/utils.rs
+++ b/core/src/parser/utils.rs
@@ -644,9 +644,9 @@ pub fn mk_let(
     }
 }
 
-/// Generate a `Fun` or a `FunPattern` (depending on `assgn` having a pattern or not)
-/// from the parsing of a function definition. This function panics if the definition
-/// somehow has neither an `Ident` nor a non-`Empty` `Destruct` pattern.
+/// Generate a `Fun` (when the pattern is trivial) or a `FunPattern` from the parsing of a function
+/// definition. This function panics if the definition somehow has neither an `Ident` nor a
+/// non-`Empty` `Destruct` pattern.
 pub fn mk_fun(pat: Pattern, body: RichTerm) -> Term {
     match pat.data {
         PatternData::Any(id) => Term::Fun(id, body),

--- a/lsp/nls/tests/inputs/completion-fun-parameter-contract.ncl
+++ b/lsp/nls/tests/inputs/completion-fun-parameter-contract.ncl
@@ -1,0 +1,18 @@
+### /file.ncl
+{
+  Schema = {
+    foo | { bar },
+    baz,
+  },
+  some_func
+    | Schema -> Dyn
+    = fun src =>
+      {
+        some_val = src.foo,
+      },
+}
+### [[request]]
+### type = "Completion"
+### textDocument.uri = "file:///file.ncl"
+### position = { line = 9, character = 23 }
+### context = { triggerKind = 2, triggerCharacter = "." }

--- a/lsp/nls/tests/snapshots/main__lsp__nls__tests__inputs__completion-fun-parameter-contract.ncl.snap
+++ b/lsp/nls/tests/snapshots/main__lsp__nls__tests__inputs__completion-fun-parameter-contract.ncl.snap
@@ -1,0 +1,5 @@
+---
+source: lsp/nls/tests/main.rs
+expression: output
+---
+[baz, foo]


### PR DESCRIPTION
Closes #1885.

When a function is annotated with a function contract, use this additional type information to enable completion in the LSP (and also use the domain as the type of the function's argument in the typing environment, even if we are in walk mode). Contract data are easy to fetch during typechecking when available and use them improve the developer experience by bringing in more static information.

I hesitated to updated the documentation about the fact that the typechecker is marginally smarter about function contracts, but I'm not sure yet we want to commit to it fully yet. Honestly I don't expect it to be used a lot in the wild, I mostly did it because it was virtually free (performance-wise and code complexity-wise).