### PR TITLE
Allow some function equality comparison

### DIFF
--- a/core/src/eval/operation.rs
+++ b/core/src/eval/operation.rs
@@ -3330,7 +3330,7 @@ impl RecPriority {
 ///
 /// # Uncomparable values
 ///
-/// Comparing two functions is undecidable. Even in simple cases, it's not trivial handle an
+/// Comparing two functions is undecidable. Even in simple cases, it's not trivial to handle an
 /// approximation (functions might capture free variables, you'd need to take eta-conversion into
 /// account to equate e.g. `fun x => x` and `fun y => y`, etc.).
 ///

--- a/core/src/eval/tests.rs
+++ b/core/src/eval/tests.rs
@@ -376,7 +376,10 @@ fn foreign_id() {
         RichTerm::from(Term::ForeignId(43)),
         RichTerm::from(Term::ForeignId(42)),
     );
-    assert_matches!(eval_no_import(t_eq), Err(EvalError::EqError { .. }));
+    assert_matches!(
+        eval_no_import(t_eq),
+        Err(EvalError::IncomparableValues { .. })
+    );
 
     // Opaque values cannot be merged (even if they're equal, since they can't get compared for equality).
     let t_merge = mk_term::op2(

--- a/core/tests/integration/inputs/contracts/equating_fn_match.ncl
+++ b/core/tests/integration/inputs/contracts/equating_fn_match.ncl
@@ -1,0 +1,7 @@
+# test.type = 'error'
+#
+# [test.metadata]
+# error = 'EvalError::IncomparableValues'
+let g = fun x => x + 1 in
+let h = match { 0 => 0 } in
+g == h

--- a/core/tests/integration/inputs/contracts/equating_fns_lhs.ncl
+++ b/core/tests/integration/inputs/contracts/equating_fns_lhs.ncl
@@ -1,6 +1,0 @@
-# test.type = 'error'
-#
-# [test.metadata]
-# error = 'EvalError::EqError'
-let f = fun x => x in
-f == 1

--- a/core/tests/integration/inputs/contracts/equating_functions.ncl
+++ b/core/tests/integration/inputs/contracts/equating_functions.ncl
@@ -1,6 +1,6 @@
 # test.type = 'error'
 #
 # [test.metadata]
-# error = 'EvalError::EqError'
+# error = 'EvalError::IncomparableValues'
 let g = fun x => x + 1 in
-"a" == g
+g == g

--- a/core/tests/integration/inputs/core/eq.ncl
+++ b/core/tests/integration/inputs/core/eq.ncl
@@ -83,5 +83,10 @@
   'Left 1 != 'Left 2,
   'Left 2 != 'Right 2,
   'Up [1,2,3] == 'Up [0+1,1+1,2+1],
+
+  # Functions can be compared to non-functions
+
+  (fun x => x) != 1,
+  ((+) 1) != null,
 ]
 |> std.test.assert_all

--- a/core/tests/integration/main.rs
+++ b/core/tests/integration/main.rs
@@ -145,8 +145,8 @@ enum Expectation {
 #[serde(tag = "error", content = "expectation")]
 enum ErrorExpectation {
     // TODO: can we somehow unify this with the `Display` impl below?
-    #[serde(rename = "EvalError::EqError")]
-    EvalEqError,
+    #[serde(rename = "EvalError::IncomparableValues")]
+    EvalIncomparableValues,
     #[serde(rename = "EvalError::Other")]
     EvalOther,
     #[serde(rename = "EvalError::UnaryPrimopTypeError")]
@@ -230,7 +230,7 @@ impl PartialEq<Error> for ErrorExpectation {
                 Error::EvalError(EvalError::IllegalPolymorphicTailAccess { .. }),
             )
             | (EvalTypeError, Error::EvalError(EvalError::TypeError(..)))
-            | (EvalEqError, Error::EvalError(EvalError::EqError { .. }))
+            | (EvalIncomparableValues, Error::EvalError(EvalError::IncomparableValues { .. }))
             | (EvalNAryPrimopTypeError, Error::EvalError(EvalError::NAryPrimopTypeError { .. }))
             | (
                 EvalUnaryPrimopTypeError,
@@ -393,7 +393,7 @@ impl std::fmt::Display for ErrorExpectation {
             ImportIoError => "ImportError::IoError".to_owned(),
             EvalBlameError => "EvalError::BlameError".to_owned(),
             EvalTypeError => "EvalError::TypeError".to_owned(),
-            EvalEqError => "EvalError::EqError".to_owned(),
+            EvalIncomparableValues => "EvalError::IncomparableValues".to_owned(),
             EvalOther => "EvalError::Other".to_owned(),
             EvalMergeIncompatibleArgs => "EvalError::MergeIncompatibleArgs".to_owned(),
             EvalNAryPrimopTypeError => "EvalError::NAryPrimopTypeError".to_owned(),


### PR DESCRIPTION
Relax the initial restriction on comparing functions, introduced in #975, which is that comparing a function to anything else errors out. In practice comparing a function to a value of some other type isn't a problem, and can be useful to allow patterns like `fun x => if x != null then ... else ...` without having first to defensively check if `x` is a function, because that would fail at runtime. One can think for example of quick contracts such as `let IsZero = from_predicate ((==) 0)`, which currently fails with a dynamic type error if we try to do `(fun x => x) | IsZero`. We'd need to do something like `from_predicate (fun x => !(std.is_function x) && x == 0)`, which is annoying.

Instead, we only forbid comparison between two function-like values (functions, match expressions and custom contracts) and between two opaque foreign values. Comparing a function-like value to a number of a string is fine and just returns false.

The initial motivation for restricting function comparison is that it's never something that is meaningful to do, so it's most probably an error, and that it breaks reflexivity of `==`, because `f != f` when `f` is a function. Arguably, the relaxed restriction proposed in this PR still fits the bill.

For context, this came up in #1975, where custom contracts is internally a pair of function `(immediate, delayed)`, each of which can be `null`, but then we can't do control flow such as `if immediate != null then ...`. While the `%typeof%` work-around does work, it doesn't feel right.