### PR TITLE
[RFC007] Fix the representation of Ast: remove inner indirection 

### DIFF
--- a/core/src/bytecode/ast/mod.rs
+++ b/core/src/bytecode/ast/mod.rs
@@ -250,7 +250,7 @@ impl AstAlloc {
         self.generic_arena.alloc(node)
     }
 
-    pub fn number<'ast>(&'ast self, number: Number) -> Node<'ast> {
+    pub fn number(&self, number: Number) -> Node<'_> {
         Node::Number(self.number_arena.alloc(number))
     }
 

--- a/core/src/bytecode/ast/typ.rs
+++ b/core/src/bytecode/ast/typ.rs
@@ -6,7 +6,7 @@ pub use mainline_typ::{EnumRowF, EnumRowsF, RecordRowF, RecordRowsF, TypeF};
 
 /// The recursive unrolling of a type, that is when we "peel off" the top-level layer to find the actual
 /// structure represented by an instantiation of `TypeF`.
-pub type TypeUnr<'ast> = TypeF<&'ast Type<'ast>, RecordRows<'ast>, EnumRows<'ast>, Ast<'ast>>;
+pub type TypeUnr<'ast> = TypeF<&'ast Type<'ast>, RecordRows<'ast>, EnumRows<'ast>, &'ast Ast<'ast>>;
 
 /// The recursive unrolling of a enum rows.
 pub type EnumRowsUnr<'ast> = EnumRowsF<&'ast Type<'ast>, &'ast EnumRows<'ast>>;


### PR DESCRIPTION
Depends on #2080.

`bytecode::ast::Ast` wasn't following the general approach that we set for designing other datastructures of the ast: use references within enums to avoid size bloat, but use owned data in structures to avoid indirection (since structures are packed).

Ast was doing something different, pushing the reference inside the individual fields to make a relatively thin pointer around `Node` and store that datastructure inline in the `Node` enum. While this essentially doesn't make a huge difference, we rather follow our simple general rule. Additionally, other data structures such as `bytecode::ast:typ::Type` follows the simple general rule, and we would rather do the same thing everywhere in a consistent manner.

Doing so, this commit also cleans a bit the interface of `AstAlloc` to reflect the ownership change and to get rid of some variations of methods in the sake of simplicity.