### PR TITLE
Force enum payloads

### DIFF
--- a/core/src/eval/operation.rs
+++ b/core/src/eval/operation.rs
@@ -1121,6 +1121,13 @@ impl<R: ImportResolver, C: Cache> VirtualMachine<R, C> {
                     // For an enum variant, `force x` is simply equivalent to `deep_seq x x`, as
                     // there's no lazy pending contract to apply.
                     Term::EnumVariant { tag, arg, attrs } => {
+                        let arg = mk_term::op1(
+                            UnaryOp::Force {
+                                ignore_not_exported,
+                            },
+                            arg,
+                        )
+                        .closurize(&mut self.cache, env.clone());
                         let cont = RichTerm::new(
                             Term::EnumVariant {
                                 tag,

--- a/core/tests/integration/inputs/adts/deep_seq_enum2.ncl
+++ b/core/tests/integration/inputs/adts/deep_seq_enum2.ncl
@@ -1,0 +1,7 @@
+# test.type = 'error'
+#
+# [test.metadata]
+# error = 'EvalError::NAryPrimopTypeError'
+
+# Check that deep_seq correctly deeply evaluates the content of an enum variant
+%deep_seq% ('Foo { bar = 5 + "a" }) null

--- a/core/tests/integration/inputs/adts/force_enum2.ncl
+++ b/core/tests/integration/inputs/adts/force_enum2.ncl
@@ -1,0 +1,7 @@
+# test.type = 'error'
+#
+# [test.metadata]
+# error = 'EvalError::NAryPrimopTypeError'
+
+# Check that force correctly deeply evaluates the content of an enum variant
+%force% ('Foo { bar = 5 + "a" })


### PR DESCRIPTION
Currently, enum payloads are being evaluated when the enum is forced, but not *deeply* evaluated. For example:
```
nickel> 'Foo { bar = 1 + 2 }
'Foo { bar = 1 + 2, }
```

Based on the comment in operation.rs, this seems unintentional (because `deep_seq` does deeply evaluate the payload). This PR changes the behavior to
```
nickel> 'Foo { bar = 1 + 2 }
'Foo { bar = 3, }
```