### PR TITLE
[Performance] Use primop for the most basic contracts

### DIFF
--- a/core/src/parser/grammar.lalrpop
+++ b/core/src/parser/grammar.lalrpop
@@ -1307,6 +1307,12 @@ BOpPre: BinaryOp = {
     "contract/check" => BinaryOp::ContractCheck,
     "contract/array_lazy_app" => BinaryOp::ContractArrayLazyApp,
     "contract/record_lazy_app" => BinaryOp::ContractRecordLazyApp,
+    "contract/builtin/dyn" => BinaryOp::ContractBuiltin(BuiltinContract::Dyn),
+    "contract/builtin/string" =>
+    BinaryOp::ContractBuiltin(BuiltinContract::String),
+    "contract/builtin/number" =>
+    BinaryOp::ContractBuiltin(BuiltinContract::Number),
+    "contract/builtin/bool" => BinaryOp::ContractBuiltin(BuiltinContract::Bool),
     "unseal" => BinaryOp::Unseal,
     "seal" => BinaryOp::Seal,
     "label/go_field" => BinaryOp::LabelGoField,
@@ -1529,6 +1535,10 @@ extern {
         "contract/array_lazy_app" => Token::Normal(NormalToken::ContractArrayLazyApp),
         "contract/record_lazy_app" => Token::Normal(NormalToken::ContractRecordLazyApp),
         "contract/custom" => Token::Normal(NormalToken::ContractCustom),
+        "contract/builtin/dyn" => Token::Normal(NormalToken::ContractBuiltinDyn),
+        "contract/builtin/string" => Token::Normal(NormalToken::ContractBuiltinString),
+        "contract/builtin/bool" => Token::Normal(NormalToken::ContractBuiltinBool),
+        "contract/builtin/number" => Token::Normal(NormalToken::ContractBuiltinNumber),
         "op force" => Token::Normal(NormalToken::OpForce),
         "blame" => Token::Normal(NormalToken::Blame),
         "label/flip_polarity" => Token::Normal(NormalToken::LabelFlipPol),

--- a/core/src/parser/lexer.rs
+++ b/core/src/parser/lexer.rs
@@ -225,6 +225,15 @@ pub enum NormalToken<'input> {
     #[token("%label/lookup_type_variable%")]
     LabelLookupTypeVar,
 
+    #[token("%contract/builtin/dyn%")]
+    ContractBuiltinDyn,
+    #[token("%contract/builtin/number%")]
+    ContractBuiltinNumber,
+    #[token("%contract/builtin/string%")]
+    ContractBuiltinString,
+    #[token("%contract/builtin/bool%")]
+    ContractBuiltinBool,
+
     #[token("%seal%")]
     Seal,
     #[token("%unseal%")]

--- a/core/src/term/mod.rs
+++ b/core/src/term/mod.rs
@@ -1682,6 +1682,14 @@ pub enum RecordOpKind {
     ConsiderAllFields,
 }
 
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum BuiltinContract {
+    Bool,
+    Number,
+    Dyn,
+    String,
+}
+
 /// Primitive binary operators
 #[derive(Clone, Debug, PartialEq)]
 pub enum BinaryOp {
@@ -1754,6 +1762,8 @@ pub enum BinaryOp {
     /// typically wouldn't play very well with boolean combinators. On the other hand,
     /// [Self::ContractCheck] preserves the immediate/delayed part of the called contract.
     ContractCheck,
+
+    ContractBuiltin(BuiltinContract),
 
     /// Take a record of type `{message | String | optional, notes | String | optional}`.
     LabelWithErrorData,
@@ -1909,6 +1919,10 @@ impl fmt::Display for BinaryOp {
             GreaterOrEq => write!(f, "(>=)"),
             ContractApply => write!(f, "contract/apply"),
             ContractCheck => write!(f, "contract/check"),
+            ContractBuiltin(BuiltinContract::Dyn) => write!(f, "contract/builtin/dyn"),
+            ContractBuiltin(BuiltinContract::Number) => write!(f, "contract/builtin/number"),
+            ContractBuiltin(BuiltinContract::Bool) => write!(f, "contract/builtin/bool"),
+            ContractBuiltin(BuiltinContract::String) => write!(f, "contract/builtin/string"),
             LabelWithErrorData => write!(f, "label/with_error_data"),
             Unseal => write!(f, "unseal"),
             LabelGoField => write!(f, "label/go_field"),

--- a/core/src/typecheck/operation.rs
+++ b/core/src/typecheck/operation.rs
@@ -544,6 +544,12 @@ pub fn get_bop_type(
 
             (dict.clone(), dict.clone(), dict)
         }
+        // Dyn -> Dyn -> Dyn
+        BinaryOp::ContractBuiltin(_) => (
+            mk_uniftype::dynamic(),
+            mk_uniftype::dynamic(),
+            mk_uniftype::dynamic(),
+        ),
     })
 }
 

--- a/core/stdlib/internals.ncl
+++ b/core/stdlib/internals.ncl
@@ -9,28 +9,16 @@
   # |]` as well.
 
   # Contract for the `Dyn` type. It's just an always accepting contract.
-  "$dyn" = fun _label value => 'Ok value,
+  "$dyn" = fun label value => %contract/builtin/dyn% label value,
 
   # Contract for the `Number` type.
-  "$num" = fun _label value =>
-    if %typeof% value == 'Number then
-      'Ok value
-    else
-      'Error {},
+  "$num" = fun label value => %contract/builtin/number% label value,
 
   # Contract for the `Bool` type.
-  "$bool" = fun _label value =>
-    if %typeof% value == 'Bool then
-      'Ok value
-    else
-      'Error {},
+  "$bool" = fun label value => %contract/builtin/bool% label value,
 
   # Contract for the `String` type.
-  "$string" = fun _label value =>
-    if %typeof% value == 'String then
-      'Ok value
-    else
-      'Error {},
+  "$string" = fun label value => %contract/builtin/string% label value,
 
   # Contract for `ForeignId` values.
   "$foreign_id" = fun _label value =>
@@ -379,7 +367,6 @@
   # just add the extra fields back to the returned value. See
   # `$record_type/delayed`.
   "$dyn_tail" = fun extra_fields label value => 'Ok (%record/disjoint_merge% value extra_fields),
-
   # Tail wrapper of a helper for an empty tail. At this point, we've already
   # checked (in the main contract implementation for record types) that there
   # are no extra fields, so we can just ignore them and return the value as is.


### PR DESCRIPTION
This is an experimentation that uses primops instead of the most basic contracts (number, booleans, strings and dyn) to see if that makes a difference, performance-wise, rather than have them defined in Nickel. Although they aren't very costly, they should be called _a lot_, which thus could make a difference.