### PR TITLE
Make the LSP configurable

### DIFF
--- a/lsp/lsp-harness/src/lib.rs
+++ b/lsp/lsp-harness/src/lib.rs
@@ -126,13 +126,16 @@ impl Default for TestHarness {
 }
 
 impl TestHarness {
-    pub fn new() -> Self {
+    pub fn new_with_options(initialization_options: Option<serde_json::Value>) -> Self {
         let cmd = std::process::Command::cargo_bin("nls").unwrap();
-        let srv = Server::new(cmd).unwrap();
+        let srv = Server::new_with_options(cmd, initialization_options).unwrap();
         Self {
             srv,
             out: Vec::new(),
         }
+    }
+    pub fn new() -> Self {
+        Self::new_with_options(None)
     }
 
     pub fn request<T: LspRequest>(&mut self, params: T::Params)

--- a/lsp/nls/src/config.rs
+++ b/lsp/nls/src/config.rs
@@ -1,0 +1,73 @@
+//! Configuration for the nls server
+use serde::{Deserialize, Serialize};
+
+use std::time::Duration;
+
+fn default_eval_timeout() -> Duration {
+    Duration::from_secs(1)
+}
+fn default_recursion_limit() -> usize {
+    128
+}
+fn default_blacklist_duration() -> Duration {
+    Duration::from_secs(30)
+}
+
+/**
+Limits to appy to the LSP background evaluator.
+If an evaluation reaches one of these limits, it will be canceled and the offending file will be
+temporarily blacklisted.
+*/
+#[derive(Debug, Deserialize, Serialize)]
+pub struct LspEvalLimits {
+    /// Time out at which to cancel the background evaluation
+    #[serde(default = "default_eval_timeout")]
+    pub timeout: Duration,
+    /// The maximum recursion level to allow in the background evaluator
+    #[serde(default = "default_recursion_limit")]
+    pub recursion_limit: usize,
+}
+impl Default for LspEvalLimits {
+    fn default() -> Self {
+        LspEvalLimits {
+            timeout: default_eval_timeout(),
+            recursion_limit: default_recursion_limit(),
+        }
+    }
+}
+
+/// The configuration of the LSP evaluator
+#[derive(Debug, Deserialize, Serialize)]
+pub struct LspEvalConfig {
+    #[serde(default)]
+    pub eval_limits: LspEvalLimits,
+    /// The duration during which a file that broke the background evaluator will be blacklisted
+    /// from it
+    #[serde(default = "default_blacklist_duration")]
+    pub blacklist_duration: Duration,
+}
+
+impl Default for LspEvalConfig {
+    fn default() -> Self {
+        LspEvalConfig {
+            eval_limits: Default::default(),
+            // The duration during which a file causing the evaluator to timeout will be blacklisted from further
+            // evaluations
+            blacklist_duration: default_blacklist_duration(),
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct LspConfig {
+    #[serde(default)]
+    pub eval_config: LspEvalConfig,
+}
+
+impl Default for LspConfig {
+    fn default() -> Self {
+        LspConfig {
+            eval_config: Default::default(),
+        }
+    }
+}

--- a/lsp/nls/src/server.rs
+++ b/lsp/nls/src/server.rs
@@ -19,6 +19,7 @@ use crate::{
     actions,
     background::BackgroundJobs,
     command,
+    config::LspConfig,
     requests::{completion, formatting, goto, hover, rename, symbols},
     trace::Trace,
     world::World,
@@ -73,11 +74,11 @@ impl Server {
         }
     }
 
-    pub fn new(connection: Connection) -> Server {
+    pub fn new(connection: Connection, config: LspConfig) -> Server {
         Server {
             connection,
             world: World::default(),
-            background_jobs: BackgroundJobs::new(),
+            background_jobs: BackgroundJobs::new(config.eval_config),
         }
     }
 


### PR DESCRIPTION
Make the LSP options configurable

Take into account the configuration sent by the client through [`InitializeParams.initializationOptions`](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#initializeParams).

This is currently used to set the limits for the background evaluation, although it also creates the infrastructure for setting more things.

Depends on https://github.com/tweag/nickel/pull/1973 as they both touch the same code.
