### PR TITLE
[Doc] Update manual and examples with latest pattern features

### DIFF
--- a/core/stdlib/std.ncl
+++ b/core/stdlib/std.ncl
@@ -943,7 +943,8 @@
                   |> blame,
 
             # Outside of lazy data structures, we just use (==)
-            _ => fun ctr_label value =>
+            _ =>
+              fun ctr_label value =>
                 value
                 |> check_typeof_eq ctr_label
                 |> from_predicate ((==) constant) ctr_label,

--- a/doc/manual/contracts.md
+++ b/doc/manual/contracts.md
@@ -90,13 +90,13 @@ custom contract:
 ```nickel
 {
   IsFoo = fun label value =>
-    if std.is_string value then
-      if value == "foo" then
-        value
-      else
-        std.contract.blame_with_message "not equal to \"foo\"" label
-    else
-      std.contract.blame_with_message "not a string" label,
+    value |> match {
+      "foo" => value,
+      value if std.is_string value =>
+        std.contract.blame_with_message "not equal to \"foo\"" label,
+      _ =>
+        std.contract.blame_with_message "not a string" label,
+    }
 }
 ```
 

--- a/doc/manual/correctness.md
+++ b/doc/manual/correctness.md
@@ -207,7 +207,9 @@ using contract and type annotations.
 `split` can be given a contract annotation as follows:
 
 ```nickel #no-check
-split | forall a. Array {key: String, value: a} -> {keys: Array String, values: Array a} = # etc.
+split
+  | forall a. Array {key: String, value: a}
+    -> {keys: Array String, values: Array a} = # etc.
 ```
 
 Contract annotations are checked at runtime. At this point functions are
@@ -266,7 +268,9 @@ that:
 `split` can be given a type annotation as follows:
 
 ```nickel #no-check
-split : forall a. Array {key: String, value: a} -> {keys: Array String, values: Array a} = # etc.
+split
+  : forall a. Array {key: String, value: a}
+    -> {keys: Array String, values: Array a} = # etc.
 ```
 
 Type annotations also give rise to contracts, which means that even if `split`'s

--- a/doc/manual/merging.md
+++ b/doc/manual/merging.md
@@ -607,10 +607,12 @@ argument), we do get a contract violation error:
     required_field2,
   }
   in
+ 
   let intermediate =
     { foo | FooContract }
     & { foo.required_field1 = "here" }
   in
+  
   intermediate
   & { foo.required_field2 = "here" }
   |> std.deep_seq intermediate
@@ -620,7 +622,7 @@ error: missing definition for `required_field2`
    3 │     required_field2,
      │     ^^^^^^^^^^^^^^^ required here
      ·
-   8 │     & { foo.required_field1 = "here" }
+   9 │     & { foo.required_field1 = "here" }
      │             ------------------------ in this record
      │
 [...]

--- a/doc/manual/tutorial.md
+++ b/doc/manual/tutorial.md
@@ -183,3 +183,7 @@ keyword, this field must be set in the final configuration.
 The second part tells us that in the first record in the users list, the field
 `name` has no value while it should have one. This is to be expected as we
 removed it earlier.
+
+From Nickel 1.5 and higher, if you are using the Nickel Language Server, you
+should even see this contract violation being reported in your editor as you
+type.

--- a/doc/manual/types-vs-contracts.md
+++ b/doc/manual/types-vs-contracts.md
@@ -33,7 +33,7 @@ What to do depends on the context:
     local to a file, if your function is bound to a variable, it can be
     potentially reused in different places.
 
-    Example: `let append_tm: String -> String = fun s => s ++ "(TM)" in ...`
+    Example: `let append_tm: String -> String = fun s => "%{s} (TM)" in ...`
 
 - *Let-bound function inside a typed block: nothing or type annotation*. Inside
     a typed block, types are inferred, so it is OK for simple functions to not

