### PR TITLE
Re-introduce unified representation for custom contracts, migrate builtin contracts

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -148,12 +148,12 @@ Rust integration tests, which run the file and assert that no errors were
 raised during evaluation.
 
 Each of these `.ncl` files is structured as an array of `Bool` expressions,
-which is ultimately passed to `std.contract.check` function defined in the
-standard library. This function applies an `Assert` (`std.test.Assert`)
-contract to each value in the array, which checks that the value it is applied
-to evaluates to `true`. The benefit of using a contract for this is that if a
-test fails we can simply run the file directly using Nickel, which gives better
-error messages than the ones we get by default from `cargo test`.
+which is ultimately passed to `std.test.check` function defined in the standard
+library. This function applies an `Assert` (`std.test.Assert`) contract to each
+value in the array, which checks that the value it is applied to evaluates to
+`true`. The benefit of using a contract for this is that if a test fails we can
+simply run the file directly using Nickel, which gives better error messages
+than the ones we get by default from `cargo test`.
 
 Tests which are expected to fail may be written in Rust in `core/tests/integration`.
 However, simple failure test cases can make use of the test annotation support

--- a/cli/tests/snapshot/inputs/errors/validator_custom_error.ncl
+++ b/cli/tests/snapshot/inputs/errors/validator_custom_error.ncl
@@ -2,7 +2,7 @@
 # command = ['eval']
 let Is42 = std.contract.from_validator (fun value =>
   if value == 42 then
-    'Ok value
+    'Ok
   else
     'Error {
       message = "Value must be 42",

--- a/cli/tests/snapshot/snapshots/snapshot__eval_stderr_array_at_empty_array.ncl.snap
+++ b/cli/tests/snapshot/snapshots/snapshot__eval_stderr_array_at_empty_array.ncl.snap
@@ -4,9 +4,9 @@ expression: err
 ---
 error: contract broken by the caller of `at`
        invalid array indexing
-    ┌─ <stdlib/std.ncl>:167:9
+    ┌─ <stdlib/std.ncl>:166:9
     │
-167 │       | std.contract.unstable.IndexedArrayFun 'Index
+166 │       | std.contract.unstable.IndexedArrayFun 'Index
     │         -------------------------------------------- expected type
     │
     ┌─ [INPUTS_PATH]/errors/array_at_empty_array.ncl:3:16

--- a/cli/tests/snapshot/snapshots/snapshot__eval_stderr_array_at_out_of_bound.ncl.snap
+++ b/cli/tests/snapshot/snapshots/snapshot__eval_stderr_array_at_out_of_bound.ncl.snap
@@ -4,9 +4,9 @@ expression: err
 ---
 error: contract broken by the caller of `at`
        invalid array indexing
-    ┌─ <stdlib/std.ncl>:167:9
+    ┌─ <stdlib/std.ncl>:166:9
     │
-167 │       | std.contract.unstable.IndexedArrayFun 'Index
+166 │       | std.contract.unstable.IndexedArrayFun 'Index
     │         -------------------------------------------- expected type
     │
     ┌─ [INPUTS_PATH]/errors/array_at_out_of_bound.ncl:3:16

--- a/cli/tests/snapshot/snapshots/snapshot__eval_stderr_array_range_reversed_indices.ncl.snap
+++ b/cli/tests/snapshot/snapshots/snapshot__eval_stderr_array_range_reversed_indices.ncl.snap
@@ -4,9 +4,9 @@ expression: err
 ---
 error: contract broken by the caller of `range`
        invalid range
-    ┌─ <stdlib/std.ncl>:706:9
+    ┌─ <stdlib/std.ncl>:705:9
     │
-706 │       | std.contract.unstable.RangeFun Dyn
+705 │       | std.contract.unstable.RangeFun Dyn
     │         ---------------------------------- expected type
     │
     ┌─ [INPUTS_PATH]/errors/array_range_reversed_indices.ncl:3:19

--- a/cli/tests/snapshot/snapshots/snapshot__eval_stderr_array_range_step_negative_step.ncl.snap
+++ b/cli/tests/snapshot/snapshots/snapshot__eval_stderr_array_range_step_negative_step.ncl.snap
@@ -4,9 +4,9 @@ expression: err
 ---
 error: contract broken by the caller of `range_step`
        invalid range step
-    ┌─ <stdlib/std.ncl>:681:9
+    ┌─ <stdlib/std.ncl>:680:9
     │
-681 │       | std.contract.unstable.RangeFun (std.contract.unstable.RangeStep -> Dyn)
+680 │       | std.contract.unstable.RangeFun (std.contract.unstable.RangeStep -> Dyn)
     │         ----------------------------------------------------------------------- expected type
     │
     ┌─ [INPUTS_PATH]/errors/array_range_step_negative_step.ncl:3:27

--- a/cli/tests/snapshot/snapshots/snapshot__eval_stderr_caller_contract_violation.ncl.snap
+++ b/cli/tests/snapshot/snapshots/snapshot__eval_stderr_caller_contract_violation.ncl.snap
@@ -3,9 +3,10 @@ source: cli/tests/snapshot/main.rs
 expression: err
 ---
 error: contract broken by the caller of `map`
-    ┌─ <stdlib/std.ncl>:151:33
+       expected an array
+    ┌─ <stdlib/std.ncl>:150:33
     │
-151 │       : forall a b. (a -> b) -> Array a -> Array b
+150 │       : forall a b. (a -> b) -> Array a -> Array b
     │                                 ------- expected type of the argument provided by the caller
     │
     ┌─ [INPUTS_PATH]/errors/caller_contract_violation.ncl:3:31

--- a/core/src/eval/operation.rs
+++ b/core/src/eval/operation.rs
@@ -1561,7 +1561,7 @@ impl<R: ImportResolver, C: Cache> VirtualMachine<R, C> {
                     label.arg_pos = self.cache.get_then(idx.clone(), |c| c.body.pos);
                     label.arg_idx = Some(idx);
 
-                    // Otherwise, we push the label back on the stack and we properly convert the
+                    // We push the label back on the stack and we properly convert the
                     // contract to a naked function of a label and a value, which will have the
                     // stack in the same state as if it had been applied normally to both
                     // arguments.

--- a/core/src/parser/grammar.lalrpop
+++ b/core/src/parser/grammar.lalrpop
@@ -1127,8 +1127,7 @@ UOp: UnaryOp = {
     "enum/make_variant" => UnaryOp::EnumMakeVariant,
     "enum/is_variant" => UnaryOp::EnumIsVariant,
     "enum/get_tag" => UnaryOp::EnumGetTag,
-    "contract/get_immediate" => UnaryOp::ContractGetImmediate,
-    "contract/get_delayed" => UnaryOp::ContractGetDelayed,
+    "contract/custom" => UnaryOp::ContractCustom,
 }
 
 PatternGuard: RichTerm = "if" <Term> => <>;
@@ -1301,7 +1300,6 @@ BOpPre: BinaryOp = {
     "contract/apply" => BinaryOp::ContractApply,
     "contract/array_lazy_app" => BinaryOp::ContractArrayLazyApp,
     "contract/record_lazy_app" => BinaryOp::ContractRecordLazyApp,
-    "contract/custom" => BinaryOp::ContractCustom,
     "unseal" => BinaryOp::Unseal,
     "seal" => BinaryOp::Seal,
     "label/go_field" => BinaryOp::LabelGoField,
@@ -1519,8 +1517,6 @@ extern {
         "contract/array_lazy_app" => Token::Normal(NormalToken::ContractArrayLazyApp),
         "contract/record_lazy_app" => Token::Normal(NormalToken::ContractRecordLazyApp),
         "contract/custom" => Token::Normal(NormalToken::ContractCustom),
-        "contract/get_immediate" => Token::Normal(NormalToken::ContractGetImmediate),
-        "contract/get_delayed" => Token::Normal(NormalToken::ContractGetDelayed),
         "op force" => Token::Normal(NormalToken::OpForce),
         "blame" => Token::Normal(NormalToken::Blame),
         "label/flip_polarity" => Token::Normal(NormalToken::LabelFlipPol),

--- a/core/src/parser/grammar.lalrpop
+++ b/core/src/parser/grammar.lalrpop
@@ -1298,6 +1298,7 @@ InfixExpr: UniTerm = {
 
 BOpPre: BinaryOp = {
     "contract/apply" => BinaryOp::ContractApply,
+    "contract/apply_as_custom" => BinaryOp::ContractApplyAsCustom,
     "contract/array_lazy_app" => BinaryOp::ContractArrayLazyApp,
     "contract/record_lazy_app" => BinaryOp::ContractRecordLazyApp,
     "unseal" => BinaryOp::Unseal,
@@ -1352,6 +1353,8 @@ NOpPre<ArgRule>: UniTerm = {
         UniTerm::from(mk_opn!(NAryOp::LabelInsertTypeVar, key, pol, label)),
     "array/slice" <t1: ArgRule> <t2: ArgRule> <t3: ArgRule> =>
         UniTerm::from(mk_opn!(NAryOp::ArraySlice, t1, t2, t3)),
+    "record/merge_contract" <t1: ArgRule> <t2: ArgRule> <t3: ArgRule> =>
+        UniTerm::from(mk_opn!(NAryOp::MergeContract, t1, t2, t3)),
 }
 
 TypeBuiltin: Type = {
@@ -1514,6 +1517,7 @@ extern {
 
         "typeof" => Token::Normal(NormalToken::Typeof),
         "contract/apply" => Token::Normal(NormalToken::ContractApply),
+        "contract/apply_as_custom" => Token::Normal(NormalToken::ContractApplyAsCustom),
         "contract/array_lazy_app" => Token::Normal(NormalToken::ContractArrayLazyApp),
         "contract/record_lazy_app" => Token::Normal(NormalToken::ContractRecordLazyApp),
         "contract/custom" => Token::Normal(NormalToken::ContractCustom),
@@ -1556,6 +1560,7 @@ extern {
         "record/field_is_defined_with_opts" => Token::Normal(NormalToken::RecordFieldIsDefinedWithOpts),
         "record/split_pair" => Token::Normal(NormalToken::RecordSplitPair),
         "record/disjoint_merge" => Token::Normal(NormalToken::RecordDisjointMerge),
+        "record/merge_contract" => Token::Normal(NormalToken::RecordMergeContract),
         "array/map" => Token::Normal(NormalToken::ArrayMap),
         "array/generate" => Token::Normal(NormalToken::ArrayGen),
         "array/at" => Token::Normal(NormalToken::ArrayAt),

--- a/core/src/parser/lexer.rs
+++ b/core/src/parser/lexer.rs
@@ -196,6 +196,8 @@ pub enum NormalToken<'input> {
 
     #[token("%contract/apply%")]
     ContractApply,
+    #[token("%contract/apply_as_custom%")]
+    ContractApplyAsCustom,
     #[token("%contract/array_lazy_apply%")]
     ContractArrayLazyApp,
     #[token("%contract/record_lazy_apply%")]
@@ -287,6 +289,8 @@ pub enum NormalToken<'input> {
     RecordSplitPair,
     #[token("%record/disjoint_merge%")]
     RecordDisjointMerge,
+    #[token("%record/merge_contract%")]
+    RecordMergeContract,
 
     #[token("merge")]
     Merge,

--- a/core/src/parser/lexer.rs
+++ b/core/src/parser/lexer.rs
@@ -202,10 +202,6 @@ pub enum NormalToken<'input> {
     ContractRecordLazyApp,
     #[token("%contract/custom%")]
     ContractCustom,
-    #[token("%contract/get_immediate%")]
-    ContractGetImmediate,
-    #[token("%contract/get_delayed%")]
-    ContractGetDelayed,
     #[token("%blame%")]
     Blame,
     #[token("%label/flip_polarity%")]

--- a/core/src/pretty.rs
+++ b/core/src/pretty.rs
@@ -5,9 +5,6 @@ use crate::parser::lexer::KEYWORDS;
 use crate::term::{
     pattern::*,
     record::{Field, FieldMetadata, RecordData},
-    // Because we use `Term::*`, we need to differentiate `Contract` from `Term::Contract`, so we
-    // alias the latter
-    CustomContract as ContractNode,
     *,
 };
 use crate::typ::*;
@@ -822,27 +819,14 @@ where
             StrChunks(chunks) => allocator.chunks(chunks, StringRenderStyle::Multiline),
             Fun(id, body) => allocator.function(allocator.as_string(id), body),
             // Format this as the primop application
-            // `<custom contract constructor> <immediate> <delayed>`.
-            CustomContract(ContractNode { immediate, delayed }) => {
-                let arg_or_null = |arg: &Option<RichTerm>| {
-                    docs![
-                        allocator,
-                        allocator.line(),
-                        if let Some(arg) = arg {
-                            allocator.atom(arg)
-                        } else {
-                            allocator.text("null")
-                        }
-                    ]
-                    .nest(2)
-                    .group()
-                };
-
+            // `%contract/custom% <ctr>`.
+            CustomContract(ctr) => {
                 docs![
                     allocator,
                     "%contract/custom%",
-                    arg_or_null(immediate),
-                    arg_or_null(delayed)
+                    docs![allocator, allocator.line(), allocator.atom(ctr),]
+                        .nest(2)
+                        .group(),
                 ]
             }
             FunPattern(pat, body) => allocator.function(allocator.pat_with_parens(pat), body),

--- a/core/src/stdlib.rs
+++ b/core/src/stdlib.rs
@@ -89,8 +89,8 @@ pub mod internals {
     generate_accessor!(enum_variant);
     generate_accessor!(forall_enum_tail);
 
-    generate_accessor!(record);
-    generate_accessor!(record_extend);
+    generate_accessor!(record_contract);
+    generate_accessor!(record_type);
     generate_accessor!(forall_record_tail);
     generate_accessor!(dyn_tail);
     generate_accessor!(empty_tail);

--- a/core/src/stdlib.rs
+++ b/core/src/stdlib.rs
@@ -48,16 +48,6 @@ impl StdlibModule {
 pub struct UnknownStdlibModule;
 
 macro_rules! generate_accessor {
-    ($value:ident / immediate) => {
-        pub fn $value() -> RichTerm {
-            mk_term::var(format!("${}/immediate", stringify!($value)))
-        }
-    };
-    ($value:ident / delayed) => {
-        pub fn $value() -> RichTerm {
-            mk_term::var(format!("${}/delayed", stringify!($value)))
-        }
-    };
     ($value:ident) => {
         pub fn $value() -> RichTerm {
             mk_term::var(format!("${}", stringify!($value)))
@@ -69,79 +59,49 @@ macro_rules! generate_accessor {
 pub mod internals {
     use super::*;
 
-    //TODO
-    // Same, `enum` is a reserved keyword in Rust.
+    // `dyn` is a reserved keyword in rust
+    pub fn dynamic() -> RichTerm {
+        mk_term::var("$dyn")
+    }
+
+    // `enum` is a reserved keyword in rust
     pub fn enumeration() -> RichTerm {
         mk_term::var("$enum")
     }
 
-    pub mod immediate {
-        use super::*;
+    generate_accessor!(num);
+    generate_accessor!(bool);
+    generate_accessor!(foreign_id);
+    generate_accessor!(string);
 
-        // `dyn` is a reserved keyword in Rust, so the macro `generate_accessor` doesn't work.
-        pub fn dynamic() -> RichTerm {
-            mk_term::var("$dyn/immediate")
-        }
+    generate_accessor!(array);
+    generate_accessor!(array_dyn);
 
-        // `enum` is a reserved keyword in Rust, so the macro `generate_accessor` doesn't work.
-        pub fn enumeration() -> RichTerm {
-            mk_term::var("$enum/immediate")
-        }
-
-        generate_accessor!(number / immediate);
-        generate_accessor!(bool / immediate);
-        generate_accessor!(foreign_id / immediate);
-        generate_accessor!(string / immediate);
-        generate_accessor!(fail / immediate);
-
-        generate_accessor!(forall / immediate);
-
-        generate_accessor!(array / immediate);
-        generate_accessor!(array_dyn / immediate);
-
-        generate_accessor!(func / immediate);
-        generate_accessor!(enum_variant / immediate);
-
-        generate_accessor!(record / immediate);
-        generate_accessor!(record_type / immediate);
-
-        generate_accessor!(dict_dyn / immediate);
-    }
-
-    pub mod delayed {
-        use super::*;
-
-        // `enum` is a reserved keyword in Rust, so the macro `generate_accessor` doesn't work.
-        pub fn enumeration() -> RichTerm {
-            mk_term::var("$enum/delayed")
-        }
-
-        generate_accessor!(array / delayed);
-
-        generate_accessor!(forall / delayed);
-
-        generate_accessor!(func / delayed);
-        generate_accessor!(func_dom / delayed);
-        generate_accessor!(func_codom / delayed);
-
-        generate_accessor!(record / delayed);
-        generate_accessor!(record_type / delayed);
-        generate_accessor!(dict_contract / delayed);
-        generate_accessor!(dict_type / delayed);
-    }
+    generate_accessor!(func);
+    generate_accessor!(func_dom);
+    generate_accessor!(func_codom);
+    generate_accessor!(func_dyn);
 
     generate_accessor!(forall_var);
+    generate_accessor!(forall);
 
     generate_accessor!(enum_fail);
+    generate_accessor!(enum_variant);
     generate_accessor!(forall_enum_tail);
 
+    generate_accessor!(record);
+    generate_accessor!(record_extend);
     generate_accessor!(forall_record_tail);
     generate_accessor!(dyn_tail);
     generate_accessor!(empty_tail);
 
+    generate_accessor!(dict_type);
+    generate_accessor!(dict_contract);
+    generate_accessor!(dict_dyn);
+
     generate_accessor!(stdlib_contract_equal);
 
-    generate_accessor!(prepare_contract);
+    generate_accessor!(prepare_custom_contract);
 
     generate_accessor!(rec_default);
     generate_accessor!(rec_force);

--- a/core/src/stdlib.rs
+++ b/core/src/stdlib.rs
@@ -48,6 +48,16 @@ impl StdlibModule {
 pub struct UnknownStdlibModule;
 
 macro_rules! generate_accessor {
+    ($value:ident / immediate) => {
+        pub fn $value() -> RichTerm {
+            mk_term::var(format!("${}/immediate", stringify!($value)))
+        }
+    };
+    ($value:ident / delayed) => {
+        pub fn $value() -> RichTerm {
+            mk_term::var(format!("${}/delayed", stringify!($value)))
+        }
+    };
     ($value:ident) => {
         pub fn $value() -> RichTerm {
             mk_term::var(format!("${}", stringify!($value)))
@@ -59,52 +69,79 @@ macro_rules! generate_accessor {
 pub mod internals {
     use super::*;
 
-    // `dyn` is a reserved keyword in rust
-    pub fn dynamic() -> RichTerm {
-        mk_term::var("$dyn")
-    }
-
-    // `enum` is a reserved keyword in rust
+    //TODO
+    // Same, `enum` is a reserved keyword in Rust.
     pub fn enumeration() -> RichTerm {
         mk_term::var("$enum")
     }
 
-    generate_accessor!(num);
-    generate_accessor!(bool);
-    generate_accessor!(foreign_id);
-    generate_accessor!(string);
-    generate_accessor!(fail);
+    pub mod immediate {
+        use super::*;
 
-    generate_accessor!(array);
-    generate_accessor!(array_dyn);
+        // `dyn` is a reserved keyword in Rust, so the macro `generate_accessor` doesn't work.
+        pub fn dynamic() -> RichTerm {
+            mk_term::var("$dyn/immediate")
+        }
 
-    generate_accessor!(func);
-    generate_accessor!(func_dom);
-    generate_accessor!(func_codom);
-    generate_accessor!(func_dyn);
+        // `enum` is a reserved keyword in Rust, so the macro `generate_accessor` doesn't work.
+        pub fn enumeration() -> RichTerm {
+            mk_term::var("$enum/immediate")
+        }
+
+        generate_accessor!(number / immediate);
+        generate_accessor!(bool / immediate);
+        generate_accessor!(foreign_id / immediate);
+        generate_accessor!(string / immediate);
+        generate_accessor!(fail / immediate);
+
+        generate_accessor!(forall / immediate);
+
+        generate_accessor!(array / immediate);
+        generate_accessor!(array_dyn / immediate);
+
+        generate_accessor!(func / immediate);
+        generate_accessor!(enum_variant / immediate);
+
+        generate_accessor!(record / immediate);
+        generate_accessor!(record_type / immediate);
+
+        generate_accessor!(dict_dyn / immediate);
+    }
+
+    pub mod delayed {
+        use super::*;
+
+        // `enum` is a reserved keyword in Rust, so the macro `generate_accessor` doesn't work.
+        pub fn enumeration() -> RichTerm {
+            mk_term::var("$enum/delayed")
+        }
+
+        generate_accessor!(array / delayed);
+
+        generate_accessor!(forall / delayed);
+
+        generate_accessor!(func / delayed);
+        generate_accessor!(func_dom / delayed);
+        generate_accessor!(func_codom / delayed);
+
+        generate_accessor!(record / delayed);
+        generate_accessor!(record_type / delayed);
+        generate_accessor!(dict_contract / delayed);
+        generate_accessor!(dict_type / delayed);
+    }
 
     generate_accessor!(forall_var);
-    generate_accessor!(forall);
 
     generate_accessor!(enum_fail);
-    generate_accessor!(enum_variant);
     generate_accessor!(forall_enum_tail);
 
-    generate_accessor!(record);
-    generate_accessor!(record_extend);
     generate_accessor!(forall_record_tail);
     generate_accessor!(dyn_tail);
     generate_accessor!(empty_tail);
 
-    generate_accessor!(dict_type);
-    generate_accessor!(dict_contract);
-    generate_accessor!(dict_dyn);
-
     generate_accessor!(stdlib_contract_equal);
 
     generate_accessor!(prepare_contract);
-    generate_accessor!(record_immediate);
-    generate_accessor!(record_delayed);
 
     generate_accessor!(rec_default);
     generate_accessor!(rec_force);

--- a/core/src/stdlib.rs
+++ b/core/src/stdlib.rs
@@ -102,6 +102,7 @@ pub mod internals {
     generate_accessor!(stdlib_contract_equal);
 
     generate_accessor!(prepare_custom_contract);
+    generate_accessor!(naked_to_custom);
 
     generate_accessor!(rec_default);
     generate_accessor!(rec_force);

--- a/core/src/term/mod.rs
+++ b/core/src/term/mod.rs
@@ -252,11 +252,12 @@ pub enum Term {
     ///
     /// # Naked functions as custom contracts
     ///
-    /// Nowadays, using dedicated constructors is the only documented way of creating custom contracts:
-    /// `std.contract.custom`, `std.contract.from_record`, etc. The requirement to use those dedicated
-    /// constructors is unfortunately a breaking change (prior to Nickel 1.8) as custom contracts were
-    /// written as naked functions before. Using naked functions is discouraged and will be deprecated
-    /// in the future, but `%contract/apply%` still supports them.
+    /// Nowadays, using dedicated constructors is the only documented way of creating custom
+    /// contracts: `std.contract.custom`, `std.contract.from_validator`, etc. The requirement to
+    /// use those dedicated constructors is unfortunately a breaking change (prior to Nickel 1.8)
+    /// as custom contracts were written as naked functions before. Using naked functions is
+    /// discouraged and will be deprecated in the future, but `%contract/apply%` still supports
+    /// them.
     #[serde(skip)]
     CustomContract(RichTerm),
 

--- a/core/src/term/mod.rs
+++ b/core/src/term/mod.rs
@@ -1672,7 +1672,29 @@ pub enum BinaryOp {
     /// also accepts contracts as records, which are translated to a function that merge said
     /// contract with its argument. Finally, this operator marks the location of the contract
     /// argument on the stack for better error reporting.
+    ///
+    /// Either the contract raises a blame error, or the primop evaluates to the value returned by
+    /// the contract that can be used in place of the original value.
     ContractApply,
+
+    /// Variant of [Self::ContractApply] which also applies an arbitrary contract to a label
+    /// and a value, but instead of either blaming or returning the value, it has the same return
+    /// value as a custom contract built via [UnaryOp::ContractCustom], that is `[| 'Ok Dyn, 'Error
+    /// {..}|]`. The value returned through `'Ok` can still have lazy blame expressions inside, of
+    /// course.
+    ///
+    /// Put differently, `%contract/apply_as_custom% (%contract/custom% custom) label value` is
+    /// equivalent to `custom label value`, modulo argument tracking. [Self::ContractApplyAsCustom]
+    /// doesn't only work on custom contracts, but on builtin contracts as well.
+    ///
+    /// This operation is useful for contract composition, that is when calling a contract from
+    /// another contract. In theory, one could use [Self::ContractApply], but the caller then needs
+    /// to wrap the result in `'Ok`, and much more importantly, `%contract/apply%` converts all
+    /// immediate errors returned as `'Error` into blame errors. This is not desirable, as blame
+    /// errors can't be caught, which artifcially makes the called contract entirely delayed. This
+    /// typically wouldn't play very well with boolean combinators. On the other hand,
+    /// [Self::ContractApplyAsCustom] preserves the immediate/delayed part of the called contract.
+    ContractApplyAsCustom,
 
     /// Unseal a sealed term.
     ///
@@ -1822,6 +1844,7 @@ impl fmt::Display for BinaryOp {
             GreaterThan => write!(f, "(>)"),
             GreaterOrEq => write!(f, "(>=)"),
             ContractApply => write!(f, "contract/apply"),
+            ContractApplyAsCustom => write!(f, "contract/apply_as_custom"),
             Unseal => write!(f, "unseal"),
             LabelGoField => write!(f, "label/go_field"),
             RecordInsert {

--- a/core/src/term/mod.rs
+++ b/core/src/term/mod.rs
@@ -1964,7 +1964,7 @@ impl fmt::Display for NAryOp {
             StringReplace => write!(f, "string/replace"),
             StringReplaceRegex => write!(f, "string/replace_regex"),
             StringSubstr => write!(f, "string/substr"),
-            MergeContract => write!(f, "merge_contract"),
+            MergeContract => write!(f, "record/merge_contract"),
             RecordSealTail => write!(f, "record/seal_tail"),
             RecordUnsealTail => write!(f, "record/unseal_tail"),
             LabelInsertTypeVar => write!(f, "label/insert_type_variable"),

--- a/core/src/term/mod.rs
+++ b/core/src/term/mod.rs
@@ -233,7 +233,7 @@ pub enum Term {
     /// Custom contracts usually have two parts, an immediate part and a delayed part.
     ///
     /// The immediate part is similar to a predicate or a validator: this is a function that takes a
-    /// value and return either `'Ok` or `'Error {..}`. The immediate part gather the checks that can
+    /// value and return either `'Ok` or `'Error {..}`. The immediate part gathers the checks that can
     /// be done eagerly, without forcing the value (the immediate part can actually force the value,
     /// but it's up to the implementer to decide - for builtin contracts, the immediate part never
     /// forces values)

--- a/core/src/term/mod.rs
+++ b/core/src/term/mod.rs
@@ -218,7 +218,7 @@ pub enum Term {
 
     /// A custom contract. The content must be a function (or function-like terms like a match
     /// expression) of two arguments: a label and the value to be checked. In particular, it must
-    /// be a weak-head normal form, and this invariant must be relied upon elsewhere in the
+    /// be a weak-head normal form, and this invariant may be relied upon elsewhere in the
     /// codebase (although it's not the case at the time of writing, to the best of my knowledge).
     ///
     /// Having a separate node for custom contracts lets us leverage the additional information for
@@ -245,7 +245,7 @@ pub enum Term {
     /// this distinction explicit, with custom contracts being represented by two different
     /// functions, one for each part. But this proved to be cumbersome in many ways (both for us
     /// language developers and for users). Instead, we decided to make custom contracts just one
-    /// function of type `Label -> Dyn -> [| 'Ok, 'Ok Dyn, 'Error {..} |]`, which gives enough
+    /// function of type `Label -> Dyn -> [| 'Ok Dyn, 'Error {..} |]`, which gives enough
     /// information to extract the immediate and the delayed part anyway. The delayed part, if any,
     /// is embedded in the return value of the case `'Ok Dyn`, where the argument is the original
     /// value with the delayed checks inside.
@@ -1691,7 +1691,7 @@ pub enum BinaryOp {
     /// another contract. In theory, one could use [Self::ContractApply], but the caller then needs
     /// to wrap the result in `'Ok`, and much more importantly, `%contract/apply%` converts all
     /// immediate errors returned as `'Error` into blame errors. This is not desirable, as blame
-    /// errors can't be caught, which artifcially makes the called contract entirely delayed. This
+    /// errors can't be caught, which artificially makes the called contract entirely delayed. This
     /// typically wouldn't play very well with boolean combinators. On the other hand,
     /// [Self::ContractApplyAsCustom] preserves the immediate/delayed part of the called contract.
     ContractApplyAsCustom,

--- a/core/src/transform/free_vars.rs
+++ b/core/src/transform/free_vars.rs
@@ -106,18 +106,10 @@ impl CollectFreeVars for RichTerm {
                     free_vars.extend(fresh);
                 }
             }
-            Term::Op1(_, t) | Term::Sealed(_, t, _) | Term::EnumVariant { arg: t, .. } => {
-                t.collect_free_vars(free_vars)
-            }
-            Term::CustomContract(custom_contract) => {
-                if let Some(ref mut immediate) = custom_contract.immediate {
-                    immediate.collect_free_vars(free_vars);
-                }
-
-                if let Some(ref mut delayed) = custom_contract.delayed {
-                    delayed.collect_free_vars(free_vars);
-                }
-            }
+            Term::Op1(_, t)
+            | Term::Sealed(_, t, _)
+            | Term::EnumVariant { arg: t, .. }
+            | Term::CustomContract(t) => t.collect_free_vars(free_vars),
             Term::OpN(_, ts) => {
                 for t in ts {
                     t.collect_free_vars(free_vars);

--- a/core/src/typ.rs
+++ b/core/src/typ.rs
@@ -46,12 +46,12 @@ use crate::{
     identifier::{Ident, LocIdent},
     impl_display_from_pretty,
     label::Polarity,
-    mk_app, mk_fun,
+    mk_app, mk_record,
     position::TermPos,
     stdlib::internals,
     term::{
-        array::Array, make as mk_term, record::RecordData, string::NickelString, IndexMap,
-        MatchBranch, MatchData, RichTerm, Term, Traverse, TraverseControl, TraverseOrder,
+        array::Array, make as mk_term, record::RecordData, string::NickelString, CustomContract,
+        IndexMap, MatchBranch, MatchData, RichTerm, Term, Traverse, TraverseControl, TraverseOrder,
     },
 };
 
@@ -780,10 +780,12 @@ trait Subcontract {
     ///
     /// # Arguments
     ///
-    /// - `vars` is an environment mapping type variables to contracts. Type variables are
-    ///   introduced locally when opening a `forall`. Note that we don't need to keep separate
-    ///   environments for different kind of type variables, as by shadowing, one name can only
-    ///   refer to one type of variable at any given time.
+    /// - `vars` is an environment mapping type variables to their respective delayed contracts.
+    ///   Type variables are introduced locally when opening a `forall`, and delayed contract -
+    ///   represented directly as a naked function `Label -> Dyn -> Dyn` - is then inserted into the
+    ///   environment. Note that we don't need to keep separate environments for different kind of
+    ///   type variables, as by shadowing in the surface syntax, one name can only refer to one type
+    ///   of variable at any given time.
     /// - `pol` is the current polarity, which is toggled when generating a contract for the
     ///   argument of an arrow type (see [`crate::label::Label`]).
     /// - `sy` is a counter used to generate fresh symbols for `forall` contracts (see
@@ -816,34 +818,52 @@ impl Subcontract for Type {
         pol: Polarity,
         sy: &mut i32,
     ) -> Result<RichTerm, UnboundTypeVariableError> {
-        let ctr = match self.typ {
-            TypeF::Dyn => internals::dynamic(),
-            TypeF::Number => internals::num(),
-            TypeF::Bool => internals::bool(),
-            TypeF::String => internals::string(),
-            TypeF::ForeignId => internals::foreign_id(),
-            // Array Dyn is specialized to array_dyn, which is constant time
-            TypeF::Array(ref ty) if matches!(ty.typ, TypeF::Dyn) => internals::array_dyn(),
-            TypeF::Array(ref ty) => mk_app!(internals::array(), ty.subcontract(vars, pol, sy)?),
+        let ctr: RichTerm = match self.typ {
+            TypeF::Dyn => CustomContract::immediate(internals::immediate::dynamic()).into(),
+            TypeF::Number => CustomContract::immediate(internals::immediate::number()).into(),
+            TypeF::Bool => CustomContract::immediate(internals::immediate::bool()).into(),
+            TypeF::String => CustomContract::immediate(internals::immediate::string()).into(),
+            TypeF::ForeignId => {
+                CustomContract::immediate(internals::immediate::foreign_id()).into()
+            }
+            // Array Dyn is specialized to just the immediate part of array contracts, which is constant time
+            TypeF::Array(ref ty) if matches!(ty.typ, TypeF::Dyn) => {
+                CustomContract::immediate(internals::immediate::array()).into()
+            }
+            TypeF::Array(ref ty) => mk_term::custom_contract(
+                internals::immediate::array(),
+                mk_app!(internals::delayed::array(), ty.subcontract(vars, pol, sy)?),
+            ),
             TypeF::Symbol => panic!("unexpected Symbol type during contract elaboration"),
-            // Similarly, any variant of `A -> B` where either `A` or `B` is `Dyn` get specialized
-            // to the corresponding builtin contract.
+            // Similarly, any variant of `A -> B` where either `A` or `B` is `Dyn` get specialized.
+            // Case 1: Dyn -> Dyn
             TypeF::Arrow(ref s, ref t) if matches!((&s.typ, &t.typ), (TypeF::Dyn, TypeF::Dyn)) => {
-                internals::func_dyn()
+                CustomContract::immediate(internals::immediate::func()).into()
             }
-            TypeF::Arrow(ref s, ref t) if matches!(s.typ, TypeF::Dyn) => {
-                mk_app!(internals::func_codom(), t.subcontract(vars, pol, sy)?)
-            }
-            TypeF::Arrow(ref s, ref t) if matches!(t.typ, TypeF::Dyn) => {
+            // Case 2: Dyn -> T
+            TypeF::Arrow(ref s, ref t) if matches!(s.typ, TypeF::Dyn) => mk_term::custom_contract(
+                internals::immediate::func(),
                 mk_app!(
-                    internals::func_dom(),
+                    internals::delayed::func_codom(),
+                    t.subcontract(vars, pol, sy)?
+                ),
+            ),
+            // Case 3: T -> Dyn
+            TypeF::Arrow(ref s, ref t) if matches!(t.typ, TypeF::Dyn) => mk_term::custom_contract(
+                internals::immediate::func(),
+                mk_app!(
+                    internals::delayed::func_dom(),
                     s.subcontract(vars.clone(), pol.flip(), sy)?
-                )
-            }
-            TypeF::Arrow(ref s, ref t) => mk_app!(
-                internals::func(),
-                s.subcontract(vars.clone(), pol.flip(), sy)?,
-                t.subcontract(vars, pol, sy)?
+                ),
+            ),
+            // General function contract where neither the domain nor the codomain is `Dyn`.
+            TypeF::Arrow(ref s, ref t) => mk_term::custom_contract(
+                internals::immediate::func(),
+                mk_app!(
+                    internals::delayed::func(),
+                    s.subcontract(vars.clone(), pol.flip(), sy)?,
+                    t.subcontract(vars, pol, sy)?
+                ),
             ),
             TypeF::Flat(ref t) => t.clone(),
             TypeF::Var(id) => get_var_contract(&vars, id, self.pos)?,
@@ -853,7 +873,11 @@ impl Subcontract for Type {
                 ref var_kind,
             } => {
                 let sealing_key = Term::SealingKey(*sy);
-                let contract = match var_kind {
+                // Note that the var's contract is necessarily delayed, so we don't bother storing
+                // it in a custom contract constructor and use naked function instead. It's only
+                // used internally during contract generation, so users aren't able to use it
+                // either.
+                let var_contract = match var_kind {
                     VarKind::Type => mk_app!(internals::forall_var(), sealing_key.clone()),
                     // For now, the enum contract doesn't enforce parametricity: see the
                     // implementation of `forall_enum_tail` inside the internal module for more
@@ -877,14 +901,20 @@ impl Subcontract for Type {
                         )
                     }
                 };
-                vars.insert(var.ident(), contract);
+                vars.insert(var.ident(), var_contract);
 
                 *sy += 1;
-                mk_app!(
-                    internals::forall(),
-                    sealing_key,
-                    Term::from(pol),
-                    body.subcontract(vars, pol, sy)?
+
+                let inner_contract = body.subcontract(vars, pol, sy)?;
+
+                mk_term::custom_contract(
+                    mk_app!(internals::immediate::forall(), inner_contract.clone()),
+                    mk_app!(
+                        internals::delayed::forall(),
+                        sealing_key,
+                        Term::from(pol),
+                        inner_contract
+                    ),
                 )
             }
             TypeF::Enum(ref erows) => erows.subcontract(vars, pol, sy)?,
@@ -894,26 +924,30 @@ impl Subcontract for Type {
             TypeF::Dict {
                 ref type_fields,
                 flavour: _,
-            } if matches!(type_fields.typ, TypeF::Dyn) => internals::dict_dyn(),
+            } if matches!(type_fields.typ, TypeF::Dyn) => {
+                CustomContract::immediate(internals::immediate::record()).into()
+            }
             TypeF::Dict {
                 ref type_fields,
                 flavour: DictTypeFlavour::Contract,
-            } => {
+            } => mk_term::custom_contract(
+                internals::immediate::record(),
                 mk_app!(
-                    internals::dict_contract(),
+                    internals::delayed::dict_contract(),
                     type_fields.subcontract(vars, pol, sy)?
-                )
-            }
+                ),
+            ),
             TypeF::Dict {
                 ref type_fields,
                 flavour: DictTypeFlavour::Type,
-            } => {
+            } => mk_term::custom_contract(
+                internals::immediate::record(),
                 mk_app!(
-                    internals::dict_type(),
+                    internals::delayed::dict_type(),
                     type_fields.subcontract(vars, pol, sy)?
-                )
-            }
-            TypeF::Wildcard(_) => internals::dynamic(),
+                ),
+            ),
+            TypeF::Wildcard(_) => CustomContract::immediate(internals::immediate::dynamic()).into(),
         };
 
         Ok(ctr)
@@ -948,42 +982,48 @@ impl Subcontract for EnumRows {
         pol: Polarity,
         sy: &mut i32,
     ) -> Result<RichTerm, UnboundTypeVariableError> {
-        use crate::term::{
-            pattern::{EnumPattern, Pattern, PatternData},
-            BinaryOp,
-        };
+        use crate::term::pattern::{EnumPattern, Pattern, PatternData};
+
+        // Generate the value `'Ok {payload = <payload>}`
+        fn ok_with_payload(payload: RichTerm) -> RichTerm {
+            mk_term::enum_variant("Ok", mk_record!(("payload", payload)))
+        }
 
         let mut branches = Vec::new();
         let mut tail_var = None;
 
-        let value_arg = LocIdent::fresh();
-        let label_arg = LocIdent::fresh();
         // We don't need to generate a different fresh variable for each match branch, as they have
         // their own scope, so we use the same name instead.
         let variant_arg = LocIdent::fresh();
 
-        // We build a match where each row corresponds to a branch, such that:
+        // We build the immediate part of the enum contract on the fly because it depends too much
+        // on the specific shape of the rows. We build a match where each row corresponds to a
+        // branch, such that:
         //
-        // - if the row is a simple enum tag, we just return the original contract argument
-        // - if the row is an enum variant, we extract the argument and apply the corresponding
-        //   contract to it
+        // - if the row is a simple enum tag, we just return `'Done`
+        // - if the row is an enum variant, we extract the argument and pass the data to the
+        // delayed part of the contract
         //
         // For the default branch, depending on the tail:
         //
         // - if the tail is an enum type variable, we perform the required sealing/unsealing
-        // - otherwise, if the enum type is closed, we add a default case which blames
+        // - otherwise, if the enum type is closed, we add a default case which is just `'Error {
+        // message = <some message> }`.
         //
         // For example, for an enum type [| 'foo, 'bar, 'Baz T |], the function looks like:
         //
         // ```
-        // fun l x =>
-        //   x |> match {
-        //     'foo => x,
-        //     'bar => x,
-        //     'Baz variant_arg => 'Baz (%contract/apply% T label_arg variant_arg),
-        //     _ => $enum_fail l
-        //   }
+        // match {
+        //   'foo => 'Done,
+        //   'bar => 'Done,
+        //   'Baz variant_arg => 'Ok { payload = 'Map T },
+        //   _ => $enum_fail
+        // }
         // ```
+        //
+        // The delayed part of the enum contract implemented in the internals module then just
+        // amounts to map the contract application of the payload provided on the argument of the
+        // value (which is guaranteed to be an enum variant).
         for row in self.iter() {
             match row {
                 EnumRowsIteratorItem::Row(row) => {
@@ -996,24 +1036,12 @@ impl Subcontract for EnumRows {
                     });
 
                     let body = if let Some(ty) = row.typ.as_ref() {
-                        // 'Tag (%contract/apply% T label_arg variant_arg)
-                        let arg = mk_app!(
-                            mk_term::op2(
-                                BinaryOp::ContractApply,
-                                ty.subcontract(vars.clone(), pol, sy)?,
-                                mk_term::var(label_arg)
-                            ),
-                            mk_term::var(variant_arg)
-                        );
-
-                        Term::EnumVariant {
-                            tag: row.id,
-                            arg,
-                            attrs: Default::default(),
-                        }
-                        .into()
+                        ok_with_payload(mk_term::enum_variant(
+                            "Map",
+                            ty.subcontract(vars.clone(), pol, sy)?,
+                        ))
                     } else {
-                        mk_term::var(value_arg)
+                        Term::Enum("Done".into()).into()
                     };
 
                     let pattern = Pattern {
@@ -1039,22 +1067,18 @@ impl Subcontract for EnumRows {
         }
 
         let (default, default_pos) = if let Some(var) = tail_var {
+            // If the tail is a variable, we need to seal/unseal it. This is the job of the
+            // delayed part, but we still need to indicate what to do in the payload. We thus
+            // return `'Ok { payload = 'Tail <var_contract> }`.
             (
-                mk_app!(
-                    mk_term::op2(
-                        BinaryOp::ContractApply,
-                        get_var_contract(&vars, var.ident(), var.pos)?,
-                        mk_term::var(label_arg)
-                    ),
-                    mk_term::var(value_arg)
-                ),
+                ok_with_payload(mk_term::enum_variant(
+                    "Tail",
+                    get_var_contract(&vars, var.ident(), var.pos)?,
+                )),
                 var.pos,
             )
         } else {
-            (
-                mk_app!(internals::enum_fail(), mk_term::var(label_arg)),
-                TermPos::None,
-            )
+            (internals::enum_fail(), TermPos::None)
         };
 
         branches.push(MatchBranch {
@@ -1067,10 +1091,12 @@ impl Subcontract for EnumRows {
             body: default,
         });
 
-        let match_expr = mk_app!(Term::Match(MatchData { branches }), mk_term::var(value_arg));
+        let matcher = Term::Match(MatchData { branches });
 
-        let case = mk_fun!(label_arg, value_arg, match_expr);
-        Ok(mk_app!(internals::enumeration(), case))
+        Ok(mk_term::custom_contract(
+            mk_app!(internals::immediate::enumeration(), matcher),
+            internals::delayed::enumeration(),
+        ))
     }
 }
 
@@ -1116,8 +1142,8 @@ impl RecordRows {
         })
     }
 
-    /// Find the row with the given identifier in the record type. Return `None` if there is no such
-    /// row.
+    /// Find the row with the given identifier in the record type. Return `None` if there is no
+    /// such row.
     ///
     /// Equivalent to `find_path(&[id])`.
     pub fn find_row(&self, id: Ident) -> Option<RecordRow> {
@@ -1159,13 +1185,20 @@ impl Subcontract for RecordRows {
             RecordRowsF::Empty => internals::empty_tail(),
             RecordRowsF::TailDyn => internals::dyn_tail(),
             RecordRowsF::TailVar(id) => get_var_contract(&vars, id.ident(), id.pos)?,
-            // Safety: the while above excludes that `tail` can have the form `Extend`.
+            // unreachable!(): the while above excludes that `tail` can have the form `Extend`.
             RecordRowsF::Extend { .. } => unreachable!(),
         };
+        let has_tail = !matches!(&rrows.0, RecordRowsF::Empty);
+        let field_contracts = RichTerm::from(Term::Record(RecordData::with_field_values(fcs)));
 
-        let rec = RichTerm::from(Term::Record(RecordData::with_field_values(fcs)));
-
-        Ok(mk_app!(internals::record(), rec, tail))
+        Ok(mk_term::custom_contract(
+            mk_app!(
+                internals::immediate::record_type(),
+                field_contracts.clone(),
+                Term::Bool(has_tail)
+            ),
+            mk_app!(internals::delayed::record_type(), field_contracts, tail),
+        ))
     }
 }
 
@@ -1319,8 +1352,11 @@ impl Type {
             .subcontract(Environment::new(), Polarity::Positive, &mut sy)
     }
 
-    /// Return the contract corresponding to a type, either as a function or a record. Said
-    /// contract must then be applied using the `ApplyContract` primitive operation.
+    /// Return the contract corresponding to a type. Flat types are just unwrapped, so whatever
+    /// they contain - be it a record contract, another type, a naked function or a custom contract
+    /// - is integrated into the resulting contract. Otherwise, all native static type constructors
+    /// return their result as a custom contract split into a delayed and an immediate part, which
+    /// makes them more amenable to boolean combinations.
     pub fn contract(&self) -> Result<RichTerm, UnboundTypeVariableError> {
         let mut sy = 0;
         self.subcontract(Environment::new(), Polarity::Positive, &mut sy)

--- a/core/src/typ.rs
+++ b/core/src/typ.rs
@@ -1165,7 +1165,7 @@ impl Subcontract for RecordRows {
 
         let rec = RichTerm::from(Term::Record(RecordData::with_field_values(fcs)));
 
-        Ok(mk_app!(internals::record(), rec, tail))
+        Ok(mk_app!(internals::record_type(), rec, tail))
     }
 }
 

--- a/core/src/typ.rs
+++ b/core/src/typ.rs
@@ -1172,7 +1172,12 @@ impl Subcontract for RecordRows {
 
         let rec = RichTerm::from(Term::Record(RecordData::with_field_values(fcs)));
 
-        Ok(mk_app!(internals::record_type(), rec, tail, Term::Bool(has_tail)))
+        Ok(mk_app!(
+            internals::record_type(),
+            rec,
+            tail,
+            Term::Bool(has_tail)
+        ))
     }
 }
 

--- a/core/src/typ.rs
+++ b/core/src/typ.rs
@@ -845,7 +845,16 @@ impl Subcontract for Type {
                 s.subcontract(vars.clone(), pol.flip(), sy)?,
                 t.subcontract(vars, pol, sy)?
             ),
-            TypeF::Flat(ref t) => t.clone(),
+            // Note that we do an early return here.
+            //
+            // All builtin contracts needs an additional wrapping as a `CustomContract`: they're
+            // written as a custom contract but they miss the `%contract/custom%` (mostly because
+            // it's nicer to do it just once at the end than littering the internals module with
+            // `%contract/custom%` applications).
+            //
+            // However, in the case of a contract embedded in a type, we don't want to do the
+            // additional wrapping, as `t` should already be a fully constructed contract.
+            TypeF::Flat(ref t) => return Ok(t.clone()),
             TypeF::Var(id) => get_var_contract(&vars, id, self.pos)?,
             TypeF::Forall {
                 ref var,
@@ -916,7 +925,7 @@ impl Subcontract for Type {
             TypeF::Wildcard(_) => internals::dynamic(),
         };
 
-        Ok(ctr)
+        Ok(mk_term::custom_contract(ctr))
     }
 }
 
@@ -978,9 +987,9 @@ impl Subcontract for EnumRows {
         // ```
         // fun l x =>
         //   x |> match {
-        //     'foo => x,
-        //     'bar => x,
-        //     'Baz variant_arg => 'Baz (%apply_contract% T label_arg variant_arg),
+        //     'foo => 'Ok x,
+        //     'bar => 'Ok x,
+        //     'Baz variant_arg => 'Ok ('Baz (%apply_contract% T label_arg variant_arg)),
         //     _ => $enum_fail l
         //   }
         // ```
@@ -1006,15 +1015,12 @@ impl Subcontract for EnumRows {
                             mk_term::var(variant_arg)
                         );
 
-                        Term::EnumVariant {
-                            tag: row.id,
-                            arg,
-                            attrs: Default::default(),
-                        }
-                        .into()
+                        mk_term::enum_variant(row.id, arg)
                     } else {
                         mk_term::var(value_arg)
                     };
+
+                    let body = mk_term::enum_variant("Ok", body);
 
                     let pattern = Pattern {
                         data: PatternData::Enum(EnumPattern {
@@ -1153,6 +1159,7 @@ impl Subcontract for RecordRows {
             rrows = tail
         }
 
+        let has_tail = !matches!(&rrows.0, RecordRowsF::Empty);
         // Now that we've dealt with the row extends, we just need to
         // work out the tail.
         let tail = match &rrows.0 {
@@ -1165,7 +1172,7 @@ impl Subcontract for RecordRows {
 
         let rec = RichTerm::from(Term::Record(RecordData::with_field_values(fcs)));
 
-        Ok(mk_app!(internals::record_type(), rec, tail))
+        Ok(mk_app!(internals::record_type(), rec, tail, Term::Bool(has_tail)))
     }
 }
 
@@ -1319,18 +1326,16 @@ impl Type {
             .subcontract(Environment::new(), Polarity::Positive, &mut sy)
     }
 
-    /// Return the contract corresponding to a type, either as a function or a record wrapped as a
-    /// [crate::term::Term::CustomContract]. Said contract must then be applied using the
+    /// Return the contract corresponding to a type. Said contract must then be applied using the
     /// `ApplyContract` primitive operation.
     pub fn contract(&self) -> Result<RichTerm, UnboundTypeVariableError> {
         let mut sy = 0;
 
         self.subcontract(Environment::new(), Polarity::Positive, &mut sy)
-            .map(Term::CustomContract)
-            .map(RichTerm::from)
     }
 
-    /// Returns true if this type is a function type, false otherwise.
+    /// Returns true if this type is a function type (including a polymorphic one), false
+    /// otherwise.
     pub fn is_function_type(&self) -> bool {
         match &self.typ {
             TypeF::Forall { body, .. } => body.is_function_type(),

--- a/core/src/typecheck/eq.rs
+++ b/core/src/typecheck/eq.rs
@@ -390,6 +390,18 @@ fn contract_eq_bounded<E: TermEnvironment>(
                 env2,
             ) && r1.attrs.open == r2.attrs.open
         }
+        (RecRecord(r1, dyn_fields, _), Record(r2)) | (Record(r1), RecRecord(r2, dyn_fields, _)) => {
+            dyn_fields.is_empty()
+                && map_eq(
+                    contract_eq_fields,
+                    state,
+                    &r1.fields,
+                    env1,
+                    &r2.fields,
+                    env2,
+                )
+                && r1.attrs.open == r2.attrs.open
+        }
         (RecRecord(r1, dyn_fields1, _), RecRecord(r2, dyn_fields2, _)) =>
         // We only compare records whose field structure is statically known (i.e. without dynamic
         // fields).
@@ -404,7 +416,7 @@ fn contract_eq_bounded<E: TermEnvironment>(
                     &r2.fields,
                     env2,
                 )
-                && r1.attrs == r2.attrs
+                && r1.attrs.open == r2.attrs.open
         }
         (Array(ts1, attrs1), Array(ts2, attrs2)) => {
             ts1.len() == ts2.len()

--- a/core/src/typecheck/mod.rs
+++ b/core/src/typecheck/mod.rs
@@ -60,8 +60,8 @@ use crate::{
     identifier::{Ident, LocIdent},
     stdlib as nickel_stdlib,
     term::{
-        record::Field, CustomContract, LabeledType, MatchBranch, RichTerm, StrChunk, Term,
-        Traverse, TraverseOrder, TypeAnnotation,
+        record::Field, LabeledType, MatchBranch, RichTerm, StrChunk, Term, Traverse, TraverseOrder,
+        TypeAnnotation,
     },
     typ::*,
     {mk_uty_arrow, mk_uty_enum, mk_uty_record, mk_uty_record_row},
@@ -1599,18 +1599,8 @@ fn walk<V: TypecheckVisitor>(
         }
         Term::EnumVariant { arg: t, ..}
         | Term::Sealed(_, t, _)
-        | Term::Op1(_, t) => walk(state, ctxt, visitor, t),
-        Term::CustomContract(CustomContract {immediate, delayed }) => {
-            if let Some(immediate) = immediate {
-                walk(state, ctxt.clone(), visitor, immediate)?;
-            }
-
-            if let Some(delayed) = delayed {
-                walk(state, ctxt, visitor, delayed)?;
-            }
-
-            Ok(())
-        }
+        | Term::Op1(_, t)
+        | Term::CustomContract(t) => walk(state, ctxt, visitor, t),
         Term::Op2(_, t1, t2) => {
             walk(state, ctxt.clone(), visitor, t1)?;
             walk(state, ctxt, visitor, t2)
@@ -1917,43 +1907,27 @@ fn check<V: TypecheckVisitor>(
         }
         // [^custom-contract-is-check]: [crate::term::CustomContract] isn't supposed to be used in
         // Nickel source code directly, but we can typecheck it. A custom contract is a
-        // datastructure holding two (optional) functions: the immediate part and the delayed part.
+        // datastructure holding a function of a specific type.
         //
-        // One can see it as the application of a `custom` constructor:
-        // `%contract/custom% immediate delayed`.
+        // Whether seen as a type constructor, or as equivalent to a standalone function, it's an
+        // introduction rule and thus it should be check.
         //
-        // It's thus not entirely obvious if this should be a checking or a infer rule: if seen as
-        // a simple function application, it should be infer (it's an elimination rule). If seen as
-        // a type constructor, it should be check (it's an introduction rule). We pick the last
-        // interpretation, because although a custom contract is built from an application of
-        // `%contract/custom%`, it's not the same thing - in particular both components of a custom
-        // contract have been reduced to a (weak head) normal form and put in a separate node. Thus
-        // we lean toward a check rule.
-        //
-        // Additionally, because this rule can't produce a polymorphic type (it produces a `Dyn`,
-        // or morally a `Contract` type, if we had one), we don't lose anything by making it a
-        // check rule, as for e.g. literals.
-        Term::CustomContract(CustomContract { immediate, delayed }) => {
+        // This rule can't produce a polymorphic type (it produces a `Dyn`, or morally a `Contract`
+        // type, if we had one), so we don't lose much by making it a check rule anyway, as for
+        // e.g. literals.
+        Term::CustomContract(t) => {
             // The overall type of a custom contract is currently `Dyn`, as we don't have a better
             // one.
             ty.unify(mk_uniftype::dynamic(), state, &ctxt)
                 .map_err(|err| err.into_typecheck_err(state, rt.pos))?;
 
-            if let Some(immediate) = immediate {
-                check(
-                    state,
-                    ctxt.clone(),
-                    visitor,
-                    immediate,
-                    operation::immediate_type(),
-                )?;
-            }
-
-            if let Some(delayed) = delayed {
-                check(state, ctxt, visitor, delayed, operation::delayed_type())?;
-            }
-
-            Ok(())
+            check(
+                state,
+                ctxt.clone(),
+                visitor,
+                t,
+                operation::custom_contract_type(),
+            )
         }
         Term::Array(terms, _) => {
             let ty_elts = state.table.fresh_type_uvar(ctxt.var_level);

--- a/core/src/typecheck/mod.rs
+++ b/core/src/typecheck/mod.rs
@@ -1926,7 +1926,7 @@ fn check<V: TypecheckVisitor>(
                 ctxt.clone(),
                 visitor,
                 t,
-                operation::custom_contract_type(),
+                operation::custom_contract_ret_type(),
             )
         }
         Term::Array(terms, _) => {

--- a/core/src/typecheck/operation.rs
+++ b/core/src/typecheck/operation.rs
@@ -632,7 +632,7 @@ pub fn custom_contract_ret_type() -> UnifType {
         .field("notes")
         .contract(Type {
             typ: TypeF::Array(Box::new(Type {
-                typ: TypeF::String.into(),
+                typ: TypeF::String,
                 pos: TermPos::None,
             })),
             pos: TermPos::None,

--- a/core/src/typecheck/operation.rs
+++ b/core/src/typecheck/operation.rs
@@ -602,14 +602,14 @@ pub fn get_nop_type(
 /// The result represents the type:
 ///
 /// ```nickel
-/// Dyn -> [| 'Ok, 'Proceed, 'Error { message: String, notes: Array String } |]
+/// Dyn -> [| 'Ok, 'Done, 'Error { message: String, notes: Array String } |]
 /// ```
 pub fn immediate_type() -> UnifType {
     mk_uty_arrow!(
         mk_uniftype::dynamic(),
         mk_uty_enum!(
             "Ok",
-            "Proceed",
+            "Done",
             (
                 "Error",
                 mk_uty_record!(

--- a/core/src/typecheck/operation.rs
+++ b/core/src/typecheck/operation.rs
@@ -617,16 +617,7 @@ pub fn custom_contract_type() -> UnifType {
     mk_uty_arrow!(
         mk_uniftype::dynamic(),
         mk_uniftype::dynamic(),
-        mk_uty_enum!(
-            ("Ok", mk_uniftype::dynamic()),
-            (
-                "Error",
-                mk_uty_record!(
-                    ("message", mk_uniftype::str()),
-                    ("notes", mk_uniftype::array(mk_uniftype::str()))
-                )
-            )
-        )
+        custom_contract_ret_type()
     )
 }
 

--- a/core/stdlib/internals.ncl
+++ b/core/stdlib/internals.ncl
@@ -5,144 +5,196 @@
   # Builtin contract implementations
 
   # Contract for the `Dyn` type. It's just an always accepting contract.
-  "$dyn" = fun _label value => 'Ok value,
+  "$dyn" = %contract/custom% (fun _label value => 'Ok value),
 
   # Contract for the `Number` type.
-  "$num" = fun _label value =>
-    if %typeof% value == 'Number then
-      'Ok value
-    else
-      'Error {},
+  "$num" =
+    %contract/custom%
+      (
+        fun _label value =>
+          if %typeof% value == 'Number then
+            'Ok value
+          else
+            'Error {}
+      ),
 
   # Contract for the `Bool` type.
-  "$bool" = fun _label value =>
-    if %typeof% value == 'Bool then
-      'Ok value
-    else
-      'Error {},
+  "$bool" =
+    %contract/custom%
+      (
+        fun _label value =>
+          if %typeof% value == 'Bool then
+            'Ok value
+          else
+            'Error {}
+      ),
 
   # Contract for the `String` type.
-  "$string" = fun _label value =>
-    if %typeof% value == 'String then
-      'Ok value
-    else
-      'Error {},
+  "$string" =
+    %contract/custom%
+      (
+        fun _label value =>
+          if %typeof% value == 'String then
+            'Ok value
+          else
+            'Error {}
+      ),
 
   # Contract for `ForeignId` values.
-  "$foreign_id" = fun _label value =>
-    if %typeof% value == 'ForeignId then
-      'Ok value
-    else
-      'Error {},
+  "$foreign_id" =
+    %contract/custom%
+      (
+        fun _label value =>
+          if %typeof% value == 'ForeignId then
+            'Ok value
+          else
+            'Error {}
+      ),
 
   # Contract for the `Array T` type, where `element_contract` is the contract
   # for `T`.
-  "$array" = fun element_contract label value =>
-    if %typeof% value == 'Array then
-      'Ok (
-        %contract/array_lazy_apply%
-          (%label/go_array% label)
-          value
-          element_contract
-      )
-    else
-      'Error { message = "expected an array" },
+  "$array" = fun Element =>
+    %contract/custom%
+      (
+        fun label value =>
+          if %typeof% value == 'Array then
+            'Ok (
+              %contract/array_lazy_apply%
+                (%label/go_array% label)
+                value
+                Element
+            )
+          else
+            'Error { message = "expected an array" }
+      ),
 
   # A specialized version of `$array $dyn`, but which is constant time.
-  "$array_dyn" = fun _label value =>
-    if %typeof% value == 'Array then
-      'Ok value
-    else
-      'Error { message = "expected an array" },
+  "$array_dyn" =
+    %contract/custom%
+      (
+        fun _label value =>
+          if %typeof% value == 'Array then
+            'Ok value
+          else
+            'Error { message = "expected an array" }
+      ),
 
   # Contract for the function type `Domain -> Codomain`.
-  "$func" = fun domain codomain label value =>
-    if %typeof% value == 'Function then
-      'Ok (
-        fun x =>
-          %contract/apply%
-            codomain
-            (%label/go_codom% label)
-            (value (%contract/apply% domain (%label/flip_polarity% (%label/go_dom% label)) x))
-      )
-    else
-      'Error { message = "expected a function" },
+  "$func" = fun Domain Codomain =>
+    %contract/custom%
+      (
+        fun label value =>
+          if %typeof% value == 'Function then
+            'Ok (
+              fun x =>
+                %contract/apply%
+                  Codomain
+                  (%label/go_codom% label)
+                  (value (%contract/apply% Domain (%label/flip_polarity% (%label/go_dom% label)) x))
+            )
+          else
+            'Error { message = "expected a function" }
+      ),
 
   # A specialied version of `_ -> Dyn`
-  "$func_dom" = fun domain label value =>
-    if %typeof% value == 'Function then
-      'Ok (
-        fun x =>
-          value
-            (
-              %contract/apply%
-                domain
-                (%label/flip_polarity% (%label/go_dom% label))
-                x
+  "$func_dom" = fun Domain =>
+    %contract/custom%
+      (
+        fun label value =>
+          if %typeof% value == 'Function then
+            'Ok (
+              fun x =>
+                value
+                  (
+                    %contract/apply%
+                      Domain
+                      (%label/flip_polarity% (%label/go_dom% label))
+                      x
+                  )
             )
-      )
-    else
-      'Error { message = "expected a function" },
+          else
+            'Error { message = "expected a function" }
+      ),
 
   # A specialied version of `Dyn -> _`
-  "$func_codom" = fun codomain label value =>
-    if %typeof% value == 'Function then
-      'Ok (
-        fun x =>
-          %contract/apply%
-            codomain
-            (%label/go_codom% label)
-            (value x)
-      )
-    else
-      'Error { message = "expected a function" },
+  "$func_codom" = fun Codomain =>
+    %contract/custom%
+      (
+        fun label value =>
+          if %typeof% value == 'Function then
+            'Ok (
+              fun x =>
+                %contract/apply%
+                  Codomain
+                  (%label/go_codom% label)
+                  (value x)
+            )
+          else
+            'Error { message = "expected a function" }
+      ),
 
   # A specialied version of `Dyn -> Dyn`
-  "$func_dyn" = fun _label value =>
-    if %typeof% value == 'Function then
-      'Ok value
-    else
-      'Error { message = "expected a function" },
+  "$func_dyn" =
+    %contract/custom%
+      (
+        fun _label value =>
+          if %typeof% value == 'Function then
+            'Ok value
+          else
+            'Error { message = "expected a function" }
+      ),
 
   # Contract for a polymorphic variable. This contract is stored in an
   # environment during contract generation when a forall introduces a variables
   # and is inserted whenever this variable occurs somewhere in the contract of
   # the body of the forall.
-  "$forall_var" = fun sealing_key label value =>
-    let current_polarity = %label/polarity% label in
-    let polarity = (%label/lookup_type_variable% sealing_key label).polarity in
-    if polarity == current_polarity then
-      'Ok (%unseal% sealing_key value (%blame% label))
-    else
-      # [^forall_label_flip_polarity]: Blame assignment for polymorphic
-      # contracts should take into account the polarity at the point the forall
-      # was introduced, not the current polarity of the variable occurrence.
-      # Indeed, forall can never blame in a negative position (relative to the
-      # forall): the contract is entirely on the callee.
-      #
-      # Thus, for correct blame assignment, we want to set the polarity to the
-      # forall polarity (here `polarity`). Because we only have the
-      # `%label/flip_polarity%` primop, and we know that in this branch they are
-      # unequal, flipping the current polarity will indeed give the original
-      # forall's polarity.
-      'Ok (%seal% sealing_key (%label/flip_polarity% label) value),
+  "$forall_var" = fun sealing_key =>
+    %contract/custom%
+      (
+        fun label value =>
+          let current_polarity = %label/polarity% label in
+          let polarity = (%label/lookup_type_variable% sealing_key label).polarity in
+          if polarity == current_polarity then
+            'Ok (%unseal% sealing_key value (%blame% label))
+          else
+            # [^forall_label_flip_polarity]: Blame assignment for polymorphic
+            # contracts should take into account the polarity at the point the forall
+            # was introduced, not the current polarity of the variable occurrence.
+            # Indeed, forall can never blame in a negative position (relative to the
+            # forall): the contract is entirely on the callee.
+            #
+            # Thus, for correct blame assignment, we want to set the polarity to the
+            # forall polarity (here `polarity`). Because we only have the
+            # `%label/flip_polarity%` primop, and we know that in this branch they are
+            # unequal, flipping the current polarity will indeed give the original
+            # forall's polarity.
+            'Ok (%seal% sealing_key (%label/flip_polarity% label) value)
+      ),
 
   # Contract for `forall a. T`, where `contract` is the contract for `T`. This
   # contract mostly set appropriate metadata in the label and forward the rest
   # to `T`.
-  "$forall" = fun sealing_key polarity contract label value =>
-    contract (%label/insert_type_variable% sealing_key polarity label) value,
+  "$forall" = fun sealing_key polarity Contract =>
+    %contract/custom%
+      (
+        fun label value =>
+          Contract (%label/insert_type_variable% sealing_key polarity label) value
+      ),
 
   # Contract for an enum type `[| 'tag1, 'tag2 arg, ... |]`. A match expression
   # depending on the structure of the enum type is generated by the interpreter
   # and provided through `matcher`, and does the bulk of the work. This contract
   # is just a wrapper that checks that the value is an enum and forwards the rest
   # to `matcher`.
-  "$enum" = fun matcher label value =>
-    if %typeof% value == 'Enum then
-      matcher label value
-    else
-      'Error { message = "expected an enum" },
+  "$enum" = fun matcher =>
+    %contract/custom%
+      (
+        fun label value =>
+          if %typeof% value == 'Enum then
+            matcher label value
+          else
+            'Error { message = "expected an enum" }
+      ),
 
   # Error branch used when elaborating the matcher for an enum type. See
   # `$enum`.
@@ -150,18 +202,22 @@
 
   # Contract for an enum variant with tag `'tag`, that is any value of the form
   # `'tag exp`.
-  "$enum_variant" = fun tag _label value =>
-    if %enum/is_variant% value then
-      let value_tag = %enum/get_tag% value in
+  "$enum_variant" = fun tag =>
+    %contract/custom%
+      (
+        fun _label value =>
+          if %enum/is_variant% value then
+            let value_tag = %enum/get_tag% value in
 
-      if value_tag == tag then
-        'Ok value
-      else
-        'Error {
-          message = "expected `'%{%to_string% tag}`, got `'%{%to_string% value_tag}`"
-        }
-    else
-      'Error { message = "expected an enum variant" },
+            if value_tag == tag then
+              'Ok value
+            else
+              'Error {
+                message = "expected `'%{%to_string% tag}`, got `'%{%to_string% value_tag}`"
+              }
+          else
+            'Error { message = "expected an enum variant" }
+      ),
 
   # Tail wrapper for the tail of an enum type.
   "$forall_enum_tail" = fun label value =>
@@ -190,7 +246,7 @@
     # While this might be an issue to investigate in the longer term, or for
     # the next major version, we continue to just not enforce parametricity
     # for enum types for now to maintain backward-compatibility.
-    value,
+    'Ok value,
 
   # Record contract.
   #
@@ -207,11 +263,15 @@
   # existence of field without a definition, missing fields are a delayed error.
   # This might have a non-obvious behavior when using boolean combinators on
   # record contracts.
-  "$record_contract" = fun record_contract label value =>
-    if %typeof% value == 'Record then
-      %record/merge_contract% label value record_contract
-    else
-      'Error { message = "expected a Record" },
+  "$record_contract" = fun record_contract =>
+    %contract/custom%
+      (
+        fun label value =>
+          if %typeof% value == 'Record then
+            %record/merge_contract% label value record_contract
+          else
+            'Error { message = "expected a Record" }
+      ),
 
   # Contract for a static record type `{ field1: T1, field2: T2, ... }`.
   #
@@ -225,83 +285,100 @@
   "$record_type" =
     let plural = fun list => if %array/length% list == 1 then "" else "s" in
 
-    fun field_contracts tail_wrapper has_tail label value =>
-      if %typeof% value == 'Record then
-        let split_result = %record/split_pair% field_contracts value in
+    fun field_contracts tail_wrapper has_tail =>
+      %contract/custom%
+        (
+          fun label value =>
+            if %typeof% value == 'Record then
+              let split_result = %record/split_pair% field_contracts value in
 
-        if split_result.left_only != {} then
-          let missing_fields = %record/fields% split_result.left_only in
+              if split_result.left_only != {} then
+                let missing_fields = %record/fields% split_result.left_only in
 
-          'Error {
-            message = "missing field%{plural missing_fields} `%{std.string.join ", " missing_fields}`",
-          }
-        else if split_result.right_only != {} && !has_tail then
-          let extra_fields = %record/fields% split_result.right_only in
+                'Error {
+                  message = "missing field%{plural missing_fields} `%{std.string.join ", " missing_fields}`",
+                }
+              else if split_result.right_only != {} && !has_tail then
+                let extra_fields = %record/fields% split_result.right_only in
 
-          'Error {
-            message = "extra field%{plural extra_fields} `%{std.string.join ", " extra_fields}`",
-          }
-        else
-          let extra_fields = split_result.right_only in
-          let fields_with_contracts =
-            %record/map%
-              (
-                fun field value =>
-                  %contract/apply%
-                    field_contracts."%{field}"
-                    (%label/go_field% field label)
-                    value
-              )
-              split_result.right_center
-          in
+                'Error {
+                  message = "extra field%{plural extra_fields} `%{std.string.join ", " extra_fields}`",
+                }
+              else
+                let extra_fields = split_result.right_only in
+                let fields_with_contracts =
+                  %record/map%
+                    (
+                      fun field value =>
+                        %contract/apply%
+                          field_contracts."%{field}"
+                          (%label/go_field% field label)
+                          value
+                    )
+                    split_result.right_center
+                in
 
-          # Note that the tail_wrapper has the same type as a custom contract
-          # and thus properly wraps the result in `'Ok`, so we can call it
-          # directly
-          tail_wrapper extra_fields label fields_with_contracts
-      else
-        'Error { message = "expected a record" },
+                # Note that the tail_wrapper has the same type as a custom contract
+                # and thus properly wraps the result in `'Ok`, so we can call it
+                # directly
+                tail_wrapper extra_fields label fields_with_contracts
+            else
+              'Error { message = "expected a record" }
+        ),
 
   # Dictionary contract for `{_ | T}`. The contracts are mapped onto fields'
   # metadata.
-  "$dict_contract" = fun contract label value =>
-    if %typeof% value == 'Record then
-      'Ok (
-        %contract/record_lazy_apply%
-          (%label/go_dict% label)
-          value
-          (fun _field => contract)
-      )
-    else
-      'Error { message = "not a record" },
+  "$dict_contract" = fun Contract =>
+    %contract/custom%
+      (
+        fun label value =>
+          if %typeof% value == 'Record then
+            'Ok (
+              %contract/record_lazy_apply%
+                (%label/go_dict% label)
+                value
+                (fun _field => contract)
+            )
+          else
+            'Error { message = "not a record" }
+      ),
 
   # Dictionary contract for `{_ : T}`. The contracts are mapped directly onto
   # the fields' values, which makes it more eager (in some specific sense - this
   # contract is still lazy/delayed) than `$dict_contract`.
-  "$dict_type" = fun contract label value =>
-    if %typeof% value == 'Record then
-      'Ok (
-        %record/map%
-          value
-          (
-            fun _field field_value =>
-              %contract/apply% contract (%label/go_dict% label) field_value
-          )
-      )
-    else
-      'Error { message = "not a record" },
+  "$dict_type" = fun Contract =>
+    %contract/custom%
+      (
+        fun label value =>
+          if %typeof% value == 'Record then
+            'Ok (
+              %record/map%
+                value
+                (
+                  fun _field field_value =>
+                    %contract/apply% contract (%label/go_dict% label) field_value
+                )
+            )
+          else
+            'Error { message = "not a record" }
+      ),
 
   # A specialized version of either `{_ | Dyn}` or `{_ : Dyn}` (which are
   # equivalent), but which is constant time.
-  "$dict_dyn" = fun label value =>
-    if %typeof% value == 'Record then
-      'Ok
-    else
-      'Error { message = "not a record" },
+  "$dict_dyn" =
+    %contract/custom%
+      (
+        fun label value =>
+          if %typeof% value == 'Record then
+            'Ok
+          else
+            'Error { message = "not a record" }
+      ),
 
   # Tail wrapper for a polymorphic tail. Wrappers are used in the implementation
   # of the contract for static record types, and have the same return type as
-  # other contract implementations.
+  # other contract implementations. Because we apply them right away, we don't
+  # wrap them in %contract/custom%.
   #
   # The `sealing_key` is the sealing key corresponding to the variable occuring
   # in the tail. `constr` are the fields that can't appear in the value because
@@ -324,9 +401,11 @@
       if extra_fields == {} then
         let tagged_label = %label/with_message% "polymorphic tail mismatch" label in
         let tail = %record/unseal_tail% sealing_key tagged_label extra_fields in
+
         'Ok (%record/disjoint_merge% value tail)
       else
         let extra_fields = %record/fields% extra_fields in
+
         'Error {
           message = "extra field%{plural extra_fields} `%{std.string.join ", " extra_fields}`",
         }
@@ -342,6 +421,7 @@
           (fun field => std.array.elem field constr)
           (%record/fields% extra_fields)
       in
+
       if conflicts != [] then
         'Error {
           message = "field%{plural conflicts} not allowed in tail: `%{std.string.join ", " conflicts}`",
@@ -364,18 +444,17 @@
   # Tail wrapper of a helper for an empty tail. At this point, we've already
   # checked (in the main contract implementation for record types) that there
   # are no extra fields, so we can just ignore them and return the value as is.
-  "$empty_tail" = fun _extra_fields _label _value => 'Ok,
+  "$empty_tail" = fun _extra_fields _label value => 'Ok value,
 
-  # Take a contract as a validator, built using %contract/from_validator%, and
-  # turn it into a generic custom contract (a partial identity Label -> Dyn ->
-  # Dyn) that can be passed to %contract/apply%.
-  "$prepare_custom_contract" = fun validator label value =>
-    validator value
+  # Take a a partial identity Label -> Dyn -> Dyn that can then be passed
+  # applied as a normal funtion in the implementation of `contract/apply`.
+  "$prepare_custom_contract" = fun custom_contract label value =>
+    custom_contract label value
     |> match {
       'Ok value => value,
       'Error { message ? null, notes ? [], .. } =>
         let label =
-          if message != null && std.is_string message then
+          if std.is_string message then
             %label/with_message% message label
           else
             label

--- a/core/stdlib/internals.ncl
+++ b/core/stdlib/internals.ncl
@@ -3,78 +3,72 @@
   # valid starting character for an identifier.
 
   # Builtin contract implementations
-  "$dyn" = fun _label value => value,
 
-  "$num" = fun label value => if %typeof% value == 'Number then value else %blame% label,
+  "$dyn/immediate" = fun _value => 'Ok,
 
-  "$bool" = fun label value => if %typeof% value == 'Bool then value else %blame% label,
+  "$number/immediate" = fun value => if %typeof% value == 'Number then 'Ok else 'Error {},
 
-  "$string" = fun label value => if %typeof% value == 'String then value else %blame% label,
+  "$bool/immediate" = fun value => if %typeof% value == 'Bool then 'Ok else 'Error {},
 
-  "$foreign_id" = fun label value => if %typeof% value == 'ForeignId then value else %blame% label,
+  "$string/immediate" = fun value => if %typeof% value == 'String then 'Ok else 'Error {},
 
-  "$fail" = fun label _value => %blame% label,
+  "$foreign_id/immediate" = fun value =>
+    if %typeof% value == 'ForeignId then 'Ok else 'Error {},
 
-  "$array" = fun element_contract label value =>
-    if %typeof% value == 'Array then
-      %contract/array_lazy_apply% (%label/go_array% label) value element_contract
-    else
-      %blame% label,
+  "$fail/immediate" = fun _value => 'Error {},
+
+  "$array/immediate" = fun value =>
+    if %typeof% value == 'Array then 'Ok else 'Error {},
+
+  "$array/delayed" = fun ElemContract label value =>
+    %contract/array_lazy_apply% (%label/go_array% label) value ElemContract,
 
   # A specialized version of `$array $dyn`, but which is constant time.
-  "$array_dyn" = fun label value =>
+  "$array_dyn/immediate" = fun value =>
     if %typeof% value == 'Array then
-      value
+      'Ok
     else
-      %blame% label,
+      'Error {},
 
-  "$func" = fun domain codomain label value =>
+  "$func/immediate" = fun value =>
     if %typeof% value == 'Function then
-      (
-        fun x =>
-          %contract/apply%
-            codomain
-            (%label/go_codom% label)
-            (value (%contract/apply% domain (%label/flip_polarity% (%label/go_dom% label)) x))
-      )
+      'Ok
     else
-      %blame% label,
+      'Error {},
 
-  # A specialied version of `_ -> Dyn`
-  "$func_dom" = fun domain label value =>
-    if %typeof% value == 'Function then
-      (
-        fun x =>
+  "$func/delayed" = fun Domain Codomain label value =>
+    fun x =>
+      %contract/apply%
+        Codomain
+        (%label/go_codom% label)
+        (
           value
             (
               %contract/apply%
-                domain
+                Domain
                 (%label/flip_polarity% (%label/go_dom% label))
                 x
             )
-      )
-    else
-      %blame% label,
+        ),
+
+  # A specialied version of `_ -> Dyn`
+  "$func_dom/delayed" = fun domain label value =>
+    fun x =>
+      value
+        (
+          %contract/apply%
+            domain
+            (%label/flip_polarity% (%label/go_dom% label))
+            x
+        ),
 
   # A specialied version of `Dyn -> _`
-  "$func_codom" = fun codomain label value =>
-    if %typeof% value == 'Function then
-      (
-        fun x =>
-          %contract/apply%
-            codomain
-            (%label/go_codom% label)
-            (value x)
-      )
-    else
-      %blame% label,
-
-  # A specialied version of `Dyn -> Dyn`
-  "$func_dyn" = fun label value =>
-    if %typeof% value == 'Function then
-      value
-    else
-      %blame% label,
+  "$func_codom/delayed" = fun Codomain label value =>
+    fun x =>
+      %contract/apply%
+        Codomain
+        (%label/go_codom% label)
+        (value x),
 
   "$forall_var" = fun sealing_key label value =>
     let current_polarity = %label/polarity% label in
@@ -95,31 +89,67 @@
       # forall's polarity.
       %seal% sealing_key (%label/flip_polarity% label) value,
 
-  "$forall" = fun sealing_key polarity contract label value =>
-    contract (%label/insert_type_variable% sealing_key polarity label) value,
+  # Contracts for a `forall a. T` type. Mostly a wrapper around `T` that
+  # properly sets additional metadata for polymorphic (un)sealing.
+  # The immediate part just forwards to the immediate part of `T`.
+  "$forall/immediate" = fun contract => (%contract/get_immediate% contract),
+  "$forall/delayed" = fun sealing_key polarity contract label =>
+    (%contract/get_delayed% contract)
+      (%label/insert_type_variable% sealing_key polarity label),
 
-  "$enum" = fun case label value =>
+  "$enum_fail" = 'Error { message = "wrong enum tag" },
+
+  "$enum/immediate" = fun matcher value =>
     if %typeof% value == 'Enum then
-      %contract/apply% case label value
+      matcher value
     else
-      %blame% (%label/with_message% "expected an enum" label),
+      'Error { message = "expected an enum" },
 
-  "$enum_fail" = fun label =>
-    %blame% (%label/with_message% "tag not in the enum type" label),
+  "$enum/delayed" = fun payload label value =>
+    payload
+    |> match {
+      'Map Contract =>
+        # it's basically
+        #
+        # ```nickel
+        # std.enum.map
+        #  (std.contract.apply Contract label)
+        #  value
+        # ```
+        #
+        # but reimplemented directly to avoid stdlib references, which are always a
+        # pain to handle in `$internals` as members of this module must be able to
+        # run correctly in an arbitrary environment, which could shadow stdlib
+        # members.
+        #
+        # Since `std.enum.map` is short, it's simpler to just inline it here.
+        %enum/make_variant%
+          (%to_string% (%enum/get_tag% value))
+          (%contract/apply% Contract label (%enum/get_arg% value)),
+      # If there's no contract provided by the immediate part, we are in the
+      # tail case, where we need to apply a potential sealing/unsealing operation
+      # implemented by the enum variant's argument.
+      'Tail tail_contract =>
+        tail_contract label value,
+    },
 
   # Contract for an enum variant with tag `'tag`, that is any value of the form
   # `'tag exp`.
-  "$enum_variant" = fun tag label value =>
+  "$enum_variant/immediate" = fun tag value =>
     if %enum/is_variant% value then
       let value_tag = %enum/get_tag% value in
 
       if value_tag == tag then
-        value
+        'Ok
       else
-        let msg = "expected `'%{%to_string% tag}`, got `'%{%to_string% value_tag}`" in
-        %blame% (%label/with_message% "tag mismatch: %{msg}" label)
+        'Error {
+          message = "tag mismatch",
+          notes = [
+            "Expected tag `'%{%to_string% tag}`, got tag `'%{%to_string% value_tag}`"
+          ]
+        }
     else
-      %blame% (%label/with_message% "expected an enum variant" label),
+      'Error { message = "expected an enum variant" },
 
   "$forall_enum_tail" = fun label value =>
     # Theoretically, we should seal/unseal values that are part of enum tail
@@ -139,113 +169,137 @@
     # precise parametricity-breaking pattern.
     #
     # Unfortunately, that would break the current stdlib because parametricity
-    # hasn't never been enforced correctly for enum types in the past. For
-    # example, `std.string.from_enum` has contract
-    # `forall a. [|; a |] -> String` which does violate parametricity, as it
-    # looks inside its argument although it's part of a polymorphic tail.
+    # has never been enforced correctly for enum types in the past. For example,
+    # `std.string.from_enum` has contract `forall a. [|; a |] -> String` which
+    # does violate parametricity, as it looks inside its argument although it's
+    # part of a polymorphic tail.
     #
     # While this might be an issue to investigate in the longer term, or for
     # the next major version, we continue to just not enforce parametricity
     # for enum types for now to maintain backward-compatibility.
     value,
 
-  "$record" = fun field_contracts tail_contract label value =>
+  # An immediate contract that simply checks that a value has the type 'Record.
+  "$record/immediate" = fun value =>
     if %typeof% value == 'Record then
-      # Returns the sub-record of `left` containing only those fields which are not
-      # present in `right`. If `left` has a sealed polymorphic tail then it will be
-      # preserved.
-      let field_diff = fun left right =>
-        std.array.fold_left
-          (
-            fun acc field =>
-              if %record/has_field% field right then
-                acc
-              else
-                %record/insert% field acc (left."%{field}")
-          )
-          (%record/empty_with_tail% left)
-          (%record/fields% left)
-      in
-      let contracts_not_in_value = field_diff field_contracts value in
-      let missing_fields = %record/fields% contracts_not_in_value in
-      if %array/length% missing_fields == 0 then
-        let tail_fields = field_diff value field_contracts in
-        let fields_with_contracts =
-          std.array.fold_left
-            (
-              fun acc field =>
-                if %record/has_field% field field_contracts then
-                  let contract = field_contracts."%{field}" in
-                  let label = %label/go_field% field label in
-                  let val = value."%{field}" in
-                  %record/insert% field acc (%contract/apply% contract label val)
-                else
-                  acc
-            )
-            {}
-            (%record/fields% value)
-        in
-        tail_contract fields_with_contracts label tail_fields
+      'Ok
+    else
+      'Error { message = "expected a record" },
+
+  # The immediate part of the contract for static record types.
+  #
+  # Takes as additional parameters a record mapping field names to their type
+  # and a boolean indicating if the record type has a tail, which in practice
+  # allows for extra fields.
+  #
+  # The immediate part checks that there are no missing fields, and that there
+  # are no extra fields if there is no tail. Then, it passes the computed split
+  # of the dictionary of contracts and the provided record value to the delayed
+  # part as a payload.
+  "$record_type/immediate" =
+    let plural = fun list => if %array/length% list == 1 then "" else "s" in
+
+    fun field_contracts has_tail label value =>
+      if %typeof% value == 'Record then
+        let split_result = %record/split_pair% field_contracts value in
+
+        if split_result.left_only != {} then
+          let missing_fields = %record/fields% split_result.left_only in
+
+          'Error {
+            message = "missing field%{plural missing_fields} `%{std.string.join ", " missing_fields}`",
+          }
+        else if split_result.right_only != {} && !has_tail then
+          let extra_fields = %record/fields% split_result.right_only in
+
+          'Error {
+            message = "extra field%{plural extra_fields} `%{std.string.join ", " extra_fields}`",
+          }
+        else
+          'Ok { payload = split_result }
       else
-        let plural = if %array/length% missing_fields == 1 then "" else "s" in
-        %blame%
-          (
-            %label/with_message%
-              "missing field%{plural} `%{std.string.join ", " missing_fields}`"
-              label
-          )
-    else
-      %blame% (%label/with_message% "not a record" label),
+        'Error { message = "expected a record" },
 
-  # Delayed dictionary contract for `{_ | T}`
-  "$dict_contract" = fun contract label value =>
-    if %typeof% value == 'Record then
-      %contract/record_lazy_apply% (%label/go_dict% label) value (fun _field => contract)
-    else
-      %blame% (%label/with_message% "not a record" label),
-
-  # Immediate dictionary contract for `{_ : T}`
-  "$dict_type" = fun contract label value =>
-    if %typeof% value == 'Record then
+  # The delayed part of the contract for static record types.
+  #
+  # Takes as additional parameters a record mapping field names to their type
+  # and a helper handling the tail sealing/unsealing.
+  #
+  # The delayed part applies the contracts for each field (through record
+  # mapping) and then applies the tail contract to potential extra fields that
+  # might require sealing.
+  "$record_type/delayed" = fun field_contracts tail_contract payload label value =>
+    let extra_fields = payload.right_only in
+    let fields_with_contracts =
       %record/map%
-        value
         (
-          fun _field field_value =>
-            %contract/apply% contract (%label/go_dict% label) field_value
+          fun field value =>
+            %contract/apply%
+              field_contracts."%{field}"
+              (%label/go_field% field label)
+              value
         )
-    else
-      %blame% (%label/with_message% "not a record" label),
+        payload.right_center
+    in
 
-  # A specialized version of either `{_ | Dyn}` or `{_ : Dyn}` (which are
-  # equivalent), but which is constant time.
-  "$dict_dyn" = fun label value =>
-    if %typeof% value == 'Record then
+    tail_contract extra_fields label fields_with_contracts,
+
+  # Delayed part of the Lazy dictionary contract for `{_ | T}`. It's lazy in the
+  # sense that the contracts for fields are pushed inside each fields' metadata,
+  # where they are stored but applied lazily.
+  "$dict_contract/delayed" = fun contract label value =>
+    %contract/record_lazy_apply%
+      (%label/go_dict% label)
       value
-    else
-      %blame% (%label/with_message% "not a record" label),
+      (fun _field => contract),
 
-  "$forall_record_tail" = fun sealing_key constr acc label value =>
+  # Delayed part of the eager dictionary contract for `{_ : T}`. It's not eager
+  # in the sense that the field contracts are run immediately - they are not.
+  # However, as opposed to `$dict_contract`, the contract is mapped onto the
+  # content of each field directly using record mapping, instead of being pushed
+  # inside fields' metadata.
+  "$dict_type/delayed" = fun contract label value =>
+    %record/map%
+      value
+      (
+        fun _field field_value =>
+          %contract/apply% contract (%label/go_dict% label) field_value
+      ),
+
+  # Implementation of a helper for a polymorphic record tail.
+  "$forall_record_tail" = fun sealing_key constr extra_fields label value =>
     let current_polarity = %label/polarity% label in
     let polarity = (%label/lookup_type_variable% sealing_key label).polarity in
     let plural = fun list => if %array/length% list == 1 then "" else "s" in
+
+    # If the polarity of the forall is the same as the current polarity, we are
+    # in a positive occurrence (relative to the forall). Think of a return value
+    # of a function type. In this case, the tail is supposed to be sealed, and
+    # the function isn't allowed to inject any extra field in that sealed tail.
     if polarity == current_polarity then
-      if value == {} then
+      if extra_fields == {} then
         let tagged_label = %label/with_message% "polymorphic tail mismatch" label in
-        let tail = %record/unseal_tail% sealing_key tagged_label value in
-        acc & tail
+        let tail = %record/unseal_tail% sealing_key tagged_label extra_fields in
+        %record/disjoint_merge% value tail
       else
-        let extra_fields = %record/fields% value in
+        let extra_fields = %record/fields% extra_fields in
         %blame%
           (
             %label/with_message%
               "extra field%{plural extra_fields} `%{std.string.join ", " extra_fields}`"
               label
           )
+      # Otherwise, we are in a negative occurrence (relative to the forall). Think
+      # of the argument of a function. There, extra fields are allowed, but must
+      # be sealed in the tail to prevent the function from touching them.
     else
+      # Conflicts happen because a polymorphic record tail might have additional
+      # constraints as to what can actually be in there. See the documentation
+      # of the typechecker for more information.
       let conflicts =
         std.array.filter
           (fun field => std.array.elem field constr)
-          (%record/fields% value)
+          (%record/fields% extra_fields)
       in
       if conflicts != [] then
         %blame%
@@ -256,22 +310,17 @@
           )
       else
         # See [^forall_label_flip_polarity]
-        %record/seal_tail% sealing_key (%label/flip_polarity% label) acc value,
+        %record/seal_tail% sealing_key (%label/flip_polarity% label) value extra_fields,
 
-  "$dyn_tail" = fun acc label value => acc & value,
+  # Implementation of a helper for a dynamic tail. A dynamic tail doesn't
+  # seal anything, so we just add the extra fields back to the returned value.
+  # See `$record_type/delayed`.
+  "$dyn_tail" = fun extra_fields label value => %record/disjoint_merge% value extra_fields,
 
-  "$empty_tail" = fun acc label value =>
-    if value == {} then
-      acc
-    else
-      let extra_fields = %record/fields% value in
-      let plural = if %array/length% extra_fields == 1 then "" else "s" in
-      %blame%
-        (
-          %label/with_message%
-            "extra field%{plural} `%{std.string.join ", " extra_fields}`"
-            label
-        ),
+  # Implementation of a helper for an empty tail. At this point, we've already
+  # checked (via `$record_type/immediate`) that there are no extra fields, so
+  # we can just ignore them and return the value as is.
+  "$empty_tail" = fun _extra_fields label value => value,
 
   # Take a contract as a predicate, built using %contract/from_predicate%, and
   # turn it into a generic custom contract (a partial identity Label -> Dyn ->
@@ -338,11 +387,16 @@
       # more readable. However, internal functions are core utilities that get
       # called quite a lot (and internals should be fairly reduced), so we try
       # to use lower-level constructs to reclaim a tad more performance instead.
-      if result == 'Ok then
+      if result == 'Done then
         value
-      else if result == 'Proceed then
-        if delayed != null then
-          delayed label value
+      else if result == 'Ok then
+        # Result can currently either be 'Ok or 'Ok { payload = ... }
+        if %enum/is_variant% result then
+          let payload = (%enum/get_arg% result).payload in
+          if delayed != null then
+            delayed payload label value
+          else
+            value
         else
           value
       else if %typeof% result == 'Enum && %enum/get_tag% result == 'Error then
@@ -372,7 +426,7 @@
               (
                 %force%
                   [
-                    "The immediate part of this contract returned an invalid result (which must be either `'Ok`, `'Proceed`  or `'Error {..}`)",
+                    "The immediate part of this contract returned an invalid result (which must be either `'Ok`, `'Done`  or `'Error {..}`)",
                     "Please check the implementation of the contract that has been broken"
                   ]
               )
@@ -382,11 +436,6 @@
       delayed label value
     else
       value,
-
-  # Those are placeholder for future implementation. Right now they aren't used
-  # yet.
-  "$record_immediate" = fun _ _ => 'Proceed,
-  "$record_delayed" = fun _ _ value => value,
 
   # Recursive priorities operators
 

--- a/core/stdlib/internals.ncl
+++ b/core/stdlib/internals.ncl
@@ -74,7 +74,7 @@
       else
         'Error { message = "expected a function" },
 
-  # A specialied version of `_ -> Dyn`
+  # A specialized version of `_ -> Dyn`
   "$func_dom" = fun Domain =>
     fun label value =>
       if %typeof% value == 'Function then
@@ -113,7 +113,7 @@
       'Error { message = "expected a function" },
 
   # Contract for a polymorphic variable. This contract is stored in an
-  # environment during contract generation when a forall introduces a variables
+  # environment during contract generation when a forall introduces a variable
   # and is inserted whenever this variable occurs somewhere in the contract of
   # the body of the forall.
   "$forall_var" = fun sealing_key =>

--- a/core/stdlib/internals.ncl
+++ b/core/stdlib/internals.ncl
@@ -192,6 +192,27 @@
     # for enum types for now to maintain backward-compatibility.
     value,
 
+  # Record contract.
+  #
+  # Record contracts are written and manipulated as standard record literals by
+  # the user, which is convenient (they can be written in a natural way and all
+  # record operations apply on them, they can be merged, extended, accessed, etc.)
+  #
+  # Before being applied, they still need to be wrapped to provide a proper
+  # error message when the checked value isn't a record, and to apply the proper
+  # merge operator flavour.
+  #
+  # Note that `%record/contract_merge%` returns an immediate error as `'Error`
+  # in case of extra fields. However, due to the lazy nature of merging and the
+  # existence of field without a definition, missing fields are a delayed error.
+  # This might have a non-obvious behavior when using boolean combinators on
+  # record contracts.
+  "$record_contract" = fun record_contract label value =>
+    if %typeof% value == 'Record then
+      %record/merge_contract% label value record_contract
+    else
+      'Error { message = "expected a Record" },
+
   # Contract for a static record type `{ field1: T1, field2: T2, ... }`.
   #
   # The record type is reified by the interpreter as a record value `{ field1 =
@@ -201,7 +222,7 @@
   # `has_tail` is a boolean indicating if the record type has a non-empty tail,
   # which makes it possible to push more checks in the immediate part of the
   # contract.
-  "$record" =
+  "$record_type" =
     let plural = fun list => if %array/length% list == 1 then "" else "s" in
 
     fun field_contracts tail_wrapper has_tail label value =>
@@ -234,6 +255,9 @@
               split_result.right_center
           in
 
+          # Note that the tail_wrapper has the same type as a custom contract
+          # and thus properly wraps the result in `'Ok`, so we can call it
+          # directly
           tail_wrapper extra_fields label fields_with_contracts
       else
         'Error { message = "expected a record" },
@@ -348,8 +372,7 @@
   "$prepare_custom_contract" = fun validator label value =>
     validator value
     |> match {
-      'Ok => value,
-      'Ok processed => processed,
+      'Ok value => value,
       'Error { message ? null, notes ? [], .. } =>
         let label =
           if message != null && std.is_string message then

--- a/core/stdlib/internals.ncl
+++ b/core/stdlib/internals.ncl
@@ -2,184 +2,146 @@
   # Internal operations. Can't be accessed from user code because `$` is not a
   # valid starting character for an identifier.
 
-  # Builtin contract implementations
+  # Builtin contract implementations. Note that these are wrapped in a
+  # `CustomContract` constructor by the interpreter on the Rust side, so they
+  # can be written without calling to `%contract/custom%`, but they still follow
+  # the same convention (in particular the return type is [| 'Ok _, 'Error {..}
+  # |]` as well.
 
   # Contract for the `Dyn` type. It's just an always accepting contract.
-  "$dyn" = %contract/custom% (fun _label value => 'Ok value),
+  "$dyn" = fun _label value => 'Ok value,
 
   # Contract for the `Number` type.
-  "$num" =
-    %contract/custom%
-      (
-        fun _label value =>
-          if %typeof% value == 'Number then
-            'Ok value
-          else
-            'Error {}
-      ),
+  "$num" = fun _label value =>
+    if %typeof% value == 'Number then
+      'Ok value
+    else
+      'Error {},
 
   # Contract for the `Bool` type.
-  "$bool" =
-    %contract/custom%
-      (
-        fun _label value =>
-          if %typeof% value == 'Bool then
-            'Ok value
-          else
-            'Error {}
-      ),
+  "$bool" = fun _label value =>
+    if %typeof% value == 'Bool then
+      'Ok value
+    else
+      'Error {},
 
   # Contract for the `String` type.
-  "$string" =
-    %contract/custom%
-      (
-        fun _label value =>
-          if %typeof% value == 'String then
-            'Ok value
-          else
-            'Error {}
-      ),
+  "$string" = fun _label value =>
+    if %typeof% value == 'String then
+      'Ok value
+    else
+      'Error {},
 
   # Contract for `ForeignId` values.
-  "$foreign_id" =
-    %contract/custom%
-      (
-        fun _label value =>
-          if %typeof% value == 'ForeignId then
-            'Ok value
-          else
-            'Error {}
-      ),
+  "$foreign_id" = fun _label value =>
+    if %typeof% value == 'ForeignId then
+      'Ok value
+    else
+      'Error {},
 
   # Contract for the `Array T` type, where `element_contract` is the contract
   # for `T`.
   "$array" = fun Element =>
-    %contract/custom%
-      (
-        fun label value =>
-          if %typeof% value == 'Array then
-            'Ok (
-              %contract/array_lazy_apply%
-                (%label/go_array% label)
-                value
-                Element
-            )
-          else
-            'Error { message = "expected an array" }
-      ),
+    fun label value =>
+      if %typeof% value == 'Array then
+        'Ok (
+          %contract/array_lazy_apply%
+            (%label/go_array% label)
+            value
+            Element
+        )
+      else
+        'Error { message = "expected an array" },
 
   # A specialized version of `$array $dyn`, but which is constant time.
-  "$array_dyn" =
-    %contract/custom%
-      (
-        fun _label value =>
-          if %typeof% value == 'Array then
-            'Ok value
-          else
-            'Error { message = "expected an array" }
-      ),
+  "$array_dyn" = fun _label value =>
+    if %typeof% value == 'Array then
+      'Ok value
+    else
+      'Error { message = "expected an array" },
 
   # Contract for the function type `Domain -> Codomain`.
   "$func" = fun Domain Codomain =>
-    %contract/custom%
-      (
-        fun label value =>
-          if %typeof% value == 'Function then
-            'Ok (
-              fun x =>
-                %contract/apply%
-                  Codomain
-                  (%label/go_codom% label)
-                  (value (%contract/apply% Domain (%label/flip_polarity% (%label/go_dom% label)) x))
-            )
-          else
-            'Error { message = "expected a function" }
-      ),
+    fun label value =>
+      if %typeof% value == 'Function then
+        'Ok (
+          fun x =>
+            %contract/apply%
+              Codomain
+              (%label/go_codom% label)
+              (value (%contract/apply% Domain (%label/flip_polarity% (%label/go_dom% label)) x))
+        )
+      else
+        'Error { message = "expected a function" },
 
   # A specialied version of `_ -> Dyn`
   "$func_dom" = fun Domain =>
-    %contract/custom%
-      (
-        fun label value =>
-          if %typeof% value == 'Function then
-            'Ok (
-              fun x =>
-                value
-                  (
-                    %contract/apply%
-                      Domain
-                      (%label/flip_polarity% (%label/go_dom% label))
-                      x
-                  )
-            )
-          else
-            'Error { message = "expected a function" }
-      ),
+    fun label value =>
+      if %typeof% value == 'Function then
+        'Ok (
+          fun x =>
+            value
+              (
+                %contract/apply%
+                  Domain
+                  (%label/flip_polarity% (%label/go_dom% label))
+                  x
+              )
+        )
+      else
+        'Error { message = "expected a function" },
 
   # A specialied version of `Dyn -> _`
   "$func_codom" = fun Codomain =>
-    %contract/custom%
-      (
-        fun label value =>
-          if %typeof% value == 'Function then
-            'Ok (
-              fun x =>
-                %contract/apply%
-                  Codomain
-                  (%label/go_codom% label)
-                  (value x)
-            )
-          else
-            'Error { message = "expected a function" }
-      ),
+    fun label value =>
+      if %typeof% value == 'Function then
+        'Ok (
+          fun x =>
+            %contract/apply%
+              Codomain
+              (%label/go_codom% label)
+              (value x)
+        )
+      else
+        'Error { message = "expected a function" },
 
   # A specialied version of `Dyn -> Dyn`
-  "$func_dyn" =
-    %contract/custom%
-      (
-        fun _label value =>
-          if %typeof% value == 'Function then
-            'Ok value
-          else
-            'Error { message = "expected a function" }
-      ),
+  "$func_dyn" = fun _label value =>
+    if %typeof% value == 'Function then
+      'Ok value
+    else
+      'Error { message = "expected a function" },
 
   # Contract for a polymorphic variable. This contract is stored in an
   # environment during contract generation when a forall introduces a variables
   # and is inserted whenever this variable occurs somewhere in the contract of
   # the body of the forall.
   "$forall_var" = fun sealing_key =>
-    %contract/custom%
-      (
-        fun label value =>
-          let current_polarity = %label/polarity% label in
-          let polarity = (%label/lookup_type_variable% sealing_key label).polarity in
-          if polarity == current_polarity then
-            'Ok (%unseal% sealing_key value (%blame% label))
-          else
-            # [^forall_label_flip_polarity]: Blame assignment for polymorphic
-            # contracts should take into account the polarity at the point the forall
-            # was introduced, not the current polarity of the variable occurrence.
-            # Indeed, forall can never blame in a negative position (relative to the
-            # forall): the contract is entirely on the callee.
-            #
-            # Thus, for correct blame assignment, we want to set the polarity to the
-            # forall polarity (here `polarity`). Because we only have the
-            # `%label/flip_polarity%` primop, and we know that in this branch they are
-            # unequal, flipping the current polarity will indeed give the original
-            # forall's polarity.
-            'Ok (%seal% sealing_key (%label/flip_polarity% label) value)
-      ),
+    fun label value =>
+      let current_polarity = %label/polarity% label in
+      let polarity = (%label/lookup_type_variable% sealing_key label).polarity in
+      if polarity == current_polarity then
+        'Ok (%unseal% sealing_key value (%blame% label))
+      else
+        # [^forall_label_flip_polarity]: Blame assignment for polymorphic
+        # contracts should take into account the polarity at the point the forall
+        # was introduced, not the current polarity of the variable occurrence.
+        # Indeed, forall can never blame in a negative position (relative to the
+        # forall): the contract is entirely on the callee.
+        #
+        # Thus, for correct blame assignment, we want to set the polarity to the
+        # forall polarity (here `polarity`). Because we only have the
+        # `%label/flip_polarity%` primop, and we know that in this branch they are
+        # unequal, flipping the current polarity will indeed give the original
+        # forall's polarity.
+        'Ok (%seal% sealing_key (%label/flip_polarity% label) value),
 
   # Contract for `forall a. T`, where `contract` is the contract for `T`. This
   # contract mostly set appropriate metadata in the label and forward the rest
   # to `T`.
-  "$forall" = fun sealing_key polarity Contract =>
-    %contract/custom%
-      (
-        fun label value =>
-          Contract (%label/insert_type_variable% sealing_key polarity label) value
-      ),
+  "$forall" = fun sealing_key polarity Contract label value =>
+    let label = (%label/insert_type_variable% sealing_key polarity label) in
+    %contract/apply_as_custom% Contract label value,
 
   # Contract for an enum type `[| 'tag1, 'tag2 arg, ... |]`. A match expression
   # depending on the structure of the enum type is generated by the interpreter
@@ -187,37 +149,31 @@
   # is just a wrapper that checks that the value is an enum and forwards the rest
   # to `matcher`.
   "$enum" = fun matcher =>
-    %contract/custom%
-      (
-        fun label value =>
-          if %typeof% value == 'Enum then
-            matcher label value
-          else
-            'Error { message = "expected an enum" }
-      ),
+    fun label value =>
+      if %typeof% value == 'Enum then
+        matcher label value
+      else
+        'Error { message = "expected an enum" },
 
   # Error branch used when elaborating the matcher for an enum type. See
   # `$enum`.
-  "$enum_fail" = 'Error { message = "tag not in the enum type" },
+  "$enum_fail" = fun _value => 'Error { message = "tag not in the enum type" },
 
   # Contract for an enum variant with tag `'tag`, that is any value of the form
   # `'tag exp`.
   "$enum_variant" = fun tag =>
-    %contract/custom%
-      (
-        fun _label value =>
-          if %enum/is_variant% value then
-            let value_tag = %enum/get_tag% value in
+    fun _label value =>
+      if %enum/is_variant% value then
+        let value_tag = %enum/get_tag% value in
 
-            if value_tag == tag then
-              'Ok value
-            else
-              'Error {
-                message = "expected `'%{%to_string% tag}`, got `'%{%to_string% value_tag}`"
-              }
-          else
-            'Error { message = "expected an enum variant" }
-      ),
+        if value_tag == tag then
+          'Ok value
+        else
+          'Error {
+            message = "expected `'%{%to_string% tag}`, got `'%{%to_string% value_tag}`"
+          }
+      else
+        'Error { message = "expected an enum variant" },
 
   # Tail wrapper for the tail of an enum type.
   "$forall_enum_tail" = fun label value =>
@@ -264,14 +220,11 @@
   # This might have a non-obvious behavior when using boolean combinators on
   # record contracts.
   "$record_contract" = fun record_contract =>
-    %contract/custom%
-      (
-        fun label value =>
-          if %typeof% value == 'Record then
-            %record/merge_contract% label value record_contract
-          else
-            'Error { message = "expected a Record" }
-      ),
+    fun label value =>
+      if %typeof% value == 'Record then
+        %record/merge_contract% label value record_contract
+      else
+        'Error { message = "expected a Record" },
 
   # Contract for a static record type `{ field1: T1, field2: T2, ... }`.
   #
@@ -286,99 +239,85 @@
     let plural = fun list => if %array/length% list == 1 then "" else "s" in
 
     fun field_contracts tail_wrapper has_tail =>
-      %contract/custom%
-        (
-          fun label value =>
-            if %typeof% value == 'Record then
-              let split_result = %record/split_pair% field_contracts value in
+      fun label value =>
+        if %typeof% value == 'Record then
+          let split_result = %record/split_pair% field_contracts value in
 
-              if split_result.left_only != {} then
-                let missing_fields = %record/fields% split_result.left_only in
+          if split_result.left_only != {} then
+            let missing_fields = %record/fields% split_result.left_only in
 
-                'Error {
-                  message = "missing field%{plural missing_fields} `%{std.string.join ", " missing_fields}`",
-                }
-              else if split_result.right_only != {} && !has_tail then
-                let extra_fields = %record/fields% split_result.right_only in
+            'Error {
+              message = "missing field%{plural missing_fields} `%{std.string.join ", " missing_fields}`",
+            }
+          else if split_result.right_only != {} && !has_tail then
+            let extra_fields = %record/fields% split_result.right_only in
 
-                'Error {
-                  message = "extra field%{plural extra_fields} `%{std.string.join ", " extra_fields}`",
-                }
-              else
-                let extra_fields = split_result.right_only in
-                let fields_with_contracts =
-                  %record/map%
-                    (
-                      fun field value =>
-                        %contract/apply%
-                          field_contracts."%{field}"
-                          (%label/go_field% field label)
-                          value
-                    )
-                    split_result.right_center
-                in
+            'Error {
+              message = "extra field%{plural extra_fields} `%{std.string.join ", " extra_fields}`",
+            }
+          else
+            let extra_fields = split_result.right_only in
+            let fields_with_contracts =
+              %record/map%
+                split_result.right_center
+                (
+                  fun field value =>
+                    %contract/apply%
+                      field_contracts."%{field}"
+                      (%label/go_field% field label)
+                      value
+                )
+            in
 
-                # Note that the tail_wrapper has the same type as a custom contract
-                # and thus properly wraps the result in `'Ok`, so we can call it
-                # directly
-                tail_wrapper extra_fields label fields_with_contracts
-            else
-              'Error { message = "expected a record" }
-        ),
+            # Note that the tail_wrapper has the same type as a custom contract
+            # and thus properly wraps the result in `'Ok`, so we can call it
+            # directly
+            tail_wrapper extra_fields label fields_with_contracts
+        else
+          'Error { message = "expected a record" },
 
   # Dictionary contract for `{_ | T}`. The contracts are mapped onto fields'
   # metadata.
   "$dict_contract" = fun Contract =>
-    %contract/custom%
-      (
-        fun label value =>
-          if %typeof% value == 'Record then
-            'Ok (
-              %contract/record_lazy_apply%
-                (%label/go_dict% label)
-                value
-                (fun _field => contract)
-            )
-          else
-            'Error { message = "not a record" }
-      ),
+    fun label value =>
+      if %typeof% value == 'Record then
+        'Ok (
+          %contract/record_lazy_apply%
+            (%label/go_dict% label)
+            value
+            (fun _field => Contract)
+        )
+      else
+        'Error { message = "not a record" },
 
   # Dictionary contract for `{_ : T}`. The contracts are mapped directly onto
   # the fields' values, which makes it more eager (in some specific sense - this
   # contract is still lazy/delayed) than `$dict_contract`.
   "$dict_type" = fun Contract =>
-    %contract/custom%
-      (
-        fun label value =>
-          if %typeof% value == 'Record then
-            'Ok (
-              %record/map%
-                value
-                (
-                  fun _field field_value =>
-                    %contract/apply% contract (%label/go_dict% label) field_value
-                )
+    fun label value =>
+      if %typeof% value == 'Record then
+        'Ok (
+          %record/map%
+            value
+            (
+              fun _field field_value =>
+                %contract/apply% Contract (%label/go_dict% label) field_value
             )
-          else
-            'Error { message = "not a record" }
-      ),
+        )
+      else
+        'Error { message = "not a record" },
 
   # A specialized version of either `{_ | Dyn}` or `{_ : Dyn}` (which are
   # equivalent), but which is constant time.
-  "$dict_dyn" =
-    %contract/custom%
-      (
-        fun label value =>
-          if %typeof% value == 'Record then
-            'Ok
-          else
-            'Error { message = "not a record" }
-      ),
+  "$dict_dyn" = fun label value =>
+    if %typeof% value == 'Record then
+      'Ok
+    else
+      'Error { message = "not a record" },
 
   # Tail wrapper for a polymorphic tail. Wrappers are used in the implementation
   # of the contract for static record types, and have the same return type as
-  # other contract implementations. Because we apply them right away, we don't
-  # wrap them in %contract/custom%.
+  # other contract implementations.
   #
   # The `sealing_key` is the sealing key corresponding to the variable occuring
   # in the tail. `constr` are the fields that can't appear in the value because
@@ -472,20 +411,31 @@
       # never reach this case. However, nothing prevents user from using
       # `%contract/custom%` directly, so we still try to handle a misbehaving
       # custom contract gracefully.
-      _ =>
+      value =>
         %blame%
           (
             %label/with_notes%
               (
                 %force%
-                  [
-                    "The implementation of this custom contract returned an invalid result (which must be of type `[| 'Ok Dyn, 'Error {..} |]`)",
-                    "Please check the implementation of the contract that has been broken"
-                  ]
+                  (
+                    %trace%
+                      value
+                      [
+                        "The implementation of this custom contract returned an invalid result (which must be of type `[| 'Ok Dyn, 'Error {..} |]`)",
+                        "Please check the implementation of the contract that has been broken"
+                      ]
+                  )
               )
               label
           )
     },
+
+  # Dual of prepare_custom_contract. Turns a naked function of a label and a
+  # value to a custom contract-like representation (that is, a function
+  # returning an enum - however the result is still a naked function, which must
+  # be applicable as a normal function, and isn't wrapped in
+  # `%contract/custom%`).
+  "$naked_to_custom" = fun naked label value => 'Ok (naked label value),
 
   # Recursive priorities operators
 

--- a/core/stdlib/internals.ncl
+++ b/core/stdlib/internals.ncl
@@ -5,33 +5,33 @@
   # Builtin contract implementations
 
   # Contract for the `Dyn` type. It's just an always accepting contract.
-  "$dyn" = fun _label _value => 'Ok,
+  "$dyn" = fun _label value => 'Ok value,
 
   # Contract for the `Number` type.
   "$num" = fun _label value =>
     if %typeof% value == 'Number then
-      'Ok
+      'Ok value
     else
       'Error {},
 
   # Contract for the `Bool` type.
   "$bool" = fun _label value =>
     if %typeof% value == 'Bool then
-      'Ok
+      'Ok value
     else
       'Error {},
 
   # Contract for the `String` type.
   "$string" = fun _label value =>
     if %typeof% value == 'String then
-      'Ok
+      'Ok value
     else
       'Error {},
 
   # Contract for `ForeignId` values.
   "$foreign_id" = fun _label value =>
     if %typeof% value == 'ForeignId then
-      'Ok
+      'Ok value
     else
       'Error {},
 
@@ -51,7 +51,7 @@
   # A specialized version of `$array $dyn`, but which is constant time.
   "$array_dyn" = fun _label value =>
     if %typeof% value == 'Array then
-      'Ok
+      'Ok value
     else
       'Error { message = "expected an array" },
 
@@ -100,7 +100,7 @@
   # A specialied version of `Dyn -> Dyn`
   "$func_dyn" = fun _label value =>
     if %typeof% value == 'Function then
-      'Ok
+      'Ok value
     else
       'Error { message = "expected a function" },
 
@@ -155,7 +155,7 @@
       let value_tag = %enum/get_tag% value in
 
       if value_tag == tag then
-        'Ok
+        'Ok value
       else
         'Error {
           message = "expected `'%{%to_string% tag}`, got `'%{%to_string% value_tag}`"
@@ -400,7 +400,7 @@
               (
                 %force%
                   [
-                    "The implementation of this custom contract returned an invalid result (which must be of type `[| 'Ok, 'Ok Dyn, 'Error {..} |]`)",
+                    "The implementation of this custom contract returned an invalid result (which must be of type `[| 'Ok Dyn, 'Error {..} |]`)",
                     "Please check the implementation of the contract that has been broken"
                   ]
               )

--- a/core/stdlib/internals.ncl
+++ b/core/stdlib/internals.ncl
@@ -311,7 +311,7 @@
   # equivalent), but which is constant time.
   "$dict_dyn" = fun label value =>
     if %typeof% value == 'Record then
-      'Ok
+      'Ok value
     else
       'Error { message = "not a record" },
 

--- a/core/stdlib/internals.ncl
+++ b/core/stdlib/internals.ncl
@@ -4,77 +4,115 @@
 
   # Builtin contract implementations
 
-  "$dyn/immediate" = fun _value => 'Ok,
+  # Contract for the `Dyn` type. It's just an always accepting contract.
+  "$dyn" = fun _label _value => 'Ok,
 
-  "$number/immediate" = fun value => if %typeof% value == 'Number then 'Ok else 'Error {},
+  # Contract for the `Number` type.
+  "$num" = fun _label value =>
+    if %typeof% value == 'Number then
+      'Ok
+    else
+      'Error {},
 
-  "$bool/immediate" = fun value => if %typeof% value == 'Bool then 'Ok else 'Error {},
+  # Contract for the `Bool` type.
+  "$bool" = fun _label value =>
+    if %typeof% value == 'Bool then
+      'Ok
+    else
+      'Error {},
 
-  "$string/immediate" = fun value => if %typeof% value == 'String then 'Ok else 'Error {},
+  # Contract for the `String` type.
+  "$string" = fun _label value =>
+    if %typeof% value == 'String then
+      'Ok
+    else
+      'Error {},
 
-  "$foreign_id/immediate" = fun value =>
-    if %typeof% value == 'ForeignId then 'Ok else 'Error {},
+  # Contract for `ForeignId` values.
+  "$foreign_id" = fun _label value =>
+    if %typeof% value == 'ForeignId then
+      'Ok
+    else
+      'Error {},
 
-  "$fail/immediate" = fun _value => 'Error {},
-
-  "$array/immediate" = fun value =>
-    if %typeof% value == 'Array then 'Ok else 'Error {},
-
-  "$array/delayed" = fun ElemContract label value =>
-    %contract/array_lazy_apply% (%label/go_array% label) value ElemContract,
+  # Contract for the `Array T` type, where `element_contract` is the contract
+  # for `T`.
+  "$array" = fun element_contract label value =>
+    if %typeof% value == 'Array then
+      'Ok (
+        %contract/array_lazy_apply%
+          (%label/go_array% label)
+          value
+          element_contract
+      )
+    else
+      'Error { message = "expected an array" },
 
   # A specialized version of `$array $dyn`, but which is constant time.
-  "$array_dyn/immediate" = fun value =>
+  "$array_dyn" = fun _label value =>
     if %typeof% value == 'Array then
       'Ok
     else
-      'Error {},
+      'Error { message = "expected an array" },
 
-  "$func/immediate" = fun value =>
+  # Contract for the function type `Domain -> Codomain`.
+  "$func" = fun domain codomain label value =>
     if %typeof% value == 'Function then
-      'Ok
+      'Ok (
+        fun x =>
+          %contract/apply%
+            codomain
+            (%label/go_codom% label)
+            (value (%contract/apply% domain (%label/flip_polarity% (%label/go_dom% label)) x))
+      )
     else
-      'Error {},
+      'Error { message = "expected a function" },
 
-  "$func/delayed" = fun Domain Codomain label value =>
-    fun x =>
-      %contract/apply%
-        Codomain
-        (%label/go_codom% label)
-        (
+  # A specialied version of `_ -> Dyn`
+  "$func_dom" = fun domain label value =>
+    if %typeof% value == 'Function then
+      'Ok (
+        fun x =>
           value
             (
               %contract/apply%
-                Domain
+                domain
                 (%label/flip_polarity% (%label/go_dom% label))
                 x
             )
-        ),
-
-  # A specialied version of `_ -> Dyn`
-  "$func_dom/delayed" = fun domain label value =>
-    fun x =>
-      value
-        (
-          %contract/apply%
-            domain
-            (%label/flip_polarity% (%label/go_dom% label))
-            x
-        ),
+      )
+    else
+      'Error { message = "expected a function" },
 
   # A specialied version of `Dyn -> _`
-  "$func_codom/delayed" = fun Codomain label value =>
-    fun x =>
-      %contract/apply%
-        Codomain
-        (%label/go_codom% label)
-        (value x),
+  "$func_codom" = fun codomain label value =>
+    if %typeof% value == 'Function then
+      'Ok (
+        fun x =>
+          %contract/apply%
+            codomain
+            (%label/go_codom% label)
+            (value x)
+      )
+    else
+      'Error { message = "expected a function" },
 
+  # A specialied version of `Dyn -> Dyn`
+  "$func_dyn" = fun _label value =>
+    if %typeof% value == 'Function then
+      'Ok
+    else
+      'Error { message = "expected a function" },
+
+  # Contract for a polymorphic variable. This contract is stored in an
+  # environment during contract generation when a forall introduces a variables
+  # and is inserted whenever this variable occurs somewhere in the contract of
+  # the body of the forall.
   "$forall_var" = fun sealing_key label value =>
     let current_polarity = %label/polarity% label in
     let polarity = (%label/lookup_type_variable% sealing_key label).polarity in
     if polarity == current_polarity then
-      %unseal% sealing_key value (%blame% label)
+      'Ok (%unseal% sealing_key value (%blame% label))
     else
       # [^forall_label_flip_polarity]: Blame assignment for polymorphic
       # contracts should take into account the polarity at the point the forall
@@ -87,55 +125,32 @@
       # `%label/flip_polarity%` primop, and we know that in this branch they are
       # unequal, flipping the current polarity will indeed give the original
       # forall's polarity.
-      %seal% sealing_key (%label/flip_polarity% label) value,
+      'Ok (%seal% sealing_key (%label/flip_polarity% label) value),
 
-  # Contracts for a `forall a. T` type. Mostly a wrapper around `T` that
-  # properly sets additional metadata for polymorphic (un)sealing.
-  # The immediate part just forwards to the immediate part of `T`.
-  "$forall/immediate" = fun contract => (%contract/get_immediate% contract),
-  "$forall/delayed" = fun sealing_key polarity contract label =>
-    (%contract/get_delayed% contract)
-      (%label/insert_type_variable% sealing_key polarity label),
+  # Contract for `forall a. T`, where `contract` is the contract for `T`. This
+  # contract mostly set appropriate metadata in the label and forward the rest
+  # to `T`.
+  "$forall" = fun sealing_key polarity contract label value =>
+    contract (%label/insert_type_variable% sealing_key polarity label) value,
 
-  "$enum_fail" = 'Error { message = "wrong enum tag" },
-
-  "$enum/immediate" = fun matcher value =>
+  # Contract for an enum type `[| 'tag1, 'tag2 arg, ... |]`. A match expression
+  # depending on the structure of the enum type is generated by the interpreter
+  # and provided through `matcher`, and does the bulk of the work. This contract
+  # is just a wrapper that checks that the value is an enum and forwards the rest
+  # to `matcher`.
+  "$enum" = fun matcher label value =>
     if %typeof% value == 'Enum then
-      matcher value
+      matcher label value
     else
       'Error { message = "expected an enum" },
 
-  "$enum/delayed" = fun payload label value =>
-    payload
-    |> match {
-      'Map Contract =>
-        # it's basically
-        #
-        # ```nickel
-        # std.enum.map
-        #  (std.contract.apply Contract label)
-        #  value
-        # ```
-        #
-        # but reimplemented directly to avoid stdlib references, which are always a
-        # pain to handle in `$internals` as members of this module must be able to
-        # run correctly in an arbitrary environment, which could shadow stdlib
-        # members.
-        #
-        # Since `std.enum.map` is short, it's simpler to just inline it here.
-        %enum/make_variant%
-          (%to_string% (%enum/get_tag% value))
-          (%contract/apply% Contract label (%enum/get_arg% value)),
-      # If there's no contract provided by the immediate part, we are in the
-      # tail case, where we need to apply a potential sealing/unsealing operation
-      # implemented by the enum variant's argument.
-      'Tail tail_contract =>
-        tail_contract label value,
-    },
+  # Error branch used when elaborating the matcher for an enum type. See
+  # `$enum`.
+  "$enum_fail" = 'Error { message = "tag not in the enum type" },
 
   # Contract for an enum variant with tag `'tag`, that is any value of the form
   # `'tag exp`.
-  "$enum_variant/immediate" = fun tag value =>
+  "$enum_variant" = fun tag _label value =>
     if %enum/is_variant% value then
       let value_tag = %enum/get_tag% value in
 
@@ -143,14 +158,12 @@
         'Ok
       else
         'Error {
-          message = "tag mismatch",
-          notes = [
-            "Expected tag `'%{%to_string% tag}`, got tag `'%{%to_string% value_tag}`"
-          ]
+          message = "expected `'%{%to_string% tag}`, got `'%{%to_string% value_tag}`"
         }
     else
       'Error { message = "expected an enum variant" },
 
+  # Tail wrapper for the tail of an enum type.
   "$forall_enum_tail" = fun label value =>
     # Theoretically, we should seal/unseal values that are part of enum tail
     # and `$forall_enum_tail` should be defined similarly to
@@ -169,37 +182,29 @@
     # precise parametricity-breaking pattern.
     #
     # Unfortunately, that would break the current stdlib because parametricity
-    # has never been enforced correctly for enum types in the past. For example,
-    # `std.string.from_enum` has contract `forall a. [|; a |] -> String` which
-    # does violate parametricity, as it looks inside its argument although it's
-    # part of a polymorphic tail.
+    # hasn't never been enforced correctly for enum types in the past. For
+    # example, `std.string.from_enum` has contract
+    # `forall a. [|; a |] -> String` which does violate parametricity, as it
+    # looks inside its argument although it's part of a polymorphic tail.
     #
     # While this might be an issue to investigate in the longer term, or for
     # the next major version, we continue to just not enforce parametricity
     # for enum types for now to maintain backward-compatibility.
     value,
 
-  # An immediate contract that simply checks that a value has the type 'Record.
-  "$record/immediate" = fun value =>
-    if %typeof% value == 'Record then
-      'Ok
-    else
-      'Error { message = "expected a record" },
-
-  # The immediate part of the contract for static record types.
+  # Contract for a static record type `{ field1: T1, field2: T2, ... }`.
   #
-  # Takes as additional parameters a record mapping field names to their type
-  # and a boolean indicating if the record type has a tail, which in practice
-  # allows for extra fields.
-  #
-  # The immediate part checks that there are no missing fields, and that there
-  # are no extra fields if there is no tail. Then, it passes the computed split
-  # of the dictionary of contracts and the provided record value to the delayed
-  # part as a payload.
-  "$record_type/immediate" =
+  # The record type is reified by the interpreter as a record value `{ field1 =
+  # <contract of T1>, field2 = <contract of T2>, ... }` and given as the
+  # `field_contracts` argument. Depending on the tail of the record type, the
+  # corresponding `tail_wrapper` is also provided by the interpreter. Finally,
+  # `has_tail` is a boolean indicating if the record type has a non-empty tail,
+  # which makes it possible to push more checks in the immediate part of the
+  # contract.
+  "$record" =
     let plural = fun list => if %array/length% list == 1 then "" else "s" in
 
-    fun field_contracts has_tail label value =>
+    fun field_contracts tail_wrapper has_tail label value =>
       if %typeof% value == 'Record then
         let split_result = %record/split_pair% field_contracts value in
 
@@ -216,57 +221,72 @@
             message = "extra field%{plural extra_fields} `%{std.string.join ", " extra_fields}`",
           }
         else
-          'Ok { payload = split_result }
+          let extra_fields = split_result.right_only in
+          let fields_with_contracts =
+            %record/map%
+              (
+                fun field value =>
+                  %contract/apply%
+                    field_contracts."%{field}"
+                    (%label/go_field% field label)
+                    value
+              )
+              split_result.right_center
+          in
+
+          tail_wrapper extra_fields label fields_with_contracts
       else
         'Error { message = "expected a record" },
 
-  # The delayed part of the contract for static record types.
+  # Dictionary contract for `{_ | T}`. The contracts are mapped onto fields'
+  # metadata.
+  "$dict_contract" = fun contract label value =>
+    if %typeof% value == 'Record then
+      'Ok (
+        %contract/record_lazy_apply%
+          (%label/go_dict% label)
+          value
+          (fun _field => contract)
+      )
+    else
+      'Error { message = "not a record" },
+
+  # Dictionary contract for `{_ : T}`. The contracts are mapped directly onto
+  # the fields' values, which makes it more eager (in some specific sense - this
+  # contract is still lazy/delayed) than `$dict_contract`.
+  "$dict_type" = fun contract label value =>
+    if %typeof% value == 'Record then
+      'Ok (
+        %record/map%
+          value
+          (
+            fun _field field_value =>
+              %contract/apply% contract (%label/go_dict% label) field_value
+          )
+      )
+    else
+      'Error { message = "not a record" },
+
+  # A specialized version of either `{_ | Dyn}` or `{_ : Dyn}` (which are
+  # equivalent), but which is constant time.
+  "$dict_dyn" = fun label value =>
+    if %typeof% value == 'Record then
+      'Ok
+    else
+      'Error { message = "not a record" },
+
+  # Tail wrapper for a polymorphic tail. Wrappers are used in the implementation
+  # of the contract for static record types, and have the same return type as
+  # other contract implementations.
   #
-  # Takes as additional parameters a record mapping field names to their type
-  # and a helper handling the tail sealing/unsealing.
+  # The `sealing_key` is the sealing key corresponding to the variable occuring
+  # in the tail. `constr` are the fields that can't appear in the value because
+  # they are already in the tail. Both are provided by the interpreter when
+  # applying this function.
   #
-  # The delayed part applies the contracts for each field (through record
-  # mapping) and then applies the tail contract to potential extra fields that
-  # might require sealing.
-  "$record_type/delayed" = fun field_contracts tail_contract payload label value =>
-    let extra_fields = payload.right_only in
-    let fields_with_contracts =
-      %record/map%
-        (
-          fun field value =>
-            %contract/apply%
-              field_contracts."%{field}"
-              (%label/go_field% field label)
-              value
-        )
-        payload.right_center
-    in
-
-    tail_contract extra_fields label fields_with_contracts,
-
-  # Delayed part of the Lazy dictionary contract for `{_ | T}`. It's lazy in the
-  # sense that the contracts for fields are pushed inside each fields' metadata,
-  # where they are stored but applied lazily.
-  "$dict_contract/delayed" = fun contract label value =>
-    %contract/record_lazy_apply%
-      (%label/go_dict% label)
-      value
-      (fun _field => contract),
-
-  # Delayed part of the eager dictionary contract for `{_ : T}`. It's not eager
-  # in the sense that the field contracts are run immediately - they are not.
-  # However, as opposed to `$dict_contract`, the contract is mapped onto the
-  # content of each field directly using record mapping, instead of being pushed
-  # inside fields' metadata.
-  "$dict_type/delayed" = fun contract label value =>
-    %record/map%
-      value
-      (
-        fun _field field_value =>
-          %contract/apply% contract (%label/go_dict% label) field_value
-      ),
-
-  # Implementation of a helper for a polymorphic record tail.
+  # `extra_fields` is provided by the caller `$record`, and is the set of fields
+  # that are weren't part of the record type (thus are candidates for being in
+  # the tail).
   "$forall_record_tail" = fun sealing_key constr extra_fields label value =>
     let current_polarity = %label/polarity% label in
     let polarity = (%label/lookup_type_variable% sealing_key label).polarity in
@@ -280,15 +300,12 @@
       if extra_fields == {} then
         let tagged_label = %label/with_message% "polymorphic tail mismatch" label in
         let tail = %record/unseal_tail% sealing_key tagged_label extra_fields in
-        %record/disjoint_merge% value tail
+        'Ok (%record/disjoint_merge% value tail)
       else
         let extra_fields = %record/fields% extra_fields in
-        %blame%
-          (
-            %label/with_message%
-              "extra field%{plural extra_fields} `%{std.string.join ", " extra_fields}`"
-              label
-          )
+        'Error {
+          message = "extra field%{plural extra_fields} `%{std.string.join ", " extra_fields}`",
+        }
       # Otherwise, we are in a negative occurrence (relative to the forall). Think
       # of the argument of a function. There, extra fields are allowed, but must
       # be sealed in the tail to prevent the function from touching them.
@@ -302,42 +319,37 @@
           (%record/fields% extra_fields)
       in
       if conflicts != [] then
-        %blame%
-          (
-            %label/with_message%
-              "field%{plural conflicts} not allowed in tail: `%{std.string.join ", " conflicts}`"
-              label
-          )
+        'Error {
+          message = "field%{plural conflicts} not allowed in tail: `%{std.string.join ", " conflicts}`",
+        }
       else
         # See [^forall_label_flip_polarity]
-        %record/seal_tail% sealing_key (%label/flip_polarity% label) value extra_fields,
+        'Ok (
+          %record/seal_tail%
+            sealing_key
+            (%label/flip_polarity% label)
+            value
+            extra_fields
+        ),
 
-  # Implementation of a helper for a dynamic tail. A dynamic tail doesn't
-  # seal anything, so we just add the extra fields back to the returned value.
-  # See `$record_type/delayed`.
-  "$dyn_tail" = fun extra_fields label value => %record/disjoint_merge% value extra_fields,
+  # Tail wrapper for a dynamic tail. A dynamic tail doesn't seal anything, so we
+  # just add the extra fields back to the returned value. See
+  # `$record_type/delayed`.
+  "$dyn_tail" = fun extra_fields label value => 'Ok (%record/disjoint_merge% value extra_fields),
 
-  # Implementation of a helper for an empty tail. At this point, we've already
-  # checked (via `$record_type/immediate`) that there are no extra fields, so
-  # we can just ignore them and return the value as is.
-  "$empty_tail" = fun _extra_fields label value => value,
-
-  # Take a contract as a predicate, built using %contract/from_predicate%, and
-  # turn it into a generic custom contract (a partial identity Label -> Dyn ->
-  # Dyn) that can be passed to %contract/apply%.
-  "$predicate_to_ctr" = fun predicate label value =>
-    if predicate value then
-      value
-    else
-      %blame% label,
+  # Tail wrapper of a helper for an empty tail. At this point, we've already
+  # checked (in the main contract implementation for record types) that there
+  # are no extra fields, so we can just ignore them and return the value as is.
+  "$empty_tail" = fun _extra_fields _label _value => 'Ok,
 
   # Take a contract as a validator, built using %contract/from_validator%, and
   # turn it into a generic custom contract (a partial identity Label -> Dyn ->
   # Dyn) that can be passed to %contract/apply%.
-  "$validator_to_ctr" = fun validator label value =>
+  "$prepare_custom_contract" = fun validator label value =>
     validator value
     |> match {
       'Ok => value,
+      'Ok processed => processed,
       'Error { message ? null, notes ? [], .. } =>
         let label =
           if message != null && std.is_string message then
@@ -354,10 +366,10 @@
         in
 
         %blame% label,
-      # The contract of `std.contract.from_validator` should guarantee that we
+      # The contract of `std.contract.custom` should guarantee that we
       # never reach this case. However, nothing prevents user from using
-      # `%contract/from_validator%` directly, so we still try to handle a
-      # misbehaving validator gracefully.
+      # `%contract/custom%` directly, so we still try to handle a misbehaving
+      # custom contract gracefully.
       _ =>
         %blame%
           (
@@ -365,77 +377,13 @@
               (
                 %force%
                   [
-                    "The validator for this contract returned an invalid result (which must be either `'Ok` or `'Error {message, ..}`)",
+                    "The implementation of this custom contract returned an invalid result (which must be of type `[| 'Ok, 'Ok Dyn, 'Error {..} |]`)",
                     "Please check the implementation of the contract that has been broken"
                   ]
               )
               label
           )
     },
-
-  # Take a custom contract split as an immediate and delayed part, both of which
-  # can be null, and transform it into a partial identity function that can be
-  # given to %contract/apply%.
-  "$prepare_contract" = fun contract label value =>
-    let immediate = %contract/get_immediate% contract in
-    let delayed = %contract/get_delayed% contract in
-
-    if immediate != null then
-      let result = immediate value in
-
-      # In user code, we would have used a match construct here, which would be
-      # more readable. However, internal functions are core utilities that get
-      # called quite a lot (and internals should be fairly reduced), so we try
-      # to use lower-level constructs to reclaim a tad more performance instead.
-      if result == 'Done then
-        value
-      else if result == 'Ok then
-        # Result can currently either be 'Ok or 'Ok { payload = ... }
-        if %enum/is_variant% result then
-          let payload = (%enum/get_arg% result).payload in
-          if delayed != null then
-            delayed payload label value
-          else
-            value
-        else
-          value
-      else if %typeof% result == 'Enum && %enum/get_tag% result == 'Error then
-        let payload = %enum/get_arg% result in
-
-        let label =
-          if %record/field_is_defined% "message" payload
-          && std.is_string payload.message then
-            %label/with_message% payload.message label
-          else
-            label
-        in
-
-        let label =
-          if %record/field_is_defined% "notes" payload
-          && std.is_array payload.notes then
-            %label/with_notes% (%force% payload.notes) label
-          else
-            label
-        in
-
-        %blame% label
-      else
-        %blame%
-          (
-            %label/with_notes%
-              (
-                %force%
-                  [
-                    "The immediate part of this contract returned an invalid result (which must be either `'Ok`, `'Done`  or `'Error {..}`)",
-                    "Please check the implementation of the contract that has been broken"
-                  ]
-              )
-              label
-          )
-    else if delayed != null then
-      delayed label value
-    else
-      value,
 
   # Recursive priorities operators
 

--- a/core/stdlib/std.ncl
+++ b/core/stdlib/std.ncl
@@ -65,7 +65,7 @@
             fun value =>
               if %typeof% value == 'Array then
                 if %array/length% value != 0 then
-                  'Ok
+                  'Done
                 else
                   'Error { message = "empty array" }
               else
@@ -1013,7 +1013,7 @@
       | (
         Dyn -> [|
           'Ok,
-          'Proceed,
+          'Done,
           'Error { message | String | optional, notes | Array String | optional }
         |]
       ) -> (Dyn -> Dyn -> Dyn) -> Dyn
@@ -1034,24 +1034,24 @@
           arrays) or contracts that might take other delayed contracts as
           parameters and apply them (using `std.contract.apply`).
 
-          Custom contracts built using `std.contract.custom` are the most
-          general form of custom contracts. They consist of an immediate part
-          and a delayed part.
+          Custom contracts built using `std.contract.custom` and
+          `std.contract.custom_piped` are the most general form of custom
+          contracts. They consist of an immediate part and a delayed part.
 
           ## Immediate part
 
           The immediate part is a function that takes the checked value as a
           parameter and returns either:
 
-          - `'Ok` indicating that the whole contract should succeed immediately
+          - `'Done` indicating that the whole contract should succeed immediately
             without running the delayed part
-          - `'Proceed` indicating that the immediate part has succeeded but that
+          - `'Ok` indicating that the immediate part has succeeded but that
             we should still proceed with the delayed part
           - `'Error {..}` indicating that the contract should fail with provided
             error information.
 
           The immediate part is thus similar to a validator, excepted that they
-          can return the additional `'Proceed` value (see
+          can return the additional `'Done` value (see
           `std.contract.from_validator`).
 
           ## Delayed part
@@ -1077,9 +1077,9 @@
             std.contract.custom
               (fun value =>
                 if value == null then
-                  'Ok
+                  'Done
                 else
-                  'Proceed
+                  'Ok
               )
               (std.contract.apply Contract)
           in
@@ -1089,16 +1089,64 @@
         "%
       = fun immediate delayed => %contract/custom% immediate delayed,
 
+    custom_piped
+      | (
+        Dyn -> [|
+          'Ok { payload },
+          'Done,
+          'Error { message | String | optional, notes | Array String | optional }
+        |]
+      ) -> (Dyn -> Dyn -> Dyn -> Dyn) -> Dyn
+      | doc m%"
+          Variant of `std.contract.custom` where the immediate part can return
+          additional data upon success to be piped to the delayed part. See
+          the documentation of `std.contract.custom` for general information on
+          custom contracts, the delayed part and the immediate part.
+
+          In some contract implementations, the delayed part might take
+          different code paths depending on what the immediate part has already
+          checked. Of course, the delayed part has access to the same value to
+          be checked, so it could in theroy recover all the information it needs. However,
+          that means code duplication and work duplication.
+
+          `std.contract.custom_piped` allows the immediate part to forward
+          arbitrary data to the delayed part through the `payload` field
+          provided to the argument of `'Ok`. This payload will be passed as the
+          first argument of the delayed contract, before the label.
+
+          # Examples
+
+          The following example implements a contracts for `{tag = 'Number,
+          value | Number}` or `{tag = 'Number, value | String}`. Depending on
+          the value of `tag`, which is forced immediately, we either check that
+          the value is a number or a string.
+
+          ```nickel
+          let Union = fun Contract =>
+            std.contract.custom_piped
+              (match {
+                { tag = 'Number, value } => 'Ok {payload = Number},
+                { tag = 'String, value } => 'Ok {payload = String},
+                _ => 'Error {},
+              )
+              (fun Payload => std.contract.apply { value | Payload, .. })
+          in
+          { tag = 'Number, value = 1 } | Union
+            => { tag = 'Number, value = 1 }
+          ```
+        "%
+      = fun immediate delayed => %contract/custom% immediate delayed,
+
     delayed
       | (Dyn -> Dyn -> Dyn) -> Dyn
       | doc m%"
           Build a generic delayed custom contract.
 
-          `std.contract.delayed contract_impl` is a shortcut for
+          `std.contract.delayed contract_impl` is equivalent to
 
           ```nickel
           std.contract.custom
-            (fun _ => 'Proceed)
+            (fun _ => 'Ok)
             contract_impl
           ```
 
@@ -1291,9 +1339,9 @@
               let Contract = std.contract.custom
                 (fun value =>
                   if std.is_number value then
-                    'Proceed
-                  else
                     'Ok
+                  else
+                    'Done
                 )
                 (fun label value =>
                   std.contract.apply
@@ -1337,9 +1385,9 @@
               let Contract = std.contract.custom
                 (fun value =>
                   if std.is_number value then
-                    'Proceed
-                  else
                     'Ok
+                  else
+                    'Done
                 )
                 (fun label value =>
                   std.contract.apply
@@ -1421,9 +1469,9 @@
             std.contract.custom
               (fun value =>
                 if value == null then
-                  'Ok
+                  'Done
                 else
-                  'Proceed
+                  'Ok
               )
               (std.contract.apply Contract)
           in

--- a/core/stdlib/std.ncl
+++ b/core/stdlib/std.ncl
@@ -1116,8 +1116,12 @@
         Dyn -> [|
           'Ok,
           'Error {
-            message | String | optional,
-            notes | Array String | optional
+            message
+              | String
+              | optional,
+            notes
+              | Array String
+              | optional,
           }
         |]
       ) -> Dyn
@@ -1625,10 +1629,15 @@
                 )
             in
 
-            %contract/apply%
-              DependentFun
-              Dyn
-              (fun start => RangeSecond start -> Codomain),
+            fun label value =>
+              %contract/apply%
+                (
+                  DependentFun
+                    Dyn
+                    (fun start => RangeSecond start -> Codomain)
+                )
+                label
+                value,
 
         IndexedArrayFun
           | [| 'Index, 'Split |] -> Dyn
@@ -1704,7 +1713,7 @@
             in
 
             fun type =>
-                DependentFun
+              DependentFun
                 ArrayIndexFirst
                 (fun index => ArrayIndexSecond type index -> Dyn),
 

--- a/core/stdlib/std.ncl
+++ b/core/stdlib/std.ncl
@@ -1010,7 +1010,7 @@
 
     custom
       : (
-        Dyn -> [|
+        Dyn -> Dyn -> [|
           'Ok Dyn,
           'Error {
             message | String | optional,

--- a/core/stdlib/std.ncl
+++ b/core/stdlib/std.ncl
@@ -3100,7 +3100,7 @@
       =
         %contract/custom%
           (
-            fun value =>
+            fun _label value =>
               if %typeof% value == 'String then
                 if %string/length% value > 0 then
                   'Ok value
@@ -3108,8 +3108,7 @@
                   'Error { message = "empty string" }
               else
                 'Error { message = "not a string" }
-          )
-          null,
+          ),
 
     join
       : String -> Array String -> String
@@ -3935,7 +3934,7 @@
       ```
     "%
     = fun msg =>
-      %contract/custom% (fun _ _ => 'Error { message = msg }),
+      %contract/custom% (fun _label _value => 'Error { message = msg }),
 
   fail_with
     | String -> Dyn

--- a/core/stdlib/std.ncl
+++ b/core/stdlib/std.ncl
@@ -1625,7 +1625,8 @@
                 )
             in
 
-            DependentFun
+            %contract/apply%
+              DependentFun
               Dyn
               (fun start => RangeSecond start -> Codomain),
 
@@ -1702,13 +1703,10 @@
                 )
             in
 
-            let contract = fun type =>
-              DependentFun
+            fun type =>
+                DependentFun
                 ArrayIndexFirst
-                (fun index => ArrayIndexSecond type index -> Dyn)
-            in
-
-            contract,
+                (fun index => ArrayIndexSecond type index -> Dyn),
 
         ArraySliceFun
           | doc m%"

--- a/core/stdlib/std.ncl
+++ b/core/stdlib/std.ncl
@@ -1035,9 +1035,6 @@
           The label should only be used for delayed checks. The preferred method
           to indicate a contract violation is to return `'Error {..}`.
 
-          Custom contracts built using `std.contract.custom` are the most
-          general form of custom contracts.
-
           For more details on custom contracts and delayed contracts, please
           refer to the corresponding section of the user manual.
 
@@ -1389,27 +1386,22 @@
           with a broken contract error if the contract fails, or proceeds with
           the evaluation of the value.
 
-          Using a contract annotation, such as in `value | Contract`, eventually
-          translates to a call such as `std.contract.apply Contract label value`
-          where `label` is inserted by the Nickel interpreter.
+          A contract annotation such as `value | Contract` is eventually
+          translated (automatically) to a call to `std.contract.apply Contract label
+          value` where `label` is inserted by the Nickel interpreter.
 
           Type: `Contract -> Label -> Dyn -> Dyn`
           (for technical reasons, this function isn't actually statically typed)
-
-          Although contracts used to be naked functions a long time ago,
-          nowadays Nickel supports user-defined contracts defined as predicates,
-          as general functions, as records, etc. The interpreter also performs
-          additional bookkeeping for error reporting when applying a contract in
-          an expression `value | Contract`. You should thus not use standard
-          function application to apply a contract, even when defined as a
-          function, but use `std.contract.apply` instead.
 
           # Arguments
 
           `apply` takes three arguments. The arguments are in order:
 
-          - a contract which is currently either a custom contract, a naked
-            function or a record.
+          - a contract which is currently either a custom contract (produced by
+            the stdlib constructors `std.contract.custom`,
+            `std.contract.from_validator` or `std.contract.from_predicate`), a
+            record, a static type or a naked function (see legacy contracts
+            below).
           - a label (see `std.contract.label`)
           - the value to be checked
 
@@ -1419,23 +1411,19 @@
           delayed checks inserted inside. Some contracts even return a modified
           value, such as record contract which can set default values.
 
-          # Custom contracts
-
-          When applying a custom contract, the argument must have been produced
-          by one of the stdlib function for creating custom contracts, such as
-          `std.contract.from_predicate` or `std.contract.custom`.
+          # Legacy contracts
 
           For backward-compatibility reasons, the argument can also be a naked
           function `Label -> Dyn -> Dyn`, but this is discouraged and will be
           deprecated in the future. For such a contract, please wrap it using
-          `std.contract.custom` instead.
+          `std.contract.custom` instead (the return type must be adapted).
 
           # Examples
 
-          The example is a custom re-implementation of the builtin contract
+          This example is a custom re-implementation of the builtin contract
           `[| 'Foo Number |]`. This makes for a short illustration of `apply`,
-          but you should of course just use the builtin contract in real
-          wolrd applications.
+          but you should of course just use the builtin contract in real-world
+          applications.
 
           ```nickel
           let FooOfNumber = fun Contract =>
@@ -1486,7 +1474,7 @@
           using the parent contract message and note.
 
           This behavior is also observed when manipulating the label directly
-          instead of returning an error value.
+          and using `std.contract.blame` instead of returning an error value.
           ```
         "%
       = fun contract label value =>

--- a/core/stdlib/std.ncl
+++ b/core/stdlib/std.ncl
@@ -65,7 +65,7 @@
             fun _label value =>
               if %typeof% value == 'Array then
                 if %array/length% value != 0 then
-                  'Ok
+                  'Ok value
                 else
                   'Error { message = "empty array" }
               else
@@ -1011,31 +1011,32 @@
     custom
       : (
         Dyn -> [|
-          'Ok,
           'Ok Dyn,
-          'Error { message | String | optional, notes | Array String | optional }
+          'Error {
+            message | String | optional,
+            notes | Array String | optional
+          }
         |]
       ) -> Dyn
       | doc m%"
           Build a generic custom contract. Whenever possible, more restricted
           constructors such as `std.contract.from_predicate` or
-          `std.contract.from_validator` should be used. However,
-          `std.contract.custom` might be required to write delayed contracts or
-          contracts taking other contracts as parameters.
+          `std.contract.from_validator` should be used. However, the most
+          general `std.contract.custom` might be required to write delayed
+          contracts or contracts taking other contracts as parameters.
 
           # Custom contracts
 
           The argument of `std.contract.custom` is a function that takes a label
-          and the value to be checked, and returns either `'Ok`, `'Ok value` to
-          return a value with delayed checks inside, or `'Error {..}` to signal
-          a contract violation.
+          and the value to be checked, and returns `'Ok value` to return
+          the original value with potential delayed checks inside, or `'Error
+          {..}` to signal an immediate contract violation.
 
           The label should only be used for delayed checks. The preferred method
           to indicate a contract violiation is to return `'Error {..}`.
 
           Custom contracts built using `std.contract.custom` are the most
-          general form of custom contracts. They consist of an immediate part and a
-          delayed part.
+          general form of custom contracts.
 
           For more details on custom contracts and delayed contracts, please
           refer to the corresponding section of the user manual.
@@ -1053,11 +1054,12 @@
           let Nullable = fun Contract =>
             std.contract.custom (fun label value =>
               if value == null then
-                'Ok
+                'Ok value
               else
-                std.contract.apply Contract label value
+                std.contract.apply_as_custom Contract label value
             )
           in
+
           null | Nullable Number
             => null
           ```
@@ -1076,10 +1078,11 @@
           apply it as a normal function, as in
           `(std.contract.from_predicate my_pred) label value`. While possible,
           this wasn't recommended nor really officially supported: all contracts
-          should be applied using a contract annotation or `std.contract.apply`,
-          as explained in the documentation of `std.contract.apply`.
+          should be applied using a contract annotation or `std.contract.apply`
+          and its variants, as explained in the documentation of
+          `std.contract.apply`.
 
-          From Nickel 1.8 and ownwards, `from_predicate` generates a bespoke
+          From Nickel 1.8 and onwards, `from_predicate` generates a bespoke
           contract value that can only be used in an annotation, be passed to
           `std.contract.apply` or other operations on contracts, but can't be
           used as normal function anymore.
@@ -1103,7 +1106,7 @@
           (
             fun _label value =>
               if pred value then
-                'Ok
+                'Ok value
               else
                 'Error {}
           ),
@@ -1112,7 +1115,10 @@
       | (
         Dyn -> [|
           'Ok,
-          'Error { message | String | optional, notes | Array String | optional }
+          'Error {
+            message | String | optional,
+            notes | Array String | optional
+          }
         |]
       ) -> Dyn
       | doc m%%"
@@ -1149,12 +1155,23 @@
               'Error { message = "expected a number, got a %{vtype}" }
           })
           in
+
           0 | IsZero
           ```
         "%%
       # A validator turns out to be a valid custom contract as well (which just
       # never returns a value with delayed checks)
-      = fun validator => %contract/custom% validator,
+      = fun validator =>
+        %contract/custom%
+          (
+            fun label value =>
+              let result = validator value in
+
+              if result == 'Ok then
+                'Ok value
+              else
+                result
+          ),
 
     Sequence
       | doc m%"
@@ -1189,11 +1206,25 @@
           x | C
           ```
         "%
-      = fun contracts label value =>
-        std.array.fold_left
-          (fun acc contract => std.contract.apply contract label acc)
-          value
-          contracts,
+      = fun contracts =>
+        %contract/custom%
+          (
+            fun label value =>
+              std.array.fold_left
+                (
+                  fun acc Contract =>
+                    acc
+                    |> match {
+                      'Ok value =>
+                        std.contract.apply_as_custom Contract label value,
+                      # if we encountered an error at some point in the pipeline, we
+                      # just forward it from this point
+                      error => error
+                    }
+                )
+                ('Ok value)
+                contracts
+          ),
 
     label
       | doc m%"
@@ -1219,12 +1250,13 @@
           can't be modified anymore. All diagnostics will be shown during error
           reporting, with the most recent being used as the main one.
 
-          `std.contract.apply` is the operation that pushes a new fresh diagnostic on
-          the stack, saving the previously current error diagnostic. The function
-          `std.contract.apply` is typically used to apply subcontracts inside a parent
-          contract. Stacking the current diagnostic potentially customized by
-          the parent contract saves the information inside, and provides a fresh
-          diagnostic for the child contract to use.
+          `std.contract.apply` and `std.contract.apply_as_custom` are the
+          operations that pushes a new fresh diagnostic on the stack, saving the
+          previously current error diagnostic. `apply` and friends are typically
+          used to apply subcontracts inside a parent contract. Stacking the
+          current diagnostic potentially customized by the parent contract saves
+          the information inside, and provides a fresh diagnostic for the child
+          contract to use.
         "%
       = {
         with_message
@@ -1329,8 +1361,8 @@
               # Examples
 
               This example is illustrative. In practice, returning `'Error {..}`
-              should always be preferred over manipulating the label directly,
-              at least whenever possible.
+              should always be preferred over manipulating the label directly
+              whenever possible.
 
               ```nickel
               let AlwaysFailWithNotes = std.contract.custom (fun label _ =>
@@ -1349,24 +1381,41 @@
 
     apply
       | doc m%"
-          Applies a contract to a label and a value.
+          Applies a contract to a label and a value. Either aborts the execution
+          with a broken contract error if the contract fails, or proceed with
+          the evaluation of the value.
+
+          Using a contract annotation, such as in `value | Contract`, eventually
+          translates to a call such as `std.contract.apply Contract label value`
+          where `label` is inserted by the Nickel interpreter.
 
           Type: `Contract -> Label -> Dyn -> Dyn`
           (for technical reasons, this function isn't actually statically typed)
 
-          Nickel supports user-defined contracts defined as predicates, as
-          general functions, as records, etc. The interpreter also performs additional
-          bookkeeping for error reporting when applying a contract in an
-          expression `value | Contract`. You should thus not use standard
+          Although contracts used to be naked functions a long time ago,
+          nowadays Nickel supports user-defined contracts defined as predicates,
+          as general functions, as records, etc. The interpreter also performs
+          additional bookkeeping for error reporting when applying a contract in
+          an expression `value | Contract`. You should thus not use standard
           function application to apply a contract, even when defined as a
           function, but use `std.contract.apply` instead.
 
-          # Argument
+          # Arguments
 
-          The argument must be a contract, which is currently either a custom
-          contract or a record.
+          `apply` takes three arguments. The arguments are in order:
 
-          ## Custom contracts
+          - a contract which is currently either a custom contract, a naked
+            function or a record.
+          - a label (see `std.contract.label`)
+          - the value to be checked
+
+          # Return value
+
+          `apply` returns the original value upon success, with potential
+          delayed checks inserted inside. Some contracts even return a modified
+          value, such as record contract which can set default values.
+
+          # Custom contracts
 
           When applying a custom contract, the argument must have been produced
           by one of the stdlib function for creating custom contracts, such as
@@ -1379,14 +1428,19 @@
 
           # Examples
 
+          The example is a custom re-implementation of the builtin contract
+          `[| 'Foo Number |]`. This makes for a short illustration of `apply`,
+          but you should of course just use the builtin contract in real
+          wolrd applications.
+
           ```nickel
-          let Nullable = fun Contract =>
+          let FooOfNumber = fun Contract =>
             std.contract.custom
-              (fun value =>
-                if value == null then
-                  'Ok
-                else
-                  'Ok (std.contract.apply Contract label value)
+              (fun label =>
+                match {
+                  'Foo arg => 'Foo (std.contract.apply Contract label value),
+                  _ => 'Error {},
+                }
               )
           in
 
@@ -1404,7 +1458,7 @@
           ## Illustration
 
           ```nickel
-          let ChildContract = std.contract.custom (fun _ _ =>
+          let ChildContract = std.contract.from_validator (fun _ =>
             'Error {
               message = "child's message",
               notes = ["child's note"]
@@ -1412,7 +1466,7 @@
           )
           in
 
-          let ParentContract = std.contract.custom (fun _ _ =>
+          let ParentContract = std.contract.from_validator (fun _ =>
             'Error {
               message = "parent's message",
               notes = ["parent's note"]
@@ -1433,6 +1487,40 @@
         "%
       = fun contract label value =>
         %contract/apply% contract (%label/push_diag% label) value,
+
+    apply_as_custom
+      | doc m%"
+          Variant of `std.contract.apply` which returns `'Error {..}` upon
+          immediate failure of the contract instead of aborting the execution
+          with blame error, and wraps the return value of `std.contract.apply as
+          `'Ok value` otherwise.
+
+          Beside the return value and error handling, `apply_as_custom` has the
+          same behavior as `std.contract.apply`. See `std.contract.apply` for
+          more details.
+
+          `apply_as_custom` is intended to be used when calling a contract from
+          a custom contract, since the return type of `apply_as_custom` is
+          precisely the same the return type of a custom contract.
+
+          # Examples
+
+          ```nickel
+          let Nullable = fun Contract =>
+            std.contract.custom
+              (fun label value =>
+                if value == null then
+                  'Ok value
+                else
+                  std.contract.apply_as_custom Contract label value
+              )
+          in
+
+          { foo = 1 } | Nullable {foo | Number}
+          ```
+        "%
+      = fun contract label value =>
+        %contract/apply_as_custom% contract (%label/push_diag% label) value,
 
     unstable
       | doc m%"
@@ -1467,13 +1555,13 @@
             %contract/custom%
               (
                 fun label function =>
-                  fun arg =>
-                    let arg_with_ctr = std.contract.apply Domain label arg in
+                  'Ok (
+                    fun arg =>
+                      let arg_with_ctr = std.contract.apply Domain label arg in
 
-                    'Ok (
                       function arg_with_ctr
                       |> std.contract.apply (Codomain arg_with_ctr) label
-                    )
+                  )
               ),
 
         RangeStep
@@ -1497,7 +1585,7 @@
                       notes = ["Expected a positive number, got %{%to_string% value}"],
                     }
                   else
-                    'Ok
+                    'Ok value
               ),
 
         RangeFun
@@ -1533,7 +1621,7 @@
                         ]
                       }
                     else
-                      'Ok
+                      'Ok value
                 )
             in
 
