### PR TITLE
[Optimization] Remove the contract guarding contract.apply

### DIFF
--- a/core/stdlib/std.ncl
+++ b/core/stdlib/std.ncl
@@ -1424,7 +1424,6 @@
       },
 
     apply
-      : Dyn -> Dyn -> Dyn -> Dyn
       | doc m%"
           Applies a contract to a label and a value. Either aborts the execution
           with a broken contract error if the contract fails, or proceeds with
@@ -1437,6 +1436,12 @@
           Note that depending on the situation, you might need the variant
           `std.contract.check` instead. Please refer to the documentation of
           `std.contract.check` for more information.
+
+          # Type
+
+          For technical reasons, `apply` isn't statically typed nor protected by
+          a contract. The hypothetical type of `apply` is `Contract -> Label ->
+          Dyn -> Dyn` (note `Contract` and `Label` currently don't exist).
 
           # Arguments
 


### PR DESCRIPTION
Many contract helpers didn't have any type nor contract themselves in the latest stable version of Nickel. With the contract system rework, we've added missing annotations to make sure user writing contracts would have better error messages.

However, this isn't free: on a medium-sized benchmark (25kLoC), `contract.apply` (the one from the stdlib, not the primop, which is called even more obviously) is called approximately 100k times, which has an impact on performance. While `contract.custom` or `contract.check` need their contract which is non trivial, `contract.apply` is hard to type and thus gets a rather vague type `Dyn -> Dyn -> Dyn -> Dyn`, which doesn't add much validation.

This commit removes the contract of `std.contract.apply`, reverting back to the 1.7 situation, which shows non trivial improvements on the benchmark mentioned above (around 10% gain).