### PR TITLE
Update dependencies in the background evaluator

### DIFF
--- a/lsp/nls/src/server.rs
+++ b/lsp/nls/src/server.rs
@@ -188,6 +188,8 @@ impl Server {
                     .update_file(uri.clone(), contents, &self.world);
                 self.background_jobs.eval_file(uri);
                 for uri in invalid {
+                    self.background_jobs
+                        .update_file_deps(uri.clone(), &self.world);
                     self.background_jobs.eval_file(uri);
                 }
                 Ok(())
@@ -203,6 +205,8 @@ impl Server {
                     .update_file(uri.clone(), contents, &self.world);
                 self.background_jobs.eval_file(uri);
                 for uri in invalid {
+                    self.background_jobs
+                        .update_file_deps(uri.clone(), &self.world);
                     self.background_jobs.eval_file(uri);
                 }
                 Ok(())


### PR DESCRIPTION
The background evaluator needs to track dependencies separately, because it doesn't share file ids with the main cache. This updates the background dependencies when the foreground ones get updated.

This fixes an unreported bug that I noticed while testing #1944, where eval diagnostics would flash on and off when opening an import of an already-opened file.