@@ -1574,9 +1662,9 @@
                         |> attach_message
                         |> label_module.append_note "Expected array index to be a positive integer, got %{%to_string% value} "
                       in
-                      'Ok (std.contract.apply std.number.Nat label value)
+                      std.contract.apply_as_custom std.number.Nat label value
                     else
-                      'Ok
+                      'Ok value
                 )
             in
 
@@ -1585,7 +1673,13 @@
                 (
                   fun _label value =>
                     if %typeof% min_size == 'Number && %typeof% value == 'Array then
-                      let max_idx = type |> match { 'Index => %array/length% value - 1, 'Split => %array/length% value } in
+                      let max_idx =
+                        type
+                        |> match {
+                          'Index => %array/length% value - 1,
+                          'Split => %array/length% value
+                        }
+                      in
 
                       if min_size > max_idx then
                         let index_as_str = %to_string% min_size in
@@ -1602,9 +1696,9 @@
                           notes = [note],
                         }
                       else
-                        'Ok
+                        'Ok value
                     else
-                      'Ok
+                      'Ok value
                 )
             in
 
@@ -1648,9 +1742,9 @@
                         |> attach_message
                         |> label_module.append_note "Expected the array slice start index to be a positive integer, got %{%to_string% value}"
                       in
-                      'Ok (std.contract.apply std.number.Nat label value)
+                      std.contract.apply_as_custom std.number.Nat label value
                     else
