### PR TITLE
[Profiling] Track more metrics

### DIFF
--- a/core/src/eval/mod.rs
+++ b/core/src/eval/mod.rs
@@ -81,6 +81,7 @@ use crate::{
     identifier::Ident,
     identifier::LocIdent,
     match_sharedterm,
+    metrics::increment,
     position::TermPos,
     program::FieldPath,
     term::{
@@ -775,6 +776,8 @@ impl<R: ImportResolver, C: Cache> VirtualMachine<R, C> {
                     }
                 }
                 Term::ResolvedImport(id) => {
+                    increment!(format!("import:{id:?}"));
+
                     if let Some(t) = self.import_resolver.get(id) {
                         Closure::atomic_closure(t)
                     } else {
@@ -838,6 +841,8 @@ impl<R: ImportResolver, C: Cache> VirtualMachine<R, C> {
                 // avoiding repeated contract application. Annotations could then be a good way of
                 // remembering which contracts have been applied to a value.
                 Term::Annotated(annot, inner) => {
+                    increment!("contract:free-standing(annotated)");
+
                     // We apply the contract coming from the static type annotation separately as
                     // it is optimized.
                     let static_contract = annot.static_contract();

--- a/core/src/pretty.rs
+++ b/core/src/pretty.rs
@@ -1277,6 +1277,32 @@ macro_rules! impl_display_from_pretty {
     };
 }
 
+/// Provide a method to pretty-print a long term, type, etc. (anything that implements `ToString`,
+/// really) capped to a maximum length.
+pub trait PrettyPrintCap: ToString {
+    /// Pretty print an object capped to a given max length (in characters). Useful to limit the
+    /// size of terms reported e.g. in typechecking errors. If the output of pretty printing is
+    /// greater than the bound, the string is truncated to `max_width` and the last character after
+    /// truncate is replaced by the ellipsis unicode character U+2026.
+    fn pretty_print_cap(&self, max_width: usize) -> String {
+        let output = self.to_string();
+
+        if output.len() <= max_width {
+            output
+        } else {
+            let (end, _) = output.char_indices().nth(max_width).unwrap();
+            let mut truncated = String::from(&output[..end]);
+
+            if max_width >= 2 {
+                truncated.pop();
+                truncated.push('\u{2026}');
+            }
+
+            truncated
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use pretty::BoxAllocator;

--- a/core/src/repl/query_print.rs
+++ b/core/src/repl/query_print.rs
@@ -1,9 +1,13 @@
 //! Rendering of the results of a metadata query.
-use crate::identifier::{Ident, LocIdent};
-use crate::term::{
-    record::{Field, FieldMetadata},
-    MergePriority, Term,
+use crate::{
+    identifier::{Ident, LocIdent},
+    pretty::PrettyPrintCap,
+    term::{
+        record::{Field, FieldMetadata},
+        MergePriority, Term,
+    },
 };
+
 use std::{io, io::Write};
 
 /// The maximum width for pretty-printing default values. Beyond this limit, the content is cut and

--- a/core/src/term/mod.rs
+++ b/core/src/term/mod.rs
@@ -28,9 +28,12 @@ use crate::{
     label::{Label, MergeLabel},
     match_sharedterm,
     position::{RawSpan, TermPos},
+    pretty::PrettyPrintCap,
     typ::{Type, UnboundTypeVariableError},
     typecheck::eq::{contract_eq, type_eq_noenv},
 };
+
+use crate::metrics::increment;
 
 use codespan::FileId;
 
@@ -477,7 +480,10 @@ impl RuntimeContract {
         env2: &Environment,
     ) {
         for c in contracts.iter() {
+            increment!("contracts:equality-checks");
+
             if contract_eq(0, &c.contract, env1, &ctr.contract, env2) {
+                increment!("contracts:deduped");
                 return;
             }
         }
@@ -2032,29 +2038,9 @@ impl RichTerm {
         self.pos = pos;
         self
     }
-
-    /// Pretty print a term capped to a given max length (in characters). Useful to limit the size
-    /// of terms reported e.g. in typechecking errors. If the output of pretty printing is greater
-    /// than the bound, the string is truncated to `max_width` and the last character after
-    /// truncate is replaced by the ellipsis unicode character U+2026.
-    pub fn pretty_print_cap(&self, max_width: usize) -> String {
-        let output = self.to_string();
-
-        if output.len() <= max_width {
-            output
-        } else {
-            let (end, _) = output.char_indices().nth(max_width).unwrap();
-            let mut truncated = String::from(&output[..end]);
-
-            if max_width >= 2 {
-                truncated.pop();
-                truncated.push('\u{2026}');
-            }
-
-            truncated
-        }
-    }
 }
+
+impl PrettyPrintCap for RichTerm {}
 
 /// Flow control for tree traverals.
 pub enum TraverseControl<S, U> {

--- a/core/src/term/pattern/compile.rs
+++ b/core/src/term/pattern/compile.rs
@@ -24,6 +24,7 @@
 //! we can generate inlined versions on-the-fly here).
 use super::*;
 use crate::{
+    metrics::increment,
     mk_app,
     term::{
         make, record::FieldMetadata, BinaryOp, MatchBranch, MatchData, NAryOp, RecordExtKind,
@@ -873,6 +874,8 @@ impl Compile for MatchData {
     //      # this primop evaluates body with an environment extended with bindings_id
     //      %pattern_branch% body bindings_id
     fn compile(mut self, value: RichTerm, pos: TermPos) -> RichTerm {
+        increment!("pattern_compile");
+
         if self.branches.iter().all(|branch| {
             // While we could get something working even with a guard, it's a bit more work and
             // there's no current incentive to do so (a guard on a tags-only match is arguably less
@@ -1034,6 +1037,8 @@ struct TagsOnlyMatch {
 
 impl Compile for TagsOnlyMatch {
     fn compile(self, value: RichTerm, pos: TermPos) -> RichTerm {
+        increment!("pattern_comile(tags_only_match)");
+
         // We simply use the corresponding specialized primop in that case.
         let match_op = mk_app!(
             make::op1(

--- a/core/src/typ.rs
+++ b/core/src/typ.rs
@@ -46,8 +46,10 @@ use crate::{
     identifier::{Ident, LocIdent},
     impl_display_from_pretty,
     label::Polarity,
+    metrics::increment,
     mk_app, mk_fun,
     position::TermPos,
+    pretty::PrettyPrintCap,
     stdlib::internals,
     term::{
         array::Array, make as mk_term, record::RecordData, string::NickelString, IndexMap,
@@ -1334,6 +1336,8 @@ impl Type {
     /// Return the contract corresponding to a type. Said contract must then be applied using the
     /// `ApplyContract` primitive operation.
     pub fn contract(&self) -> Result<RichTerm, UnboundTypeVariableError> {
+        increment!(format!("gen_contract:{}", self.pretty_print_cap(40)));
+
         let mut sy = 0;
 
         self.subcontract(Environment::new(), Polarity::Positive, &mut sy)
@@ -1484,3 +1488,5 @@ impl_display_from_pretty!(EnumRow);
 impl_display_from_pretty!(EnumRows);
 impl_display_from_pretty!(RecordRow);
 impl_display_from_pretty!(RecordRows);
+
+impl PrettyPrintCap for Type {}


### PR DESCRIPTION
This PR adds many more metrics to what's currently being tracked (when compiled with the `metrics` feature and run with `--metrics` argument). In particular, we track the number of times each primop is called individually, each contract is applied, the number of contract deduped, etc. We also sort the result to ease diffing across different revisions.

Metrics are mostly used by us maintainers for performance profiling and aren't user-facing (gated by both a feature flag and an argument).