### PR TITLE
Add a type parameter to TypeF for contracts

### DIFF
--- a/cli/src/doctest.rs
+++ b/cli/src/doctest.rs
@@ -428,7 +428,7 @@ fn doctest_transform(
                                 ["contract", "Equal"],
                             );
                             let eq = mk_app!(eq, expected_term);
-                            let eq_ty = Type::from(TypeF::Flat(eq));
+                            let eq_ty = Type::from(TypeF::Contract(eq));
                             test_term = Term::Annotated(
                                 TypeAnnotation {
                                     typ: None,

--- a/core/src/eval/merge.rs
+++ b/core/src/eval/merge.rs
@@ -229,7 +229,7 @@ pub fn merge<C: Cache>(
             );
 
             let label = Label {
-                typ: Rc::new(TypeF::Flat(contract_for_display).into()),
+                typ: Rc::new(TypeF::Contract(contract_for_display).into()),
                 span: MergeLabel::from(mode).span,
                 ..Default::default()
             }

--- a/core/src/pretty.rs
+++ b/core/src/pretty.rs
@@ -136,7 +136,7 @@ fn contains_carriage_return<T>(chunks: &[StrChunk<T>]) -> bool {
 /// example when said term is a function function. This function precisely determines if the given
 /// type is such a term.
 fn needs_parens_in_type_pos(typ: &Type) -> bool {
-    if let TypeF::Flat(term) = &typ.typ {
+    if let TypeF::Contract(term) = &typ.typ {
         matches!(
             term.as_ref(),
             Term::Fun(..)
@@ -1248,7 +1248,7 @@ impl<'a> Pretty<'a, Allocator> for &Type {
             .group(),
             ForeignId => allocator.text("ForeignId"),
             Symbol => allocator.text("Symbol"),
-            Flat(t) => t.pretty(allocator),
+            Contract(t) => t.pretty(allocator),
             Var(var) => allocator.as_string(var),
             Forall { var, ref body, .. } => {
                 let mut curr = body.as_ref();

--- a/core/src/transform/free_vars.rs
+++ b/core/src/transform/free_vars.rs
@@ -227,7 +227,7 @@ impl CollectFreeVars for Type {
                 ty1.as_mut().collect_free_vars(set);
                 ty2.as_mut().collect_free_vars(set);
             }
-            TypeF::Flat(ref mut rt) => rt.collect_free_vars(set),
+            TypeF::Contract(ref mut rt) => rt.collect_free_vars(set),
         }
     }
 }

--- a/core/src/typecheck/eq.rs
+++ b/core/src/typecheck/eq.rs
@@ -1,4 +1,4 @@
-//! Computation of type equality for contracts (flat types).
+//! Computation of type equality for contracts.
 //!
 //! Determine if two contracts are equal as opaque types. Used to decide if two contract should
 //! unify.
@@ -702,7 +702,7 @@ fn type_eq_bounded<E: TermEnvironment>(
                         })
                         .unwrap_or(false)
                 }
-                (TypeF::Flat(t1), TypeF::Flat(t2)) => {
+                (TypeF::Contract((t1, env1)), TypeF::Contract((t2, env2))) => {
                     contract_eq_bounded(state, t1, env1, t2, env2)
                 }
                 (
@@ -757,9 +757,6 @@ fn type_eq_bounded<E: TermEnvironment>(
             id1 == id2
         }
         (GenericUnifType::Constant(i1), GenericUnifType::Constant(i2)) => i1 == i2,
-        (GenericUnifType::Contract(t1, env2), GenericUnifType::Contract(t2, env1)) => {
-            contract_eq_bounded(state, t1, env1, t2, env2)
-        }
         _ => false,
     }
 }

--- a/core/src/typecheck/error.rs
+++ b/core/src/typecheck/error.rs
@@ -8,7 +8,6 @@ use crate::{
     identifier::LocIdent,
     label::ty_path,
     position::TermPos,
-    term::RichTerm,
     typ::{TypeF, VarKindDiscriminant},
 };
 
@@ -231,12 +230,6 @@ pub enum UnifError {
         expected_const_id: VarId,
         inferred: UnifType,
     },
-    /// A flat type, which is an opaque type corresponding to custom contracts, contained a Nickel
-    /// term different from a variable. Only a variables is a legal inner term of a flat type.
-    IncomparableFlatTypes {
-        expected: RichTerm,
-        inferred: RichTerm,
-    },
     /// An unbound type variable was referenced.
     UnboundTypeVariable(LocIdent),
     /// An error occurred when unifying the domains of two arrows.
@@ -353,13 +346,6 @@ impl UnifError {
                 violating_type: inferred.to_type(names_reg, state.table),
                 pos,
             },
-            UnifError::IncomparableFlatTypes { expected, inferred } => {
-                TypecheckError::IncomparableFlatTypes {
-                    expected,
-                    inferred,
-                    pos,
-                }
-            }
             UnifError::MissingRow {
                 id,
                 expected,

--- a/core/src/typecheck/operation.rs
+++ b/core/src/typecheck/operation.rs
@@ -643,16 +643,7 @@ pub fn custom_contract_type() -> UnifType {
 /// |]
 /// ```
 pub fn custom_contract_ret_type() -> UnifType {
-    mk_uty_enum!(
-        ("Ok", mk_uniftype::dynamic()),
-        // /!\ IMPORTANT
-        //
-        // During typechecking, `TypeF::Flat` all have been transformed to `UnifType::Contract(..)`
-        // with their associated environment. Generating a `TypeF::Flat` at this point will panic
-        // in the best case (we should catch that), or have incorrect behavior in the worst case.
-        // Do not turn this into `UnifType::concrete(TypeF::Flat(..))`.
-        ("Error", error_data_type())
-    )
+    mk_uty_enum!(("Ok", mk_uniftype::dynamic()), ("Error", error_data_type()))
 }
 
 /// The type of error data that can be returned by a custom contract:
@@ -686,5 +677,8 @@ fn error_data_type() -> UnifType {
         .optional()
         .no_value();
 
-    UnifType::Contract(error_data.build(), SimpleTermEnvironment::new())
+    UnifType::concrete(TypeF::Contract((
+        error_data.build(),
+        SimpleTermEnvironment::new(),
+    )))
 }

--- a/core/src/typecheck/reporting.rs
+++ b/core/src/typecheck/reporting.rs
@@ -156,11 +156,11 @@ impl ToType for UnifType {
                     |btyp, reg| Box::new(btyp.to_type(reg, table)),
                     |rrows, reg| rrows.to_type(reg, table),
                     |erows, reg| erows.to_type(reg, table),
+                    |(ctr, _env), _reg| ctr,
                     reg,
                 );
                 Type::from(mapped)
             }
-            UnifType::Contract(t, _) => Type::from(TypeF::Flat(t)),
         }
     }
 }

--- a/core/tests/integration/inputs/typecheck/type_in_term_position.ncl
+++ b/core/tests/integration/inputs/typecheck/type_in_term_position.ncl
@@ -2,5 +2,5 @@
 # eval = 'typecheck'
 # 
 # [test.metadata]
-# error = 'TypecheckError::FlatTypeInTermPosition'
+# error = 'TypecheckError::CtrTypeInTermPos'
 (let c = Number -> (4 + 1) in 3): _

--- a/core/tests/integration/main.rs
+++ b/core/tests/integration/main.rs
@@ -202,8 +202,8 @@ enum ErrorExpectation {
     TypecheckMissingDynTail,
     #[serde(rename = "TypecheckError::ArrowTypeMismatch")]
     TypecheckArrowTypeMismatch { cause: Box<ErrorExpectation> },
-    #[serde(rename = "TypecheckError::FlatTypeInTermPosition")]
-    TypecheckFlatTypeInTermPosition,
+    #[serde(rename = "TypecheckError::CtrTypeInTermPos")]
+    TypecheckCtrTypeInTermPos,
     #[serde(rename = "TypecheckError::VarLevelMismatch")]
     TypecheckVarLevelMismatch { type_var: String },
     #[serde(rename = "TypecheckError::OrPatternVarsMismatch")]
@@ -264,8 +264,8 @@ impl PartialEq<Error> for ErrorExpectation {
             )
             | (TypecheckExtraDynTail, Error::TypecheckError(TypecheckError::ExtraDynTail { .. }))
             | (
-                TypecheckFlatTypeInTermPosition,
-                Error::TypecheckError(TypecheckError::FlatTypeInTermPosition { .. }),
+                TypecheckCtrTypeInTermPos,
+                Error::TypecheckError(TypecheckError::CtrTypeInTermPos { .. }),
             )
             | (ImportParseError, Error::ImportError(ImportError::ParseErrors(..)))
             | (ImportIoError, Error::ImportError(ImportError::IOError(..)))
@@ -448,7 +448,7 @@ impl std::fmt::Display for ErrorExpectation {
             TypecheckArrowTypeMismatch { cause } => {
                 format!("TypecheckError::ArrowTypeMismatch({cause})")
             }
-            TypecheckFlatTypeInTermPosition => "TypecheckError::FlatTypeInTermPosition".to_owned(),
+            TypecheckCtrTypeInTermPos => "TypecheckError::CtrTypeInTermPos".to_owned(),
             TypecheckVarLevelMismatch { type_var } => {
                 format!("TypecheckError::VarLevelMismatch({type_var})")
             }

--- a/lsp/nls/src/field_walker.rs
+++ b/lsp/nls/src/field_walker.rs
@@ -482,7 +482,7 @@ impl<'a> FieldResolver<'a> {
             TypeF::Record(rows) => vec![Container::RecordType(rows.clone())],
             TypeF::Dict { type_fields, .. } => vec![Container::Dict(type_fields.as_ref().clone())],
             TypeF::Array(elt_ty) => vec![Container::Array(elt_ty.as_ref().clone())],
-            TypeF::Flat(rt) => self.resolve_container(rt),
+            TypeF::Contract(rt) => self.resolve_container(rt),
             _ => Default::default(),
         }
     }


### PR DESCRIPTION
The TypeF recursion scheme is parametrized by a number of (Rust) types: the type of Nickel types, the type of enum rows and the type of record rows. There is one more Rust type that can be stored in a TypeF: a contract. It's currently hardcoded to be a `RichTerm`, which is fine because we never want to use another Rust type to store something else

With the development of the experimental bytecode interpreter, we are changing the representation of terms. Because we want to keep mailine Nickel operational during the transition, we have to copy paste all the `typ` module somewhere else, replacing `RichTerm` with the type of the new AST.

There is an alternative: as `TypeF` is already parametrized by a bunch of things, why not also parametrize the type of what's stored inside `TypeF::Contract`? This adds a bit more complexity, and requires an additional closure when mapping on or recursing into a `Type`. But the price doesn't seem too high, and we can reuse the same implementation for both mainline Nickel and bytecode Nickel.

There is an unexpected benefit: in fact, we do store something else than a `RichTerm`! During typechecking, we need to store an additional environment alongside a contract in order to properly compute contract equality. This led to having an additional constructor `GenericUnifType::Contract`, that must be handled separately from concrete types. When converting from a `Type` to a `UnifType`, the node `TypeF::Flat` is converted to`GenericUnifType::Contract`, and all typechecking functions then assume the invariant that they will never encounter a `TypeF::Flat`. But the Rust type system can't guarantee it. There's also a bespoke runtime error for that (although we're pretty sure it can't happen), a bunch of `debug_assert`, etc.

We can thus kill two birds with one stone: by parametrizing `TypeF`, we can now instantiate it with `(RichTerm, Environment)` for unification types. No need for runtime invariants or ad-hoc treatment anymore.

Doing so, we also rename `TypeF::Flat` to `TypeF::Contract`, the former being a historical but bad name.