### PR TITLE
Opaque values

### DIFF
--- a/core/src/eval/mod.rs
+++ b/core/src/eval/mod.rs
@@ -1157,7 +1157,7 @@ pub fn subst<C: Cache>(
         // loop. Although avoidable, this requires some care and is not currently needed.
         | v @ Term::Fun(..)
         | v @ Term::Lbl(_)
-        | v @ Term::Opaque(_)
+        | v @ Term::ForeignId(_)
         | v @ Term::SealingKey(_)
         | v @ Term::Enum(_)
         | v @ Term::Import(_)

--- a/core/src/eval/mod.rs
+++ b/core/src/eval/mod.rs
@@ -1157,6 +1157,7 @@ pub fn subst<C: Cache>(
         // loop. Although avoidable, this requires some care and is not currently needed.
         | v @ Term::Fun(..)
         | v @ Term::Lbl(_)
+        | v @ Term::Opaque(_)
         | v @ Term::SealingKey(_)
         | v @ Term::Enum(_)
         | v @ Term::Import(_)

--- a/core/src/eval/operation.rs
+++ b/core/src/eval/operation.rs
@@ -3439,6 +3439,14 @@ fn eq<C: Cache>(
             eq_pos: pos_op,
             term: RichTerm::new(Term::Fun(i, rt), pos2),
         }),
+        (Term::Opaque(v), _) => Err(EvalError::EqError {
+            eq_pos: pos_op,
+            term: RichTerm::new(Term::Opaque(v), pos1),
+        }),
+        (_, Term::Opaque(v)) => Err(EvalError::EqError {
+            eq_pos: pos_op,
+            term: RichTerm::new(Term::Opaque(v), pos2),
+        }),
         (_, _) => Ok(EqResult::Bool(false)),
     }
 }

--- a/core/src/eval/operation.rs
+++ b/core/src/eval/operation.rs
@@ -3439,13 +3439,13 @@ fn eq<C: Cache>(
             eq_pos: pos_op,
             term: RichTerm::new(Term::Fun(i, rt), pos2),
         }),
