### PR TITLE
Fix nls crash, and better refresh diagnostics.

### DIFF
--- a/core/src/cache.rs
+++ b/core/src/cache.rs
@@ -1013,6 +1013,13 @@ impl Cache {
             .map(|TermEntry { state, .. }| std::mem::replace(state, new))
     }
 
+    /// Remove the cached term associated with this id.
+    ///
+    /// The file contents associated with this id remain, and they will be re-parsed if necessary.
+    pub fn reset(&mut self, file_id: FileId) {
+        self.terms.remove(&file_id);
+    }
+
     /// Retrieve the state of an entry. Return `None` if the entry is not in the term cache,
     /// meaning that the content of the source has been loaded but has not been parsed yet.
     pub fn entry_state(&self, file_id: FileId) -> Option<EntryState> {

--- a/core/src/cache.rs
+++ b/core/src/cache.rs
@@ -1013,11 +1013,36 @@ impl Cache {
             .map(|TermEntry { state, .. }| std::mem::replace(state, new))
     }
 
-    /// Remove the cached term associated with this id.
+    /// Remove the cached term associated with this id, and any cached terms
+    /// that import it.
     ///
-    /// The file contents associated with this id remain, and they will be re-parsed if necessary.
-    pub fn reset(&mut self, file_id: FileId) {
-        self.terms.remove(&file_id);
+    /// The file contents associated with this id remain, and they will be
+    /// re-parsed if necessary.
+    ///
+    /// This invalidation scheme is probably too aggressive; there are
+    /// situations where a change in one file doesn't require invalidation
+    /// of other files that import it. For example, if the parse status (i.e.
+    /// success/failure) of a file doesn't change, files that import it don't
+    /// need to re-resolve their imports. If the checked type of a file doesn't
+    /// change, files that import it don't need to be re-typechecked.
+    ///
+    /// Returns all the additional (i.e. not including the passed one) file ids
+    /// whose caches were invalidated.
+    pub fn invalidate_cache(&mut self, file_id: FileId) -> Vec<FileId> {
+        fn invalidate_rec(slf: &mut Cache, acc: &mut Vec<FileId>, file_id: FileId) {
+            slf.terms.remove(&file_id);
+            slf.imports.remove(&file_id);
+            let rev_deps = slf.rev_imports.remove(&file_id).unwrap_or_default();
+
+            acc.extend(rev_deps.iter().copied());
+            for f in &rev_deps {
+                invalidate_rec(slf, acc, *f);
+            }
+        }
+
+        let mut ret = vec![];
+        invalidate_rec(self, &mut ret, file_id);
+        ret
     }
 
     /// Retrieve the state of an entry. Return `None` if the entry is not in the term cache,

--- a/lsp/nls/src/files.rs
+++ b/lsp/nls/src/files.rs
@@ -23,7 +23,8 @@ pub(crate) fn uri_to_path(uri: &Url) -> std::result::Result<PathBuf, Error> {
     }
 }
 
-pub fn handle_open(server: &mut Server, params: DidOpenTextDocumentParams) -> Result<()> {
+/// Returns a list of open files that were potentially invalidated by the changes.
+pub fn handle_open(server: &mut Server, params: DidOpenTextDocumentParams) -> Result<Vec<Url>> {
     let id: RequestId = format!(
         "{}#{}",
         params.text_document.uri, params.text_document.version
@@ -49,10 +50,11 @@ pub fn handle_open(server: &mut Server, params: DidOpenTextDocumentParams) -> Re
         server.issue_diagnostics(*rev_dep, diags);
     }
     Trace::reply(id);
-    Ok(())
+    Ok(server.world.uris(invalid).cloned().collect())
 }
 
-pub fn handle_save(server: &mut Server, params: DidChangeTextDocumentParams) -> Result<()> {
+/// Returns a list of open files that were potentially invalidated by the changes.
+pub fn handle_save(server: &mut Server, params: DidChangeTextDocumentParams) -> Result<Vec<Url>> {
     let id: RequestId = format!(
         "{}#{}",
         params.text_document.uri, params.text_document.version
@@ -80,5 +82,5 @@ pub fn handle_save(server: &mut Server, params: DidChangeTextDocumentParams) -> 
         server.issue_diagnostics(*f, errors);
     }
     Trace::reply(id);
-    Ok(())
+    Ok(server.world.uris(invalid).cloned().collect())
 }

--- a/lsp/nls/src/files.rs
+++ b/lsp/nls/src/files.rs
@@ -76,7 +76,7 @@ pub fn handle_save(server: &mut Server, params: DidChangeTextDocumentParams) -> 
     server.issue_diagnostics(file_id, diags);
 
     for f in &invalid {
-        let errors = server.world.typecheck(*f).err().unwrap_or_default();
+        let errors = server.world.parse_and_typecheck(*f);
         server.issue_diagnostics(*f, errors);
     }
     Trace::reply(id);

--- a/lsp/nls/src/world.rs
+++ b/lsp/nls/src/world.rs
@@ -5,6 +5,7 @@ use std::{
 };
 
 use codespan::FileId;
+use log::warn;
 use lsp_server::{ErrorCode, ResponseError};
 use lsp_types::Url;
 use nickel_lang_core::{
@@ -355,5 +356,14 @@ impl World {
             }
         }
         inner(self, span).unwrap_or_default()
+    }
+
+    pub fn uris(&self, ids: impl IntoIterator<Item = FileId>) -> impl Iterator<Item = &Url> {
+        ids.into_iter().filter_map(|id| {
+            self.file_uris.get(&id).or_else(|| {
+                warn!("no uri for {id:?}");
+                None
+            })
+        })
     }
 }

--- a/lsp/nls/src/world.rs
+++ b/lsp/nls/src/world.rs
@@ -94,6 +94,8 @@ impl World {
         // cache if it was imported by an already-open file.
         let file_id = self.cache.replace_string(SourcePath::Path(path), contents);
 
+        // The cache automatically invalidates reverse-dependencies; we also need
+        // to track them, so that we can clear our own analysis.
         let mut invalid = failed_to_import.clone();
         invalid.extend(self.cache.invalidate_cache(file_id));
 


### PR DESCRIPTION
In nls, if `main.ncl` imports `dep.ncl` and `dep.ncl` changes, we need
to invalidate some cached data about `main.ncl` and re-check it.
Previously we were simply resetting `main.ncl` to the "parsed" state in
the cache, but this isn't sufficient because our cached term for
`main.ncl` might depend on `dep.ncl`. Specifically, import resolution of
`main.ncl` transforms the term in a way that depends on whether
`dep.ncl` parsed.

This PR does the most inefficient (but easiest to get correct)
thing: throwing out all the parsed data and re-parsing from scratch.
This can be optimized, but it probably isn't too much slower than the
status quo, because we were re-typechecking from scratch anyway.

Fixes #1943 and maybe also #1942 and #1935. There are still some bugs related to cache state in the background worker, which I will investigate next.