### PR TITLE
More aggressive type/contract deduplication on hover

### DIFF
--- a/lsp/nls/src/requests/hover.rs
+++ b/lsp/nls/src/requests/hover.rs
@@ -161,7 +161,9 @@ pub fn handle(
     if let Some(hover) = hover_data {
         let mut contents = Vec::new();
 
-        // Collect all the type and contract annotations we can find. (We don't distinguish between them.)
+        // Collect all the type and contract annotations we can find. We don't distinguish between them
+        // (and we deduplicate annotations if they're present as both types and contracts). However, we
+        // do give some special attention to the inferred static type if there is one: we list it first.
         let mut annotations: Vec<_> = hover
             .metadata
             .iter()

--- a/lsp/nls/src/requests/hover.rs
+++ b/lsp/nls/src/requests/hover.rs
@@ -12,7 +12,7 @@ use serde_json::Value;
 use crate::{
     cache::CacheExt,
     diagnostic::LocationCompat,
-    field_walker::{FieldResolver, Record},
+    field_walker::{Def, FieldResolver, Record},
     identifier::LocIdent,
     server::Server,
     world::World,
@@ -93,6 +93,10 @@ fn ident_hover(ident: LocIdent, world: &World) -> Option<HoverData> {
                     }
                     ret.metadata.push(cousin.metadata);
                 }
+            }
+
+            if let Def::Field { metadata, .. } = def {
+                ret.metadata.push(metadata.clone());
             }
         }
     }

--- a/lsp/nls/src/requests/hover.rs
+++ b/lsp/nls/src/requests/hover.rs
@@ -15,6 +15,7 @@ use crate::{
     field_walker::{Def, FieldResolver, Record},
     identifier::LocIdent,
     server::Server,
+    utils::dedup,
     world::World,
 };
 
@@ -164,15 +165,7 @@ pub fn handle(
         let mut annotations: Vec<_> = hover
             .metadata
             .iter()
-            .flat_map(|m| {
-                let maybe_typ = m.annotation.typ.as_ref().map(|typ| typ.typ.to_string());
-                let contracts = m
-                    .annotation
-                    .contracts
-                    .iter()
-                    .map(|c| c.label.typ.to_string());
-                maybe_typ.into_iter().chain(contracts)
-            })
+            .flat_map(|m| m.annotation.iter().map(|typ| typ.typ.to_string()))
             .chain(
                 hover
                     .values
@@ -181,8 +174,7 @@ pub fn handle(
                     .map(|contract| contract.label.typ.to_string()),
             )
             .collect();
-        annotations.sort();
-        annotations.dedup();
+        dedup(&mut annotations);
 
         let ty = hover
             .ty

--- a/lsp/nls/src/utils.rs
+++ b/lsp/nls/src/utils.rs
@@ -1,3 +1,5 @@
+use std::collections::HashSet;
+
 use nickel_lang_core::{
     cache::Cache,
     environment::Environment,
@@ -40,4 +42,12 @@ pub(crate) fn initialize_stdlib(
         }
     }
     initial_env
+}
+
+/// De-duplicate a vec without changing the order. The first instance of each unique
+/// element will be kept.
+pub fn dedup<T: std::hash::Hash + Eq + Clone>(xs: &mut Vec<T>) {
+    let mut seen = HashSet::new();
+    // Clone is needed because the signature of retain doesn't let us keep the reference.
+    xs.retain(|x| seen.insert(x.clone()));
 }

--- a/lsp/nls/tests/inputs/hover-basic.ncl
+++ b/lsp/nls/tests/inputs/hover-basic.ncl
@@ -18,3 +18,11 @@ record.foo.bar
 ### type = "Hover"
 ### textDocument.uri = "file:///main.ncl"
 ### position = { line = 6, character = 12 }
+### [[request]]
+### type = "Hover"
+### textDocument.uri = "file:///main.ncl"
+### position = { line = 1, character = 3 }
+### [[request]]
+### type = "Hover"
+### textDocument.uri = "file:///main.ncl"
+### position = { line = 2, character = 5 }

--- a/lsp/nls/tests/snapshots/main__lsp__nls__tests__inputs__hover-basic.ncl.snap
+++ b/lsp/nls/tests/snapshots/main__lsp__nls__tests__inputs__hover-basic.ncl.snap
@@ -9,8 +9,11 @@ Dyn
 Dyn
 ```, middle]
 <6:0-6:14>[```nickel
-Dyn
-```, ```nickel
 Number
 ```, innermost]
-
+<1:2-1:5>[```nickel
+Dyn
+```, middle]
+<2:4-2:7>[```nickel
+Number
+```, innermost]

--- a/lsp/nls/tests/snapshots/main__lsp__nls__tests__inputs__hover-cousin.ncl.snap
+++ b/lsp/nls/tests/snapshots/main__lsp__nls__tests__inputs__hover-cousin.ncl.snap
@@ -7,18 +7,13 @@ Dyn
 ```, outer]
 <1:10-1:13>[```nickel
 Number
-```, ```nickel
-Number
 ```, inner]
 <2:9-2:12>[```nickel
 Dyn
 ```, outer]
 <2:9-2:16>[```nickel
-Dyn
-```, ```nickel
 Number
 ```, inner]
 <3:6-3:10>[```nickel
 Dyn
 ```, longer path]
-

--- a/lsp/nls/tests/snapshots/main__lsp__nls__tests__inputs__hover-pattern.ncl.snap
+++ b/lsp/nls/tests/snapshots/main__lsp__nls__tests__inputs__hover-pattern.ncl.snap
@@ -15,13 +15,8 @@ Dyn
 { bar : Dyn }
 ```]
 <9:2-9:11>[```nickel
-Dyn
-```, ```nickel
 Number
 ```, innermost]
 <10:2-10:11>[```nickel
-Dyn
-```, ```nickel
 Number
 ```, innermost]
-


### PR DESCRIPTION
Fixes #1972.

While testing this, I noticed that some field documentation was missed when hovering over the exact field that was annotated, so I fixed that too.