### PR TITLE
Track benchmarks in CI

### DIFF
--- a/.github/workflows/benchmark-master.yaml
+++ b/.github/workflows/benchmark-master.yaml
@@ -1,8 +1,7 @@
-name: benchmark pull requests
+name: benchmark master
 on:
   push:
     branches: master
-  pull_request:
 jobs:
   benchmark-master:
     name: benchmark master

--- a/.github/workflows/benchmark-pr.yaml
+++ b/.github/workflows/benchmark-pr.yaml
@@ -1,0 +1,28 @@
+name: benchmark pull requests
+on:
+  pull_request:
+    types: [opened, reopened, edited, synchronize]
+
+jobs:
+  benchmark-pr:
+    name: benchmark pr
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: cachix/install-nix-action@V27
+        name: "Installing Nix"
+        with:
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+            accept-flake-config = true
+          nix_path: "nixpkgs=channel:nixos-unstable"
+      - name: run benchmarks
+        run: |
+          nix develop --command cargo bench --package nickel-lang-core --bench numeric > criterion-output.txt
+      - name: upload results
+        uses: actions/upload-artifact@v4
+        with:
+          name: criterion-output
+          path: criterion-output.txt

--- a/.github/workflows/benchmark-pr.yaml
+++ b/.github/workflows/benchmark-pr.yaml
@@ -1,3 +1,14 @@
+# This is the part of the benchmark runner that runs on pull requests.
+# It's separate from the master runner for two reasons:
+# - to track it differently on bencher.dev, because we only want to use master as
+#   the historical baseline for comparison
+# - because it might want to run on PRs from forks, and those don't get access to the
+#   bencher API key.
+#
+# See the [bencher docs] for more details.
+#
+# [bencher docs]:  https://bencher.dev/docs/how-to/github-actions/#benchmark-fork-pr-and-upload-from-default-branch
+
 name: benchmark pull requests
 on:
   pull_request:

--- a/.github/workflows/release-artifacts.yaml
+++ b/.github/workflows/release-artifacts.yaml
@@ -1,4 +1,4 @@
-name: Upload release artifacts
+name: Test Docker manifest
 on:
   release:
     types: [published]

--- a/.github/workflows/run-benchmark.yaml
+++ b/.github/workflows/run-benchmark.yaml
@@ -14,4 +14,4 @@ jobs:
           fetch-depth: 0
       - name: Run benchmarks
         run: |
-          cargo bench --package nickel-lang-core --bench numeric
+          nix develop --command cargo bench --package nickel-lang-core --bench numeric

--- a/.github/workflows/run-benchmark.yaml
+++ b/.github/workflows/run-benchmark.yaml
@@ -19,7 +19,7 @@ jobs:
           --project nickel \
           --token '${{ secrets.BENCHER_API_TOKEN }}' \
           --branch main \
-          --testbed ubuntu-latest
-          --adapter criterion
+          --testbed ubuntu-latest \
+          --adapter criterion \
           --err \
           cargo bench --package nickel-lang-core --bench numeric

--- a/.github/workflows/run-benchmark.yaml
+++ b/.github/workflows/run-benchmark.yaml
@@ -20,6 +20,6 @@ jobs:
           --token '${{ secrets.BENCHER_API_TOKEN }}' \
           --branch main \
           --testbed ubuntu-latest \
-          --adapter criterion \
+          --adapter rust_criterion \
           --err \
           cargo bench --package nickel-lang-core --bench numeric

--- a/.github/workflows/run-benchmark.yaml
+++ b/.github/workflows/run-benchmark.yaml
@@ -7,19 +7,11 @@ on:
 jobs:
   runBenchmark:
     name: run benchmark
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: bencherdev/bencher@main
       - name: Run benchmarks
         run: |
-          bencher run \
-          --project nickel \
-          --token '${{ secrets.BENCHER_API_TOKEN }}' \
-          --branch main \
-          --testbed ubuntu-latest \
-          --adapter rust_criterion \
-          --err \
           cargo bench --package nickel-lang-core --bench numeric

--- a/.github/workflows/run-benchmark.yaml
+++ b/.github/workflows/run-benchmark.yaml
@@ -1,17 +1,23 @@
 name: benchmark pull requests
 on:
   push:
-    branches:
-      - master
+    branches: master
   pull_request:
 jobs:
-  runBenchmark:
-    name: run benchmark
+  benchmark-master:
+    name: benchmark master
     runs-on: [self-hosted, Linux, X64]
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Run benchmarks
+      - uses: bencherdev/bencher@main
+      - name: Track benchmarks on master
         run: |
