### PR TITLE
Implement pattern guards

### DIFF
--- a/core/src/eval/mod.rs
+++ b/core/src/eval/mod.rs
@@ -90,8 +90,8 @@ use crate::{
         make as mk_term,
         pattern::compile::Compile,
         record::{Field, RecordData},
-        BinaryOp, BindingType, LetAttrs, MatchData, RecordOpKind, RichTerm, RuntimeContract,
-        StrChunk, Term, UnaryOp,
+        BinaryOp, BindingType, LetAttrs, MatchBranch, MatchData, RecordOpKind, RichTerm,
+        RuntimeContract, StrChunk, Term, UnaryOp,
     },
 };
 
@@ -1191,11 +1191,12 @@ pub fn subst<C: Cache>(
         Term::Match(data) => {
             let branches = data.branches
                 .into_iter()
-                .map(|(pat, branch)| {
-                    (
-                        pat,
-                        subst(cache, branch, initial_env, env),
-                    )
+                .map(|MatchBranch { pattern, guard, body} | {
+                    MatchBranch {
+                        pattern,
+                        guard: guard.map(|cond| subst(cache, cond, initial_env, env)),
+                        body: subst(cache, body, initial_env, env),
+                    }
                 })
                 .collect();
 

--- a/core/src/parser/grammar.lalrpop
+++ b/core/src/parser/grammar.lalrpop
@@ -307,10 +307,10 @@ Applicative: UniTerm = {
     <op: BOpPre> <t1: AsTerm<Atom>> <t2: AsTerm<Atom>>
         => UniTerm::from(mk_term::op2(op, t1, t2)),
     NOpPre<AsTerm<Atom>>,
-    "match" "{" <branches: (MatchCase ",")*> <last: MatchCase?> "}" => {
+    "match" "{" <branches: (MatchBranch ",")*> <last: MatchBranch?> "}" => {
         let branches = branches
             .into_iter()
-            .map(|(case, _comma)| case)
+            .map(|(branch, _comma)| branch)
             .chain(last)
             .collect();
 
@@ -876,9 +876,11 @@ UOp: UnaryOp = {
     "enum_get_tag" => UnaryOp::EnumGetTag(),
 }
 
-MatchCase: (Pattern, RichTerm) = {
-    <pat: Pattern> "=>" <t: Term> => (pat, t),
-};
+PatternGuard: RichTerm = "if" <Term> => <>;
+
+MatchBranch: MatchBranch =
+    <pattern: Pattern> <guard: PatternGuard?> "=>" <body: Term> =>
+        MatchBranch { pattern, guard, body};
 
 // Infix operators by precedence levels. Lowest levels take precedence over
 // highest ones.

--- a/core/src/pretty.rs
+++ b/core/src/pretty.rs
@@ -884,20 +884,12 @@ where
                     allocator,
                     allocator.line(),
                     allocator.intersperse(
-                        data.branches
-                            .iter()
-                            .map(|(pat, t)| (pat.pretty(allocator), t))
-                            .map(|(lhs, t)| docs![
-                                allocator,
-                                lhs,
-                                allocator.space(),
-                                "=>",
-                                allocator.line(),
-                                t,
-                                ","
-                            ]
-                            .nest(2)),
-                        allocator.line()
+                        data.branches.iter().map(|branch| docs![
+                            allocator,
+                            branch.pretty(allocator),
+                            ","
+                        ]),
+                        allocator.line(),
                     ),
                 ]
                 .nest(2)
@@ -1182,6 +1174,30 @@ where
             .group(),
             Wildcard(_) => allocator.text("_"),
         }
+    }
+}
+
+impl<'a, D, A> Pretty<'a, D, A> for &MatchBranch
+where
+    D: NickelAllocatorExt<'a, A>,
+    D::Doc: Clone,
+    A: Clone + 'a,
+{
+    fn pretty(self, allocator: &'a D) -> DocBuilder<'a, D, A> {
+        let guard = if let Some(guard) = &self.guard {
+            docs![allocator, allocator.line(), "if", allocator.space(), guard]
+        } else {
+            allocator.nil()
+        };
+
+        docs![
+            allocator,
+            &self.pattern,
+            guard,
+            allocator.space(),
+            "=>",
+            docs![allocator, allocator.line(), self.body.pretty(allocator),].nest(2),
+        ]
     }
 }
 

--- a/core/src/term/mod.rs
+++ b/core/src/term/mod.rs
@@ -612,7 +612,7 @@ pub struct MatchBranch {
     /// A potential guard, which is an additional side-condition defined as `if cond`. The value
     /// stored in this field is the boolean condition itself.
     pub guard: Option<RichTerm>,
-    /// The body of the branch, on the left hand side of `=>`.
+    /// The body of the branch, on the right hand side of `=>`.
     pub body: RichTerm,
 }
 

--- a/core/src/term/pattern/compile.rs
+++ b/core/src/term/pattern/compile.rs
@@ -668,11 +668,15 @@ impl Compile for MatchData {
     //      # this primop evaluates body with an environment extended with bindings_id
     //      %pattern_branch% body bindings_id
     fn compile(mut self, value: RichTerm, pos: TermPos) -> RichTerm {
-        if self.branches.iter().all(|MatchBranch { pattern, .. }| {
+        if self.branches.iter().all(|branch| {
+            // While we could get something working even with a guard, it's a bit more work and
+            // there's no current incentive to do so (a guard on a tags-only match is arguably less
+            // common, as such patterns don't bind any variable). For the time being, we just
+            // exclude guards from the tags-only optimization.
             matches!(
-                pattern.data,
+                branch.pattern.data,
                 PatternData::Enum(EnumPattern { pattern: None, .. }) | PatternData::Wildcard
-            )
+            ) && branch.guard.is_none()
         }) {
             let wildcard_pat = self.branches.iter().enumerate().find_map(
                 |(

--- a/core/src/term/pattern/compile.rs
+++ b/core/src/term/pattern/compile.rs
@@ -26,8 +26,8 @@ use super::*;
 use crate::{
     mk_app,
     term::{
-        make, record::FieldMetadata, BinaryOp, MatchData, RecordExtKind, RecordOpKind, RichTerm,
-        Term, UnaryOp,
+        make, record::FieldMetadata, BinaryOp, MatchBranch, MatchData, RecordExtKind, RecordOpKind,
+        RichTerm, Term, UnaryOp,
     },
 };
 
@@ -668,23 +668,28 @@ impl Compile for MatchData {
     //      # this primop evaluates body with an environment extended with bindings_id
     //      %pattern_branch% body bindings_id
     fn compile(mut self, value: RichTerm, pos: TermPos) -> RichTerm {
-        if self.branches.iter().all(|(pat, _)| {
+        if self.branches.iter().all(|MatchBranch { pattern, .. }| {
             matches!(
-                pat.data,
+                pattern.data,
                 PatternData::Enum(EnumPattern { pattern: None, .. }) | PatternData::Wildcard
             )
         }) {
-            let wildcard_pat = self
-                .branches
-                .iter()
-                .enumerate()
-                .find_map(|(idx, (pat, body))| {
-                    if let PatternData::Wildcard = pat.data {
+            let wildcard_pat = self.branches.iter().enumerate().find_map(
+                |(
+                    idx,
+                    MatchBranch {
+                        pattern,
+                        guard,
+                        body,
+                    },
+                )| {
+                    if matches!((&pattern.data, guard), (PatternData::Wildcard, None)) {
                         Some((idx, body.clone()))
                     } else {
                         None
                     }
-                });
+                },
+            );
 
             // If we find a wildcard pattern, we record its index in order to discard all the
             // patterns coming after the wildcard, because they are unreachable.
@@ -698,13 +703,19 @@ impl Compile for MatchData {
             let tags_only = self
                 .branches
                 .into_iter()
-                .filter_map(|(pat, body)| {
-                    if let PatternData::Enum(EnumPattern { tag, .. }) = pat.data {
-                        Some((tag, body))
-                    } else {
-                        None
-                    }
-                })
+                .filter_map(
+                    |MatchBranch {
+                         pattern,
+                         guard: _,
+                         body,
+                     }| {
+                        if let PatternData::Enum(EnumPattern { tag, .. }) = pattern.data {
+                            Some((tag, body))
+                        } else {
+                            None
+                        }
+                    },
+                )
                 .collect();
 
             return TagsOnlyMatch {
@@ -726,14 +737,14 @@ impl Compile for MatchData {
 
         // The fold block:
         //
-        // <for (pattern, body) in branches.rev()
+        // <for branch in branches.rev()
         //  - cont is the accumulator
         //  - initial accumulator is the default branch (or error if not default branch)
         // >
         //    let init_bindings_id = {} in
         //    let bindings_id = <pattern.compile_part(value_id, init_bindings)> in
         //
-        //    if bindings_id == null then
+        //    if bindings_id == null || !<guard> then
         //      cont
         //    else
         //      # this primop evaluates body with an environment extended with bindings_id
@@ -742,9 +753,30 @@ impl Compile for MatchData {
             .branches
             .into_iter()
             .rev()
-            .fold(error_case, |cont, (pat, body)| {
+            .fold(error_case, |cont, branch| {
                 let init_bindings_id = LocIdent::fresh();
                 let bindings_id = LocIdent::fresh();
+
+                // inner if condition:
+                // bindings_id == null || !<guard>
+                let inner_if_cond = make::op2(BinaryOp::Eq(), Term::Var(bindings_id), Term::Null);
+                let inner_if_cond = if let Some(guard) = branch.guard {
+                    // the guard must be evaluated in the same environment as the body of the
+                    // branch, as it might use bindings introduced by the pattern. Since `||` is
+                    // lazy in Nickel, we know that `bindings_id` is not null if the guard
+                    // condition is ever evaluated.
+                    let guard_cond = mk_app!(
+                        make::op1(UnaryOp::PatternBranch(), Term::Var(bindings_id)),
+                        guard
+                    );
+
+                    mk_app!(
+                        make::op1(UnaryOp::BoolOr(), inner_if_cond),
+                        make::op1(UnaryOp::BoolNot(), guard_cond)
+                    )
+                } else {
+                    inner_if_cond
+                };
 
                 // inner if block:
                 //
@@ -754,11 +786,11 @@ impl Compile for MatchData {
                 //   # this primop evaluates body with an environment extended with bindings_id
                 //   %pattern_branch% bindings_id body
                 let inner = make::if_then_else(
-                    make::op2(BinaryOp::Eq(), Term::Var(bindings_id), Term::Null),
+                    inner_if_cond,
                     cont,
                     mk_app!(
                         make::op1(UnaryOp::PatternBranch(), Term::Var(bindings_id),),
-                        body
+                        branch.body
                     ),
                 );
 
@@ -772,7 +804,7 @@ impl Compile for MatchData {
                     Term::Record(RecordData::empty()),
                     make::let_in(
                         bindings_id,
-                        pat.compile_part(value_id, init_bindings_id),
+                        branch.pattern.compile_part(value_id, init_bindings_id),
                         inner,
                     ),
                 )

--- a/core/src/transform/desugar_destructuring.rs
+++ b/core/src/transform/desugar_destructuring.rs
@@ -10,7 +10,7 @@
 use crate::{
     identifier::LocIdent,
     match_sharedterm,
-    term::{pattern::*, MatchData, RichTerm, Term},
+    term::{pattern::*, MatchBranch, MatchData, RichTerm, Term},
 };
 
 /// Entry point of the destructuring desugaring transformation.
@@ -48,16 +48,20 @@ pub fn desugar_fun(mut pat: Pattern, body: RichTerm) -> Term {
 /// Desugar a destructuring let-binding.
 ///
 /// A let-binding `let <pat> = bound in body` is desugared to `<bound> |> match { <pat> => body }`.
-pub fn desugar_let(pat: Pattern, bound: RichTerm, body: RichTerm) -> Term {
+pub fn desugar_let(pattern: Pattern, bound: RichTerm, body: RichTerm) -> Term {
     // the position of the match expression is used during error reporting, so we try to provide a
     // sensible one.
-    let match_expr_pos = pat.pos.fuse(bound.pos);
+    let match_expr_pos = pattern.pos.fuse(bound.pos);
 
     // `(match { <pat> => <body> }) <bound>`
     Term::App(
         RichTerm::new(
             Term::Match(MatchData {
-                branches: vec![(pat, body)],
+                branches: vec![MatchBranch {
+                    pattern,
+                    guard: None,
+                    body,
+                }],
             }),
             match_expr_pos,
         ),

--- a/core/src/typ.rs
+++ b/core/src/typ.rs
@@ -51,7 +51,7 @@ use crate::{
     stdlib::internals,
     term::{
         array::Array, make as mk_term, record::RecordData, string::NickelString, IndexMap,
-        MatchData, RichTerm, Term, Traverse, TraverseControl, TraverseOrder,
+        MatchBranch, MatchData, RichTerm, Term, Traverse, TraverseControl, TraverseOrder,
     },
 };
 
@@ -1022,7 +1022,11 @@ impl Subcontract for EnumRows {
                         pos: row.id.pos,
                     };
 
-                    branches.push((pattern, body));
+                    branches.push(MatchBranch {
+                        pattern,
+                        guard: None,
+                        body,
+                    });
                 }
                 EnumRowsIteratorItem::TailVar(var) => {
                     tail_var = Some(var);
@@ -1049,14 +1053,15 @@ impl Subcontract for EnumRows {
             )
         };
 
-        branches.push((
-            Pattern {
+        branches.push(MatchBranch {
+            pattern: Pattern {
                 data: PatternData::Wildcard,
                 alias: None,
                 pos: default_pos,
             },
-            default,
-        ));
+            guard: None,
+            body: default,
+        });
 
         let match_expr = mk_app!(Term::Match(MatchData { branches }), mk_term::var(value_arg));
 

--- a/core/tests/integration/inputs/pattern-matching/guards.ncl
+++ b/core/tests/integration/inputs/pattern-matching/guards.ncl
@@ -1,0 +1,32 @@
+# test.type = 'pass'
+let {check, ..} = import "../lib/assert.ncl" in
+
+[
+  'Ok |> match {
+    'Ok if false => false,
+    'Ok if true => true,
+    _ => false,
+  },
+
+  'Some "true" |> match {
+    'Some x if std.is_number x => false,
+    'Some x if std.is_bool x => false,
+    'Some x if std.is_string x => x == "true",
+    _ => false,
+  },
+
+  {
+    hello = ["hello"],
+    world=["world"]
+  }
+  |> match {
+    {hello, world} if std.array.length hello == 0 => false,
+    {hello, universe} if true => false,
+    {hello, world}
+      if (world |> (@) hello
+        |> std.string.join ", ")
+        == "hello, world" => true,
+    _ => false
+  }
+]
+|> check

--- a/core/tests/integration/inputs/pattern-matching/non_bool_guard.ncl
+++ b/core/tests/integration/inputs/pattern-matching/non_bool_guard.ncl
@@ -1,0 +1,7 @@
+# test.type = 'error'
+#
+# [test.metadata]
+# error = 'EvalError::UnaryPrimopTypeError'
+{foo = 'Foo 5, bar = 5} |> match {
+  {foo = 'Foo x, bar} if x => x,
+}

--- a/core/tests/integration/inputs/typecheck/pattern_non_bool_guard.ncl
+++ b/core/tests/integration/inputs/typecheck/pattern_non_bool_guard.ncl
@@ -1,0 +1,16 @@
+# test.type = 'error'
+# eval = 'typecheck'
+#
+# [test.metadata]
+# error = 'TypecheckError::TypeMismatch'
+#
+# [test.metadata.expectation]
+# expected = 'Bool'
+# inferred = 'Number'
+(
+  {foo = 1, bar = 2}
+  |> match {
+    {foo, bar} if 1+1 => foo + bar,
+    _ => 0,
+  }
+) : _

--- a/core/tests/integration/inputs/typecheck/pattern_unbound_identifier_guard.ncl
+++ b/core/tests/integration/inputs/typecheck/pattern_unbound_identifier_guard.ncl
@@ -1,0 +1,15 @@
+# test.type = 'error'
+# eval = 'typecheck'
+#
+# [test.metadata]
+# error = 'TypecheckError::UnboundIdentifier'
+#
+# [test.metadata.expectation]
+# identifier = 'baz'
+(
+  {foo = 1, bar = 2}
+  |> match {
+    {foo, bar} if foo+bar+baz == 0 => foo + bar,
+    _ => 0,
+  }
+) : _

--- a/core/tests/integration/main.rs
+++ b/core/tests/integration/main.rs
@@ -149,6 +149,8 @@ enum ErrorExpectation {
     EvalEqError,
     #[serde(rename = "EvalError::Other")]
     EvalOther,
+    #[serde(rename = "EvalError::UnaryPrimopTypeError")]
+    EvalUnaryPrimopTypeError,
     #[serde(rename = "EvalError::NAryPrimopTypeError")]
     EvalNAryPrimopTypeError,
     #[serde(rename = "EvalError::BlameError")]
@@ -228,6 +230,10 @@ impl PartialEq<Error> for ErrorExpectation {
             | (EvalTypeError, Error::EvalError(EvalError::TypeError(..)))
             | (EvalEqError, Error::EvalError(EvalError::EqError { .. }))
             | (EvalNAryPrimopTypeError, Error::EvalError(EvalError::NAryPrimopTypeError { .. }))
+            | (
+                EvalUnaryPrimopTypeError,
+                Error::EvalError(EvalError::UnaryPrimopTypeError { .. }),
+            )
             | (EvalInfiniteRecursion, Error::EvalError(EvalError::InfiniteRecursion(..)))
             | (
                 EvalMergeIncompatibleArgs,
@@ -385,6 +391,7 @@ impl std::fmt::Display for ErrorExpectation {
             EvalOther => "EvalError::Other".to_owned(),
             EvalMergeIncompatibleArgs => "EvalError::MergeIncompatibleArgs".to_owned(),
             EvalNAryPrimopTypeError => "EvalError::NAryPrimopTypeError".to_owned(),
+            EvalUnaryPrimopTypeError => "EvalError::UnaryPrimopTypeError".to_owned(),
             EvalInfiniteRecursion => "EvalError::InfiniteRecursion".to_owned(),
             EvalIllegalPolymorphicTailAccess => {
                 "EvalError::IllegalPolymorphicTailAccess".to_owned()

--- a/lsp/nls/src/position.rs
+++ b/lsp/nls/src/position.rs
@@ -135,7 +135,7 @@ impl PositionLookup {
                     let ids = data
                         .branches
                         .iter()
-                        .flat_map(|(pat, _branch)| pat.bindings().into_iter())
+                        .flat_map(|branch| branch.pattern.bindings().into_iter())
                         .map(|(_path, id, _)| id);
                     idents.extend(ids);
                 }


### PR DESCRIPTION
This PR implements pattern guards, which are side conditions that can be added to the branch of a match expression, following the pattern, to further constrain the matching. A guard is introduced by the (already existing) `if` keyword. For example:

```nickel
nickel> {list = std.array.generate std.function.id 20}
|> match {
  {list} if std.array.length list > 10 => 'Big,
  {list} if list == [] => 'Empty,
  {list} => 'Small
}
'Big

nickel>
```

The compilation is rather straightforward, as a pattern is already compiled to a tree of if-then-else while also building the bindings introduced by pattern variables. After all the conditions coming from the pattern have been tested, we just additionally check for the guard (injecting the bindings in the condition since the guard can - and most often does - use variables bound by the pattern).

I expect this feature to be particularly nice for writing custom contracts, which are currently in practice sizeable nested if-then-else trees, which could hopefully be aggressively flattened with patterns and guards.