### PR TITLE
Fix LSP not showing type signature in untyped code

### DIFF
--- a/lsp/nls/tests/inputs/hover-stdlib-type.ncl
+++ b/lsp/nls/tests/inputs/hover-stdlib-type.ncl
@@ -1,0 +1,12 @@
+### /main.ncl
+let foo = { bar.baz : String -> Number = fun x => 1 }
+in
+foo.bar.baz "0" + std.string.to_number "1"
+### [[request]]
+### type = "Hover"
+### textDocument.uri = "file:///main.ncl"
+### position = { line = 2, character = 10 }
+### [[request]]
+### type = "Hover"
+### textDocument.uri = "file:///main.ncl"
+### position = { line = 2, character = 30 }

--- a/lsp/nls/tests/snapshots/main__lsp__nls__tests__inputs__hover-stdlib-type.ncl.snap
+++ b/lsp/nls/tests/snapshots/main__lsp__nls__tests__inputs__hover-stdlib-type.ncl.snap
@@ -1,0 +1,19 @@
+---
+source: lsp/nls/tests/main.rs
+expression: output
+---
+<2:0-2:11>[```nickel
+String -> Number
+```]
+<2:18-2:38>[Converts a string that represents a number to that number.
+
+# Examples
+
+```nickel
+std.string.to_number "123"
+  => 123
+```, ```nickel
+NumberLiteral -> Dyn
+```, ```nickel
+String -> Number
+```]


### PR DESCRIPTION
Most of the time, hovering over a symbol in untyped code would show `Dyn` even though the symbol has a type annotation - typically for records accessed via a non-trivial path, e.g. `foo.bar.baz`. This is an issue especially because we don't get to see the right types for stdlib symbols when hovering over them.

![Capture d’écran du 2024-04-12 15-58-40](https://github.com/tweag/nickel/assets/6530104/7e5df75d-161d-4b1e-a63d-630251f67ec2)

This PR fixes the issue by taking the type annotation (technically one of the aggregated type annotations) instead of the type provided by the typechecker when the latter is `Dyn`.