-                      'Ok
+                      'Ok value
                 )
             in
 
@@ -1672,16 +1766,16 @@
                           |> attach_message
                           |> label_module.append_note "Expected the array slice end index to be a positive integer, got %{%to_string% value}"
                         in
-                        'Ok (std.contract.apply std.number.Nat label value)
+                        std.contract.apply_as_custom std.number.Nat label value
                     else
-                      'Ok
+                      'Ok value
                 )
             in
 
             let ArraySliceArray = fun end_index =>
               %contract/custom%
                 (
-                  fun label value =>
+                  fun _label value =>
                     if %typeof% end_index == 'Number
                     && %typeof% value == 'Array
                     && end_index > %array/length% value then
@@ -1695,7 +1789,7 @@
                         ],
                       }
                     else
-                      'Ok
+                      'Ok value
                 )
             in
 
@@ -1752,7 +1846,7 @@
                         ]
                       }
                     else
-                      'Ok
+                      'Ok value
                 )
             in
 
@@ -1795,7 +1889,14 @@
           error
         "%
       =
-        %contract/custom% (fun _label value => if std.is_enum value then 'Ok else 'Error {}),
+        %contract/custom%
+          (
+            fun _label value =>
+              if std.is_enum value then
+                'Ok value
+              else
+                'Error {}
+          ),
 
     TagOrString
       | doc m%%"
