### PR TITLE
[RFC007] Bytecode interpreter

### DIFF
--- a/rfcs/007-bytecode-interpreter.md
+++ b/rfcs/007-bytecode-interpreter.md
@@ -304,14 +304,17 @@ machine which is the basis of the low-level operational semantics of Haskell.
 #### Memory representation
 
 Closures (thunks and functions) are represented uniformly as an environment and
-a code pointer. In some other machines for lazy lambda calculi, thunks hold
-additional data such as a flag (evaluated or suspended) and a potential value
-that is filled after the thunk has been forced. When accessing a thunk, the
-caller checks the state, and then either retrieve the value or initiate an
-update sequence and retrieve the code of the unevaluated expression. In Haskell,
-the update process is performed _by the callee_ instead (the thunk's code), such
-that thunk access is uniform: it's an unconditional jump to the corresponding
-code.
+a pointer to a closure info table. The closure info table contains the code
+pointer and other garbage-collection related data. The closure info table is
+generated only once per binding appearing in the code and thus shared by dynamic
+instances of the same code. In some other machines for lazy lambda calculi,
+thunks hold additional data such as a flag (evaluated or suspended) and a
+potential value that is filled after the thunk has been forced. When accessing a
+thunk, the caller checks the state, and then either retrieve the value or
+initiate an update sequence and retrieve the code of the unevaluated expression.
+In Haskell, the update process is performed _by the callee_ instead (the thunk's
+code), such that thunk access is uniform: it's an unconditional jump to the
+corresponding code.
 
 As with other VMs, the environment -- immediately inlined after the code pointer
 -- stores the free variables of the expression that are captured by the closure.
@@ -338,10 +341,7 @@ code pointer is followed by the constructor's argument (instead of the
 environment in the case of closures). As each constructor usage potentially
 generates very similar code, GHC is smart enough to share common constructors
 instead of generating them again and again (typically the one for an empty
-list). Specific optimizations and compilation schemes are implemented to
-alleviate the cost of the additional (code) pointer indirection for data values.
-
-In practice, when compiled to native code, the closures ???
+list).
 
 #### Virtual machine
 

--- a/rfcs/007-bytecode-interpreter.md
+++ b/rfcs/007-bytecode-interpreter.md
@@ -224,10 +224,19 @@ While the ZAM is considered stack-based, it has a few predefined registers:
 ### Haskell
 
 Despite not being advertised, Haskell has an interpreter as well, which is used
-mostly for the GHCi REPL.
+mostly for the GHCi REPL. This section describes what we know of the actual the
+bytecode interpreter, but also incoporates some aspect of the original STG
+machine which is the basis of the low-level operational semantics of Haskell.
+
+### Memory representation
+
+Haskell, like Nickel, needs to represent thunks - unevaluated expressions -
+which can capture variables from the environment. In some sense, everything is
+potentially a closure.
 
 #### References
 
