### PR TITLE
Add `--format` argument to `nickel query` command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1744,6 +1744,7 @@ dependencies = [
  "nickel-lang-core",
  "nickel-lang-utils",
  "serde",
+ "serde_json",
  "tempfile",
  "test-generator",
 ]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -28,6 +28,7 @@ nickel-lang-core = { workspace = true, features = [ "markdown" ], default-featur
 
 clap = { workspace = true, features = ["derive", "string"] }
 serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
 directories.workspace = true
 
 tempfile = { workspace = true, optional = true }

--- a/cli/src/query.rs
+++ b/cli/src/query.rs
@@ -1,4 +1,13 @@
-use nickel_lang_core::repl::query_print;
+use std::{fs, io::Write, path::PathBuf};
+
+use nickel_lang_core::{
+    error::{Error, IOError},
+    identifier::{Ident, LocIdent},
+    repl::query_print,
+    serialize::{self, MetadataExportFormat},
+    term::{record::Field, LabeledType, MergePriority, RichTerm, Term},
+};
+use serde::Serialize;
 
 use crate::{
     cli::GlobalOptions,
@@ -24,8 +33,80 @@ pub struct QueryCommand {
     #[arg(long)]
     pub value: bool,
 
+    /// Export the value and all metadata of selected field in the specified format.
+    ///
+    /// This flag cannot be used along with the following flags: --doc, --contract, --type, --default, --value
+    #[arg(long, short, value_enum, default_value_t, conflicts_with_all(["doc", "contract", "typ", "default", "value"]))]
+    pub format: MetadataExportFormat,
+
+    /// Output file. Standard output by default
+    #[arg(short, long, conflicts_with_all(["doc", "contract", "typ", "default", "value"]))]
+    pub output: Option<PathBuf>,
+
     #[command(flatten)]
     pub inputs: InputOptions<ExtractFieldOnly>,
+}
+
+#[derive(Clone, Debug, Serialize)]
+struct QueryResult {
+    pub doc: Option<String>,
+    pub typ: Option<LabeledType>,
+    pub contracts: Vec<LabeledType>,
+    pub optional: bool,
+    pub not_exported: bool,
+    pub priority: MergePriority,
+    pub sub_fields: Option<Vec<Ident>>,
+    pub value: Option<RichTerm>,
+}
+
+impl From<Field> for QueryResult {
+    fn from(field: Field) -> Self {
+        let sub_fields = match field.value {
+            Some(ref val) => match val.as_ref() {
+                Term::Record(record) if !record.fields.is_empty() => {
+                    let mut fields: Vec<_> = record.fields.keys().collect();
+                    fields.sort();
+                    Some(fields.into_iter().map(LocIdent::ident).collect())
+                }
+                Term::RecRecord(record, dyn_fields, ..) if !record.fields.is_empty() => {
+                    let mut fields: Vec<_> = record.fields.keys().map(LocIdent::ident).collect();
+                    fields.sort();
+                    let dynamic = Ident::from("<dynamic>");
+                    fields.extend(dyn_fields.iter().map(|_| dynamic));
+                    Some(fields)
+                }
+                // Empty record has empty sub_fields
+                Term::Record(..) | Term::RecRecord(..) => Some(Vec::new()),
+                // Non-record has no concept of sub-field
+                _ => None,
+            },
+            None => None,
+        };
+
+        QueryResult {
+            doc: field.metadata.doc,
+            typ: field.metadata.annotation.typ,
+            contracts: field.metadata.annotation.contracts,
+            optional: field.metadata.opt,
+            not_exported: field.metadata.not_exported,
+            priority: field.metadata.priority,
+            sub_fields,
+            value: field.value,
+        }
+    }
+}
+
+impl QueryResult {
+    pub fn filter_for_export(self) -> serde_json::Map<String, serde_json::Value> {
+        let mut query_res = serde_json::to_value(&self).unwrap();
+        let query_res = query_res.as_object_mut().unwrap();
+
+        if self.value.is_none() {
+            query_res.remove("value");
+        }
+
+        query_res.to_owned()
+    }
 }
 
 impl QueryCommand {
@@ -48,6 +129,34 @@ impl QueryCommand {
         }
     }
 
+    fn export<T>(self, res: T, format: MetadataExportFormat) -> Result<(), Error>
+    where
+        T: Serialize,
+    {
+        // This is a near-verbatim copy of ExportCommand::export
+
+        // We only add a trailing newline for JSON exports. Both YAML and TOML
+        // exporters already append a trailing newline by default.
+        let trailing_newline = format == MetadataExportFormat::Json;
+
+        if let Some(file) = self.output {
+            let mut file = fs::File::create(file).map_err(IOError::from)?;
+            serialize::to_writer_metadata(&mut file, format, &res)?;
+
+            if trailing_newline {
+                writeln!(file).map_err(IOError::from)?;
+            }
+        } else {
+            serialize::to_writer_metadata(std::io::stdout(), format, &res)?;
+
+            if trailing_newline {
+                println!();
+            }
+        }
+
+        Ok(())
+    }
+
     pub fn run(self, global: GlobalOptions) -> CliResult<()> {
         let mut program = self.inputs.prepare(&global)?;
 
@@ -55,22 +164,38 @@ impl QueryCommand {
             program.report(Warning::EmptyQueryPath, global.error_format);
         }
 
-        let found = program
-            .query()
-            .map(|field| {
-                query_print::write_query_result(
-                    &mut std::io::stdout(),
-                    &field,
-                    self.query_attributes(),
-                )
-                .unwrap()
-            })
-            .report_with_program(program)?;
+        use MetadataExportFormat::*;
+        match self.format {
+            Markdown => {
+                if let Some(_) = self.output {
+                    eprintln!("Output query result in markdown format to a file is currently not supported.")
+                } else {
+                    let found = program
+                        .query()
+                        .map(|field| {
+                            query_print::write_query_result(
+                                &mut std::io::stdout(),
+                                &field,
+                                self.query_attributes(),
+                            )
+                            .unwrap()
+                        })
+                        .report_with_program(program)?;
 
-        if !found {
-            eprintln!("No metadata found for this field.")
+                    if !found {
+                        eprintln!("No metadata found for this field.")
+                    }
+                }
+            }
+            format @ (Json | Toml | Yaml) => {
+                let _ = &program
+                    .query()
+                    .map(QueryResult::from)
+                    .map(QueryResult::filter_for_export)
+                    .map(|res| self.export(res, format))
+                    .report_with_program(program)?;
+            }
         }
-
         Ok(())
     }
 }

--- a/cli/src/query.rs
+++ b/cli/src/query.rs
@@ -179,7 +179,7 @@ impl QueryCommand {
         use MetadataExportFormat::*;
         match self.format {
             Markdown => {
-                if let Some(_) = self.output {
+                if self.output.is_some() {
                     eprintln!("Output query result in markdown format to a file is currently not supported.")
                 } else {
                     let found = program

--- a/cli/src/query.rs
+++ b/cli/src/query.rs
@@ -104,6 +104,18 @@ impl QueryResult {
         if self.value.is_none() {
             query_res.remove("value");
         }
+        if self.doc.is_none() {
+            query_res.remove("doc");
+        }
+        if self.contracts.is_empty() {
+            query_res.remove("contracts");
+        }
+        if self.typ.is_none() {
+            query_res.remove("typ");
+        }
+        if self.sub_fields.is_none() {
+            query_res.remove("sub_fields");
+        }
 
         query_res.to_owned()
     }

--- a/core/src/repl/query_print.rs
+++ b/core/src/repl/query_print.rs
@@ -1,4 +1,6 @@
 //! Rendering of the results of a metadata query.
+use serde::Serialize;
+
 use crate::{
     identifier::{Ident, LocIdent},
     pretty::PrettyPrintCap,
@@ -153,7 +155,7 @@ impl QueryPrinter for MarkdownRenderer {
 }
 
 /// Represent which metadata attributes are requested by a query.
-#[derive(Clone, Copy, Eq, PartialEq)]
+#[derive(Clone, Copy, Eq, PartialEq, Serialize)]
 pub struct Attributes {
     pub doc: bool,
     pub contract: bool,

--- a/core/src/serialize.rs
+++ b/core/src/serialize.rs
@@ -399,7 +399,6 @@ where
 {
     // This is a near-verbatim copy of `to_writer`
     match format {
-        //
         MetadataExportFormat::Markdown => unimplemented!(),
         MetadataExportFormat::Json => serde_json::to_writer_pretty(writer, &item)
             .map_err(|err| ExportErrorData::Other(err.to_string())),

--- a/core/src/serialize.rs
+++ b/core/src/serialize.rs
@@ -26,7 +26,6 @@ use once_cell::sync::Lazy;
 use std::{fmt, io, rc::Rc};
 
 /// Available export formats.
-// If you add or remove variants, remember to update the CLI docs in `src/bin/nickel.rs'
 #[derive(Copy, Clone, Eq, PartialEq, Debug, Default, clap::ValueEnum)]
 pub enum ExportFormat {
     Raw,
@@ -47,8 +46,27 @@ impl fmt::Display for ExportFormat {
     }
 }
 
-// TODO: This type is publicly exposed, but never constructed.
-#[allow(dead_code)]
+/// Available metadata export formats.
+#[derive(Copy, Clone, Eq, PartialEq, Debug, Default, clap::ValueEnum)]
+pub enum MetadataExportFormat {
+    #[default]
+    Markdown,
+    Json,
+    Yaml,
+    Toml,
+}
+
+impl fmt::Display for MetadataExportFormat {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Self::Markdown => write!(f, "markdown"),
+            Self::Json => write!(f, "json"),
+            Self::Yaml => write!(f, "yaml"),
+            Self::Toml => write!(f, "toml"),
+        }
+    }
+}
+
 #[derive(Clone, Eq, PartialEq, Debug)]
 pub struct ParseFormatError(String);
 
@@ -368,6 +386,35 @@ pub fn validate(format: ExportFormat, t: &RichTerm) -> Result<(), ExportError> {
 
         result
     }
+}
+
+pub fn to_writer_metadata<W, T>(
+    mut writer: W,
+    format: MetadataExportFormat,
+    item: &T,
+) -> Result<(), ExportError>
+where
+    W: io::Write,
+    T: ?Sized + Serialize,
+{
+    // This is a near-verbatim copy of `to_writer`
+    match format {
+        //
+        MetadataExportFormat::Markdown => unimplemented!(),
+        MetadataExportFormat::Json => serde_json::to_writer_pretty(writer, &item)
+            .map_err(|err| ExportErrorData::Other(err.to_string())),
+        MetadataExportFormat::Yaml => serde_yaml::to_writer(writer, &item)
+            .map_err(|err| ExportErrorData::Other(err.to_string())),
+        MetadataExportFormat::Toml => toml::to_string_pretty(item)
+            .map_err(|err| ExportErrorData::Other(err.to_string()))
+            .and_then(|s| {
+                writer
+                    .write_all(s.as_bytes())
+                    .map_err(|err| ExportErrorData::Other(err.to_string()))
+            }),
+    }?;
+
+    Ok(())
 }
 
 pub fn to_writer<W>(mut writer: W, format: ExportFormat, rt: &RichTerm) -> Result<(), ExportError>

--- a/core/src/term/mod.rs
+++ b/core/src/term/mod.rs
@@ -46,7 +46,7 @@ pub use malachite::{
     Integer, Rational,
 };
 
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize, Serializer};
 
 // Because we use `IndexMap` for recors, consumer of Nickel (as a library) might have to
 // manipulate values of this type, so we re-export this type.
@@ -678,6 +678,15 @@ impl fmt::Display for MergePriority {
     }
 }
 
+impl Serialize for MergePriority {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&self.to_string())
+    }
+}
+
 /// A branch of a match expression.
 #[derive(Debug, PartialEq, Clone)]
 pub struct MatchBranch {
@@ -725,6 +734,15 @@ impl LabeledType {
             label: self.label.with_field_name(ident),
             ..self
         }
+    }
+}
+
+impl Serialize for LabeledType {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&self.label.typ.to_string())
     }
 }
 


### PR DESCRIPTION
Closes #1976 

This PR adds the ability for `nickel query` to export the result to JSON, YAML & TOML,  similar to that of `nickel export`. The output schema looks like:

```nickel
{
  doc | String | optional,
  "optional" | Bool,
  not_exported | Bool,
  priority | String,   # variants include: "default", "neutral", "force", and string representation of rational number ("1", "5/2", etc.)
  typ | String | optional,
  contracts | Array String | optional,
  sub_fields | Array String | optional,
  value | String | optional,
}
```

Two flags are added to nickel query: `--format` and `--output`
-  `--format` accepts 4 variants: markdown(default), json, yaml and toml. `nickel query --format markdown ...` behaves the same as the original `nickel query ...`
- `--output` is added to align with `nickel export`. There's one exception though: user is not able to output markdown formatted query result to a file. While this could be implemented, it is arguable that a markdown output is much more useful when used ad-hoc in a shell.