@@ -1837,15 +1938,14 @@
       =
         %contract/custom%
           (
-            fun label value =>
+            fun _label value =>
               %typeof% value
               |> match {
                 'String => 'Ok (%enum/from_string% value),
-                'Enum if !(is_enum_variant value) => 'Ok,
+                'Enum if !(is_enum_variant value) => 'Ok value,
                 _ =>
                   'Error {
-                    message = "expected either a string or an enum
-tag"
+                    message = "expected either a string or an enum tag"
                   },
               }
           ),
@@ -2100,7 +2200,7 @@ tag"
             fun _label value =>
               if %typeof% value == 'Number then
                 if value % 1 == 0 then
-                  'Ok
+                  'Ok value
                 else
                   'Error { message = "expected an integer" }
               else
@@ -2128,7 +2228,7 @@ tag"
             fun _label value =>
               if %typeof% value == 'Number then
                 if value % 1 == 0 && value >= 0 then
-                  'Ok
+                  'Ok value
                 else
                   'Error { message = "expected a natural" }
               else
@@ -2156,7 +2256,7 @@ tag"
             fun _label value =>
               if %typeof% value == 'Number then
                 if value % 1 == 0 && value > 0 then
-                  'Ok
+                  'Ok value
                 else
                   'Error { message = "expected a positive integer" }
               else
