### PR TITLE
Remove different behaviour when single input

### DIFF
--- a/core/src/program.rs
+++ b/core/src/program.rs
@@ -371,7 +371,7 @@ impl<EC: EvalCache> Program<EC> {
     pub fn parse(&mut self) -> Result<RichTerm, Error> {
         self.vm
             .import_resolver_mut()
-            .parse(self.main_id)
+            .parse(self.main_id, InputFormat::Nickel)
             .map_err(Error::ParseErrors)?;
         Ok(self
             .vm
@@ -496,7 +496,9 @@ impl<EC: EvalCache> Program<EC> {
 
     /// Load, parse, and typecheck the program and the standard library, if not already done.
     pub fn typecheck(&mut self) -> Result<(), Error> {
-        self.vm.import_resolver_mut().parse(self.main_id)?;
+        self.vm
+            .import_resolver_mut()
+            .parse(self.main_id, InputFormat::Nickel)?;
         self.vm.import_resolver_mut().load_stdlib()?;
         let initial_env = self.vm.import_resolver().mk_type_ctxt().expect(
             "program::typecheck(): \

--- a/core/src/repl/mod.rs
+++ b/core/src/repl/mod.rs
@@ -6,7 +6,7 @@
 //! Dually, the frontend is the user-facing part, which may be a CLI, a web application, a
 //! jupyter-kernel (which is not exactly user-facing, but still manages input/output and
 //! formatting), etc.
-use crate::cache::{Cache, Envs, ErrorTolerance, SourcePath};
+use crate::cache::{Cache, Envs, ErrorTolerance, InputFormat, SourcePath};
 use crate::error::{
     report::{self, ColorOpt, ErrorFormat},
     Error, EvalError, IOError, IntoDiagnostics, ParseError, ParseErrors, ReplError,
@@ -232,7 +232,9 @@ impl<EC: EvalCache> Repl for ReplImpl<EC> {
             .import_resolver_mut()
             .add_file(OsString::from(path.as_ref()))
             .map_err(IOError::from)?;
-        self.vm.import_resolver_mut().parse(file_id)?;
+        self.vm
+            .import_resolver_mut()
+            .parse(file_id, InputFormat::Nickel)?;
 
         let term = self.vm.import_resolver().get_owned(file_id).unwrap();
         let pos = term.pos;

--- a/lsp/nls/src/incomplete.rs
+++ b/lsp/nls/src/incomplete.rs
@@ -8,7 +8,7 @@
 use std::path::PathBuf;
 
 use nickel_lang_core::{
-    cache::SourcePath,
+    cache::{InputFormat, SourcePath},
     parser::lexer::{self, NormalToken, SpannedToken, Token},
     position::RawSpan,
     term::{RichTerm, Term},
@@ -102,7 +102,7 @@ fn resolve_imports(rt: RichTerm, world: &mut World) -> RichTerm {
     } = import_resolution::tolerant::resolve_imports(rt, &mut world.cache);
 
     for id in resolved_ids {
-        if world.cache.parse(id).is_ok() {
+        if world.cache.parse(id, InputFormat::Nickel).is_ok() {
             // If a new input got imported in an incomplete term, try to typecheck
             // (and build lookup tables etc.) for it, but don't issue diagnostics.
             let _ = world.typecheck(id);

--- a/lsp/nls/src/world.rs
+++ b/lsp/nls/src/world.rs
@@ -8,7 +8,7 @@ use codespan::FileId;
 use lsp_server::{ErrorCode, ResponseError};
 use lsp_types::Url;
 use nickel_lang_core::{
-    cache::{Cache, CacheError, ErrorTolerance, SourcePath},
+    cache::{Cache, CacheError, ErrorTolerance, InputFormat, SourcePath},
     error::{ImportError, IntoDiagnostics},
     position::{RawPos, RawSpan},
     term::{record::FieldMetadata, RichTerm, Term, UnaryOp},
@@ -160,7 +160,7 @@ impl World {
         file_id: FileId,
     ) -> Result<Vec<SerializableDiagnostic>, Vec<SerializableDiagnostic>> {
         self.cache
-            .parse(file_id)
+            .parse(file_id, InputFormat::Nickel)
             .map(|nonfatal| self.lsp_diagnostics(file_id, nonfatal.inner()))
             .map_err(|fatal| self.lsp_diagnostics(file_id, fatal))
     }

--- a/utils/src/bench.rs
+++ b/utils/src/bench.rs
@@ -171,7 +171,7 @@ macro_rules! ncl_bench_group {
     (name = $group_name:ident; config = $config:expr; $($b:tt),+ $(,)*) => {
         pub fn $group_name() {
             use nickel_lang_core::{
-                cache::{Envs, Cache, ErrorTolerance, ImportResolver},
+                cache::{Envs, Cache, ErrorTolerance, ImportResolver, InputFormat},
                 eval::{VirtualMachine, cache::{CacheImpl, Cache as EvalCache}},
                 transform::import_resolution::strict::resolve_imports,
                 error::report::{report, ColorOpt, ErrorFormat},
@@ -194,7 +194,7 @@ macro_rules! ncl_bench_group {
                                 .unwrap()
                                 .transformed_term;
                             if bench.eval_mode == $crate::bench::EvalMode::TypeCheck {
-                                cache.parse(id).unwrap();
+                                cache.parse(id, InputFormat::Nickel).unwrap();
                                 cache.resolve_imports(id).unwrap();
                             }
                             (cache, id, t)


### PR DESCRIPTION
Addresses #1901. Proposition.

It could be so simple, but it seems that cli tests rely on specific behaviour for single file input. I'll think about it later, cause it requires grasping the way tests are made... What do you think? Is it good direction?