### PR TITLE
Add get value from record with supplying default

### DIFF
--- a/core/stdlib/std.ncl
+++ b/core/stdlib/std.ncl
@@ -2147,6 +2147,27 @@
       "%%
       = fun field r => r."%{field}",
 
+    get_or
+      : forall a. String -> a -> { _ : a } -> a
+      | doc m%%"
+        Returns the field of a record with given name or default value,
+        if there is no such field.
+
+        # Examples
+
+        ```nickel
+        std.record.get_or "tree" 3 { one = 1, two = 2 }
+          => 3
+        std.record.get_or "one" 11 { one = 1, two = 2 }
+          => 1
+        ```
+      "%%
+      = fun field default_value record =>
+        if %has_field% field record then
+          record."%{field}"
+        else
+          default_value,
+
     insert
       : forall a. String -> a -> { _ : a } -> { _ : a }
       | doc m%%"


### PR DESCRIPTION
As I see there is lacking the function in stdlib for getting values from the record with assumed default in case field is lacking. Or maybe there is another idiomatic method for that, which I miss?

The name of the function could be discussed...Personally for me `get` would be the best, but it is reserved already;-> do you have better ideas?

Here also documentation should be extended...

What do you, @yannham think about it?