@@ -2182,7 +2282,7 @@ tag"
             fun _label value =>
               if %typeof% value == 'Number then
                 if value != 0 then
-                  'Ok
+                  'Ok value
                 else
                   'Error { message = "value is zero" }
               else
@@ -2894,7 +2994,7 @@ tag"
             fun _label value =>
               if %typeof% value == 'String then
                 if is_num_literal value then
-                  'Ok
+                  'Ok value
                 else
                   'Error { message = "invalid number literal" }
               else
@@ -2924,7 +3024,7 @@ tag"
             fun _label value =>
               if %typeof% value == 'String then
                 if length value == 1 then
-                  'Ok
+                  'Ok value
                 else
                   'Error { message = "length different than one" }
               else
@@ -2970,7 +3070,7 @@ tag"
               # note that `type == 'Enum` isn't sufficient, as it includes enum
               # variants
               || std.enum.is_enum_tag value then
-                'Ok
+                'Ok value
               else
                 'Error {}
           ),
@@ -2996,7 +3096,7 @@ tag"
             fun value =>
               if %typeof% value == 'String then
                 if %string/length% value > 0 then
-                  'Ok
+                  'Ok value
                 else
                   'Error { message = "empty string" }
               else
@@ -3513,7 +3613,15 @@ tag"
          => true
         ```
         "%
-      = %contract/custom% (fun _label value => if value then 'Ok else 'Error {}),
+      =
+        %contract/custom%
+          (
+            fun _label value =>
+              if value then
+                'Ok value
+              else
+                'Error {}
+          ),
 
     assert_all
       | Array Assert -> Bool

--- a/core/stdlib/std.ncl
+++ b/core/stdlib/std.ncl
@@ -1033,7 +1033,7 @@
           {..}` to signal an immediate contract violation.
 
           The label should only be used for delayed checks. The preferred method
