### PR TITLE
[Optimization] Cache contract generation and pre-compile some match expression

### DIFF
--- a/core/src/closurize.rs
+++ b/core/src/closurize.rs
@@ -289,9 +289,10 @@ pub fn should_share(t: &Term) -> bool {
         | Term::Var(_)
         | Term::Enum(_)
         | Term::Fun(_, _)
+        | Term::Closure(_)
+        | Term::Type { .. }
         // match acts like a function, and is a WHNF
-        | Term::Match {..}
-        | Term::Type(_) => false,
+        | Term::Match {..} => false,
         _ => true,
     }
 }

--- a/core/src/eval/mod.rs
+++ b/core/src/eval/mod.rs
@@ -75,7 +75,7 @@
 //! consider at some point.
 use crate::{
     cache::{Cache as ImportCache, Envs, ImportResolver},
-    closurize::{closurize_rec_record, Closurize},
+    closurize::{closurize_rec_record, should_share, Closurize},
     environment::Environment as GenericEnvironment,
     error::{Error, EvalError},
     identifier::Ident,
@@ -1165,7 +1165,7 @@ pub fn subst<C: Cache>(
         // We could recurse here, because types can contain terms which would then be subject to
         // substitution. Not recursing should be fine, though, because a type in term position
         // turns into a contract, and we don't substitute inside contracts either currently.
-        | v @ Term::Type(_) => RichTerm::new(v, pos),
+        | v @ Term::Type {..} => RichTerm::new(v, pos),
         Term::EnumVariant { tag, arg, attrs } => {
             let arg = subst(cache, arg, initial_env, env);
 

--- a/core/src/eval/mod.rs
+++ b/core/src/eval/mod.rs
@@ -75,7 +75,7 @@
 //! consider at some point.
 use crate::{
     cache::{Cache as ImportCache, Envs, ImportResolver},
-    closurize::{closurize_rec_record, should_share, Closurize},
+    closurize::{closurize_rec_record, Closurize},
     environment::Environment as GenericEnvironment,
     error::{Error, EvalError},
     identifier::Ident,

--- a/core/src/pretty.rs
+++ b/core/src/pretty.rs
@@ -1038,7 +1038,7 @@ where
                 .append(allocator.as_string(f.to_string_lossy()).double_quotes()),
             ResolvedImport(id) => allocator.text(format!("import <file_id: {id:?}>")),
             // This type is in term position, so we don't need to add parentheses.
-            Type(ty) => ty.pretty(allocator),
+            Type { typ, contract: _ } => typ.pretty(allocator),
             ParseError(_) => allocator.text("%<PARSE ERROR>"),
             RuntimeError(_) => allocator.text("%<RUNTIME ERROR>"),
             Closure(idx) => allocator.text(format!("%<closure@{idx:p}>")),

--- a/core/src/term/mod.rs
+++ b/core/src/term/mod.rs
@@ -20,9 +20,9 @@ use record::{Field, FieldDeps, FieldMetadata, RecordData, RecordDeps};
 use string::NickelString;
 
 use crate::{
+    closurize::should_share,
     error::{EvalError, ParseError},
-    eval::cache::CacheIndex,
-    eval::Environment,
+    eval::{cache::CacheIndex, Environment},
     identifier::LocIdent,
     impl_display_from_pretty,
     label::{Label, MergeLabel},
@@ -217,7 +217,14 @@ pub enum Term {
     ///
     /// During evaluation, this will get turned into a contract.
     #[serde(skip)]
-    Type(Type),
+    Type {
+        /// The static type.
+        typ: Type,
+        /// The conversion of this type to a contract, that is, `typ.contract()?`. This field
+        /// serves as a caching mechanism so we only run the contract generation code once per type
+        /// written by the user.
+        contract: RichTerm,
+    },
 
     /// A custom contract. The content must be a function (or function-like terms like a match
     /// expression) of two arguments: a label and the value to be checked. In particular, it must
@@ -362,7 +369,16 @@ impl PartialEq for Term {
             (Self::Annotated(l0, l1), Self::Annotated(r0, r1)) => l0 == r0 && l1 == r1,
             (Self::Import(l0), Self::Import(r0)) => l0 == r0,
             (Self::ResolvedImport(l0), Self::ResolvedImport(r0)) => l0 == r0,
-            (Self::Type(l0), Self::Type(r0)) => l0 == r0,
+            (
+                Self::Type {
+                    typ: l0,
+                    contract: l1,
+                },
+                Self::Type {
+                    typ: r0,
+                    contract: r1,
+                },
+            ) => l0 == r0 && l1 == r1,
             (Self::ParseError(l0), Self::ParseError(r0)) => l0 == r0,
             (Self::RuntimeError(l0), Self::RuntimeError(r0)) => l0 == r0,
             // We don't compare closure, because we can't, without the evaluation cache at hand.
@@ -948,7 +964,7 @@ impl Term {
             Term::SealingKey(_) => Some("SealingKey".to_owned()),
             Term::Sealed(..) => Some("Sealed".to_owned()),
             Term::Annotated(..) => Some("Annotated".to_owned()),
-            Term::Type(_) => Some("Type".to_owned()),
+            Term::Type { .. } => Some("Type".to_owned()),
             Term::ForeignId(_) => Some("ForeignId".to_owned()),
             Term::CustomContract(_) => Some("CustomContract".to_owned()),
             Term::Let(..)
@@ -998,9 +1014,9 @@ impl Term {
             | Term::EnumVariant {..}
             | Term::Record(..)
             | Term::Array(..)
-            | Term::Type(_)
             | Term::ForeignId(_)
-            | Term::SealingKey(_) => true,
+            | Term::SealingKey(_)
+            | Term::Type {..} => true,
             Term::Let(..)
             | Term::LetPattern(..)
             | Term::FunPattern(..)
@@ -1078,7 +1094,7 @@ impl Term {
             | Term::ResolvedImport(_)
             | Term::StrChunks(_)
             | Term::RecRecord(..)
-            | Term::Type(_)
+            | Term::Type { .. }
             | Term::ParseError(_)
             | Term::EnumVariant { .. }
             | Term::RuntimeError(_) => false,
@@ -1115,6 +1131,7 @@ impl Term {
             | Term::Op1(UnaryOp::BoolOr, _) => true,
             // A number with a minus sign as a prefix isn't a proper atom
             Term::Num(n) if *n >= 0 => true,
+            Term::Type {typ, contract: _} => typ.fmt_is_atom(),
             Term::Let(..)
             | Term::Num(..)
             | Term::EnumVariant {..}
@@ -1131,7 +1148,6 @@ impl Term {
             | Term::Annotated(..)
             | Term::Import(..)
             | Term::ResolvedImport(..)
-            | Term::Type(_)
             | Term::Closure(_)
             | Term::ParseError(_)
             | Term::RuntimeError(_) => false,
@@ -2322,8 +2338,11 @@ impl Traverse<RichTerm> for RichTerm {
                 let term = term.traverse(f, order)?;
                 RichTerm::new(Term::Annotated(annot, term), pos)
             }
-            Term::Type(ty) => {
-                RichTerm::new(Term::Type(ty.traverse(f, order)?), pos)
+            Term::Type { typ, contract } => {
+                let typ = typ.traverse(f, order)?;
+                let contract = contract.traverse(f, order)?;
+
+                RichTerm::new(Term::Type { typ, contract }, pos)
             }
             _ => rt,
         });
@@ -2417,7 +2436,10 @@ impl Traverse<RichTerm> for RichTerm {
             Term::Annotated(annot, t) => t
                 .traverse_ref(f, state)
                 .or_else(|| annot.traverse_ref(f, state)),
-            Term::Type(ty) => ty.traverse_ref(f, state),
+            Term::Type { typ, contract } => {
+                typ.traverse_ref(f, state)?;
+                contract.traverse_ref(f, state)
+            }
         }
     }
 }
@@ -2430,9 +2452,10 @@ impl Traverse<Type> for RichTerm {
         self.traverse(
             &mut |rt: RichTerm| {
                 match_sharedterm!(match (rt.term) {
-                    Term::Type(ty) => ty
-                        .traverse(f, order)
-                        .map(|ty| RichTerm::new(Term::Type(ty), rt.pos)),
+                    Term::Type { typ, contract } => {
+                        let typ = typ.traverse(f, order)?;
+                        Ok(RichTerm::new(Term::Type { typ, contract }, rt.pos))
+                    }
                     _ => Ok(rt),
                 })
             },
@@ -2447,7 +2470,7 @@ impl Traverse<Type> for RichTerm {
     ) -> Option<U> {
         self.traverse_ref(
             &mut |rt: &RichTerm, state: &S| match &*rt.term {
-                Term::Type(ty) => ty.traverse_ref(f, state).into(),
+                Term::Type { typ, contract: _ } => typ.traverse_ref(f, state).into(),
                 _ => TraverseControl::Continue,
             },
             state,

--- a/core/src/term/mod.rs
+++ b/core/src/term/mod.rs
@@ -20,7 +20,6 @@ use record::{Field, FieldDeps, FieldMetadata, RecordData, RecordDeps};
 use string::NickelString;
 
 use crate::{
-    closurize::should_share,
     error::{EvalError, ParseError},
     eval::{cache::CacheIndex, Environment},
     identifier::LocIdent,

--- a/core/src/transform/free_vars.rs
+++ b/core/src/transform/free_vars.rs
@@ -180,8 +180,9 @@ impl CollectFreeVars for RichTerm {
 
                 t.collect_free_vars(free_vars);
             }
-            Term::Type(ty) => {
-                ty.collect_free_vars(free_vars);
+            Term::Type { typ, contract } => {
+                typ.collect_free_vars(free_vars);
+                contract.collect_free_vars(free_vars);
             }
             Term::Closure(_) => {
                 unreachable!("should never see closures at the transformation stage");

--- a/core/src/typecheck/eq.rs
+++ b/core/src/typecheck/eq.rs
@@ -463,7 +463,18 @@ fn contract_eq_bounded<E: TermEnvironment>(
         (Op1(UnaryOp::RecordAccess(id1), t1), Op1(UnaryOp::RecordAccess(id2), t2)) => {
             id1 == id2 && contract_eq_bounded(state, t1, env1, t2, env2)
         }
-        (Type(ty1), Type(ty2)) => type_eq_bounded(
+        // Contract is just a caching mechanism. `typ` should be the source of truth for equality
+        // (and it's probably easier to prove types equals than their contract version).
+        (
+            Type {
+                typ: ty1,
+                contract: _,
+            },
+            Type {
+                typ: ty2,
+                contract: _,
+            },
+        ) => type_eq_bounded(
             state,
             &GenericUnifType::from_type(ty1.clone(), env1),
             env1,

--- a/core/src/typecheck/eq.rs
+++ b/core/src/typecheck/eq.rs
@@ -464,7 +464,8 @@ fn contract_eq_bounded<E: TermEnvironment>(
             id1 == id2 && contract_eq_bounded(state, t1, env1, t2, env2)
         }
         // Contract is just a caching mechanism. `typ` should be the source of truth for equality
-        // (and it's probably easier to prove types equals than their contract version).
+        // (and it's probably easier to prove that type are equal rather than their generated
+        // contract version).
         (
             Type {
                 typ: ty1,

--- a/core/src/typecheck/mod.rs
+++ b/core/src/typecheck/mod.rs
@@ -1619,7 +1619,9 @@ fn walk<V: TypecheckVisitor>(
         Term::Annotated(annot, rt) => {
             walk_annotated(state, ctxt, visitor, annot, rt)
         }
-        Term::Type(ty) => walk_type(state, ctxt, visitor, ty),
+        // The contract field is just a caching mechanism, and should be set to `None` at this
+        // point anyway. We can safely ignore it.
+        Term::Type { typ, contract: _ } => walk_type(state, ctxt, visitor, typ),
         Term::Closure(_) => unreachable!("should never see a closure at typechecking time"),
    }
 }
@@ -2350,7 +2352,7 @@ fn check<V: TypecheckVisitor>(
             ty.unify(ty_import, state, &ctxt)
                 .map_err(|err| err.into_typecheck_err(state, rt.pos))
         }
-        Term::Type(typ) => {
+        Term::Type { typ, contract: _ } => {
             if let Some(flat) = typ.find_flat() {
                 Err(TypecheckError::FlatTypeInTermPosition { flat, pos: *pos })
             } else {

--- a/lsp/nls/src/field_walker.rs
+++ b/lsp/nls/src/field_walker.rs
@@ -440,7 +440,7 @@ impl<'a> FieldResolver<'a> {
                 let defs = self.resolve_annot(annot);
                 defs.chain(self.resolve_container(term)).collect()
             }
-            Term::Type(typ) => self.resolve_type(typ),
+            Term::Type { typ, contract: _ } => self.resolve_type(typ),
             _ => Default::default(),
         };
 


### PR DESCRIPTION
This PR is guided by the metrics gathered for some run of Nickel on large codebases, which showed that some contracts were generated again and again, while coming from one initial annotation. While it's expected that an annotation might give raise to many runtime evaluations (a contract in the body of a function, typically), it's wasteful that we _generate_ the code at runtime many times (contract generation is a form of compilation from a static type to a Nickel expression, and it shouldn't happen all the time during execution).

The issue is that we now store types directly in the AST and consider them weak head normal form. So, each time we apply such a contract, `contract/apply` get a `typ::Type`, and need to make a contract out of it: generation happens again and again. This PR adds a new field to `Term::Type`, `contract: RichTerm`, which is populated at parsing time with the contract generated from the type (which is close to the behavior before the introduction of `Term::Type`). Doing so, we should only generate one contract for each user annotation in the code.

Metrics indeed show that in some big examples, the worst case was generating ~1700 times the same contract, which is brought down to one. We also tried to closurize the generated contract, so that it doesn't have to be evaluated several time, but this showed no improvement whatsoever, while it increases the number of allocated thunks, so it's been reverted.

Additionally, in the same spirit of "generating more statically, and don't do it again at runtime", we precompile the match expression generated when converting an enum contract, so that it's not recompiled again and again each time the contract is applied. This showed a reduction of around 25 to 30% of the total number of compilation of match expressions on the private benchmark.

The concrete time again aren't spectacular, as it's saving mostly Rust function calls, and not Nickel, the latter being of course the dominant cost, but there is still a small improvement.