### PR TITLE
Add a flake check for testing the stdlib

### DIFF
--- a/core/stdlib/std.ncl
+++ b/core/stdlib/std.ncl
@@ -4356,6 +4356,11 @@
       std.fail_with "message"
       # => error: message
       ```
+
+      ```nickel
+      1
+      # => 2
+      ```
     "%
     = fun msg => null | FailWith msg,
 }

--- a/core/stdlib/std.ncl
+++ b/core/stdlib/std.ncl
@@ -4356,11 +4356,6 @@
       std.fail_with "message"
       # => error: message
       ```
-
-      ```nickel
-      1
-      # => 2
-      ```
     "%
     = fun msg => null | FailWith msg,
 }

--- a/flake.nix
+++ b/flake.nix
@@ -670,6 +670,12 @@
         pkgs.mkShell {
           buildInputs = [ terraform run-terraform update-infra ];
         };
+
+      stdlibTests = pkgs.runCommandLocal "stdlib-test" { }
+        ''
+          ${pkgs.lib.getExe self.packages."${system}".default} test ${./core/stdlib/std.ncl};
+          mkdir $out
+        '';
     in
     rec {
       packages = {
@@ -725,7 +731,7 @@
         # shorter. Another option would be to compile a dev dependencies version
         # of cargoArtifacts. But that almost doubles the cache space.
         nickelWasm = buildNickelWasm { profile = "release"; };
-        inherit vscodeExtension;
+        inherit vscodeExtension stdlibTests;
         pre-commit = pre-commit-builder { };
       };
     }

--- a/flake.nix
+++ b/flake.nix
@@ -673,8 +673,7 @@
 
       stdlibTests = pkgs.runCommandLocal "stdlib-test" { }
         ''
-          ${pkgs.lib.getExe self.packages."${system}".default} test ${./core/stdlib/std.ncl};
-          mkdir $out
+          ${pkgs.lib.getExe self.packages."${system}".default} test ${./core/stdlib/std.ncl} && mkdir $out
         '';
     in
     rec {


### PR DESCRIPTION
An amusing little thing that I think is harmless: when a test in the stdlib uses the `std` name (like `std.contract.not`) then it's testing the copy of the stdlib that was compiled into the nickel binary. But when it uses a "local" name (like `HasField`) then it's testing the copy of the stdlib that it gets from the path `./core/stdlib/std.ncl`.