### PR TITLE
Include field path in non serializable error

### DIFF
--- a/cli/tests/snapshot/inputs/errors/non_serializable_print_path.ncl
+++ b/cli/tests/snapshot/inputs/errors/non_serializable_print_path.ncl
@@ -1,0 +1,22 @@
+# capture = 'stderr'
+# command = ['export']
+
+# Check that a non-serializable error prints the path in the notes. This is
+# particularly useful in the case tested below, when we haven't fully applied a
+# contract, because the error points to the contract definition site (at the
+# time of writing), and not the usage site, which is not very useful.
+let SomeParametricContract = fun parameter label value => value
+in
+{
+  foo.bar.baz =
+    [0, 1]
+    @ [
+      2,
+      (
+        {
+          inner = { qux_miss_param | SomeParametricContract = {} },
+        }
+        & { inner.qux_without_error = 1 }
+      ),
+    ],
+}

--- a/cli/tests/snapshot/snapshots/snapshot__export_stderr_non_serializable_print_path.ncl.snap
+++ b/cli/tests/snapshot/snapshots/snapshot__export_stderr_non_serializable_print_path.ncl.snap
@@ -1,0 +1,14 @@
+---
+source: cli/tests/snapshot/main.rs
+expression: err
+---
+error: non serializable term
+  ┌─ [INPUTS_PATH]/errors/non_serializable_print_path.ncl:8:30
+  │
+8 │ let SomeParametricContract = fun parameter label value => value
+  │                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  │
+  = When exporting field `foo.bar.baz[3].inner.qux_miss_param`
+  = Nickel only supports serializing to and from strings, booleans, numbers, enum tags, `null` (depending on the format), as well as records and arrays of serializable values.
+  = Functions and special values (such as contract labels) aren't serializable.
+  = If you want serialization to ignore a specific value, please use the `not_exported` metadata.

--- a/core/src/error/mod.rs
+++ b/core/src/error/mod.rs
@@ -26,7 +26,7 @@ use crate::{
     },
     position::{RawSpan, TermPos},
     repl,
-    serialize::ExportFormat,
+    serialize::{ExportFormat, NickelPointer},
     term::{record::FieldMetadata, Number, RichTerm, Term},
     typ::{EnumRow, RecordRow, Type, TypeF, VarKindDiscriminant},
 };
@@ -571,9 +571,18 @@ pub enum ImportError {
     ),
 }
 
-/// An error occurred during serialization.
 #[derive(Debug, PartialEq, Clone)]