--- a/examples/arrays/arrays.ncl
+++ b/examples/arrays/arrays.ncl
@@ -8,8 +8,7 @@ let my_array_lib = {
       if arr == [] then
         []
       else
-        let head = std.array.first arr in
-        let tail = std.array.drop_first arr in
+        let [head, ..tail] = arr in
         [f head] @ map f tail,
 
   fold : forall a b. (a -> b -> b) -> b -> Array a -> b
@@ -17,8 +16,7 @@ let my_array_lib = {
       if arr == [] then
         first
       else
-        let head = std.array.first arr in
-        let tail = std.array.drop_first arr in
+        let [head, ..tail] = arr in
         f head (fold f first tail),
 }
 in

--- a/examples/config-gcc/config-gcc.ncl
+++ b/examples/config-gcc/config-gcc.ncl
@@ -3,28 +3,28 @@
 # Validate and normalize gcc flags. They can be either a string `-Wextra` or
 # a structured value `{flag = "W", arg = "extra"}`. Arguments are not checked.
 let GccFlag =
-  # We only allow the following flags
-  let available = ["W", "c", "S", "e", "o"] in
-  fun label value =>
-    std.typeof value
-    |> match {
-      'String =>
-        if std.string.length value > 0
-        && std.array.any ((==) (std.string.substring 0 1 value)) available then
-          value
-        else
-          std.contract.blame_with_message "unknown flag %{value}" label,
-      'Record =>
-        if std.record.has_field "flag" value && std.record.has_field "arg" value then
-          if std.array.any ((==) value.flag) available then
-            #Normalize the tag to a string
-            value.flag ++ value.arg
-          else
-            std.contract.blame_with_message "unknown flag %{value.flag}" label
-        else
-          std.contract.blame_with_message
-            "bad record structure: missing field `flag` or `arg`"
-            label,
+  let supported_flags = ["W", "c", "S", "e", "o"] in
+  let is_valid_flag
+    | doc "check if a string of length > 0 is a valid flag"
+    = fun string =>
+      std.array.elem (std.string.substring 0 1 string) supported_flags
+    in
+
+  fun label =>
+    match {
+      value if std.is_string value && is_valid_flag value =>
+        value,
+      { flag, arg } if std.array.elem flag supported_flags =>
+        # Normalize the tag to a string
+        "%{flag}%{arg}",
+      value if std.is_string value =>
+        std.contract.blame_with_message "unknown flag %{value}" label,
+      { flag, arg = _ } =>
+        std.contract.blame_with_message "unknown flag %{flag}" label,
+      { .. } =>
+        std.contract.blame_with_message
+          "bad record structure: missing field `flag` or `arg`"
+          label,
       _ => std.contract.blame_with_message "expected record or string" label,
     }
 in
@@ -51,11 +51,11 @@ let SharedObjectFile = fun label value =>
     std.contract.blame_with_message "not a string" label
 in
 
-let OptLevel = fun label value =>
-  if value == 0 || value == 1 || value == 2 then
-    value
-  else
-    std.contract.blame label
+let OptLevel = fun label =>
+  match {
+    value @ (0 or 1 or 2) => value,
+    _ => std.contract.blame label,
+  }
 in
 
 let Contract = {

--- a/examples/fibonacci/fibonacci.ncl
+++ b/examples/fibonacci/fibonacci.ncl
@@ -1,13 +1,11 @@
 # test = 'pass'
 
-# This is the naive, exponential version of fibonacci: don't call it on a big
-# value!
-let rec fibonacci = fun n =>
-  if n == 0 then
-    0
-  else if n == 1 then
-    1
-  else
-    fibonacci (n - 1) + fibonacci (n - 2)
+# This is the naive, exponential version of fibonacci: don't call it on a large
+# number!
+let rec fibonacci = match {
+  0 => 0,
+  1 => 1,
+  n => fibonacci (n - 1) + fibonacci (n - 2),
+}
 in
 fibonacci 10

--- a/examples/polymorphism/polymorphism.ncl
+++ b/examples/polymorphism/polymorphism.ncl
@@ -1,8 +1,8 @@
 # test = 'pass'
 
 # First projection, statically typed
-let fst : forall a b. a -> b -> a = fun x y => x in
+let first : forall a b. a -> b -> a = fun x y => x in
 # Evaluation function, statically typed
-let ev : forall a b. (a -> b) -> a -> b = fun f x => f x in
+let eval : forall a b. (a -> b) -> a -> b = fun f x => f x in
 let id : forall a. a -> a = fun x => x in
-(ev id (fst 5 10) == 5 : Bool)
+(eval id (first 5 10) == 5 : Bool)

--- a/examples/record-contract/record-contract.ncl
+++ b/examples/record-contract/record-contract.ncl
@@ -4,6 +4,10 @@
 # Kubernetes configuration.
 # Schema and example derived from
 # https://github.com/kubernetes/examples/blob/master/guestbook-go/guestbook-controller.json.
+#
+# This example is illustrative. If you actually want to use Nickel with
+# Kubernetes, consider using the auto-generated contracts from
+# https://github.com/tweag/nickel-kubernetes/ instead
 let Port | doc "A contract for a port number"
   =
     std.contract.from_predicate

--- a/examples/simple-contracts/simple-contract-div.ncl
+++ b/examples/simple-contracts/simple-contract-div.ncl
@@ -8,12 +8,14 @@ let Even = fun label value =>
   else
     std.contract.blame label
 in
+
 let DivBy3 = fun label value =>
   if std.is_number value && value % 3 == 0 then
     value
   else
     std.contract.blame label
 in
+
 # Will cause an error! 4 is not divisible by 3.
 (
   4

--- a/flake.lock
+++ b/flake.lock
@@ -498,11 +498,11 @@
         "rust-overlay": "rust-overlay_2"
       },
       "locked": {
-        "lastModified": 1717085654,
-        "narHash": "sha256-DoaPSJEs/3EWdzrgQtdVKFIvHALtZipwUI9DqqoSWgI=",
+        "lastModified": 1717691046,
+        "narHash": "sha256-bVDoatFPN7NRuAf4URTFNrYVU7phz2vJpROmnVmqvfw=",
         "owner": "tweag",
         "repo": "topiary",
-        "rev": "42f2630130c36d8b69615ed9b96b50196451c80b",
+        "rev": "1f11babe0d037cd84f8d909129dce497323f1e49",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Closes #1911.

This PR updates the manual to take into account the latest extensions of pattern matching, namely wildcard patterns, constant patterns, array patterns, pattern guards and or-patterns.

Doing so, we also update the examples (in the manual and in the `examples` directory) to use pattern matching whenever it looks more idiomatic and make the code more readable.