-        (Term::Opaque(v), _) => Err(EvalError::EqError {
+        (Term::ForeignId(v), _) => Err(EvalError::EqError {
             eq_pos: pos_op,
-            term: RichTerm::new(Term::Opaque(v), pos1),
+            term: RichTerm::new(Term::ForeignId(v), pos1),
         }),
-        (_, Term::Opaque(v)) => Err(EvalError::EqError {
+        (_, Term::ForeignId(v)) => Err(EvalError::EqError {
             eq_pos: pos_op,
-            term: RichTerm::new(Term::Opaque(v), pos2),
+            term: RichTerm::new(Term::ForeignId(v), pos2),
         }),
         (_, _) => Ok(EqResult::Bool(false)),
     }

--- a/core/src/eval/operation.rs
+++ b/core/src/eval/operation.rs
@@ -235,6 +235,7 @@ impl<R: ImportResolver, C: Cache> VirtualMachine<R, C> {
                     Term::Array(..) => "Array",
                     Term::Record(..) | Term::RecRecord(..) => "Record",
                     Term::Lbl(..) => "Label",
+                    Term::ForeignId(_) => "ForeignId",
                     _ => "Other",
                 };
                 Ok(Closure::atomic_closure(RichTerm::new(

--- a/core/src/eval/tests.rs
+++ b/core/src/eval/tests.rs
@@ -391,4 +391,9 @@ fn foreign_id() {
         eval_full_no_import(t_merge),
         Err(EvalError::MergeIncompatibleArgs { .. })
     );
+
+    let t_typeof = mk_term::op1(UnaryOp::Typeof(), Term::ForeignId(42));
+    let ty = eval_no_import(t_typeof).unwrap();
+    let fid = LocIdent::from(Ident::new("ForeignId"));
+    assert_matches!(ty, Term::Enum(f) if f == fid);
 }

--- a/core/src/eval/tests.rs
+++ b/core/src/eval/tests.rs
@@ -8,13 +8,21 @@ use crate::term::make as mk_term;
 use crate::term::Number;
 use crate::term::{BinaryOp, StrChunk, UnaryOp};
 use crate::transform::import_resolution::strict::resolve_imports;
-use crate::{mk_app, mk_fun};
+use crate::{mk_app, mk_fun, mk_record};
+use assert_matches::assert_matches;
 use codespan::Files;
 
 /// Evaluate a term without import support.
 fn eval_no_import(t: RichTerm) -> Result<Term, EvalError> {
     VirtualMachine::<_, CacheImpl>::new(DummyResolver {}, std::io::sink())
         .eval(t)
+        .map(Term::from)
+}
+
+/// Fully evaluate a term without import support.
+fn eval_full_no_import(t: RichTerm) -> Result<Term, EvalError> {
+    VirtualMachine::<_, CacheImpl>::new(DummyResolver {}, std::io::sink())
+        .eval_full(t)
         .map(Term::from)
 }
 
@@ -345,5 +353,42 @@ fn substitution() {
         )
         .unwrap()
         .to_string()
+    );
+}
+
+#[test]
+fn opaque() {
+    let t = mk_term::op2(
+        BinaryOp::Merge(Label::default().into()),
+        mk_record!(("a", RichTerm::from(Term::Num(Number::from(1))))),
+        mk_record!(("b", RichTerm::from(Term::Opaque(42)))),
+    );
+
+    // Terms that include opaque values can be manipulated like normal, and the opaque values
+    // are passed through.
+    let Term::Record(data) = eval_no_import(t.clone()).unwrap() else {
+        panic!();
+    };
+    let b = LocIdent::from(Ident::new("b"));
+    let field = data.fields.get(&b).unwrap();
+    assert_matches!(field.value.as_ref().unwrap().as_ref(), Term::Opaque(42));
+
+    // Opaque values cannot be compared for equality.
+    let t_eq = mk_term::op2(
+        BinaryOp::Eq(),
+        RichTerm::from(Term::Opaque(43)),
+        RichTerm::from(Term::Opaque(42)),
+    );
+    assert_matches!(eval_no_import(t_eq), Err(EvalError::EqError { .. }));
+
+    // Opaque values cannot be merged (even if they're equal, since they can't get compared for equality).
+    let t_merge = mk_term::op2(
+        BinaryOp::Merge(Label::default().into()),
+        t.clone(),
+        t.clone(),
+    );
+    assert_matches!(
+        eval_full_no_import(t_merge),
+        Err(EvalError::MergeIncompatibleArgs { .. })
     );
 }

--- a/core/src/eval/tests.rs
+++ b/core/src/eval/tests.rs
@@ -357,27 +357,27 @@ fn substitution() {
 }
 
 #[test]
-fn opaque() {
+fn foreign_id() {
     let t = mk_term::op2(
         BinaryOp::Merge(Label::default().into()),
         mk_record!(("a", RichTerm::from(Term::Num(Number::from(1))))),
-        mk_record!(("b", RichTerm::from(Term::Opaque(42)))),
+        mk_record!(("b", RichTerm::from(Term::ForeignId(42)))),
     );
 
-    // Terms that include opaque values can be manipulated like normal, and the opaque values
+    // Terms that include foreign ids can be manipulated like normal, and the ids
     // are passed through.
     let Term::Record(data) = eval_no_import(t.clone()).unwrap() else {
         panic!();
     };
     let b = LocIdent::from(Ident::new("b"));
     let field = data.fields.get(&b).unwrap();
-    assert_matches!(field.value.as_ref().unwrap().as_ref(), Term::Opaque(42));
+    assert_matches!(field.value.as_ref().unwrap().as_ref(), Term::ForeignId(42));
 
-    // Opaque values cannot be compared for equality.
+    // Foreign ids cannot be compared for equality.
     let t_eq = mk_term::op2(
         BinaryOp::Eq(),
-        RichTerm::from(Term::Opaque(43)),
-        RichTerm::from(Term::Opaque(42)),
+        RichTerm::from(Term::ForeignId(43)),
+        RichTerm::from(Term::ForeignId(42)),
     );
     assert_matches!(eval_no_import(t_eq), Err(EvalError::EqError { .. }));
 

--- a/core/src/parser/uniterm.rs
+++ b/core/src/parser/uniterm.rs
@@ -692,7 +692,7 @@ impl FixTypeVars for Type {
             | TypeF::Number
             | TypeF::Bool
             | TypeF::String
-            | TypeF::Opaque
+            | TypeF::ForeignId
             | TypeF::Symbol
             | TypeF::Flat(_)
             // We don't fix type variables inside a dictionary contract. A dictionary contract

--- a/core/src/parser/uniterm.rs
+++ b/core/src/parser/uniterm.rs
@@ -692,6 +692,7 @@ impl FixTypeVars for Type {
             | TypeF::Number
             | TypeF::Bool
             | TypeF::String
+            | TypeF::Opaque
             | TypeF::Symbol
             | TypeF::Flat(_)
             // We don't fix type variables inside a dictionary contract. A dictionary contract

--- a/core/src/pretty.rs
+++ b/core/src/pretty.rs
@@ -975,7 +975,7 @@ where
                 .nest(2)
             ]
             .group(),
-            Opaque(_) => allocator.text("%<opaque>"),
+            ForeignId(_) => allocator.text("%<foreign>"),
             SealingKey(sym) => allocator.text(format!("%<sealing key: {sym}>")),
             Sealed(_i, _rt, _lbl) => allocator.text("%<sealed>"),
             Annotated(annot, rt) => allocator.atom(rt).append(annot.pretty(allocator)),
@@ -1111,7 +1111,7 @@ where
                 ]
             }
             .group(),
-            Opaque => allocator.text("Opaque"),
+            ForeignId => allocator.text("ForeignId"),
             Symbol => allocator.text("Symbol"),
             Flat(t) => t.pretty(allocator),
             Var(var) => allocator.as_string(var),

--- a/core/src/pretty.rs
+++ b/core/src/pretty.rs
@@ -975,6 +975,7 @@ where
                 .nest(2)
             ]
             .group(),
+            Opaque(_) => allocator.text("%<opaque>"),
             SealingKey(sym) => allocator.text(format!("%<sealing key: {sym}>")),
             Sealed(_i, _rt, _lbl) => allocator.text("%<sealed>"),
             Annotated(annot, rt) => allocator.atom(rt).append(annot.pretty(allocator)),
@@ -1110,6 +1111,7 @@ where
                 ]
             }
             .group(),
+            Opaque => allocator.text("Opaque"),
             Symbol => allocator.text("Symbol"),
             Flat(t) => t.pretty(allocator),
             Var(var) => allocator.as_string(var),

--- a/core/src/stdlib.rs
+++ b/core/src/stdlib.rs
@@ -71,6 +71,7 @@ pub mod internals {
 
     generate_accessor!(num);
     generate_accessor!(bool);
+    generate_accessor!(opaque);
     generate_accessor!(string);
     generate_accessor!(fail);
 

--- a/core/src/stdlib.rs
+++ b/core/src/stdlib.rs
@@ -71,7 +71,7 @@ pub mod internals {
 
     generate_accessor!(num);
     generate_accessor!(bool);
-    generate_accessor!(opaque);
+    generate_accessor!(foreign_id);
     generate_accessor!(string);
     generate_accessor!(fail);
 

--- a/core/src/term/mod.rs
+++ b/core/src/term/mod.rs
@@ -267,7 +267,7 @@ pub enum Term {
     ///
     /// This can be used by programs that embed Nickel, as they can inject these opaque
     /// values into the AST.
-    Opaque(u64),
+    ForeignId(u64),
 }
 
 // PartialEq is mostly used for tests, when it's handy to compare something to an expected result.
@@ -879,7 +879,7 @@ impl Term {
             Term::SealingKey(_) => Some("SealingKey".to_owned()),
             Term::Sealed(..) => Some("Sealed".to_owned()),
             Term::Annotated(..) => Some("Annotated".to_owned()),
-            Term::Opaque(_) => Some("Opaque".to_owned()),
+            Term::ForeignId(_) => Some("ForeignId".to_owned()),
             Term::Let(..)
             | Term::LetPattern(..)
             | Term::App(_, _)
@@ -926,7 +926,7 @@ impl Term {
             | Term::EnumVariant {..}
             | Term::Record(..)
             | Term::Array(..)
-            | Term::Opaque(_)
+            | Term::ForeignId(_)
             | Term::SealingKey(_) => true,
             Term::Let(..)
             | Term::LetPattern(..)
@@ -984,7 +984,7 @@ impl Term {
             | Term::Str(_)
             | Term::Lbl(_)
             | Term::Enum(_)
-            | Term::Opaque(_)
+            | Term::ForeignId(_)
             | Term::SealingKey(_) => true,
             Term::Let(..)
             | Term::LetPattern(..)
@@ -1027,7 +1027,7 @@ impl Term {
             | Term::Array(..)
             | Term::Var(..)
             | Term::SealingKey(..)
-            | Term::Opaque(..)
+            | Term::ForeignId(..)
             | Term::Op1(UnaryOp::StaticAccess(_), _)
             | Term::Op2(BinaryOp::DynAccess(), _, _)
             // Those special cases aren't really atoms, but mustn't be parenthesized because they
@@ -2180,7 +2180,7 @@ impl Traverse<RichTerm> for RichTerm {
             | Term::Import(_)
             | Term::ResolvedImport(_)
             | Term::SealingKey(_)
-            | Term::Opaque(_)
+            | Term::ForeignId(_)
             | Term::ParseError(_)
             | Term::RuntimeError(_) => None,
             Term::StrChunks(chunks) => chunks.iter().find_map(|ch| {

--- a/core/src/term/mod.rs
+++ b/core/src/term/mod.rs
@@ -58,6 +58,9 @@ use std::{
     rc::Rc,
 };
 
+/// The payload of a `Term::ForeignId`.
+pub type ForeignIdPayload = u64;
+
 /// The AST of a Nickel expression.
 ///
 /// Parsed terms also need to store their position in the source for error reporting.  This is why
@@ -267,7 +270,7 @@ pub enum Term {
     ///
     /// This can be used by programs that embed Nickel, as they can inject these opaque
     /// values into the AST.
-    ForeignId(u64),
+    ForeignId(ForeignIdPayload),
 }
 
 // PartialEq is mostly used for tests, when it's handy to compare something to an expected result.

--- a/core/src/term/mod.rs
+++ b/core/src/term/mod.rs
@@ -261,6 +261,13 @@ pub enum Term {
     ///
     /// This is a temporary solution, and will be removed in the future.
     Closure(CacheIndex),
+
+    #[serde(skip)]
+    /// An opaque value that cannot be constructed within Nickel code.
+    ///
+    /// This can be used by programs that embed Nickel, as they can inject these opaque
+    /// values into the AST.
+    Opaque(u64),
 }
 
 // PartialEq is mostly used for tests, when it's handy to compare something to an expected result.
@@ -872,6 +879,7 @@ impl Term {
             Term::SealingKey(_) => Some("SealingKey".to_owned()),
             Term::Sealed(..) => Some("Sealed".to_owned()),
             Term::Annotated(..) => Some("Annotated".to_owned()),
+            Term::Opaque(_) => Some("Opaque".to_owned()),
             Term::Let(..)
             | Term::LetPattern(..)
             | Term::App(_, _)
@@ -918,6 +926,7 @@ impl Term {
             | Term::EnumVariant {..}
             | Term::Record(..)
             | Term::Array(..)
+            | Term::Opaque(_)
             | Term::SealingKey(_) => true,
             Term::Let(..)
             | Term::LetPattern(..)
@@ -975,6 +984,7 @@ impl Term {
             | Term::Str(_)
             | Term::Lbl(_)
             | Term::Enum(_)
+            | Term::Opaque(_)
             | Term::SealingKey(_) => true,
             Term::Let(..)
             | Term::LetPattern(..)
@@ -1017,6 +1027,7 @@ impl Term {
             | Term::Array(..)
             | Term::Var(..)
             | Term::SealingKey(..)
+            | Term::Opaque(..)
             | Term::Op1(UnaryOp::StaticAccess(_), _)
             | Term::Op2(BinaryOp::DynAccess(), _, _)
             // Those special cases aren't really atoms, but mustn't be parenthesized because they
@@ -2169,6 +2180,7 @@ impl Traverse<RichTerm> for RichTerm {
             | Term::Import(_)
             | Term::ResolvedImport(_)
             | Term::SealingKey(_)
+            | Term::Opaque(_)
             | Term::ParseError(_)
             | Term::RuntimeError(_) => None,
             Term::StrChunks(chunks) => chunks.iter().find_map(|ch| {

--- a/core/src/transform/free_vars.rs
+++ b/core/src/transform/free_vars.rs
@@ -39,7 +39,7 @@ impl CollectFreeVars for RichTerm {
             | Term::Num(_)
             | Term::Str(_)
             | Term::Lbl(_)
-            | Term::Opaque(_)
+            | Term::ForeignId(_)
             | Term::SealingKey(_)
             | Term::Enum(_)
             | Term::Import(_)
@@ -187,7 +187,7 @@ impl CollectFreeVars for Type {
             | TypeF::Number
             | TypeF::Bool
             | TypeF::String
-            | TypeF::Opaque
+            | TypeF::ForeignId
             | TypeF::Symbol
             | TypeF::Var(_)
             | TypeF::Wildcard(_) => (),

--- a/core/src/transform/free_vars.rs
+++ b/core/src/transform/free_vars.rs
@@ -39,6 +39,7 @@ impl CollectFreeVars for RichTerm {
             | Term::Num(_)
             | Term::Str(_)
             | Term::Lbl(_)
+            | Term::Opaque(_)
             | Term::SealingKey(_)
             | Term::Enum(_)
             | Term::Import(_)
@@ -186,6 +187,7 @@ impl CollectFreeVars for Type {
             | TypeF::Number
             | TypeF::Bool
             | TypeF::String
+            | TypeF::Opaque
             | TypeF::Symbol
             | TypeF::Var(_)
             | TypeF::Wildcard(_) => (),

--- a/core/src/typ.rs
+++ b/core/src/typ.rs
@@ -269,6 +269,8 @@ pub enum TypeF<Ty, RRows, ERows> {
     ///
     /// See [`crate::term::Term::Sealed`].
     Symbol,
+    /// An opaque value, the type of `Term::Opaque`.
+    Opaque,
     /// A type created from a user-defined contract.
     Flat(RichTerm),
     /// A function.
@@ -543,6 +545,7 @@ impl<Ty, RRows, ERows> TypeF<Ty, RRows, ERows> {
             TypeF::Number => Ok(TypeF::Number),
             TypeF::Bool => Ok(TypeF::Bool),
             TypeF::String => Ok(TypeF::String),
+            TypeF::Opaque => Ok(TypeF::Opaque),
             TypeF::Symbol => Ok(TypeF::Symbol),
             TypeF::Flat(t) => Ok(TypeF::Flat(t)),
             TypeF::Arrow(dom, codom) => Ok(TypeF::Arrow(f(dom, state)?, f(codom, state)?)),
@@ -818,6 +821,7 @@ impl Subcontract for Type {
             TypeF::Number => internals::num(),
             TypeF::Bool => internals::bool(),
             TypeF::String => internals::string(),
+            TypeF::Opaque => internals::opaque(),
             // Array Dyn is specialized to array_dyn, which is constant time
             TypeF::Array(ref ty) if matches!(ty.typ, TypeF::Dyn) => internals::array_dyn(),
             TypeF::Array(ref ty) => mk_app!(internals::array(), ty.subcontract(vars, pol, sy)?),
@@ -1402,6 +1406,7 @@ impl Traverse<Type> for Type {
             | TypeF::Number
             | TypeF::Bool
             | TypeF::String
+            | TypeF::Opaque
             | TypeF::Symbol
             | TypeF::Var(_)
             | TypeF::Enum(_)

--- a/core/src/typ.rs
+++ b/core/src/typ.rs
@@ -269,8 +269,8 @@ pub enum TypeF<Ty, RRows, ERows> {
     ///
     /// See [`crate::term::Term::Sealed`].
     Symbol,
-    /// An opaque value, the type of `Term::Opaque`.
-    Opaque,
+    /// The type of `Term::ForeignId`.
+    ForeignId,
     /// A type created from a user-defined contract.
     Flat(RichTerm),
     /// A function.
@@ -545,7 +545,7 @@ impl<Ty, RRows, ERows> TypeF<Ty, RRows, ERows> {
             TypeF::Number => Ok(TypeF::Number),
             TypeF::Bool => Ok(TypeF::Bool),
             TypeF::String => Ok(TypeF::String),
-            TypeF::Opaque => Ok(TypeF::Opaque),
+            TypeF::ForeignId => Ok(TypeF::ForeignId),
             TypeF::Symbol => Ok(TypeF::Symbol),
             TypeF::Flat(t) => Ok(TypeF::Flat(t)),
             TypeF::Arrow(dom, codom) => Ok(TypeF::Arrow(f(dom, state)?, f(codom, state)?)),
@@ -821,7 +821,7 @@ impl Subcontract for Type {
             TypeF::Number => internals::num(),
             TypeF::Bool => internals::bool(),
             TypeF::String => internals::string(),
-            TypeF::Opaque => internals::opaque(),
+            TypeF::ForeignId => internals::foreign_id(),
             // Array Dyn is specialized to array_dyn, which is constant time
             TypeF::Array(ref ty) if matches!(ty.typ, TypeF::Dyn) => internals::array_dyn(),
             TypeF::Array(ref ty) => mk_app!(internals::array(), ty.subcontract(vars, pol, sy)?),
@@ -1406,7 +1406,7 @@ impl Traverse<Type> for Type {
             | TypeF::Number
             | TypeF::Bool
             | TypeF::String
-            | TypeF::Opaque
+            | TypeF::ForeignId
             | TypeF::Symbol
             | TypeF::Var(_)
             | TypeF::Enum(_)

--- a/core/src/typecheck/mk_uniftype.rs
+++ b/core/src/typecheck/mk_uniftype.rs
@@ -151,3 +151,4 @@ generate_builder!(str, String);
 generate_builder!(num, Number);
 generate_builder!(bool, Bool);
 generate_builder!(sym, Symbol);
+generate_builder!(opaque, Opaque);

--- a/core/src/typecheck/mk_uniftype.rs
+++ b/core/src/typecheck/mk_uniftype.rs
@@ -151,4 +151,4 @@ generate_builder!(str, String);
 generate_builder!(num, Number);
 generate_builder!(bool, Bool);
 generate_builder!(sym, Symbol);
-generate_builder!(opaque, Opaque);
+generate_builder!(foreign_id, ForeignId);

--- a/core/src/typecheck/mod.rs
+++ b/core/src/typecheck/mod.rs
@@ -228,7 +228,7 @@ impl<E: TermEnvironment> VarLevelUpperBound for GenericUnifTypeUnrolling<E> {
             | TypeF::Bool
             | TypeF::Number
             | TypeF::String
-            | TypeF::Opaque
+            | TypeF::ForeignId
             | TypeF::Symbol => VarLevel::NO_VAR,
             TypeF::Arrow(domain, codomain) => max(
                 domain.var_level_upper_bound(),
@@ -1443,7 +1443,7 @@ fn walk<V: TypecheckVisitor>(
         | Term::Str(_)
         | Term::Lbl(_)
         | Term::Enum(_)
-        | Term::Opaque(_)
+        | Term::ForeignId(_)
         | Term::SealingKey(_)
         // This function doesn't recursively typecheck imports: this is the responsibility of the
         // caller.
@@ -1632,7 +1632,7 @@ fn walk_type<V: TypecheckVisitor>(
        | TypeF::Number
        | TypeF::Bool
        | TypeF::String
-       | TypeF::Opaque
+       | TypeF::ForeignId
        | TypeF::Symbol
        // Currently, the parser can't generate unbound type variables by construction. Thus we
        // don't check here for unbound type variables again.
@@ -2281,8 +2281,8 @@ fn check<V: TypecheckVisitor>(
             }
         }
 
-        Term::Opaque(_) => ty
-            .unify(mk_uniftype::opaque(), state, &ctxt)
+        Term::ForeignId(_) => ty
+            .unify(mk_uniftype::foreign_id(), state, &ctxt)
             .map_err(|err| err.into_typecheck_err(state, rt.pos)),
         Term::SealingKey(_) => ty
             .unify(mk_uniftype::sym(), state, &ctxt)

--- a/core/src/typecheck/mod.rs
+++ b/core/src/typecheck/mod.rs
@@ -224,9 +224,12 @@ impl<E: TermEnvironment> VarLevelUpperBound for GenericUnifType<E> {
 impl<E: TermEnvironment> VarLevelUpperBound for GenericUnifTypeUnrolling<E> {
     fn var_level_upper_bound(&self) -> VarLevel {
         match self {
-            TypeF::Dyn | TypeF::Bool | TypeF::Number | TypeF::String | TypeF::Symbol => {
-                VarLevel::NO_VAR
-            }
+            TypeF::Dyn
+            | TypeF::Bool
+            | TypeF::Number
+            | TypeF::String
+            | TypeF::Opaque
+            | TypeF::Symbol => VarLevel::NO_VAR,
             TypeF::Arrow(domain, codomain) => max(
                 domain.var_level_upper_bound(),
                 codomain.var_level_upper_bound(),
@@ -1440,6 +1443,7 @@ fn walk<V: TypecheckVisitor>(
         | Term::Str(_)
         | Term::Lbl(_)
         | Term::Enum(_)
+        | Term::Opaque(_)
         | Term::SealingKey(_)
         // This function doesn't recursively typecheck imports: this is the responsibility of the
         // caller.
@@ -1628,6 +1632,7 @@ fn walk_type<V: TypecheckVisitor>(
        | TypeF::Number
        | TypeF::Bool
        | TypeF::String
+       | TypeF::Opaque
        | TypeF::Symbol
        // Currently, the parser can't generate unbound type variables by construction. Thus we
        // don't check here for unbound type variables again.
@@ -2276,6 +2281,9 @@ fn check<V: TypecheckVisitor>(
             }
         }
 
+        Term::Opaque(_) => ty
+            .unify(mk_uniftype::opaque(), state, &ctxt)
+            .map_err(|err| err.into_typecheck_err(state, rt.pos)),
         Term::SealingKey(_) => ty
             .unify(mk_uniftype::sym(), state, &ctxt)
             .map_err(|err| err.into_typecheck_err(state, rt.pos)),

--- a/core/src/typecheck/operation.rs
+++ b/core/src/typecheck/operation.rs
@@ -28,7 +28,16 @@ pub fn get_uop_type(
         UnaryOp::Typeof() => (
             mk_uniftype::dynamic(),
             mk_uty_enum!(
-                "Number", "Bool", "String", "Enum", "Function", "Array", "Record", "Label", "Other"
+                "Number",
+                "Bool",
+                "String",
+                "Enum",
+                "Function",
+                "Array",
+                "Record",
+                "Label",
+                "ForeignId",
+                "Other"
             ),
         ),
         // Bool -> Bool -> Bool

--- a/core/stdlib/internals.ncl
+++ b/core/stdlib/internals.ncl
@@ -11,7 +11,7 @@
 
   "$string" = fun label value => if %typeof% value == 'String then value else %blame% label,
 
-  "$opaque" = fun label value => if %typeof% value == 'Opaque then value else %blame% label,
+  "$foreign_id" = fun label value => if %typeof% value == 'ForeignId then value else %blame% label,
 
   "$fail" = fun label _value => %blame% label,
 

--- a/core/stdlib/internals.ncl
+++ b/core/stdlib/internals.ncl
@@ -11,6 +11,8 @@
 
   "$string" = fun label value => if %typeof% value == 'String then value else %blame% label,
 
+  "$opaque" = fun label value => if %typeof% value == 'Opaque then value else %blame% label,
+
   "$fail" = fun label _value => %blame% label,
 
   "$array" = fun element_contract label value =>

--- a/core/stdlib/std.ncl
+++ b/core/stdlib/std.ncl
@@ -3187,6 +3187,7 @@
       'Function,
       'Array,
       'Record,
+      'ForeignId,
       'Other
     |]
     | doc m%"


### PR DESCRIPTION
Here's a first stab at opaque values, as in #1909. The payload is a `u64` for now -- I think we could change it without breaking our backwards-compatibility promises, because you can only generate these when embedding nickel, and we don't promise much about the stability of nickel-as-a-library.