### PR TITLE
Add --version support to NLS and fix feature unification issues

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1736,6 +1736,7 @@ dependencies = [
  "csv",
  "derive_more",
  "env_logger",
+ "git-version",
  "glob",
  "insta",
  "lalrpop",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -25,7 +25,7 @@ metrics = ["dep:metrics", "dep:metrics-util", "nickel-lang-core/metrics"]
 [dependencies]
 nickel-lang-core = { workspace = true, features = [ "markdown" ], default-features = false }
 
-clap = { workspace = true, features = ["derive"] }
+clap = { workspace = true, features = ["derive", "string"] }
 serde = { workspace = true, features = ["derive"] }
 directories.workspace = true
 

--- a/core/src/program.rs
+++ b/core/src/program.rs
@@ -594,7 +594,6 @@ impl<EC: EvalCache> Program<EC> {
     /// [^missing-field-def]: Because we want to handle partial configurations as well,
     /// [crate::error::EvalError::MissingFieldDef] errors are _ignored_: if this is encountered
     /// when evaluating a field, this field is just left as it is and the evaluation proceeds.
-    #[cfg(feature = "doc")]
     pub fn eval_record_spine(&mut self) -> Result<RichTerm, Error> {
         use crate::eval::Environment;
         use crate::match_sharedterm;

--- a/lsp/nls/Cargo.toml
+++ b/lsp/nls/Cargo.toml
@@ -28,7 +28,7 @@ lalrpop.workspace = true
 [dependencies]
 anyhow.workspace = true
 bincode.workspace = true
-clap = { workspace = true, features = ["derive"] }
+clap = { workspace = true, features = ["derive", "string"] }
 codespan-reporting.workspace = true
 codespan.workspace = true
 crossbeam.workspace = true
@@ -40,12 +40,13 @@ lazy_static.workspace = true
 log.workspace = true
 lsp-server.workspace = true
 lsp-types.workspace = true
-nickel-lang-core.workspace = true
+nickel-lang-core = {workspace = true, default-features = false}
 regex.workspace = true
 scopeguard.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 thiserror.workspace = true
+git-version.workspace = true
 
 [dev-dependencies]
 assert_cmd.workspace = true


### PR DESCRIPTION
This PR adds `--version` support for the `nls` binary, using the same scheme as for the main `nickel` binary. Its absence made it hard to know which version of NLS users would currently run, which isn't great for chasing bugs.

Doing so, I discovered some underlying feature unification issues that were here but just invisible, namely that the little stunt we pull off for generating versions in different environments (in the git repo, building for crates.io and the nixified version) requires the `string` feature of clap, but we didn't enable this feature explicitly anywhere. It just happened that it was enabled previously for `nickel-lang-cli` by chance, thanks to feature unification (through `comrak` which is used for the `doc` feature). In fact building `nickel-lang-cli` without the default features is failing on current master, because the absence of `doc` doesn't pull `comrak` in, which doesn't enable the `string` feature.

This PR fixes the compilation issue by adding the missing `string` feature to the `clap` dependency for both the cli and the lsp. We also make `nickel-lang-lsp` also depend on `nickel-lang-core` without the default featurs (as most of them are useless for the LSP), and we fix another unrelated compilation error of `nickel-lang-cli` without default features by making `nickel-lang-core` always export `eval_record_spine`, which would only be included when the `doc` feature was enabled before, but is actually used for other purposes now (namely the CLI customize mode).