-          to indicate a contract violiation is to return `'Error {..}`.
+          to indicate a contract violation is to return `'Error {..}`.
 
           Custom contracts built using `std.contract.custom` are the most
           general form of custom contracts.
@@ -1069,7 +1069,7 @@
     from_predicate
       | (Dyn -> Bool) -> Dyn
       | doc m%"
-          Build a custom contract from a boolean predicate.
+          Build a contract from a boolean predicate.
 
           # Contract application
 
@@ -1126,7 +1126,7 @@
         |]
       ) -> Dyn
       | doc m%%"
-          Build a custom contract from a validator.
+          Build a contract from a validator.
 
           # Validator
 
@@ -1255,7 +1255,7 @@
           reporting, with the most recent being used as the main one.
 
           `std.contract.apply` and `std.contract.apply_as_custom` are the
-          operations that pushes a new fresh diagnostic on the stack, saving the
+          operations that push a new fresh diagnostic on the stack, saving the
           previously current error diagnostic. `apply` and friends are typically
           used to apply subcontracts inside a parent contract. Stacking the
           current diagnostic potentially customized by the parent contract saves
@@ -1386,7 +1386,7 @@
     apply
       | doc m%"
           Applies a contract to a label and a value. Either aborts the execution
-          with a broken contract error if the contract fails, or proceed with
+          with a broken contract error if the contract fails, or proceeds with
           the evaluation of the value.
 
           Using a contract annotation, such as in `value | Contract`, eventually

