### PR TITLE
Fix completions in incomplete field name position.

### DIFF
--- a/lsp/nls/tests/inputs/completion-incomplete-record-field.ncl
+++ b/lsp/nls/tests/inputs/completion-incomplete-record-field.ncl
@@ -1,0 +1,9 @@
+### /main.ncl
+{
+  field.
+} | { field = { foo } }
+### [[request]]
+### type = "Completion"
+### textDocument.uri = "file:///main.ncl"
+### position = { line = 1, character = 8 }
+### context = { triggerKind = 2, triggerCharacter = "." }

--- a/lsp/nls/tests/inputs/completion-incomplete-record-value.ncl
+++ b/lsp/nls/tests/inputs/completion-incomplete-record-value.ncl
@@ -1,0 +1,10 @@
+### /main.ncl
+let baz = { bar = 1 } in
+{
+  field.foo = baz.
+} | { field = { foo } }
+### [[request]]
+### type = "Completion"
+### textDocument.uri = "file:///main.ncl"
+### position = { line = 2, character = 18 }
+### context = { triggerKind = 2, triggerCharacter = "." }

--- a/lsp/nls/tests/snapshots/main__lsp__nls__tests__inputs__completion-incomplete-record-field.ncl.snap
+++ b/lsp/nls/tests/snapshots/main__lsp__nls__tests__inputs__completion-incomplete-record-field.ncl.snap
@@ -1,0 +1,5 @@
+---
+source: lsp/nls/tests/main.rs
+expression: output
+---
+[foo]

--- a/lsp/nls/tests/snapshots/main__lsp__nls__tests__inputs__completion-incomplete-record-value.ncl.snap
+++ b/lsp/nls/tests/snapshots/main__lsp__nls__tests__inputs__completion-incomplete-record-value.ncl.snap
@@ -1,0 +1,5 @@
+---
+source: lsp/nls/tests/main.rs
+expression: output
+---
+[bar]


### PR DESCRIPTION
This fixes part of the problem in this [tf-ncl issue](https://github.com/tweag/tf-ncl/issues/49): when input failed to parse we would always try to treat it as a record *path*, meaning that the completions we'd return for

```
{ field. } | C
```

were the same as the ones we'd return for

```
{ blah = field. } | C
```

This PR fixes the problem by (when appropriate) completing the input as we would do for a record field.

There's still a performance issue, which I think is mostly caused by the massive size of our reply: we return the full text of the contract. We should probably detect when it's large and truncate.