+          bencher run \
+          --project nickel \
+          --token '${{ secrets.BENCHER_API_TOKEN }}' \
+          --branch master \
+          --testbed build01 \
+          --adapter rust_criterion \
           nix develop --command cargo bench --package nickel-lang-core --bench numeric

--- a/.github/workflows/run-benchmark.yaml
+++ b/.github/workflows/run-benchmark.yaml
@@ -6,11 +6,18 @@ on:
 jobs:
   benchmark-master:
     name: benchmark master
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - uses: cachix/install-nix-action@V27
+        name: "Installing Nix"
+        with:
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+            accept-flake-config = true
+          nix_path: "nixpkgs=channel:nixos-unstable"
       - uses: bencherdev/bencher@main
       - name: Track benchmarks on master
         run: |
@@ -18,6 +25,6 @@ jobs:
           --project nickel \
           --token '${{ secrets.BENCHER_API_TOKEN }}' \
           --branch master \
-          --testbed build01 \
+          --testbed ubuntu-latest \
           --adapter rust_criterion \
           nix develop --command cargo bench --package nickel-lang-core --bench numeric

--- a/.github/workflows/run-benchmark.yaml
+++ b/.github/workflows/run-benchmark.yaml
@@ -1,17 +1,25 @@
 name: benchmark pull requests
 on:
+  push:
+    branches:
+      - master
   pull_request:
-    types: [labeled]
 jobs:
   runBenchmark:
-    if: ${{ github.event.label.name == 'run-benchmark' && github.event_name == 'pull_request' }}
     name: run benchmark
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: jasonwilliams/criterion-compare-action@move_to_actions
-        with:
-          branchName: ${{ github.base_ref }}
-          token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: bencherdev/bencher@main
+      - name: Run benchmarks
+        run: |
+          bencher run \
+          --project nickel \
+          --token '${{ secrets.BENCHER_API_TOKEN }}' \
+          --branch main \
+          --testbed ubuntu-latest
+          --adapter criterion
+          --err \
+          cargo bench --package nickel-lang-core --bench numeric

--- a/.github/workflows/upload-pr-benchmarks.yaml
+++ b/.github/workflows/upload-pr-benchmarks.yaml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   track_fork_pr_branch:
+    name: track pr benchmarks
     if: github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/upload-pr-benchmarks.yaml
+++ b/.github/workflows/upload-pr-benchmarks.yaml
@@ -6,7 +6,6 @@ on:
     types: [completed]
 
 jobs:
-syntax error
   track_fork_pr_branch:
     name: track pr benchmarks
     if: github.event.workflow_run.conclusion == 'success'

--- a/.github/workflows/upload-pr-benchmarks.yaml
+++ b/.github/workflows/upload-pr-benchmarks.yaml
@@ -2,7 +2,7 @@ name: Track Benchmarks with Bencher
 
 on:
   workflow_run:
-    workflows: [some non-existend workflow]
+    workflows: [Continuous integration]
     types: [completed]
 
 jobs:

--- a/.github/workflows/upload-pr-benchmarks.yaml
+++ b/.github/workflows/upload-pr-benchmarks.yaml
@@ -2,13 +2,13 @@ name: Track Benchmarks with Bencher
 
 on:
   workflow_run:
-    workflows: [Continuous integration]
+    workflows: [benchmark pull requests]
     types: [completed]
 
 jobs:
   track_fork_pr_branch:
     name: track pr benchmarks
-    if: github.event.workflow_run.conclusion == 'success'
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     env:
       BENCHMARK_RESULTS: criterion-output

--- a/.github/workflows/upload-pr-benchmarks.yaml
+++ b/.github/workflows/upload-pr-benchmarks.yaml
@@ -8,7 +8,7 @@ on:
 jobs:
   track_fork_pr_branch:
     name: track pr benchmarks
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    #if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     env:
       BENCHMARK_RESULTS: criterion-output