--- a/core/stdlib/std.ncl
+++ b/core/stdlib/std.ncl
@@ -1067,7 +1067,7 @@
       = fun contract => %contract/custom% contract,
 
     from_predicate
-      : (Dyn -> Bool) -> Dyn
+      | (Dyn -> Bool) -> Dyn
       | doc m%"
           Build a custom contract from a boolean predicate.
 

--- a/core/stdlib/std.ncl
+++ b/core/stdlib/std.ncl
@@ -62,16 +62,15 @@
       =
         %contract/custom%
           (
-            fun value =>
+            fun _label value =>
               if %typeof% value == 'Array then
                 if %array/length% value != 0 then
-                  'Done
+                  'Ok
                 else
                   'Error { message = "empty array" }
               else
                 'Error { message = "not a array" }
-          )
-          null,
+          ),
 
     first
       : forall a. Array a -> a
@@ -1010,55 +1009,33 @@
       = fun message label => %blame% (%label/with_message% message label),
 
     custom
-      | (
+      : (
         Dyn -> [|
           'Ok,
-          'Done,
+          'Ok Dyn,
           'Error { message | String | optional, notes | Array String | optional }
         |]
-      ) -> (Dyn -> Dyn -> Dyn) -> Dyn
+      ) -> Dyn
       | doc m%"
-          Build a generic custom contract from an immediate part and a delayed
-          part.
+          Build a generic custom contract. Whenever possible, more restricted
+          constructors such as `std.contract.from_predicate` or
+          `std.contract.from_validator` should be used. However,
+          `std.contract.custom` might be required to write delayed contracts or
+          contracts taking other contracts as parameters.
 
-          # Immediate vs delayed
+          # Custom contracts
 
-          In general, you should write immediate contracts whenever possible,
-          using for example `std.contract.from_predicate` or
-          `std.contract.from_validator`, as they are easier to write and support
-          more operations.
+          The argument of `std.contract.custom` is a function that takes a label
+          and the value to be checked, and returns either `'Ok`, `'Ok value` to
+          return a value with delayed checks inside, or `'Error {..}` to signal
+          a contract violation.
 
-          However, those specialized constructors might not cover all your
-          needs, in particular when implementing delayed contracts (such as
-          contracts operating on functions or data structures like records and
-          arrays) or contracts that might take other delayed contracts as
-          parameters and apply them (using `std.contract.apply`).
+          The label should only be used for delayed checks. The preferred method
+          to indicate a contract violiation is to return `'Error {..}`.
 
-          Custom contracts built using `std.contract.custom` and
-          `std.contract.custom_piped` are the most general form of custom
-          contracts. They consist of an immediate part and a delayed part.
-
-          ## Immediate part
-
-          The immediate part is a function that takes the checked value as a
-          parameter and returns either:
-
-          - `'Done` indicating that the whole contract should succeed immediately
-            without running the delayed part
-          - `'Ok` indicating that the immediate part has succeeded but that
-            we should still proceed with the delayed part
-          - `'Error {..}` indicating that the contract should fail with provided
-            error information.
-
-          The immediate part is thus similar to a validator, excepted that they
-          can return the additional `'Done` value (see
-          `std.contract.from_validator`).
-
-          ## Delayed part
-
-          The delayed part must be a function taking a label and a value as
-          parameters, and either blame the label or return the original value
-          with potential delayed checks pushed inside.
+          Custom contracts built using `std.contract.custom` are the most
+          general form of custom contracts. They consist of an immediate part and a
+          delayed part.
 
           For more details on custom contracts and delayed contracts, please
           refer to the corresponding section of the user manual.
@@ -1068,97 +1045,29 @@
           Because Nickel doesn't currently have proper types for labels and
           contracts, they are replaced with `Dyn` in the type signature. You can
           think of the actual type of the delayed part as `(Label -> Dyn ->
-          Dyn)`, and the return type of `custom` as `Contract`.
+          [| ... |])`, and the return type of `custom` as `Contract`.
 
           # Examples
 
           ```nickel
           let Nullable = fun Contract =>
-            std.contract.custom
-              (fun value =>
-                if value == null then
-                  'Done
-                else
-                  'Ok
-              )
-              (std.contract.apply Contract)
+            std.contract.custom (fun label value =>
+              if value == null then
+                'Ok
+              else
+                std.contract.apply Contract label value
+            )
           in
           null | Nullable Number
             => null
           ```
         "%
-      = fun immediate delayed => %contract/custom% immediate delayed,
-
-    custom_piped
-      | (
-        Dyn -> [|
-          'Ok { payload },
-          'Done,
-          'Error { message | String | optional, notes | Array String | optional }
-        |]
-      ) -> (Dyn -> Dyn -> Dyn -> Dyn) -> Dyn
-      | doc m%"
-          Variant of `std.contract.custom` where the immediate part can return
-          additional data upon success to be piped to the delayed part. See
-          the documentation of `std.contract.custom` for general information on
-          custom contracts, the delayed part and the immediate part.
-
-          In some contract implementations, the delayed part might take
-          different code paths depending on what the immediate part has already
-          checked. Of course, the delayed part has access to the same value to
-          be checked, so it could in theroy recover all the information it needs. However,
-          that means code duplication and work duplication.
-
-          `std.contract.custom_piped` allows the immediate part to forward
-          arbitrary data to the delayed part through the `payload` field
-          provided to the argument of `'Ok`. This payload will be passed as the
-          first argument of the delayed contract, before the label.
-
-          # Examples
-
-          The following example implements a contracts for `{tag = 'Number,
-          value | Number}` or `{tag = 'Number, value | String}`. Depending on
-          the value of `tag`, which is forced immediately, we either check that
-          the value is a number or a string.
-
-          ```nickel
-          let Union = fun Contract =>
-            std.contract.custom_piped
-              (match {
-                { tag = 'Number, value } => 'Ok {payload = Number},
-                { tag = 'String, value } => 'Ok {payload = String},
-                _ => 'Error {},
-              )
-              (fun Payload => std.contract.apply { value | Payload, .. })
-          in
-          { tag = 'Number, value = 1 } | Union
-            => { tag = 'Number, value = 1 }
-          ```
-        "%
-      = fun immediate delayed => %contract/custom% immediate delayed,
-
-    delayed
-      | (Dyn -> Dyn -> Dyn) -> Dyn
-      | doc m%"
-          Build a generic delayed custom contract.
-
-          `std.contract.delayed contract_impl` is equivalent to
-
-          ```nickel
-          std.contract.custom
-            (fun _ => 'Ok)
-            contract_impl
-          ```
-
-          Please refer to the documentation of `std.contract.custom` for more
-          details.
-        "%
-      = fun delayed => %contract/custom% null delayed,
+      = fun contract => %contract/custom% contract,
 
     from_predicate
-      | (Dyn -> Bool) -> Dyn
+      : (Dyn -> Bool) -> Dyn
       | doc m%"
-          Build an immediate custom contract from a boolean predicate.
+          Build a custom contract from a boolean predicate.
 
           # Contract application
 
@@ -1192,13 +1101,12 @@
       = fun pred =>
         %contract/custom%
           (
-            fun value =>
+            fun _label value =>
               if pred value then
                 'Ok
               else
                 'Error {}
-          )
-          null,
+          ),
 
     from_validator
       | (
@@ -1208,7 +1116,7 @@
         |]
       ) -> Dyn
       | doc m%%"
-          Build an immediate custom contract from a validator.
+          Build a custom contract from a validator.
 
           # Validator
 
@@ -1244,7 +1152,9 @@
           0 | IsZero
           ```
         "%%
-      = fun validator => %contract/custom% validator null,
+      # A validator turns out to be a valid custom contract as well (which just
+      # never returns a value with delayed checks)
+      = fun validator => %contract/custom% validator,
 
     Sequence
       | doc m%"
@@ -1297,6 +1207,10 @@
           manipulated by the functions in this module. Labels thus offer a way to
           customize the error message that will be shown if a contract is broken.
 
+          Note that the label should only be used for delayed checks. Immediate
+          error reporting is better done in custom contracts by returning an
+          error value.
+
           The setters (`with_XXX` functions) always operate on the current error
           diagnostic, which is the last diagnotic on the stack. If the stack is
           empty, a fresh diagnostic is silently created when using a setter.
@@ -1333,28 +1247,32 @@
 
               # Examples
 
-              ```nickel
-              let ContractNum = std.contract.from_predicate (fun x => x > 0 && x < 50) in
+              This example implements a contract which ensures that the value is
+              a record with a field `foo` that is an even number.
 
-              let Contract = std.contract.custom
-                (fun value =>
-                  if std.is_number value then
-                    'Ok
-                  else
-                    'Done
-                )
-                (fun label value =>
-                  std.contract.apply
-                    ContractNum
-                    (std.contract.label.with_message
-                      "num subcontract failed! (out of bound)"
-                      label
-                    )
-                    value
-                )
+              ```nickel
+              let FooIsEven = std.contract.custom (fun label =>
+                match {
+                  record @ { foo, .. } =>
+                    'Ok (
+                      std.record.map (fun key value =>
+                        if key == "foo"
+                        && !(std.is_number value && value % 2 == 0) then
+                          label
+                          |> std.contract.label.with_message "field foo must be an even number"
+                          |> std.contract.blame
+                        else
+                          value
+                      )
+                      record
+                    ),
+                  _ => 'Error {},
+                }
+              )
               in
 
-              5 | Contract
+              { foo = 4, hello = "world" } | FooIsEven
+                => { foo = 4, hello = "world" }
               ```
             "%
           = fun message label => %label/with_message% message label,
@@ -1379,31 +1297,22 @@
 
               # Examples
 
-              ```nickel
-              let ContractNum = std.contract.from_predicate (fun x => x > 0 && x < 50) in
+              This example is illustrative. In practice, returning `'Error {..}`
+              should always be preferred over manipulating the label directly,
+              at least whenever possible.
 
-              let Contract = std.contract.custom
-                (fun value =>
-                  if std.is_number value then
-                    'Ok
-                  else
-                    'Done
-                )
-                (fun label value =>
-                  std.contract.apply
-                    ContractNum
-                    (label
-                     |> std.contract.label.with_message "num subcontract failed! (out of bound)"
-                     |> std.contract.label.with_notes [
-                          "The value was a number, but this number is outside the expected bounds",
-                          "The value must be a number between 0 and 50, both excluded",
-                        ]
-                    )
-                    value
-                )
+              ```nickel
+              let AlwaysFailWithNotes = std.contract.custom (fun label _ =>
+                label
+                |> std.contract.label.with_notes [
+                  "This is note 1",
+                  "This is note 2",
+                ]
+                |> std.contract.blame
+              )
               in
 
-              5 | Contract
+              null | AlwaysFailWithNotes
               ```
             "%
           # the %label/with_notes% operator expects an array of strings which is
@@ -1419,15 +1328,21 @@
 
               # Examples
 
+              This example is illustrative. In practice, returning `'Error {..}`
+              should always be preferred over manipulating the label directly,
+              at least whenever possible.
+
               ```nickel
-              let AlwaysFailWithNotes = std.contract.delayed (fun label _ =>
+              let AlwaysFailWithNotes = std.contract.custom (fun label _ =>
                 label
                 |> std.contract.label.append_note "This is note 1"
                 |> std.contract.label.append_note "This is note 2"
                 |> std.contract.blame
               )
               in
+
               null | AlwaysFailWithNotes
+              ```
             "%
           = fun note label => %label/append_note% note label,
       },
@@ -1460,7 +1375,7 @@
           For backward-compatibility reasons, the argument can also be a naked
           function `Label -> Dyn -> Dyn`, but this is discouraged and will be
           deprecated in the future. For such a contract, please wrap it using
-          `std.contract.custom` or `std.contract.delayed` instead.
+          `std.contract.custom` instead.
 
           # Examples
 
@@ -1469,15 +1384,13 @@
             std.contract.custom
               (fun value =>
                 if value == null then
-                  'Done
-                else
                   'Ok
+                else
+                  'Ok (std.contract.apply Contract label value)
               )
-              (std.contract.apply Contract)
           in
 
-          let Contract = Nullable {foo | Number} in
-          { foo = 1 } | Contract
+          { foo = 1 } | Nullable {foo | Number}
           ```
 
           # Diagnostics stack
@@ -1491,21 +1404,19 @@
           ## Illustration
 
           ```nickel
-          let ChildContract = std.contract.delayed (fun label value =>
-            label
-            |> std.contract.label.with_message "child's message"
-            |> std.contract.label.append_note "child's note"
-            |> std.contract.blame
+          let ChildContract = std.contract.custom (fun _ _ =>
+            'Error {
+              message = "child's message",
+              notes = ["child's note"]
+            }
           )
           in
 
-          let ParentContract = std.contract.delayed (fun label value =>
-            let label =
-              label
-              |> std.contract.label.with_message "parent's message"
-              |> std.contract.label.append_note "parent's note"
-            in
-            std.contract.apply ChildContract label value
+          let ParentContract = std.contract.custom (fun _ _ =>
+            'Error {
+              message = "parent's message",
+              notes = ["parent's note"]
+            }
           )
           in
 
@@ -1516,18 +1427,8 @@
           message and note of the child contract, and a secondary diagnostic,
           using the parent contract message and note.
 
-          While we wrote both contracts as delayed contracts, note that this
-          behavior is also observed if e.g. `ChildContract` is a validator
-          instead:
-
-          ```nickel
-          let ChildContract = std.contract.from_validator (fun _ =>
-            'Error {
-              message = "child's message",
-              notes = ["child's note"]
-            }
-          ) in
-          # etc.
+          This behavior is also observed when manipulating the label directly
+          instead of returning an error value.
           ```
         "%
       = fun contract label value =>
@@ -1564,13 +1465,15 @@
             "%
           = fun Domain Codomain =>
             %contract/custom%
-              null
               (
                 fun label function =>
                   fun arg =>
                     let arg_with_ctr = std.contract.apply Domain label arg in
-                    function arg_with_ctr
-                    |> std.contract.apply (Codomain arg_with_ctr) label
+
+                    'Ok (
+                      function arg_with_ctr
+                      |> std.contract.apply (Codomain arg_with_ctr) label
+                    )
               ),
 
         RangeStep
@@ -1587,7 +1490,7 @@
           =
             %contract/custom%
               (
-                fun value =>
+                fun _label value =>
                   if %typeof% value == 'Number && value < 0 then
                     'Error {
                       message = "invalid range step",
@@ -1595,8 +1498,7 @@
                     }
                   else
                     'Ok
-              )
-              null,
+              ),
 
         RangeFun
           | doc m%"
@@ -1613,36 +1515,31 @@
               example, if the first argument is a string, this contract silently
               passes.
             "%
-          =
-            # capture the `contract.label` module to avoid name collisions with
-            # local contract argument `label`
-            let label_module = label in
-            let attach_message = label_module.with_message "invalid range" in
+          = fun Codomain =>
+            let RangeSecond = fun start =>
+              %contract/custom%
+                (
+                  fun _label value =>
+                    if %typeof% start == 'Number
+                    && %typeof% value == 'Number
+                    && start > value then
+                      let start_as_str = %to_string% start in
+                      let end_as_str = %to_string% value in
 
-            fun Codomain =>
-              let RangeSecond = fun start =>
-                %contract/custom%
-                  null
-                  (
-                    fun label value =>
-                      if %typeof% start == 'Number && %typeof% value == 'Number then
-                        if start > value then
-                          let start_as_str = %to_string% start in
-                          let end_as_str = %to_string% value in
-                          label
-                          |> attach_message
-                          |> label_module.append_note "Expected a range end greater than %{start_as_str} (range start), got %{end_as_str}"
-                          |> blame
-                        else
-                          value
-                      else
-                        value
-                  )
-              in
+                      'Error {
+                        message = "invalid range",
+                        notes = [
+                          "Expected a range end greater than %{start_as_str} (range start), got %{end_as_str}"
+                        ]
+                      }
+                    else
+                      'Ok
+                )
+            in
 