+- [The STG machine](https://dl.acm.org/doi/pdf/10.1145/99370.99385)
 - [Bytecode instruction datatype definition in GHC](https://gitlab.haskell.org/ghc/ghc/-/blob/master/compiler/GHC/ByteCode/Instr.hs#L60)
 
 ### JavaScript (V8)
@@ -283,7 +292,5 @@ machine code, for every primitive instruction, on the fly.
 - [V8 implementation: list of instructions](https://github.com/v8/v8/blob/master/src/interpreter/bytecodes.h)
 
 ### Clean
-
-
 
 ## Proposal

--- a/rfcs/007-bytecode-interpreter.md
+++ b/rfcs/007-bytecode-interpreter.md
@@ -104,7 +104,7 @@ regarding the representation of records).
 Properties of interests are in particular:
 
 - the memory representation of values
-- the structure of the virtual machine (stack-based, register-based,
+- the general structure of the virtual machine (stack-based, register-based,
     reprensetation of the environment, etc.)
 - high-level (more instructions, more complex vm, simpler compilation scheme) vs
     low-level
@@ -113,20 +113,13 @@ Properties of interests are in particular:
 
 ### OCaml
 
-#### References
-
-- [Real World OCaml chapter on bytecode](https://dev.realworldocaml.org/compiler-backend.html),
-- [Original Leroy's paper: _The ZINC experiment: an economical implementation of
-  the ML language_ (1990)](https://inria.hal.science/inria-00070049/document)
-- [OCaml bytecode instructions](http://cadmium.x9c.fr/distrib/caml-instructions.pdf)
-- [OCaml memory representation of values](https://ocaml.org/docs/memory-representation)
-
 #### Memory representation
 
 OCaml uses a uniform memory representation where any value is represented as a
 single machine word. Unboxed values (integers, floats, etc.) are distinguished
 from pointers by ther least significant bit (and are thus encoded on `n-1` bits
-compared to their, say, C equivalent).
+compared to their, say, C equivalent). This is needed for garbage collection
+only.
 
 Boxed values are represented as a pointer to a block, which is a contiguous area
 of the memory with a one-word header followed by some arbitrary content, whose
@@ -134,8 +127,38 @@ shape depends on the type of the value.
 
 #### Virtual machine
 
-The OCaml virtual machine is based on the original ZINC experiment by Leroy,
-although it has changed quite a bit since then.
+The OCaml virtual machine is based on the original ZAM (ZINC Abstract Machine)
+experiment by Leroy, although it might have changed quite a bit since then. The
+ZAM is a stack-based virtual machine derived from standard machines (like SECD)
+for call-by-value lambda-calculus, but optimized for currying and partial
+application of closures: it uses Krivine's "push-enter" strategy where the SECD
+uses "eval-apply". The environment is close to the current Nix representation
+(linked list of arrays, last layer isn't shared).
+
+The ZAM has 145 instructions where many of them are variations of the same
+operation (`APPLY`, `APPLY1`, `APPLY2` and `APPLY3` for instance). They are
+reduced to rather low-level operation: environment manipulation, function
+application, boolean and integers operations, branching, exceptions, memory
+allocation/value creation.
+
+#### Structure
+
+- PC: program counter
+- SP: stack pointer
+- ACCU: accumulator
+- TRAPSP: stack pointer of highest exception handler
+- EXTRA_ARGS: number of extra arguments to function application
+- ENV: environment
+- GLOBAL: global data
+
+#### References
+
+- [Real World OCaml chapter on bytecode](https://dev.realworldocaml.org/compiler-backend.html),
+- [Original Leroy's paper: _The ZINC experiment: an economical implementation of
+  the ML language_ (1990)](https://inria.hal.science/inria-00070049/document)
+- [OCaml bytecode instructions](http://cadmium.x9c.fr/distrib/caml-instructions.pdf)
+- [OCaml memory representation of values](https://ocaml.org/docs/memory-representation)
+- [From Krivine's machine to the Caml implementations](https://xavierleroy.org/talks/zam-kazam05.pdf)
 
 ### Haskell
 

--- a/rfcs/007-bytecode-interpreter.md
+++ b/rfcs/007-bytecode-interpreter.md
@@ -296,9 +296,10 @@ While the ZAM is considered stack-based, it has a few predefined registers:
 ### Haskell
 
 Despite not being advertised, Haskell has an interpreter as well, which is used
-mostly for the GHCi REPL. This section describes what we know of the actual the
-bytecode interpreter, but also incorporates some aspects of the original STG
-machine which is the basis of the low-level operational semantics of Haskell.
+for the GHCi REPL and staged evaluation (Template Haskell). This section
+describes what we know of the actual the bytecode interpreter, but also
+incorporates some aspects of the original STG machine which is the basis of the
+low-level operational semantics of Haskell.
 
 #### Memory representation
 

--- a/rfcs/007-bytecode-interpreter.md
+++ b/rfcs/007-bytecode-interpreter.md
@@ -1,0 +1,111 @@
+---
+feature: bytecode interpreter
+start-date: 2024-09-17
+author: Yann Hamdaoui
+---
+
+# Bytecode interpreter
+
+## Motivation
+
+Performance hasn't been the initial focus of Nickel, because figuring out the
+core language, tooling and developer experience was the first priority. The
+language has now reach reasonable stability, and medium-size codebases show that
+the performance can become a problem. More specifically, the memory usage and
+the running time is far beyond not-so-optimized languages like Nix. We can do
+better than the current situation.
+
+There are many different ways to improve performance. One route is to apply
+high-level optimizations to the source program, such as contract elision or
+contract deduplication. Such optimizations have proven very effective, but the
+most obvious ones are now implemented.
+
+Another route that we will explore is caching, or incremental evaluation. This
+is orthogonal and a possible game-changer if done right.
+
+A third route is to optimize the interpreter itself. This includes general
+program optimizations (that don't have much to do with the fact that Nickel is
+the interpreter of a programming language), and more specific optimizations.
+
+### Memory representation
+
+It was noticed recently that `term::Term`, the main data structure representing a
+Nickel value, has a whopping size of 464 bytes (!). While memory consumption is
+not necessarily the main parameter to optimize for (our first target is running
+time), such a size has the potential to stress the allocator (and dropping
+code) and thus to affect the running time, in addition to making Nickel very
+memory hungry.
+
+Indeed, [#2022](https://github.com/tweag/nickel/pull/2022) shows that reducing
+it to 74 bytes, which is still huge, can lead to 25-30% speedups on medium to
+large codebases.
+
+Similarly, `eval::stack::Marker` - which is what is stored on the evaluation
+stack - is XXX bytes. Simply sprinkling `Box` here and there on both structures
+might be able to achieve a combined gain of the order o f magnitude of up to a
+50%, at the cost of making the implementation a bit uglier (one big issue of
+`Box` is the inability to do pattern matching on it directly, which makes in
+particular nested patterns impossible).
+
+Nickel has been using, up to now, a unique representation of expressions from
+parsing to evaluation. This is has the advantage of simplicity: there is only
+one data type which is the single, shared source of truth. But this is at the
+cost of specialization: this type gathers many different concerns, and several
+constructors are useless at each stage of the pipeline. Analysis stages
+(typically the LSP and the typechecker) are hurt by the need to handle runtime
+representations (e.g. `Closure`), and by the fact that the parser needs to
+already apply some desugaring to fit the unique AST structure, losing some
+information on the way. Similarly, the evaluation stage needs to ignore or
+evaluate away many things that are only relevant before program transformations.
+Finally, uniqueness makes the representation big, as noted above.
+
+### Intermediate representations
+
+The usual way to address this issue is to adopt several representations, better
+tailored to the needs of each stage. The earlier stages usually resort to a
+usual tree-like AST representation, which is more adapted to program analysis
+and transformations. The evaluation stage, on the other hand, is optimized for
+performance. In particular:
+
+- the general structure should be cache-friendly, that is usually array-like
+    rather than tree-like (e.g. _flat ASTs_)
+- the size of the atoms of the structure (nodes, values, whatever they are
+  called) should be as small as possible, to amplify the cache-friendliness and
+  alleviate the pressure on the allocator
+
+### Toward a bytecode interpreter
+
+Those constraints naturally lead to a bytecode compiler and a virtual
+machine that will interpret this bytecode. This approach is not free:
+
+- it can be substantially more complex to design and to implement than a
+    tree-walking interpreter
+- for small configurations with little to no actual evaluation, the cost of
+   compiling and running the bytecode might be higher than the tree-walking
+   approach
+
+It is important to note that there is a whole spectrum between the naive
+tree-walking interpreter and a full-fledged, JITed bytecode interpreter. All in
+all, the simple fact of having a different representation for run-time values is
+already departing from the pure tree-walking interpreter. I don't think we need
+to go the route of a full-fledged low-level bytecode compiler and interpreter,
+but rather to find a trade-off in-between, where compilation is a relatively
+simple and cheap program transformation, while still giving some room for a more
+optimized runtime representation and a faster evaluation scheme.
+
+## VM examples
+
+This section gathers several examples or real world languages and their virtual
+machine as a source of inspiration and comparison. Those examples are selected
+from either functional languages (lazy or not) and simple dynamic language (thus
+with similar challenges regarding the representation of records).
+
+### Lua
+
+### OCaml
+
+### Haskell
+
+### JavaScript
+
+## Proposal

--- a/rfcs/007-bytecode-interpreter.md
+++ b/rfcs/007-bytecode-interpreter.md
@@ -235,11 +235,9 @@ the value.
 | size | color | tag | data ...  |
 ```
 
-ADTs are represented within the block's data as an integer for constructors with
-no argument (the tag byte then doesn't store the actual contructor's tag but has
-the same value than for a boxed `int`). For a variant with parameters, the tag
-byte is used to encode the variant and the argument is stored as a word of block
-content.
+ADTs are represented as an unboxed integer for constructors with no argument.
+For a variant with parameters, the tag byte is used to encode the variant and
+the argument is stored as a word of block content.
 
 Tuples, records and arrays are stored as a contiguous array of data.
 

--- a/rfcs/007-bytecode-interpreter.md
+++ b/rfcs/007-bytecode-interpreter.md
@@ -315,6 +315,13 @@ In Haskell, the update process is performed _by the callee_ instead (the thunk's
 code), such that thunk access is uniform: it's an unconditional jump to the
 corresponding code.
 
+While on paper it seems like there are two indirections (pointer to the closure
+info table -> code pointer -> code), a pointer to the info table is actually a
+direct pointer to the code while the rest of the metadata lies _before_ it, at
+least for native code generation. Entering the code is then a single indirect
+jump instruction on most CPUs, and metadata can be accessed by subtracting from
+the code pointer.
+
 As with other VMs, the environment -- immediately inlined after the code pointer
 -- stores the free variables of the expression that are captured by the closure.
 When entering a closure, a dedicated register holds the pointer to the

--- a/rfcs/007-bytecode-interpreter.md
+++ b/rfcs/007-bytecode-interpreter.md
@@ -104,8 +104,34 @@ with similar challenges regarding the representation of records).
 
 ### OCaml
 
+#### References
+
+- [Real World OCaml chapter on bytecode](https://dev.realworldocaml.org/compiler-backend.html),
+- [Original Leroy's paper: _The ZINC experiment: an economical implementation of
+  the ML language_ (1990)](https://inria.hal.science/inria-00070049/document)
+- [OCaml bytecode instructions](http://cadmium.x9c.fr/distrib/caml-instructions.pdf)
+- [OCaml memory representation of values](https://ocaml.org/docs/memory-representation)
+
+#### Memory representation
+
+OCaml uses a uniform memory representation where any value is represented as a
+single machine word. Unboxed values (integers, floats, etc.) are distinguished
+from pointers by ther least significant bit (and are thus encoded on `n-1` bits
+compared to their, say, C equivalent).
+
+Boxed values are represented as a pointer to a block, which is a contiguous area
+of the memory with a one-word header followed by some arbitrary content, whose
+shape depends on the type of the value.
+
+#### Virtual machine
+
+The OCaml virtual machine is based on the original ZINC experiment by Leroy,
+although it has changed quite a bit since then.
+
 ### Haskell
 
 ### JavaScript
+
+### Clean
 
 ## Proposal

--- a/rfcs/007-bytecode-interpreter.md
+++ b/rfcs/007-bytecode-interpreter.md
@@ -105,11 +105,33 @@ Properties of interests are in particular:
 
 - the memory representation of values
 - the general structure of the virtual machine (stack-based, register-based,
-    reprensetation of the environment, etc.)
+    representation of the environment, etc.)
 - high-level (more instructions, more complex vm, simpler compilation scheme) vs
     low-level
 
 ### Lua
+
+Lua is an efficient scripting language. The design of the virtual machine is
+intended to provide a lightweight and portable VM where code is both simple
+and fast to compile (one-pass) and to run, in particular as Lua is often
+embedded in other software projects (games, industrial systems, etc.).
+
+The Lua virtual machine has some optimizations that are quite Lua-specific (Lua
+represents everything as dictionaries, including traditional contiguous arrays -
+they must optimize such encoding to get reasonable performance), but is an
+interesting inspiration as a simple runtime of a dynamically typed language
+where dictionaries are ubiquitous (kinda like in Nickel).
+
+#### Memory representation
+
+#### Virtual machine
+
+The Lua virtual machine is interestingly register based while most bytecode VMs
+out there are stack-based.
+
+#### References
+
+- [The Implementation of LUA 5](https://www.lua.org/doc/jucs05.pdf)
 
 ### OCaml
 

--- a/rfcs/007-bytecode-interpreter.md
+++ b/rfcs/007-bytecode-interpreter.md
@@ -71,7 +71,9 @@ performance. In particular:
     rather than tree-like (e.g. _flat ASTs_)
 - the size of the atoms of the structure (nodes, values, whatever they are
   called) should be as small as possible, to amplify the cache-friendliness and
-  alleviate the pressure on the allocator
+  alleviate the pressure on the allocator. Of course, there's some trade-off
+  here, as reducing the size is often done by adding indirections, but this also
+  has a cost at runtime
 
 ### Toward a bytecode interpreter
 
@@ -85,26 +87,26 @@ machine that will interpret this bytecode. This approach is not free:
    approach
 
 It is important to note that there is a whole spectrum between the naive
-tree-walking interpreter and a full-fledged, JITed bytecode interpreter. All in
-all, the simple fact of having a different representation for run-time values is
-already departing from the pure tree-walking interpreter. I don't think we need
-to go the route of a full-fledged low-level bytecode compiler and interpreter,
-but rather to find a trade-off in-between, where compilation is a relatively
-simple and cheap program transformation, while still giving some room for a more
-optimized runtime representation and a faster evaluation scheme.
+tree-walking interpreter and a full-fledged, low-level, JITed bytecode
+interpreter. Thee simple fact of having a slightly different representation for
+run-time values is already departing from the pure tree-walking interpreter. I
+don't think we need to go as far as a full-fledged low-level bytecode compiler
+and interpreter, but rather to find a trade-off in-between, where compilation is
+a relatively simple and cheap program transformation while still giving some
+room for a more optimized runtime representation and a faster evaluation scheme.
 
 ## VM examples
 
 This section gathers examples of the virtual machine of real world languages as
 a source of inspiration and comparison. Those examples have been selected to
-offer a variety of design, from either strict or non-strict functional
-languages, statically typed or dynamically typed (thus with similar challenges
-regarding the representation of records).
+showcase a variety of designs and constraints, from either strict or non-strict
+functional languages, statically typed or dynamically typed (thus with similar
+challenges regarding the representation of records).
 
-Properties of interests are in particular:
+We'll look more specifically into the following aspects:
 
 - the memory representation of values
-- the general structure of the virtual machine (stack-based, register-based,
+- the general architecture of the virtual machine (stack-based, register-based,
     representation of the environment, etc.)
 - high-level (more instructions, more complex vm, simpler compilation scheme) vs
     low-level
@@ -112,14 +114,14 @@ Properties of interests are in particular:
 ### Lua
 
 Lua is an efficient scripting language. The design of the virtual machine is
-intended to provide a lightweight and portable VM where code is both simple
-and fast to compile (one-pass) and to run, in particular as Lua is often
-embedded in other software projects (games, industrial systems, etc.).
+intended to provide a lightweight and portable VM where code is both simple and
+fast to compile (one-pass) and to run. Indeed Lua is often embedded in other
+software projects (games, industrial systems, etc.).
 
 The Lua virtual machine has some optimizations that are quite Lua-specific (Lua
 represents everything as dictionaries, including traditional contiguous arrays -
-they must optimize such encoding to get reasonable performance), but is an
-interesting inspiration as a simple runtime of a dynamically typed language
+they must optimize such encoding to get good performance), but it is nonetheless
+an interesting inspiration as a simple runtime of a dynamically typed language
 where dictionaries are ubiquitous (kinda like in Nickel).
 
 #### Memory representation
@@ -130,9 +132,10 @@ Lua has 8 primitive types: `nil`, `boolean`, `number`, `string`, `function`,
 `function`, `table` and `userdata` are represented as pointers to the actual
 data.
 
-This representation takes a few words per value, which isn't small by VM
-standards. Smalltalk, for example, uses spare bits in each pointer, but this
-isn't portable or implementable in ANSI C.
+This representation takes between 3 and 4 words per value (depending on the
+architecture), which isn't small by VM standards. Smalltalk, for example, uses
+spare bits in each pointer to reduce the number of words used, but this isn't
+portable or implementable in ANSI C.
 
 Because tables are used to represent arrays, Lua 5 uses a hybrid representation
 with an array part and a hash part.
@@ -140,16 +143,16 @@ with an array part and a hash part.
 Lua also has a peculiar representation of closures. While compilation of
 closures to native code have a vast body of literature and experience in
 functional languages, most analyses involved are deemed to expensive or too
-complex for a simple one-pass compiler. Instead, outer variables are accessed
-indirectly through a slot called _upvalue_, which orignally points to the stack
-of the enclosing function owning the referenced value. When the stack frame is
-freed, the value is moved to the slot so that it can outlive the enclosing
-function call. Thanks to the additional indirection, this move is invisible to
-the closures themselves. This is combined with flat closures (access to more
-than one outer level causes the corresponding variable to be pulled in the
-enclosing function), and a list of open upvalues to ensure that there's only on
-such slot pointing to one given value at all time, although this slot might be
-shared by many closures.
+complex for a simple one-pass compiler. Instead, in Lua, outer variables are
+accessed indirectly through a slot called _upvalue_, which originally points to
+the stack of the enclosing function owning the referenced value. When the stack
+frame is freed, the value is moved to the slot so that it can outlive the
+enclosing function call. Thanks to the additional indirection, this move is
+invisible to the closures themselves. This is combined with flat closures
+(access to more than one outer level causes the corresponding variable to be
+pulled in the enclosing function), and a list of open upvalues to ensure that
+there's only on such slot pointing to one given value at all time, even if this
+slot is shared by many closures.
 
 #### Virtual machine
 
@@ -159,7 +162,7 @@ are purely stack-based. Registers save many `push` and `pop` operations, which
 both avoids a non-trivial amount of copying (especially with the tagged union
 representation) and reduces the number of instructions (albeit the instructions
 are larger, because they often need additional operands to indicate which
-registers they operate on). Register also reduce the number of instructions
+registers they operate on). Registers also reduce the number of instructions
 needed: the Lua VM only has 35. The Lua VM has 256 registers represented as an
 array at runtime guaranteeing fast access.
 
@@ -183,13 +186,13 @@ shape depends on the type of the value.
 
 #### Virtual machine
 
-The OCaml virtual machine is based on the original ZAM (ZINC Abstract Machine)
-experiment by Leroy, although it might have changed quite a bit since then. The
-ZAM is a stack-based virtual machine derived from standard machines (like SECD)
-for call-by-value lambda-calculus, but optimized for currying and partial
-application of closures: it uses Krivine's "push-enter" strategy where the SECD
-uses "eval-apply". The environment is close to the current Nix representation
-(linked list of arrays, last layer isn't shared).
+The OCaml virtual machine is based on the ZAM (ZINC Abstract Machine) experiment
+by Leroy, although it has evolved a bit since then. The ZAM is a stack-based
+virtual machine derived from standard machines  for call-by-value
+lambda-calculus (like SECD). The ZAM is optimized for currying and partial
+application of closures: it uses a "push-enter" evaluation strategy, as in the
+Krivine machine, where the SECD uses "eval-apply". The environment is close to
+the current Nix representation (linked list of arrays, last layer isn't shared).
 
 The ZAM has 145 instructions where many of them are variations of the same
 operation (`APPLY`, `APPLY1`, `APPLY2` and `APPLY3` for instance). They are
@@ -197,7 +200,7 @@ reduced to rather low-level operation: environment manipulation, function
 application, boolean and integers operations, branching, exceptions, memory
 allocation/value creation.
 
-#### Structure
+**Registers**
 
 - PC: program counter
 - SP: stack pointer
@@ -219,6 +222,46 @@ allocation/value creation.
 ### Haskell
 
 ### JavaScript
+
+JavaScript doesn't have one official virtual machine, but rather many different
+performance-oriented implementations. We'll focus on the V8 engine, which is one
+of the most ubiquitous and performant. V8 is a really complex JIT compiler,
+which doesn't really fit the model of a basic bytecode interpreter, but it still
+has a bytecode interpreter (Ignition) and interesting memory representations
+optimized for dynamic dictionaries (JavaScript's objects).
+
+#### Memory representation
+
+V8 uses a technique called _fast properties_ to represent objects, which is in
+substance not very different from the technique used in Lua, and for similar
+reasons (make array operation fasts although they are technically just objects
+with integer properties).
+
+#### Virtual machine
+
+V8 is designed to be an optimizing JIT native code compiler. Ignition adds a new
+intermediate representation, higher-level than native code but lower-level than
+the AST, that serves both as a good and cheap to compile runtime representation,
+which can then be specialized to native code when needed. It also serves as a
+source of truth and an exchange format between the different optimizing
+compilers.
+
+The bytecode has been optimized for size more than speed, as the main motivation
+behind Ignition was to reduce the memory footprint of the V8 engine. The VM is
+register-based, with an unbounded number of local registers (or so it seems,
+which are stored on the local stack of the function - so register are more like
+stack slots?). It also needs to fit as an input to the Turbofan optimizing
+compiler, and to be easy to go from bytecode to machine code. In fact, the
+Ignition interpreter is more like a very lazy compiler: interpretation is done
+by generating on-the-fly macro-assembly (a kind of portable assembly used by the
+Turbofan optimizing compiler) that is then transpiled by Turbofan to machine
+code, and this for every primitive instruction.
+
+#### References
+
+- [V8 documentation: fast properties](https://v8.dev/blog/ignition-interpreter)
+- [V8 documentation: Ignition interpreter](https://v8.dev/blog/ignition-interpreter)
+- [V8 implementation: list of instructions](https://github.com/v8/v8/blob/master/src/interpreter/bytecodes.h)
 
 ### Clean
 

--- a/rfcs/007-bytecode-interpreter.md
+++ b/rfcs/007-bytecode-interpreter.md
@@ -207,8 +207,9 @@ represented as a packed array at runtime, guaranteeing fast access.
 #### Memory representation
 
 The following notes on the memory representation applies to the native code
-backend's representation. I'm not sure how closures are represented in the Zinc
-Abstract Machine.
+backend's representation. As far as I can tell, closures are represented the
+same way in the Zinc Abstract Machine. Itmust be so at least to some degree
+forthe sake of the FFI where OCaml values can be manipulated.
 
 OCaml uses a uniform memory representation where any value is represented as a
 single machine word. Unboxed values (integers, etc.) are distinguished from

--- a/rfcs/007-bytecode-interpreter.md
+++ b/rfcs/007-bytecode-interpreter.md
@@ -331,7 +331,7 @@ environment for fast access.
 The STG paper argues that this uniform thunk representation (with "self-handled
 update") simplifies the compilation process and gives room for some specific
 optimizations (vectored return for pattern matching, for example) that should be
-beneficial to Haskell programs.
+beneficial to Haskell programs[^haskell-closure-tagging].
 
 In Haskell, every data is considered to be an algebraic data type, including
 primitive types such as integers, which is just `data Int = MkInt Int#` (where
@@ -349,6 +349,11 @@ environment in the case of closures). As each constructor usage potentially
 generates very similar code, GHC is smart enough to share common constructors
 instead of generating them again and again (typically the one for an empty
 list).
+
+[^haskell-closure-tagging]: In practice, since the STG paper was written, GHC
+    uses some pointer tagging to mark if a thunk is already forced (inlining the
+    constructors of the datatype in the tag), for efficiency when pattern
+    matching.
 
 #### Virtual machine
 

--- a/rfcs/007-bytecode-interpreter.md
+++ b/rfcs/007-bytecode-interpreter.md
@@ -95,10 +95,19 @@ optimized runtime representation and a faster evaluation scheme.
 
 ## VM examples
 
-This section gathers several examples or real world languages and their virtual
-machine as a source of inspiration and comparison. Those examples are selected
-from either functional languages (lazy or not) and simple dynamic language (thus
-with similar challenges regarding the representation of records).
+This section gathers examples of the virtual machine of real world languages as
+a source of inspiration and comparison. Those examples have been selected to
+offer a variety of design, from either strict or non-strict functional
+languages, statically typed or dynamically typed (thus with similar challenges
+regarding the representation of records).
+
+Properties of interests are in particular:
+
+- the memory representation of values
+- the structure of the virtual machine (stack-based, register-based,
+    reprensetation of the environment, etc.)
+- high-level (more instructions, more complex vm, simpler compilation scheme) vs
+    low-level
 
 ### Lua
 


### PR DESCRIPTION
Although the name is a bit pompous, the goal of this RFC is mostly to be a working document for designing a more compact and efficient run-time representation for Nickel expressions.

While this is something that won't be user-facing (at least in a direct way), and thus can be changed later without breaking backward-compatibility, I think the technical scope of this effort is such that I find it better to discuss it formally here before going for a first implementation.