### PR TITLE
[Optimization] Implement `prepare_custom_contract` natively

### DIFF
--- a/cli/tests/snapshot/snapshots/snapshot__eval_stderr_function_contract_domain_violation.ncl.snap
+++ b/cli/tests/snapshot/snapshots/snapshot__eval_stderr_function_contract_domain_violation.ncl.snap
@@ -16,15 +16,7 @@ error: contract broken by the caller
   │ --- evaluated to this value
 
 note: 
-  ┌─ [INPUTS_PATH]/errors/function_contract_domain_violation.ncl:5:31
-  │
-5 │ let Foo = Number -> Number in ((fun x => x) | Foo) "a"
-  │                               ------------------------ (1) calling <func>
-
-note: 
   ┌─ [INPUTS_PATH]/errors/function_contract_domain_violation.ncl:5:32
   │
 5 │ let Foo = Number -> Number in ((fun x => x) | Foo) "a"
-  │                                ------------ (2) calling <func>
-
-
+  │                                ^^^^^^^^^^^^ While calling to x

--- a/cli/tests/snapshot/snapshots/snapshot__eval_stderr_record_forall_constraints_contract.ncl.snap
+++ b/cli/tests/snapshot/snapshots/snapshot__eval_stderr_record_forall_constraints_contract.ncl.snap
@@ -16,15 +16,3 @@ note:
   │
 3 │ let f | forall r. { ; r } -> { x: Number; r } = fun r => %record/insert% "x" r 1 in f { x = 0 }
   │                                                          ^^^^^^^^^^^^^^^^^^^^^^^ While calling to r
-
-note: 
-  ┌─ [INPUTS_PATH]/errors/record_forall_constraints_contract.ncl:3:85
-  │
-3 │ let f | forall r. { ; r } -> { x: Number; r } = fun r => %record/insert% "x" r 1 in f { x = 0 }
-  │                                                                                     ----------- (1) calling f
-
-note: 
-  ┌─ [INPUTS_PATH]/errors/record_forall_constraints_contract.ncl:3:49
-  │
-3 │ let f | forall r. { ; r } -> { x: Number; r } = fun r => %record/insert% "x" r 1 in f { x = 0 }
-  │                                                 -------------------------------- (2) calling <func>