--- a/.github/workflows/upload-pr-benchmarks.yaml
+++ b/.github/workflows/upload-pr-benchmarks.yaml
@@ -1,0 +1,71 @@
+name: upload pr benchmarks to bencher
+
+on:
+  workflow_run:
+    workflows: [benchmark pull requests]
+    types: [completed]
+
+jobs:
+  upload_pr_bencmhark:
+    if: github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+  env:
+    BENCHMARK_RESULTS: criterion-output
+    PR_EVENT: event.json
+  steps:
+    - name: download results
+      uses: actions/github-script@v6
+      with:
+        script: |
+          async function downloadArtifact(artifactName) {
+            let allArtifacts = await github.rest.actions.listWorkflowRunArtifacts({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: context.payload.workflow_run.id,
+            });
+            let matchArtifact = allArtifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == artifactName
+            })[0];
+            if (!matchArtifact) {
+              core.setFailed(`Failed to find artifact: ${artifactName}`);
+            }
+            let download = await github.rest.actions.downloadArtifact({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              artifact_id: matchArtifact.id,
+              archive_format: 'zip',
+            });
+            let fs = require('fs');
+            fs.writeFileSync(`${process.env.GITHUB_WORKSPACE}/${artifactName}.zip`, Buffer.from(download.data));
+          }
+          await downloadArtifact(process.env.BENCHMARK_RESULTS);
+          await downloadArtifact(process.env.PR_EVENT);
+    - name: Unzip Benchmark Results
+      run: |
+        unzip $BENCHMARK_RESULTS.zip
+        unzip $PR_EVENT.zip
+    - name: Export PR Event Data
+      uses: actions/github-script@v6
+      with:
+        script: |
+          let fs = require('fs');
+          let prEvent = JSON.parse(fs.readFileSync(process.env.PR_EVENT, {encoding: 'utf8'}));
+          core.exportVariable("PR_HEAD", `${prEvent.number}/merge`);
+          core.exportVariable("PR_BASE", prEvent.pull_request.base.ref);
+          core.exportVariable("PR_BASE_SHA", prEvent.pull_request.base.sha);
+          core.exportVariable("PR_NUMBER", prEvent.number);
+    - uses: bencherdev/bencher@main
+    - name: Track Benchmarks with Bencher
+      run: |
+        bencher run \
+        --project nickel \
+        --token '${{ secrets.BENCHER_API_TOKEN }}' \
+        --branch '${{ env.PR_HEAD }}' \
+        --branch-start-point '${{ env.PR_BASE }}' \
+        --branch-start-point-hash '${{ env.PR_BASE_SHA }}' \
+        --testbed ubuntu-latest \
+        --adapter rust_criterion \
+        --err \
+        --github-actions '${{ secrets.GITHUB_TOKEN }}' \
+        --ci-number '${{ env.PR_NUMBER }}' \
+        --file "$BENCHMARK_RESULTS"

--- a/.github/workflows/upload-pr-benchmarks.yaml
+++ b/.github/workflows/upload-pr-benchmarks.yaml
@@ -6,6 +6,7 @@ on:
     types: [completed]
 
 jobs:
+syntax error
   track_fork_pr_branch:
     name: track pr benchmarks
     if: github.event.workflow_run.conclusion == 'success'

--- a/.github/workflows/upload-pr-benchmarks.yaml
+++ b/.github/workflows/upload-pr-benchmarks.yaml
@@ -1,4 +1,4 @@
-name: upload pr benchmarks to bencher
+name: Track Benchmarks with Bencher
 
 on:
   workflow_run:
@@ -6,66 +6,66 @@ on:
     types: [completed]
 
 jobs:
-  upload_pr_bencmhark:
+  track_fork_pr_branch:
     if: github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