-pub enum ExportError {
+pub struct ExportError {
+    /// The path to the field that contains a non-serializable value. This might be empty if the
+    /// error occurred before entering any record.
+    pub path: NickelPointer,
+    /// The cause of the error.
+    pub data: ExportErrorData,
+}
+
+/// The type of error occurring during serialization.
+#[derive(Debug, PartialEq, Clone)]
+pub enum ExportErrorData {
     /// Encountered a null value for a format that doesn't support them.
     UnsupportedNull(ExportFormat, RichTerm),
     /// Tried exporting something else than a `String` to raw format.
@@ -588,6 +597,15 @@ pub enum ExportError {
         value: Number,
     },
     Other(String),
+}
+
+impl From<ExportErrorData> for ExportError {
+    fn from(data: ExportErrorData) -> ExportError {
+        ExportError {
+            path: NickelPointer::new(),
+            data,
+        }
+    }
 }
 
 /// A general I/O error, occurring when reading a source file or writing an export.
@@ -2544,22 +2562,28 @@ impl IntoDiagnostics<FileId> for ExportError {
         files: &mut Files<String>,
         _stdlib_ids: Option<&Vec<FileId>>,
     ) -> Vec<Diagnostic<FileId>> {
-        match self {
-            ExportError::NotAString(rt) => vec![Diagnostic::error()
+        let mut notes = if !self.path.0.is_empty() {
+            vec![format!("When exporting field `{}`", self.path)]
+        } else {
+            vec![]
+        };
+
+        match self.data {
+            ExportErrorData::NotAString(rt) => vec![Diagnostic::error()
                 .with_message(format!(
                     "raw export expects a String value, but got {}",
                     rt.as_ref()
                         .type_of()
                         .unwrap_or_else(|| String::from("<unevaluated>"))
                 ))
-                .with_labels(vec![primary_term(&rt, files)])],
-            ExportError::UnsupportedNull(format, rt) => vec![Diagnostic::error()
-                .with_message(format!("{format} format doesn't support null values"))
-                .with_labels(vec![primary_term(&rt, files)])],
-            ExportError::NonSerializable(rt) => vec![Diagnostic::error()
-                .with_message("non serializable term")
                 .with_labels(vec![primary_term(&rt, files)])
-                .with_notes(vec![
+                .with_notes(notes)],
+            ExportErrorData::UnsupportedNull(format, rt) => vec![Diagnostic::error()
+                .with_message(format!("{format} format doesn't support null values"))
+                .with_labels(vec![primary_term(&rt, files)])
+                .with_notes(notes)],
+            ExportErrorData::NonSerializable(rt) => {
+                notes.extend([
                     "Nickel only supports serializing to and from strings, booleans, numbers, \
                     enum tags, `null` (depending on the format), as well as records and arrays \
                     of serializable values."
@@ -2570,27 +2594,43 @@ impl IntoDiagnostics<FileId> for ExportError {
                     "If you want serialization to ignore a specific value, please use the \
                     `not_exported` metadata."
                         .into(),
-                ])],
-            ExportError::NoDocumentation(rt) => vec![Diagnostic::error()
-                .with_message("no documentation found")
-                .with_labels(vec![primary_term(&rt, files)])
-                .with_notes(vec![
-                    "documentation can only be collected from a record.".to_owned()
-                ])],
-            ExportError::NumberOutOfRange { term, value } => vec![Diagnostic::error()
-                .with_message(format!(
-                    "The number {} is too large (in absolute value) to be serialized.",
-                    value.to_sci()
-                ))
-                .with_labels(vec![primary_term(&term, files)])
-                .with_notes(vec![format!(
+                ]);
+
+                vec![Diagnostic::error()
+                    .with_message("non serializable term")
+                    .with_labels(vec![primary_term(&rt, files)])
+                    .with_notes(notes)]
+            }
+            ExportErrorData::NoDocumentation(rt) => {
+                notes.push("documentation can only be collected from a record.".to_owned());
+
+                vec![Diagnostic::error()
+                    .with_message("no documentation found")
+                    .with_labels(vec![primary_term(&rt, files)])
+                    .with_notes(notes)]
+            }
+            ExportErrorData::NumberOutOfRange { term, value } => {
+                notes.push(format!(
                     "Only numbers in the range {:e} to {:e} can be portably serialized",
                     f64::MIN,
                     f64::MAX
-                )])],
-            ExportError::Other(msg) => vec![Diagnostic::error()
-                .with_message("serialization failed")
-                .with_notes(vec![msg])],
+                ));
+
+                vec![Diagnostic::error()
+                    .with_message(format!(
+                        "The number {} is too large (in absolute value) to be serialized.",
+                        value.to_sci()
+                    ))
+                    .with_labels(vec![primary_term(&term, files)])
+                    .with_notes(notes)]
+            }
+            ExportErrorData::Other(msg) => {
+                notes.push(msg);
+
+                vec![Diagnostic::error()
+                    .with_message("serialization failed")
+                    .with_notes(notes)]
+            }
         }
     }
 }

--- a/core/src/program.rs
+++ b/core/src/program.rs
@@ -622,11 +622,11 @@ impl<EC: EvalCache> Program<EC> {
     /// Extract documentation from the program
     #[cfg(feature = "doc")]
     pub fn extract_doc(&mut self) -> Result<doc::ExtractedDocumentation, Error> {
-        use crate::error::ExportError;
+        use crate::error::ExportErrorData;
 
         let term = self.eval_record_spine()?;
         doc::ExtractedDocumentation::extract_from_term(&term).ok_or(Error::ExportError(
-            ExportError::NoDocumentation(term.clone()),
+            ExportErrorData::NoDocumentation(term.clone()).into(),
         ))
     }
 
@@ -664,7 +664,7 @@ impl<EC: EvalCache> Program<EC> {
 
 #[cfg(feature = "doc")]
 mod doc {
-    use crate::error::{Error, ExportError, IOError};
+    use crate::error::{Error, ExportErrorData, IOError};
     use crate::term::{RichTerm, Term};
     use comrak::arena_tree::NodeEdge;
     use comrak::nodes::{
@@ -744,7 +744,7 @@ mod doc {
 
         pub fn write_json(&self, out: &mut dyn Write) -> Result<(), Error> {
             serde_json::to_writer(out, self)
-                .map_err(|e| Error::ExportError(ExportError::Other(e.to_string())))
+                .map_err(|e| Error::ExportError(ExportErrorData::Other(e.to_string()).into()))
         }
 
         pub fn write_markdown(&self, out: &mut dyn Write) -> Result<(), Error> {

--- a/core/tests/integration/main.rs
+++ b/core/tests/integration/main.rs
@@ -1,7 +1,9 @@
 use std::{io::Cursor, thread};
 
 use nickel_lang_core::{
-    error::{Error, EvalError, ExportError, ImportError, ParseError, TypecheckError},
+    error::{
+        Error, EvalError, ExportError, ExportErrorData, ImportError, ParseError, TypecheckError,
+    },
     term::Term,
 };
 use nickel_lang_utils::{
@@ -252,7 +254,8 @@ impl PartialEq<Error> for ErrorExpectation {
             | (ImportIoError, Error::ImportError(ImportError::IOError(..)))
             | (
                 SerializeNumberOutOfRange,
-                Error::EvalError(EvalError::SerializationError(ExportError::NumberOutOfRange {
+                Error::EvalError(EvalError::SerializationError(ExportError {
+                    data: ExportErrorData::NumberOutOfRange { .. },
                     ..
                 })),
             ) => true,


### PR DESCRIPTION
Related #1460.

When failing to serialize a function which hasn't been properly applied (applied to too few arguments), the error often  points to a unusable location: it is most often the definition site of the function, which doesn't help in finding the usage site that is at fault. This happens in particular with contracts, and the error is even more surprising there, because the user didn't really put a function somewhere in their config (see #1460).

This commit enriches the error message of non-serializable errors with a path, à la JSON pointer (such that it also integrates array indices), whenever possible. This should make debugging non serializable error much nicer.