### PR TITLE
clean up outdated primitive operator names

### DIFF
--- a/cli/tests/snapshot/snapshots/snapshot__eval_stderr_record_access.ncl.snap
+++ b/cli/tests/snapshot/snapshots/snapshot__eval_stderr_record_access.ncl.snap
@@ -2,6 +2,6 @@
 source: cli/tests/snapshot/main.rs
 expression: err
 ---
-error: record_insert: tried to extend a record with the field bar, but it already exists
+error: record/insert: tried to extend a record with the field bar, but it already exists
 
 

--- a/core/src/term/mod.rs
+++ b/core/src/term/mod.rs
@@ -1235,8 +1235,8 @@ pub enum UnaryOp {
     /// Typecast an enum to a larger enum type.
     ///
     /// `EnumEmbed` is used to upcast enums. For example, if a value `x` has enum type `a | b`,
-    /// then `enum/embed c x` will have enum type `a | b | c`. It only affects typechecking as at
-    /// runtime `enum/embed someId` acts like the identity function.
+    /// then `%enum/embed% c x` will have enum type `a | b | c`. It only affects typechecking as at
+    /// runtime `%enum/embed% someId` acts like the identity function.
     EnumEmbed(LocIdent),
 
     /// A specialized primop for match when all patterns are enum tags. In that case, instead of
@@ -1257,7 +1257,7 @@ pub enum UnaryOp {
     ///
     /// The mapped function must take two arguments, the name of the field as a string, and the
     /// content of the field. `RecordMap` then replaces the content of each field by the result of
-    /// the function: i.e., `record/map f {a=2;}` evaluates to `{a=(f "a" 2);}`.
+    /// the function: i.e., `%record/map% f {a=2;}` evaluates to `{a=(f "a" 2);}`.
     RecordMap,
 
     /// Inverse the polarity of a label.
@@ -2721,7 +2721,7 @@ pub mod make {
         Term::OpN(op, args.into_iter().map(T::into).collect()).into()
     }
 
-    pub fn contract_apply<T>(
+    pub fn apply_contract<T>(
         typ: Type,
         l: Label,
         t: T,

--- a/core/src/term/mod.rs
+++ b/core/src/term/mod.rs
@@ -1234,9 +1234,9 @@ pub enum UnaryOp {
 
     /// Typecast an enum to a larger enum type.
     ///
-    /// `Embed` is used to upcast enums. For example, if a value `x` has enum type `a | b`, then
-    /// `embed c x` will have enum type `a | b | c`. It only affects typechecking as at runtime
-    /// `embed someId` act like the identity.
+    /// `EnumEmbed` is used to upcast enums. For example, if a value `x` has enum type `a | b`,
+    /// then `enum/embed c x` will have enum type `a | b | c`. It only affects typechecking as at
+    /// runtime `enum/embed someId` acts like the identity function.
     EnumEmbed(LocIdent),
 
     /// A specialized primop for match when all patterns are enum tags. In that case, instead of
@@ -1257,7 +1257,7 @@ pub enum UnaryOp {
     ///
     /// The mapped function must take two arguments, the name of the field as a string, and the
     /// content of the field. `RecordMap` then replaces the content of each field by the result of
-    /// the function: i.e., `recordMap f {a=2;}` evaluates to `{a=(f "a" 2);}`.
+    /// the function: i.e., `record/map f {a=2;}` evaluates to `{a=(f "a" 2);}`.
     RecordMap,
 
     /// Inverse the polarity of a label.
@@ -2721,7 +2721,7 @@ pub mod make {
         Term::OpN(op, args.into_iter().map(T::into).collect()).into()
     }
 
-    pub fn apply_contract<T>(
+    pub fn contract_apply<T>(
         typ: Type,
         l: Label,
         t: T,

--- a/core/src/typ.rs
+++ b/core/src/typ.rs
@@ -980,7 +980,7 @@ impl Subcontract for EnumRows {
         //   x |> match {
         //     'foo => x,
         //     'bar => x,
-        //     'Baz variant_arg => 'Baz (%apply_contract% T label_arg variant_arg),
+        //     'Baz variant_arg => 'Baz (%contract/apply% T label_arg variant_arg),
         //     _ => $enum_fail l
         //   }
         // ```
@@ -996,7 +996,7 @@ impl Subcontract for EnumRows {
                     });
 
                     let body = if let Some(ty) = row.typ.as_ref() {
-                        // 'Tag (%apply_contract% T label_arg variant_arg)
+                        // 'Tag (%contract/apply% T label_arg variant_arg)
                         let arg = mk_app!(
                             mk_term::op2(
                                 BinaryOp::ContractApply,

--- a/core/stdlib/internals.ncl
+++ b/core/stdlib/internals.ncl
@@ -82,16 +82,17 @@
     if polarity == current_polarity then
       %unseal% sealing_key value (%blame% label)
     else
-      # [^forall_chng_pol]: Blame assignment for polymorphic contracts
-      # should take into account the polarity at the point the forall was
-      # introduced, not the current polarity of the variable occurrence. Indeed,
-      # forall can never blame in a negative position (relative to the
+      # [^forall_label_flip_polarity]: Blame assignment for polymorphic
+      # contracts should take into account the polarity at the point the forall
+      # was introduced, not the current polarity of the variable occurrence.
+      # Indeed, forall can never blame in a negative position (relative to the
       # forall): the contract is entirely on the callee.
       #
       # Thus, for correct blame assignment, we want to set the polarity to the
-      # forall polarity (here `polarity`). Because we only have the `chng_pol`
-      # primop, and we know that in this branch they are unequal, flipping the
-      # current polarity will indeed give the original forall's polarity.
+      # forall polarity (here `polarity`). Because we only have the
+      # `label/flip_polarity` primop, and we know that in this branch they are
+      # unequal, flipping the current polarity will indeed give the original
+      # forall's polarity.
       %seal% sealing_key (%label/flip_polarity% label) value,
 
   "$forall" = fun sealing_key polarity contract label value =>
@@ -254,7 +255,7 @@
               label
           )
       else
-        # See [^forall_chng_pol]
+        # See [^forall_label_flip_polarity]
         %record/seal_tail% sealing_key (%label/flip_polarity% label) acc value,
 
   "$dyn_tail" = fun acc label value => acc & value,

--- a/core/stdlib/internals.ncl
+++ b/core/stdlib/internals.ncl
@@ -90,7 +90,7 @@
       #
       # Thus, for correct blame assignment, we want to set the polarity to the
       # forall polarity (here `polarity`). Because we only have the
-      # `label/flip_polarity` primop, and we know that in this branch they are
+      # `%label/flip_polarity%` primop, and we know that in this branch they are
       # unequal, flipping the current polarity will indeed give the original
       # forall's polarity.
       %seal% sealing_key (%label/flip_polarity% label) value,

--- a/notes/fixing-sealing-and-recursive-records.md
+++ b/notes/fixing-sealing-and-recursive-records.md
@@ -120,14 +120,14 @@ Final result:
 Run of a `%record/map% { foo | Num =  1, bar | PosNat | Even = foo + 1} (fun _key ((+) 1)`
 
 ```
-App(Op1(record_map, record), function)
-Op1(record_map, record); {stack..}
+App(Op1(record/map, record), function)
+Op1(record/map, record); {stack..}
 record ~ RecRecord {..}
 
 RECORD{ foo |pending Num = %1, bar |pending [PosNat,Even] = %2}
-%2 := (%apply_contract% Num label %1) + 1
+%2 := (%contract/apply% Num label %1) + 1
 
-RECORD{ foo = f (%apply_contract% Num %1), bar = f (%apply_contract% PosNat,Even %2) }
+RECORD{ foo = f (%contract/apply% Num %1), bar = f (%contract/apply% PosNat,Even %2) }
 
 # With a call to pending_contract.dualize()
 


### PR DESCRIPTION
PR #1937 recently renamed many primitive operators. It missed some instances of the previous names, though. In particular:

- error messages
- comments
- documentation
- an unused function "apply_contract" in core/src/term/mod.rs

While most of these names were only made obsolete in #1937, some of them have been incorrect for longer, eg "%array_access%" in core/src/term/pattern/compile.rs and "recordMap" in core/src/term/mod.rs.

I caught as many as I could find. However it's hard to be sure I got all of them, given that some of the previous names are very general terms like "value", "fields", "length", and "map".

The full list of renames I identifiend are as follows, formatted as `<old name> <new name>`.

First, the easy cases:

    chng_pol label/flip_polarity
    record_map record/map
    str_trim string/trim
    str_chars string/chars
    str_uppercase string/uppercase
    str_lowercase string/lowercase
    str_length string/length
    str_from to_string
    num_from number/from_string
    enum_from enum/from_string
    str_is_match string/is_match
    str_find string/find
    str_find_all string/find_all
    record_empty_with_tail record/empty_with_tail
    label_push_diag label/push_diag
    enum_unwrap_variant enum/unwrap_variant
    enum_is_variant enum/is_variant
    enum_get_tag enum/get_tag
    apply_contract contract/apply
    array_lazy_app_ctr contract/array_lazy_app
    record_lazy_app_ctr contract/record_lazy_app
    elem_at array/at
    str_split string/split
    str_contains string/contains
    record_insert record/insert
    record_insert_with_opts record/insert_with_opts
    record_remove record/remove
    record_remove_with_opts record/remove_with_opts
    label_with_message label/with_message
    label_with_notes label/with_notes
    label_append_note label/append_note
    str_replace string/replace
    str_replace_regex string/replace_regex
    str_substr string/substr
    record_seal_tail record/seal_tail
    record_unseal_tail record/unseal_tail
    array_slice array/slice

Then the harder cases:

    polarity label/polarity
    go_dom label/go_dom
    go_codom label/go_codom
    go_array label/go_array
    go_dict label/go_dict
    embed enum/embed
    map array/map
    generate array/generate
    length array/length
    fields record/fields
    fields_with_opts record/fields_with_opts
    values record/values
    go_field label/go_field
    has_field record/has_field
    has_field_with_opts record/has_field_with_opts
    field_is_defined record/field_is_defined
    field_is_defined_with_opts record/field_is_defined_with_opts
    lookup_type_variable label/lookup_type_variable
    insert_type_variable label/insert_type_variable

Finally, two cases that I didn't understand and seem to be unused:

    rec_force_op op rec_force
    rec_default_op op rec_default