### PR TITLE
[RFC007] New AST for types

### DIFF
--- a/core/src/bytecode/ast/typ.rs
+++ b/core/src/bytecode/ast/typ.rs
@@ -1,0 +1,33 @@
+//! Representation of Nickel types in the AST.
+
+use super::{Ast, TermPos};
+use crate::typ as mainline_typ;
+pub use mainline_typ::{EnumRowF, EnumRowsF, RecordRowF, RecordRowsF, TypeF};
+
+/// The recursive unrolling of a type, that is when we "peel off" the top-level layer to find the actual
+/// structure represented by an instantiation of `TypeF`.
+pub type TypeUnr<'ast> = TypeF<&'ast Type<'ast>, RecordRows<'ast>, EnumRows<'ast>, Ast<'ast>>;
+
+/// The recursive unrolling of a enum rows.
+pub type EnumRowsUnr<'ast> = EnumRowsF<&'ast Type<'ast>, &'ast EnumRows<'ast>>;
+
+/// The recursive unrolling of record rows.
+pub type RecordRowsUnr<'ast> = RecordRowsF<&'ast Type<'ast>, &'ast RecordRows<'ast>>;
+
+/// Concrete, recursive definition for an enum row.
+pub type EnumRow<'ast> = EnumRowF<&'ast Type<'ast>>;
+/// Concrete, recursive definition for enum rows.
+#[derive(Clone, PartialEq, Debug)]
+pub struct EnumRows<'ast>(pub EnumRowsUnr<'ast>);
+/// Concrete, recursive definition for a record row.
+pub type RecordRow<'ast> = RecordRowF<&'ast Type<'ast>>;
+#[derive(Clone, PartialEq, Debug)]
+/// Concrete, recursive definition for record rows.
+pub struct RecordRows<'ast>(pub RecordRowsUnr<'ast>);
+
+/// Concrete, recursive type for a Nickel type.
+#[derive(Clone, PartialEq, Debug)]
+pub struct Type<'ast> {
+    pub typ: TypeUnr<'ast>,
+    pub pos: TermPos,
+}


### PR DESCRIPTION
Depends on #2072

The previous PR #2072 introducing the new AST used the "old" type representation from mainline Nickel. Now that `typ::Type` has been made more generic in #2078, we can use a better representation that can be arena allocated as well and can contain contracts that are themselves represented in the new AST.

This PR integrates this new type representation and adds corresponding translation functions from the mainline implementation.