### PR TITLE
Fix and improve contract generation optimization for static types

### DIFF
--- a/core/src/identifier.rs
+++ b/core/src/identifier.rs
@@ -33,6 +33,14 @@ impl Ident {
     pub fn into_label(self) -> String {
         self.label().to_owned()
     }
+
+    /// Create a new fresh identifier. This identifier is unique and is guaranteed not to collide
+    /// with any identifier defined before. Generated identifiers start with a special prefix that
+    /// can't be used by normal, user-defined identifiers.
+    pub fn fresh() -> Self {
+        increment!("Ident::fresh");
+        Self::new(format!("{}{}", GEN_PREFIX, GeneratedCounter::next()))
+    }
 }
 
 impl fmt::Display for Ident {
@@ -122,12 +130,9 @@ impl LocIdent {
         LocIdent { pos, ..self }
     }
 
-    /// Create a new fresh identifier. This identifier is unique and is guaranteed not to collide
-    /// with any identifier defined before. Generated identifiers start with a special prefix that
-    /// can't be used by normal, user-defined identifiers.
+    /// Create a fresh identifier with no position. See [Ident::fresh].
     pub fn fresh() -> Self {
-        increment!("LocIdent::fresh");
-        Self::new(format!("{}{}", GEN_PREFIX, GeneratedCounter::next()))
+        Ident::fresh().into()
     }
 
     /// Return the identifier without its position.

--- a/core/src/stdlib.rs
+++ b/core/src/stdlib.rs
@@ -92,6 +92,7 @@ pub mod internals {
     generate_accessor!(record_contract);
     generate_accessor!(record_type);
     generate_accessor!(forall_record_tail);
+    generate_accessor!(forall_record_tail_excluded_only);
     generate_accessor!(dyn_tail);
     generate_accessor!(empty_tail);
 

--- a/core/src/typ.rs
+++ b/core/src/typ.rs
@@ -1224,7 +1224,7 @@ impl RecordRows {
     ///
     /// # Simplification of tail variable
     ///
-    /// The following paragraphs distinguish between a tail variable (and thus and enclosing record
+    /// The following paragraphs distinguish between a tail variable (and thus an enclosing record
     /// type) in positive position and a tail variable in negative position (the polarity of the
     /// introducing forall is yet another dimension, covered in each paragraph).
     ///
@@ -1274,7 +1274,7 @@ impl RecordRows {
     /// In a positive position, we can replace the tail with `Dyn` if the tail isn't a variable
     /// introduced in negative position, because a typed term can never violate row constraints.
     ///
-    /// For a variable introduyced by a forall in negative position, we need to keep the unsealing
+    /// For a variable introduced by a forall in negative position, we need to keep the unsealing
     /// operation to make sure the corresponding forall type doesn't blame. But the unsealing
     /// operation needs prior sealing to work out, so we need to keep the tail even for record
     /// types in positive position. What's more, _we can't elide any field in this case_. Indeed,
@@ -1288,7 +1288,7 @@ impl RecordRows {
     ) -> Self {
         // This helper does a first traversal of record rows in order to peek the tail and check if
         // it's a variable introduced by a forall in negative position. In this case, the second
-        // component of the result will be `true` and we can't elide any field during the actual
+        // component of the result will be `false` and we can't elide any field during the actual
         // simplification.
         //
         // As we will need the set of all fields later, we build during this first traversal as well.
@@ -1890,7 +1890,7 @@ mod tests {
             .unwrap()
     }
 
-    /// Parse a type, simplify it and assert that the result correspond to the second argument
+    /// Parse a type, simplify it and assert that the result corresponds to the second argument
     /// (which is parsed and printed again to eliminate formatting differences). This function also
     /// checks that the contract generation from the simplified version works without an unbound
     /// type variable error.

--- a/core/stdlib/internals.ncl
+++ b/core/stdlib/internals.ncl
@@ -375,6 +375,30 @@
             extra_fields
         ),
 
+  # Specialized version of `$forall_record_tail` for a `forall` introduced in a
+  # positive position and a tail in a negative position which only check for
+  # excluded fields but doesn't seal the tail. This version is used by the
+  # contract simplifier, when optimizing contracts coming from a static type
+  # annotation.
+  "$forall_record_tail_excluded_only" = fun constr extra_fields label value =>
+    let plural = fun list => if %array/length% list == 1 then "" else "s" in
+
+    # Conflicts happen because a polymorphic record tail might have additional
+    # constraints as to what can actually be in there. See the documentation
+    # of the typechecker for more information.
+    let conflicts =
+      std.array.filter
+        (fun field => std.array.elem field constr)
+        (%record/fields% extra_fields)
+    in
+
+    if conflicts != [] then
+      'Error {
+        message = "field%{plural conflicts} not allowed in tail: `%{std.string.join ", " conflicts}`",
+      }
+    else
+      'Ok value,
+
   # Tail wrapper for a dynamic tail. A dynamic tail doesn't seal anything, so we
   # just add the extra fields back to the returned value. See
   # `$record_type/delayed`.

--- a/core/stdlib/internals.ncl
+++ b/core/stdlib/internals.ncl
@@ -376,7 +376,7 @@
         ),
 
   # Specialized version of `$forall_record_tail` for a `forall` introduced in a
-  # positive position and a tail in a negative position which only check for
+  # positive position and a tail in a negative position which only checks for
   # excluded fields but doesn't seal the tail. This version is used by the
   # contract simplifier, when optimizing contracts coming from a static type
   # annotation.

--- a/core/tests/integration/inputs/contracts/simplify_doesnt_remove_fields.ncl
+++ b/core/tests/integration/inputs/contracts/simplify_doesnt_remove_fields.ncl
@@ -1,0 +1,8 @@
+# test.type = 'pass'
+
+# Regression test for issue #2014 "Record row polymorphism can be destructive"
+# (https://github.com/tweag/nickel/issues/2014)
+let f : forall tail. { a : Number; tail } -> { a : Number; tail }
+  = fun o => o
+  in
+f { a = 1, b = ".." } == { a = 1, b = ".." }


### PR DESCRIPTION
Fixes #2014.

## Motivation

This PR fixes a number of issues with the optimization of contract generation from a static type annotation. This optimization has been introduced to take advantage of the guarantees of static typing to simplify the generated contract and elide a number of useless checks at run-time.

However, the original optimization is too agressive: it turns any non-function type in a positive position to `Dyn`. 

Contracts in negative position must be kept around, because they check what's come from the (potentially untyped) external world inside the function: the fact that a function is statically typed doesn't ensure it'll be called with the
right arguments. Basic contracts in positive position can be elided though: if a function has been statically checked to be of type `Number ->  Number`, we now that it'll always return a `Number` at runtime, and we can simplify the contract to `Number -> Dyn` (which is further specialized to an implementation that doesn't check anything on the codomain). Alas, this isn't true for more complex types in positive positions.

### Unsoundness

The first issue is that a type constructor in positive position can hide negative contracts inside. Typically, take `let functions: Array (Number -> Number) in (std.array.at 0 functions) "a"`. The application is untyped, and wrongly passes a string to a function of the array. However, the current optimization will turn this contract to just `Dyn` at runtime and get rid of entirely, because there's an `Array _` in positive position, and won't blame at runtime (might get a primop dynamic type error, or nothing, depending what exactly does the function). The elision is only valid if `_` doesn't contain any arrow type, which it does, in this example.

Another issue stems from the sealing/unsealing symmetry of polymorphic row contracts. Take `let id : forall r. {foo : Number; r} -> {foo : Number; r} = fun x => x in id {foo = 1, bar = 2}`. The current version would return `{foo = 1}`, with the `bar` field missing. The issue is that the second `{foo : Number; r}` is a record type in positive position, which currently gets entirely elided, giving `forall r. {foo : Number; r} -> Dyn` as an optimized contract. The argument contract seals anything else than `foo` in the record's tail, but there's no dual contract to unseal it anymore, such that `bar` stays sealed in the tail forever and thus invisible.

This commit implements a more complicated strategy, but which is hopefully correct. Instead of getting rid of type constructor in positive positions, we try to simplify their content as well, and only if the content is simplified down to `Dyn` (or `{; Dyn}` for record rows, etc.), we get rid of the entire constructor. Otherwise, we try to pay only for the necessary checks. For example, `{foo : Number, bar : Number -> Number}` now gets simplified to `{bar : Number -> Dyn; Dyn}` instead of just `Dyn` before (which was incorrect).

The full simplification rules around polymorphic row contracts are a bit intricate and are detailed in the documentation of the corresponding methods.