### PR TITLE
Add basic runtime metrics for different phases

### DIFF
--- a/core/src/metrics.rs
+++ b/core/src/metrics.rs
@@ -28,5 +28,24 @@ macro_rules! sample {
     ( $( $args:expr ),+ ) => {};
 }
 
+#[cfg(feature = "metrics")]
+macro_rules! measure_runtime {
+    ( $counter:expr, $expr:expr ) => {{
+        let start_time = ::std::time::Instant::now();
+        let result = $expr;
+        let duration = start_time.elapsed();
+        ::metrics::counter!($counter, duration.as_millis() as u64);
+        result
+    }};
+}
+
+#[cfg(not(feature = "metrics"))]
+macro_rules! measure_runtime {
+    ( $counter: expr, $expr: expr ) => {
+        $expr
+    };
+}
+
 pub(crate) use increment;
+pub(crate) use measure_runtime;
 pub(crate) use sample;


### PR DESCRIPTION
The goal is to have some coarse metrics to decide if switching the parser to the new AST and then converting back to the old one (to replace the current pipeline step by step) is going to have any noticeable performance hit. And also because it's quite useful in general to see which phases are the most costly. 

As a first experiment, on the private benchmark of 24kLoC of Nickel (plus 10-15kLoc of JSON or YAML), it's already interesting to see that the evaluation cost trumps pretty much everything else measured (type checking, stdlib prep, transformation, etc.). Preparing (parse + import resolution + transformation + type checking) is < 2% of the eval time (not even the total time, which is probably also impacted by serialization, substitution and pretty printing). Preparing the stdlib is < 0.1%, typechecking the main file is < 0.5%, and parsing is in the same order of magnitude as those.

On a small example (GCC example), almost all operations are negligible anyway (a handful of ms for each stage). So there's a good chance that the conversion from the new ast to the old ast will be reasonable in both case (in small cases it should be fast, in large examples it should be trumped by evaluation). But we'll make a more thorough benchmarking anyway.