-              DependentFun
-                Dyn
-                (fun start => RangeSecond start -> Codomain),
+            DependentFun
+              Dyn
+              (fun start => RangeSecond start -> Codomain),
 
         IndexedArrayFun
           | [| 'Index, 'Split |] -> Dyn
@@ -1669,7 +1566,6 @@
 
             let ArrayIndexFirst =
               %contract/custom%
-                null
                 (
                   fun label value =>
                     if %typeof% value == 'Number then
@@ -1678,19 +1574,19 @@
                         |> attach_message
                         |> label_module.append_note "Expected array index to be a positive integer, got %{%to_string% value} "
                       in
-                      std.contract.apply std.number.Nat label value
+                      'Ok (std.contract.apply std.number.Nat label value)
                     else
-                      value
+                      'Ok
                 )
             in
 
             let ArrayIndexSecond = fun type min_size =>
               %contract/custom%
-                null
                 (
-                  fun label value =>
+                  fun _label value =>
                     if %typeof% min_size == 'Number && %typeof% value == 'Array then
                       let max_idx = type |> match { 'Index => %array/length% value - 1, 'Split => %array/length% value } in
+
                       if min_size > max_idx then
                         let index_as_str = %to_string% min_size in
                         let max_as_str = %to_string% max_idx in
@@ -1700,14 +1596,15 @@
                           else
                             "Expected an array index between 0 and %{max_as_str} (included), got %{index_as_str}"
                         in
-                        label
-                        |> attach_message
-                        |> label_module.append_note note
-                        |> blame
+
+                        'Error {
+                          message = "invalid array indexing",
+                          notes = [note],
+                        }
                       else
-                        value
+                        'Ok
                     else
-                      value
+                      'Ok
                 )
             in
 
@@ -1743,7 +1640,6 @@
 
             let SliceIndexFirst =
               %contract/custom%
-                null
                 (
                   fun label value =>
                     if %typeof% value == 'Number then
@@ -1752,54 +1648,57 @@
                         |> attach_message
                         |> label_module.append_note "Expected the array slice start index to be a positive integer, got %{%to_string% value}"
                       in
-                      std.contract.apply std.number.Nat label value
+                      'Ok (std.contract.apply std.number.Nat label value)
                     else
-                      value
+                      'Ok
                 )
             in
 
             let SliceIndexSecond = fun start =>
               %contract/custom%
-                null
                 (
                   fun label value =>
                     if %typeof% start == 'Number && %typeof% value == 'Number then
                       if value < start then
-                        label
-                        |> attach_message
-                        |> label_module.append_note "Expected the array slice indices to satisfy `start <= end`, but got %{%to_string% start} (start) and %{%to_string% value} (end)"
-                        |> blame
+                        'Error {
+                          message = "invalid array slice indexing",
+                          notes = [
+                            "Expected the array slice indices to satisfy `start <= end`, but got %{%to_string% start} (start) and %{%to_string% value} (end)"
+                          ],
+                        }
                       else
                         let label =
                           label
                           |> attach_message
                           |> label_module.append_note "Expected the array slice end index to be a positive integer, got %{%to_string% value}"
                         in
-                        %contract/apply% std.number.Nat label value
+                        'Ok (std.contract.apply std.number.Nat label value)
                     else
-                      value
+                      'Ok
                 )
             in
 
             let ArraySliceArray = fun end_index =>
               %contract/custom%
-                null
                 (
                   fun label value =>
-                    if %typeof% end_index == 'Number && %typeof% value == 'Array then
-                      if end_index > %array/length% value then
-                        let index_as_str = %to_string% end_index in
-                        let size_as_str = %to_string% (%array/length% value) in
-                        label
-                        |> attach_message
-                        |> label_module.append_note "Expected the slice end index to be between 0 and %{size_as_str} (array's length), got %{index_as_str}"
-                        |> blame
-                      else
-                        value
+                    if %typeof% end_index == 'Number
+                    && %typeof% value == 'Array
+                    && end_index > %array/length% value then
+                      let index_as_str = %to_string% end_index in
+                      let size_as_str = %to_string% (%array/length% value) in
+
+                      'Error {
+                        message = "invalid array slice indexing",
+                        notes = [
+                          "Expected the slice end index to be between 0 and %{size_as_str} (array's length), got %{index_as_str}"
+                        ],
+                      }
                     else
-                      value
+                      'Ok
                 )
             in
+
             DependentFun
               SliceIndexFirst
               (
@@ -1838,34 +1737,28 @@
               In this example, the first call to `f` won't blame, but the second
               will, as `baz` isn't a field of the record argument.
             "%%
-          =
-            # capture the `contract.label` module to avoid name collisions with
-            # local contract argument `label`
-            let label_module = label in
-            let attach_message = label_module.with_message "missing field" in
-
-            fun Codomain =>
-              let HasFieldSecond = fun field =>
-                %contract/custom%
-                  null
-                  (
-                    fun label value =>
-                      if %typeof% field == 'String
-                      && %typeof% value == 'Record
-                      && !(%record/has_field% field value) then
-                        label
-                        |> attach_message
-                        |> label_module.append_note
+          = fun Codomain =>
+            let HasFieldSecond = fun field =>
+              %contract/custom%
+                (
+                  fun _label value =>
+                    if %typeof% field == 'String
+                    && %typeof% value == 'Record
+                    && !(%record/has_field% field value) then
+                      'Error {
+                        message = "missing field",
+                        notes = [
                           "The record given as an argument lacks the required field `%{field}`."
-                        |> blame
-                      else
-                        value
-                  )
-              in
+                        ]
+                      }
+                    else
+                      'Ok
+                )
+            in
 
-              DependentFun
-                Dyn
-                (fun field => HasFieldSecond field -> Codomain),
+            DependentFun
+              Dyn
+              (fun field => HasFieldSecond field -> Codomain),
       }
   },
 
@@ -1902,9 +1795,7 @@
           error
         "%
       =
-        %contract/custom%
-          (fun value => if std.is_enum value then 'Ok else 'Error {})
-          null,
+        %contract/custom% (fun _label value => if std.is_enum value then 'Ok else 'Error {}),
 
     TagOrString
       | doc m%%"
@@ -1945,23 +1836,17 @@
       "%%
       =
         %contract/custom%
-          null
           (
             fun label value =>
-              let label =
-                std.contract.label.with_message
-                  "expected either a string or an enum tag"
-                  label
-              in
               %typeof% value
               |> match {
-                'String => %enum/from_string% value,
-                'Enum =>
-                  if is_enum_variant value then
-                    std.contract.blame label
-                  else
-                    value,
-                _ => std.contract.blame label,
+                'String => 'Ok (%enum/from_string% value),
+                'Enum if !(is_enum_variant value) => 'Ok,
+                _ =>
+                  'Error {
+                    message = "expected either a string or an enum
+tag"
+                  },
               }
           ),
 
@@ -2212,16 +2097,15 @@
       =
         %contract/custom%
           (
-            fun value =>
+            fun _label value =>
               if %typeof% value == 'Number then
                 if value % 1 == 0 then
                   'Ok
                 else
-                  'Error { message = "not an integer" }
+                  'Error { message = "expected an integer" }
               else
-                'Error { message = "not a number" }
-          )
-          null,
+                'Error { message = "expected a number" }
+          ),
 
     Nat
       | doc m%"
@@ -2241,16 +2125,15 @@
       =
         %contract/custom%
           (
-            fun value =>
+            fun _label value =>
               if %typeof% value == 'Number then
                 if value % 1 == 0 && value >= 0 then
                   'Ok
                 else
-                  'Error { message = "not a natural" }
+                  'Error { message = "expected a natural" }
               else
-                'Error { message = "not a number" }
-          )
-          null,
+                'Error { message = "expected a number" }
+          ),
 
     PosNat
       | doc m%"
@@ -2270,16 +2153,15 @@
       =
         %contract/custom%
           (
-            fun value =>
+            fun _label value =>
               if %typeof% value == 'Number then
                 if value % 1 == 0 && value > 0 then
                   'Ok
                 else
-                  'Error { message = "not positive integer" }
+                  'Error { message = "expected a positive integer" }
               else
-                'Error { message = "not a number" }
-          )
-          null,
+                'Error { message = "expected a number" }
+          ),
 
     NonZero
       | doc m%"
@@ -2297,16 +2179,15 @@
       =
         %contract/custom%
           (
-            fun value =>
+            fun _label value =>
               if %typeof% value == 'Number then
                 if value != 0 then
                   'Ok
                 else
-                  'Error { message = "is zero" }
+                  'Error { message = "value is zero" }
               else
-                'Error { message = "not a number" }
-          )
-          null,
+                'Error { message = "expected a number" }
+          ),
 
     is_integer
       : Number -> Bool
@@ -3010,16 +2891,15 @@
 
         %contract/custom%
           (
-            fun value =>
+            fun _label value =>
               if %typeof% value == 'String then
                 if is_num_literal value then
                   'Ok
                 else
                   'Error { message = "invalid number literal" }
               else
-                'Error { message = "not a string" }
-          )
-          null,
+                'Error { message = "expected a string" }
+          ),
 
     Character
       | doc m%"
@@ -3041,16 +2921,15 @@
       =
         %contract/custom%
           (
-            fun value =>
+            fun _label value =>
               if %typeof% value == 'String then
                 if length value == 1 then
                   'Ok
                 else
                   'Error { message = "length different than one" }
               else
-                'Error { message = "not a string" }
-          )
-          null,
+                'Error { message = "expected a string" }
+          ),
 
     Stringable
       | doc m%"
@@ -3081,24 +2960,20 @@
       =
         %contract/custom%
           (
-            fun value =>
+            fun _label value =>
               let type = std.typeof value in
-              let check =
-                value == null
-                || type == 'Number
-                || type == 'Bool
-                || type == 'String
-                # note that `type == 'Enum` isn't sufficient, as it includes enum
-                # variants
-                || std.enum.is_enum_tag value
-              in
 
-              if check then
+              if value == null
+              || type == 'Number
+              || type == 'Bool
+              || type == 'String
+              # note that `type == 'Enum` isn't sufficient, as it includes enum
+              # variants
+              || std.enum.is_enum_tag value then
                 'Ok
               else
                 'Error {}
-          )
-          null,
+          ),
 
     NonEmpty
       | doc m%"
@@ -3638,7 +3513,7 @@
          => true
         ```
         "%
-      = %contract/custom% (fun value => if value then 'Ok else 'Error {}) null,
+      = %contract/custom% (fun _label value => if value then 'Ok else 'Error {}),
 
     assert_all
       | Array Assert -> Bool
@@ -3945,7 +3820,7 @@
       ```
     "%
     = fun msg =>
-      %contract/custom% (fun _ => 'Error { message = msg }) null,
+      %contract/custom% (fun _ _ => 'Error { message = msg }),
 
   fail_with
     | String -> Dyn

--- a/core/tests/integration/inputs/contracts/custom_generic_fail.ncl
+++ b/core/tests/integration/inputs/contracts/custom_generic_fail.ncl
@@ -2,5 +2,5 @@
 #
 # [test.metadata]
 # error = 'EvalError::BlameError'
-let AlwaysFail = std.contract.custom (fun _ => 'Proceed) (fun label _ => std.contract.blame label) in
+let AlwaysFail = std.contract.custom (fun _ => 'Ok) (fun label _ => std.contract.blame label) in
 3 | AlwaysFail

--- a/core/tests/integration/inputs/contracts/custom_generic_fail.ncl
+++ b/core/tests/integration/inputs/contracts/custom_generic_fail.ncl
@@ -2,5 +2,5 @@
 #
 # [test.metadata]
 # error = 'EvalError::BlameError'
-let AlwaysFail = std.contract.custom (fun _ => 'Ok) (fun label _ => std.contract.blame label) in
+let AlwaysFail = std.contract.custom (fun label _ => std.contract.blame label) in
 3 | AlwaysFail

--- a/core/tests/integration/inputs/contracts/custom_generic_immediate_fail.ncl
+++ b/core/tests/integration/inputs/contracts/custom_generic_immediate_fail.ncl
@@ -2,5 +2,5 @@
 #
 # [test.metadata]
 # error = 'EvalError::BlameError'
-let AlwaysFail = std.contract.custom (fun _ => 'Error {}) (fun _ value => value) in
+let AlwaysFail = std.contract.custom (fun _ _ => 'Error {}) in
 3 | AlwaysFail

--- a/core/tests/integration/inputs/contracts/custom_generic_succeed.ncl
+++ b/core/tests/integration/inputs/contracts/custom_generic_succeed.ncl
@@ -1,9 +1,7 @@
 # test.type = 'pass'
-let AlwaysSucceedImmediate = std.contract.custom (fun _ => 'Done) (fun label _ => std.contract.blame label) in
-let AlwaysSucceedFull = std.contract.custom (fun _ => 'Ok) (fun _ value => value) in
+let AlwaysSucceed = std.contract.custom (fun _ value => 'Ok value) in
 
 (
   3
-    | AlwaysSucceedImmediate
-    | AlwaysSucceedFull
+    | AlwaysSucceed
 ) == 3

--- a/core/tests/integration/inputs/contracts/custom_generic_succeed.ncl
+++ b/core/tests/integration/inputs/contracts/custom_generic_succeed.ncl
@@ -1,6 +1,6 @@
 # test.type = 'pass'
-let AlwaysSucceedImmediate = std.contract.custom (fun _ => 'Ok) (fun label _ => std.contract.blame label) in
-let AlwaysSucceedFull = std.contract.custom (fun _ => 'Proceed) (fun _ value => value) in
+let AlwaysSucceedImmediate = std.contract.custom (fun _ => 'Done) (fun label _ => std.contract.blame label) in
+let AlwaysSucceedFull = std.contract.custom (fun _ => 'Ok) (fun _ value => value) in
 
 (
   3

--- a/doc/manual/contracts.md
+++ b/doc/manual/contracts.md
@@ -348,7 +348,7 @@ let Nullable = fun Contract =>
       if value == null then
         'Ok value
       else
-        'Ok (std.contract.apply Contract label value)
+        'Ok (std.contract.apply_as_custom Contract label value)
     )
 in
 

--- a/doc/manual/contracts.md
+++ b/doc/manual/contracts.md
@@ -931,7 +931,7 @@ execute the `Bool` contracts right away*. Each contract will only be run when
 the individual fields will be accessed or exported.
 
 We proceed to the immediate checks. We first check if the value is a record and
-return `'Error {..}` otherwise. Then, we iterate over over all the record field
+return `'Error {..}` otherwise. Then, we iterate over all the record field
 names and check that each one is a sequence of digits. We use a right fold
 because of its short-circuiting capabilities: as soon as an `'Error` is
 encountered, `fold_right` doesn't need to evaluate the rest and returns

--- a/doc/manual/contracts.md
+++ b/doc/manual/contracts.md
@@ -323,9 +323,9 @@ let Nullable = fun Contract =>
   std.contract.custom
     (fun value =>
       if value == null then
-        'Ok
+        'Done
       else
-        'Proceed
+        'Ok
     )
     (std.contract.apply Contract)
 in
@@ -732,8 +732,8 @@ The most general form of contract thus has two parts:
 
 - the *immediate part* which is evaluated first and produces an answer right
     away. This answer is either:
-  - `'Ok` to signal immediate success and forego the delayed checks (if any)
-  - `'Proceed` to signal that the immediate part didin't detect any error, but
+  - `'Done` to signal immediate success and forego the delayed checks (if any)
+  - `'Ok` to signal that the immediate part didn't detect any error, but
       the delayed checks must still be performed
   - `'Error {..}` to signal immediate failure
 
@@ -744,7 +744,7 @@ The most general form of contract thus has two parts:
   ```nickel
   Dyn -> [|
     'Ok,
-    'Proceed,
+    'Done,
     'Error {
       message | String | optional,
       notes | Array String | optional
@@ -835,7 +835,7 @@ value which is wrapping the original value with delayed checks inside**:
                   message = "field name `%{field_name}` is not a number"
                 }
             )
-            'Proceed
+            'Ok
         else
           'Error { message = "not a record" }
       )
@@ -862,9 +862,9 @@ the value is a record and return `'Error {..}` otherwise. Then, we loop over
 over all the record field names and check that each one is a sequence of digits.
 We use a right fold because of its short-circuiting capabilities: as soon as an
 `'Error` is encountered, `fold_right` doesn't need to evaluate the rest and
-returns immediately. We provide the base value `'Proceed`, which will be
-picked if all the fields are valid, and indicates that the immediate part has
-succeeded and that the contract system should now proceed with the delayed part.
+returns immediately. We provide the base value `'Ok`, which will be picked if
+all the fields are valid, and indicates that the immediate part has succeeded
+and that the contract system should now proceed with the delayed part.
 
 We could theoretically have made the whole contact delayed by pushing those
 checks down each field, together with the `Bool` contract application, but it's
@@ -898,7 +898,7 @@ Let us see if we indeed preserved laziness:
                   message = "field name `%{field_name}` is not a number"
                 }
             )
-            'Proceed
+            'Ok
         else
           'Error { message = "not a record" }
       )
@@ -944,7 +944,7 @@ it check anything, though?
                   message = "field name `%{field_name}` is not a number"
                 }
             )
-            'Proceed
+            'Ok
         else
           'Error { message = "not a record" }
       )

--- a/doc/manual/typing.md
+++ b/doc/manual/typing.md
@@ -588,9 +588,9 @@ calling to the statically typed `std.array.filter` from dynamically typed code:
 ```nickel #repl
 > std.array.filter (fun x => if x % 2 == 0 then x else null) [1,2,3,4,5,6]
 error: contract broken by the caller of `filter`
-    ┌─ <stdlib/std.ncl>:378:25
+    ┌─ <stdlib/std.ncl>:377:25
     │
-378 │       : forall a. (a -> Bool) -> Array a -> Array a
+377 │       : forall a. (a -> Bool) -> Array a -> Array a
     │                         ---- expected return type of a function provided by the caller
     │
     ┌─ <repl-input-6>:1:55

--- a/examples/config-gcc/config-gcc.ncl
+++ b/examples/config-gcc/config-gcc.ncl
@@ -13,8 +13,8 @@ let GccFlag =
   std.contract.custom
     (
       match {
-        value if std.is_string value && is_valid_flag value => 'Ok,
-        { flag, arg } if std.array.elem flag supported_flags => 'Proceed,
+        value if std.is_string value && is_valid_flag value => 'Done,
+        { flag, arg } if std.array.elem flag supported_flags => 'Ok,
         value if std.is_string value =>
           'Error { message = "unknown flag %{value}" },
         { flag, arg = _ } =>

--- a/examples/config-gcc/config-gcc.ncl
+++ b/examples/config-gcc/config-gcc.ncl
@@ -12,25 +12,23 @@ let GccFlag =
 
   std.contract.custom
     (
-      match {
-        value if std.is_string value && is_valid_flag value => 'Done,
-        { flag, arg } if std.array.elem flag supported_flags => 'Ok,
-        value if std.is_string value =>
-          'Error { message = "unknown flag %{value}" },
-        { flag, arg = _ } =>
-          'Error { message = "unknown flag %{flag}" },
-        { .. } =>
-          'Error {
-            message = "bad record structure: missing field `flag` or `arg`",
-          },
-        _ => 'Error { message = "expected record or string" },
-      }
+      fun label =>
+        match {
+          value if std.is_string value && is_valid_flag value => 'Ok value,
+          { flag, arg } if std.array.elem flag supported_flags =>
+            # We normalize a record representation to a string
+            'Ok "%{flag}%{arg}",
+          value if std.is_string value =>
+            'Error { message = "unknown flag %{value}" },
+          { flag, arg = _ } =>
+            'Error { message = "unknown flag %{flag}" },
+          { .. } =>
+            'Error {
+              message = "bad record structure: missing field `flag` or `arg`",
+            },
+          _ => 'Error { message = "expected record or string" },
+        }
     )
-    # The delayed part is only used for normalization. Given the immediate part,
-    # we enter the delayed part if and only if the flag has the form
-    # `{flag, arg}`. We don't perform any check and just normalize it to a
-    # string
-    (fun _ value => "%{value.flag}%{value.arg}")
 in
 
 let Path =


### PR DESCRIPTION
#1975 introduced a new model for custom contracts, where they are split between an immediate and a delayed part.

The motivation is to eventually introduce boolean combinators (`any_of`, `not`, etc.), and also to make the user interface of contracts more friendly.

This PR started as a migration of all the builtin contracts to the new model. However, it didn't exactly go as expected.

## Issues with split representation

### Data flow

Some cases in the stdlib required to pass data from the immediate part to the delayed part. Of course, this data can be recomputed, because the delayed part gets the original value as well, but those computations might be expensive: in our case, it's the projection of a record onto a record type (separating the tail from the rest), which is supposedly at least linear in the size of the records.

The original fix was to have a new possible return value for the immediate part, `'Ok {payload = _}`, and call the delayed part with this payload, so the delayed part becomes `fun payload label value => ...`. This adds complications in explaining this interface in the manual, and I originally kept two version of `std.contract.custom`, one without payload and one with payload.

What's more, the contract for record types makes more sense as one block. Separating it into the immediate part and the delayed part felt a bit artificial and made the logic harder to follow (although the forced separation is kinda the point of the current line of work).

### Contract composition

The split representation makes contract composition tricky:

```nickel
let Nullable = fun Contract =>
  std.contract.custom
    (fun value =>
      if value == null then
        'Done
      else
        'Ok
     )
    (std.contract.apply Contract)
  )
```

This is a natural definition of `Nullable`, but it's not the right one: `Nullable Number` is now a delayed contract (running the immediate part only tells you if the value is null, but not if it's a number, while it could be known immediately). So the right definition would be something like:

```nickel
let Nullable = fun Contract =>
  std.contract.custom
    (fun value =>
      if value == null then
        'Done
      else
        (std.contract.get_immediate Contract) value
     )
    (std.contract.get_delayed Contract)
  )
```

as noticed by @jneem in #1975, but this is more cumbersome and not very intuitive. 

### Implementation complexities

The split design also just makes for much more code in the implementation. Several things are duplicated for immediate and delayed part, each builtin contract now needs two internal implementations (the immediate and the delayed), this requires also more stdlib functions (`get_delayed`, `get_immediate`, `custom_piped`, etc.), and the design with `%contract/custom%` taking nullable parts was questionable (impossible to type statically, null tests in the internals module, etc.).

All in all, after the first round of migrating builtin contracts to the split representation, and migrating it back to the new representation of this PR, the diff was something like (before test fixes and documentation updates):

```
12 files changed, 685 insertions(+), 1147 deletions(-)
```

which does hint at the fact that the new approach is just simpler.

## A combined representation

This PR adopts a different representation. The fundamental observation is that we can encode the immediate/delayed distinction in the return type of a custom contract, using an enum:

```
CustomContractImp := Label -> Dyn -> [| 'Ok Dyn, 'Error {..} |]
```

This type is a mix of the type of the immediate part and the delayed part introduced in #1975. It takes both a value and a label, but return an enum. The idea is that immediate errors are reported using the return value (instead of blaming the label), which makes them catchable and subject to boolean operations. When the immediate checks succeed, the contract can return `'Ok`, but also provides the new value with the delayed checks. Now, it's quite easy to implement `get_immediate` and `get_delayed` in term of this unique representation:

```nickel
get_immediate : CustomContractImpl -> Validator = fun impl value =>
  impl null value
  |> match {
    'Ok _ => 'Ok,
    error => error,
  }

get_delayed: CustomContractImpl -> Delayed = fun impl label value =>
  impl label value
  |> match {
    'Ok value => value,
    error =>
      let label_with_error_data = [...] in
      std.contract.blame label_with_error_data,
  }
```

There is the minor detail that we need to provide a label in the immediate part, and we give `null`, which should be fine because the label shouldn't be used in the immediate check, but we can't predict that still. It's irrelevant anyway; we actually don't need proper `get_immediate` and `get_delayed` functions. The point is that this contract representation encodes the same information and is sufficient to implement boolean operations.

### Composition

With the all-smashed-in-one design, the naive composition has already the right properties:

```
let Nullable = fun Contract =>
  std.contract.custom
    (fun label value =>
      if value == null then
        'Ok
      else
        std.contract.apply_as_custom Contract label value
    )
```

There is one caveat: we can't use `std.contract.apply` here. I mean, we could:

```
let Nullable = fun Contract =>
  std.contract.custom
    (fun label value =>
      if value == null then
        'Ok
      else
        'Ok (std.contract.apply Contract label value)
    )
```

But we would be in the same situation as before: we artificially make `Contract` entirely delayed. So, this PR adds a `apply_as_custom`, whose name is to be bikeshed, which applies a contract but doesn't convet `'Error` to throwing blame error like `apply` does. Instead, it preserve the catchable errors and the immediate part of composition of contracts.

## Content

This PR changes the representation of custom contracts to the new one, and migrates all builtin contracts to the new representation. It adds some new primops and stdlib function, and update the documentation as well.

### Record contracts

Record contracts application was conveniently implemented just as a variant of the merge operation. This PR needs to adapt this code, because `merge` would signal immediate errors by returning a `BlameError`, which makes it delayed/non catchable. One possibility would have been to implement part of the contract in pure Nickel, but this is wasteful: merge has to perform a field splitting operation anyway, so checking for extra field immediately is basically free. Doing that in user-code would be duplicating this work, or would need to make yet a new version of merge that can take a partially prepared result.

In fact, it was simpler to just make the existing variant of merge to adapt to the custom contract signature: it wraps the result in `'Ok` and signal immediate errors by generating an `'Error` term.

## Future

- bikeshed the name of `std.contract.apply_as_custom`
- Implement the boolean operators on contracts