-  env:
-    BENCHMARK_RESULTS: criterion-output
-    PR_EVENT: event.json
-  steps:
-    - name: download
-      uses: actions/github-script@v6
-      with:
-        script: |
-          async function downloadArtifact(artifactName) {
-            let allArtifacts = await github.rest.actions.listWorkflowRunArtifacts({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              run_id: context.payload.workflow_run.id,
-            });
-            let matchArtifact = allArtifacts.data.artifacts.filter((artifact) => {
-              return artifact.name == artifactName
-            })[0];
-            if (!matchArtifact) {
-              core.setFailed(`Failed to find artifact: ${artifactName}`);
+    env:
+      BENCHMARK_RESULTS: criterion-output
+      PR_EVENT: event.json
+    steps:
+      - name: Download Benchmark Results
+        uses: actions/github-script@v6
+        with:
+          script: |
+            async function downloadArtifact(artifactName) {
+              let allArtifacts = await github.rest.actions.listWorkflowRunArtifacts({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                run_id: context.payload.workflow_run.id,
+              });
+              let matchArtifact = allArtifacts.data.artifacts.filter((artifact) => {
+                return artifact.name == artifactName
+              })[0];
+              if (!matchArtifact) {
+                core.setFailed(`Failed to find artifact: ${artifactName}`);
+              }
+              let download = await github.rest.actions.downloadArtifact({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                artifact_id: matchArtifact.id,
+                archive_format: 'zip',
+              });
+              let fs = require('fs');
+              fs.writeFileSync(`${process.env.GITHUB_WORKSPACE}/${artifactName}.zip`, Buffer.from(download.data));
             }
-            let download = await github.rest.actions.downloadArtifact({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              artifact_id: matchArtifact.id,
-              archive_format: 'zip',
-            });
+            await downloadArtifact(process.env.BENCHMARK_RESULTS);
+            await downloadArtifact(process.env.PR_EVENT);
+      - name: Unzip Benchmark Results
+        run: |
+          unzip $BENCHMARK_RESULTS.zip
+          unzip $PR_EVENT.zip
+      - name: Export PR Event Data
+        uses: actions/github-script@v6
+        with:
+          script: |
             let fs = require('fs');
-            fs.writeFileSync(`${process.env.GITHUB_WORKSPACE}/${artifactName}.zip`, Buffer.from(download.data));
-          }
-          await downloadArtifact(process.env.BENCHMARK_RESULTS);
-          await downloadArtifact(process.env.PR_EVENT);
-    - name: Unzip Benchmark Results
-      run: |
-        unzip $BENCHMARK_RESULTS.zip
-        unzip $PR_EVENT.zip
-    - name: Export PR Event Data
-      uses: actions/github-script@v6
-      with:
-        script: |
-          let fs = require('fs');
-          let prEvent = JSON.parse(fs.readFileSync(process.env.PR_EVENT, {encoding: 'utf8'}));
-          core.exportVariable("PR_HEAD", `${prEvent.number}/merge`);
-          core.exportVariable("PR_BASE", prEvent.pull_request.base.ref);
-          core.exportVariable("PR_BASE_SHA", prEvent.pull_request.base.sha);
-          core.exportVariable("PR_NUMBER", prEvent.number);
-    - uses: bencherdev/bencher@main
-    - name: Track Benchmarks with Bencher
-      run: |
-        bencher run \
-        --project nickel \
-        --token '${{ secrets.BENCHER_API_TOKEN }}' \
-        --branch '${{ env.PR_HEAD }}' \
-        --branch-start-point '${{ env.PR_BASE }}' \
-        --branch-start-point-hash '${{ env.PR_BASE_SHA }}' \
-        --testbed ubuntu-latest \
-        --adapter rust_criterion \
-        --err \
-        --github-actions '${{ secrets.GITHUB_TOKEN }}' \
-        --ci-number '${{ env.PR_NUMBER }}' \
-        --file "$BENCHMARK_RESULTS"
+            let prEvent = JSON.parse(fs.readFileSync(process.env.PR_EVENT, {encoding: 'utf8'}));
+            core.exportVariable("PR_HEAD", `${prEvent.number}/merge`);
+            core.exportVariable("PR_BASE", prEvent.pull_request.base.ref);
+            core.exportVariable("PR_BASE_SHA", prEvent.pull_request.base.sha);
+            core.exportVariable("PR_NUMBER", prEvent.number);
+      - uses: bencherdev/bencher@main
+      - name: Track Benchmarks with Bencher
+        run: |
+          bencher run \
+          --project nickel \
+          --token '${{ secrets.BENCHER_API_TOKEN }}' \
+          --branch '${{ env.PR_HEAD }}' \
+          --branch-start-point '${{ env.PR_BASE }}' \
+          --branch-start-point-hash '${{ env.PR_BASE_SHA }}' \
+          --testbed ubuntu-latest \
+          --adapter criterion_rust \
+          --err \
+          --github-actions '${{ secrets.GITHUB_TOKEN }}' \
+          --ci-number '${{ env.PR_NUMBER }}' \
+          --file "$BENCHMARK_RESULTS.txt"

--- a/.github/workflows/upload-pr-benchmarks.yaml
+++ b/.github/workflows/upload-pr-benchmarks.yaml
@@ -2,7 +2,7 @@ name: Track Benchmarks with Bencher
 
 on:
   workflow_run:
-    workflows: [benchmark pull requests]
+    workflows: [some non-existend workflow]
     types: [completed]
 
 jobs:

--- a/.github/workflows/upload-pr-benchmarks.yaml
+++ b/.github/workflows/upload-pr-benchmarks.yaml
@@ -13,7 +13,7 @@ jobs:
     BENCHMARK_RESULTS: criterion-output
     PR_EVENT: event.json
   steps:
-    - name: download results
+    - name: download
       uses: actions/github-script@v6
       with:
         script: |

--- a/.github/workflows/upload-pr-benchmarks.yaml
+++ b/.github/workflows/upload-pr-benchmarks.yaml
@@ -8,7 +8,7 @@ on:
 jobs:
   track_fork_pr_branch:
     name: track pr benchmarks
-    #if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     env:
       BENCHMARK_RESULTS: criterion-output


### PR DESCRIPTION
This is an initial attempt to track benchmarks in CI.

It runs (just a few) benchmarks on every push to master, and on each pr it also runs a few benchmarks and compares them to master. It uses bencher.dev to track benchmark results over time.

This probably doesn't work yet. I've been trying to debug why the PR benchmark result uploads don't work; it turns out the workflow file needs to be in the default branch before it will run...