--- a/core/src/term/mod.rs
+++ b/core/src/term/mod.rs
@@ -1501,6 +1501,13 @@ pub enum UnaryOp {
     /// type constructor for custom contracts.
     ContractCustom,
 
+    /// After applying a custom contract (or a builtin contract), the result is either `'Ok value`
+    /// or `'Error err_data`. This primop post-processes this return value (the first argument) to
+    /// either produce `value` in the first case or to attach the error data to the label (the
+    /// second argument, taken from the stack, as this op isn't strict in the label) and blame in
+    /// the second.
+    ContractPostprocessResult,
+
     /// The cosinus function.
     NumberArcCos,
 
@@ -1580,6 +1587,7 @@ impl fmt::Display for UnaryOp {
 
             PatternBranch => write!(f, "pattern_branch"),
             ContractCustom => write!(f, "contract/custom"),
+            ContractPostprocessResult => write!(f, "contract/postprocess_result"),
 
             NumberArcCos => write!(f, "number/arccos"),
             NumberArcSin => write!(f, "number/arcsin"),
@@ -1732,6 +1740,9 @@ pub enum BinaryOp {
     /// [Self::ContractCheck] preserves the immediate/delayed part of the called contract.
     ContractCheck,
 
+    /// Take a record of type `{message | String | optional, notes | String | optional}`.
+    LabelWithErrorData,
+
     /// Unseal a sealed term.
     ///
     /// See [`BinaryOp::Seal`].
@@ -1883,6 +1894,7 @@ impl fmt::Display for BinaryOp {
             GreaterOrEq => write!(f, "(>=)"),
             ContractApply => write!(f, "contract/apply"),
             ContractCheck => write!(f, "contract/check"),
+            LabelWithErrorData => write!(f, "label/with_error_data"),
             Unseal => write!(f, "unseal"),
             LabelGoField => write!(f, "label/go_field"),
             RecordInsert {

--- a/core/stdlib/internals.ncl
+++ b/core/stdlib/internals.ncl
@@ -385,51 +385,6 @@
   # are no extra fields, so we can just ignore them and return the value as is.
   "$empty_tail" = fun _extra_fields _label value => 'Ok value,
 
-  # Take a a partial identity Label -> Dyn -> Dyn that can then be passed
-  # applied as a normal funtion in the implementation of `contract/apply`.
-  "$prepare_custom_contract" = fun custom_contract label value =>
-    custom_contract label value
-    |> match {
-      'Ok value => value,
-      'Error { message ? null, notes ? [], .. } =>
-        let label =
-          if std.is_string message then
-            %label/with_message% message label
-          else
-            label
-        in
-
-        let label =
-          if notes != [] && std.is_array notes then
-            %label/with_notes% (%force% notes) label
-          else
-            label
-        in
-
-        %blame% label,
-      # The contract of `std.contract.custom` should guarantee that we
-      # never reach this case. However, nothing prevents user from using
-      # `%contract/custom%` directly, so we still try to handle a misbehaving
-      # custom contract gracefully.
-      value =>
-        %blame%
-          (
-            %label/with_notes%
-              (
-                %force%
-                  (
-                    %trace%
-                      value
-                      [
-                        "The implementation of this custom contract returned an invalid result (which must be of type `[| 'Ok Dyn, 'Error {..} |]`)",
-                        "Please check the implementation of the contract that has been broken"
-                      ]
-                  )
-              )
-              label
-          )
-    },
-
   # Dual of prepare_custom_contract. Turns a naked function of a label and a
   # value to a custom contract-like representation (that is, a function
   # returning an enum - however the result is still a naked function, which must


### PR DESCRIPTION
## Motivation and content

After the rework of the contract system that sets enum as the default return type of most custom and builtin contracts, some additional glue code was needed to post-process such enums (and raise blame accordingly). This has been implemented in the new internal function `$prepare_custom_contract`.

While this function wasn't very long or involved, measurements showed that contract application is a code path that is taken so much that this additional blob of pure Nickel slowed down real world example by potentially a huge factor (up to 5x).

While this is the symptom of other inefficiencies related to the contract system in general (related to pattern matching, missed caching opportunities for contract generation, etc.), bringing back the logic of `$prepare_custom_contract` to native code brings back the overhead (master compared to latest stable 1.7) to something like 1.1x or 1.2x.

This commit implements this strategy, by introducing two new primops:

- `%contract/postprocess_result%` which takes an enum `[| 'Ok value, 'Error error_data |]` and either unwrap `'Ok`, or modify the label using the `error_data` and then blame
- `%label/with_error_data%`, which is used in the previous primop implementation but can be useful as a stand alone primop and stdlib wrapper in the future, which takes a value `{message, notes}`, a label, and update the label's data with the corresponding diagnostic message and notes

Additionally, this commit tries to avoid generating terms at run-time, but rather setup the stack directly, to further make this hot path faster.

Overall, it's a very ad-hoc optimization, which is a little sad and makes the Rust code a bit heavier. We should strive for general optimizations or architectural improvements that would be global (and not just for contract application), but in this case, the measures show that `contract/apply` is just run so much that a specialization is mandated. It doesn't prevent us from seeking more general optimizations.

## Stack traces

Some snapshot tests show that the stack trace seems to be much shorter than previously. I'm not sure if it's the error reporting code that decides to cut them, or the stack elements that we generate at run-time make some of the callstack analysis heuristics fail. In any case, I don't have a simple solution, and honestly the callstack handling has been rather dark magic until then - maybe it's time to fix it in a more systematic rework of this part,