### PR TITLE
Make files copy-on-write

### DIFF
--- a/cli/src/error.rs
+++ b/cli/src/error.rs
@@ -3,9 +3,10 @@
 use nickel_lang_core::{
     error::{
         report::{ColorOpt, ErrorFormat},
-        Diagnostic, FileId, Files, IntoDiagnostics, ParseError,
+        Diagnostic, IntoDiagnostics, ParseError,
     },
     eval::cache::lazy::CBNCache,
+    files::{FileId, Files},
     program::{FieldOverride, FieldPath, Program},
 };
 
@@ -62,12 +63,8 @@ pub enum Error {
     FailedTests,
 }
 
-impl IntoDiagnostics<FileId> for CliUsageError {
-    fn into_diagnostics(
-        self,
-        files: &mut Files<String>,
-        stdlib_ids: Option<&Vec<FileId>>,
-    ) -> Vec<Diagnostic<FileId>> {
+impl IntoDiagnostics for CliUsageError {
+    fn into_diagnostics(self, files: &mut Files) -> Vec<Diagnostic<FileId>> {
         fn mk_unknown_diags<FileId>(
             data: UnknownFieldData,
             method: &str,
@@ -120,7 +117,7 @@ impl IntoDiagnostics<FileId> for CliUsageError {
                     ])]
             }
             CliUsageError::AssignmentParseError { error } => {
-                let mut diags = IntoDiagnostics::into_diagnostics(error, files, stdlib_ids);
+                let mut diags = IntoDiagnostics::into_diagnostics(error, files);
                 diags.push(
                     Diagnostic::note()
                         .with_message("when parsing a field assignment on the command line")
@@ -135,7 +132,7 @@ impl IntoDiagnostics<FileId> for CliUsageError {
                 diags
             }
             CliUsageError::FieldPathParseError { error } => {
-                let mut diags = IntoDiagnostics::into_diagnostics(error, files, stdlib_ids);
+                let mut diags = IntoDiagnostics::into_diagnostics(error, files);
                 diags.push(
                     Diagnostic::note()
                         .with_message("when parsing a field path on the command line")
@@ -164,12 +161,8 @@ pub enum Warning {
     EmptyQueryPath,
 }
 
-impl<FileId> IntoDiagnostics<FileId> for Warning {
-    fn into_diagnostics(
-        self,
-        _files: &mut Files<String>,
-        _stdlib_ids: Option<&Vec<FileId>>,
-    ) -> Vec<Diagnostic<FileId>> {
+impl IntoDiagnostics for Warning {
+    fn into_diagnostics(self, _files: &mut Files) -> Vec<Diagnostic<FileId>> {
         vec![Diagnostic::warning()
             .with_message("empty query path")
             .with_notes(vec![

--- a/core/src/cache.rs
+++ b/core/src/cache.rs
@@ -1126,13 +1126,6 @@ impl Cache {
         &self.files
     }
 
-    /// Get a mutable reference to the underlying files. Required by
-    /// [crate::error::IntoDiagnostics::into_diagnostics].
-    /// TODO: maybe we can delete this now?
-    pub fn files_mut(&mut self) -> &mut Files {
-        &mut self.files
-    }
-
     /// Get an immutable reference to the cached term roots
     pub fn terms(&self) -> &HashMap<FileId, TermEntry> {
         &self.terms

--- a/core/src/cache.rs
+++ b/core/src/cache.rs
@@ -4,6 +4,7 @@ use crate::closurize::Closurize as _;
 use crate::error::{Error, ImportError, ParseError, ParseErrors, TypecheckError};
 use crate::eval::cache::Cache as EvalCache;
 use crate::eval::Closure;
+use crate::files::{FileId, Files};
 use crate::metrics::measure_runtime;
 #[cfg(feature = "nix-experimental")]
 use crate::nix_ffi;
@@ -18,7 +19,6 @@ use crate::typ::UnboundTypeVariableError;
 use crate::typecheck::{self, type_check, TypecheckMode, Wildcards};
 use crate::{eval, parser, transform};
 
-use codespan::{FileId, Files};
 use io::Read;
 use serde::Deserialize;
 use std::collections::hash_map;
@@ -110,7 +110,7 @@ impl InputFormat {
 #[derive(Debug, Clone)]
 pub struct Cache {
     /// The content of the program sources plus imports.
-    files: Files<String>,
+    files: Files,
     file_paths: HashMap<FileId, SourcePath>,
     /// The name-id table, holding file ids stored in the database indexed by source names.
     file_ids: HashMap<SourcePath, NameIdEntry>,
@@ -120,8 +120,6 @@ pub struct Cache {
     rev_imports: HashMap<FileId, HashSet<FileId>>,
     /// The table storing parsed terms corresponding to the entries of the file database.
     terms: HashMap<FileId, TermEntry>,
-    /// The list of ids corresponding to the stdlib modules
-    stdlib_ids: Option<HashMap<StdlibModule, FileId>>,
     /// The inferred type of wildcards for each `FileId`.
     wildcards: HashMap<FileId, Wildcards>,
     /// Whether processing should try to continue even in case of errors. Needed by the NLS.
@@ -374,7 +372,6 @@ impl Cache {
             wildcards: HashMap::new(),
             imports: HashMap::new(),
             rev_imports: HashMap::new(),
-            stdlib_ids: None,
             error_tolerance,
             import_paths: Vec::new(),
 
@@ -458,6 +455,9 @@ impl Cache {
         Ok(self.add_string(source_name, buffer))
     }
 
+    /// Returns the source code of a file.
+    ///
+    /// Panics if the file id is invalid.
     pub fn source(&self, id: FileId) -> &str {
         self.files.source(id)
     }
@@ -561,9 +561,7 @@ impl Cache {
         format: InputFormat,
     ) -> Result<(RichTerm, ParseErrors), ParseError> {
         let attach_pos = |t: RichTerm| -> RichTerm {
-            let pos: TermPos =
-                crate::position::RawSpan::from_codespan(file_id, self.files.source_span(file_id))
-                    .into();
+            let pos: TermPos = self.files.source_span(file_id).into();
             t.with_pos(pos)
         };
 
@@ -1124,13 +1122,14 @@ impl Cache {
 
     /// Get a reference to the underlying files. Required by
     /// the WASM REPL error reporting code and LSP functions.
-    pub fn files(&self) -> &Files<String> {
+    pub fn files(&self) -> &Files {
         &self.files
     }
 
     /// Get a mutable reference to the underlying files. Required by
     /// [crate::error::IntoDiagnostics::into_diagnostics].
-    pub fn files_mut(&mut self) -> &mut Files<String> {
+    /// TODO: maybe we can delete this now?
+    pub fn files_mut(&mut self) -> &mut Files {
         &mut self.files
     }
 
@@ -1202,16 +1201,15 @@ impl Cache {
     /// Returns true if a particular file id represents a Nickel standard library file, false
     /// otherwise.
     pub fn is_stdlib_module(&self, file: FileId) -> bool {
-        let Some(table) = &self.stdlib_ids else {
-            return false;
-        };
-        table.values().any(|stdlib_file| *stdlib_file == file)
+        self.files.is_stdlib(file)
     }
 
     /// Retrieve the FileId for a given standard libray module.
     pub fn get_submodule_file_id(&self, module: StdlibModule) -> Option<FileId> {
-        let file = self.stdlib_ids.as_ref()?.get(&module).copied()?;
-        Some(file)
+        self.files
+            .stdlib_modules()
+            .find(|(m, _id)| m == &module)
+            .map(|(_, id)| id)
     }
 
     /// Returns the set of files that this file imports.
@@ -1248,34 +1246,17 @@ impl Cache {
         ret
     }
 
-    /// Retrieve the FileIds for all the stdlib modules
-    pub fn get_all_stdlib_modules_file_id(&self) -> Option<Vec<FileId>> {
-        let ids = self.stdlib_ids.as_ref()?;
-        Some(ids.values().copied().collect())
-    }
-
     /// Load and parse the standard library in the cache.
     pub fn load_stdlib(&mut self) -> Result<CacheOp<()>, Error> {
-        if self.stdlib_ids.is_some() {
-            return Ok(CacheOp::Cached(()));
-        }
+        let mut ret = CacheOp::Cached(());
 
-        let file_ids: HashMap<StdlibModule, FileId> = nickel_stdlib::modules()
-            .into_iter()
-            .map(|module| {
-                let content = module.content();
-                (
-                    module,
-                    self.add_string(SourcePath::Std(module), String::from(content)),
-                )
-            })
-            .collect();
-
-        for (_, file_id) in file_ids.iter() {
-            self.parse(*file_id, InputFormat::Nickel)?;
+        for (_, file_id) in self.files.stdlib_modules() {
+            let op = self.parse(file_id, InputFormat::Nickel)?;
+            if matches!(op, CacheOp::Done(_)) {
+                ret = CacheOp::Done(());
+            }
         }
-        self.stdlib_ids.replace(file_ids);
-        Ok(CacheOp::Done(()))
+        Ok(ret)
     }
 
     /// Typecheck the standard library. Currently only used in the test suite.
@@ -1301,17 +1282,14 @@ impl Cache {
         &mut self,
         initial_ctxt: &typecheck::Context,
     ) -> Result<CacheOp<()>, CacheError<TypecheckError>> {
-        if let Some(ids) = self.stdlib_ids.as_ref().cloned() {
-            ids.iter()
-                .try_fold(CacheOp::Cached(()), |cache_op, (_, file_id)| {
-                    match self.typecheck(*file_id, initial_ctxt, TypecheckMode::Walk)? {
-                        done @ CacheOp::Done(()) => Ok(done),
-                        _ => Ok(cache_op),
-                    }
-                })
-        } else {
-            Err(CacheError::NotParsed)
-        }
+        self.files
+            .stdlib_modules()
+            .try_fold(CacheOp::Cached(()), |cache_op, (_, file_id)| {
+                match self.typecheck(file_id, initial_ctxt, TypecheckMode::Walk)? {
+                    done @ CacheOp::Done(()) => Ok(done),
+                    _ => Ok(cache_op),
+                }
+            })
     }
 
     /// Load, parse, and apply program transformations to the standard library. Do not typecheck for
@@ -1326,11 +1304,8 @@ impl Cache {
         self.load_stdlib()?;
         let type_ctxt = self.mk_type_ctxt().unwrap();
 
-        self.stdlib_ids
-            .as_ref()
-            .cloned()
-            .expect("cache::prepare_stdlib(): stdlib has been loaded but stdlib_ids is None")
-            .into_iter()
+        self.files
+            .stdlib_modules()
             // We need to handle the internals module separately. Each field
             // is bound directly in the environment without evaluating it first, so we can't
             // tolerate top-level let bindings that would be introduced by `transform`.
@@ -1361,19 +1336,17 @@ impl Cache {
     /// Generate the initial typing context from the list of `file_ids` corresponding to the
     /// standard library parts.
     pub fn mk_type_ctxt(&self) -> Result<typecheck::Context, CacheError<Void>> {
-        let stdlib_terms_vec: Vec<(StdlibModule, RichTerm)> =
-            self.stdlib_ids
-                .as_ref()
-                .map_or(Err(CacheError::NotParsed), |ids| {
-                    Ok(ids
-                        .iter()
-                        .map(|(module, file_id)| {
-                            (*module, self.get_owned(*file_id).expect(
-                                "cache::mk_type_env(): can't build environment, stdlib not parsed",
-                            ))
-                        })
-                        .collect())
-                })?;
+        let stdlib_terms_vec: Vec<(StdlibModule, RichTerm)> = self
+            .files
+            .stdlib_modules()
+            .map(|(module, file_id)| {
+                (
+                    module,
+                    self.get_owned(file_id)
+                        .expect("cache::mk_type_env(): can't build environment, stdlib not parsed"),
+                )
+            })
+            .collect();
         Ok(typecheck::mk_initial_ctxt(&stdlib_terms_vec).unwrap())
     }
 
@@ -1383,44 +1356,39 @@ impl Cache {
         &self,
         eval_cache: &mut EC,
     ) -> Result<eval::Environment, CacheError<Void>> {
-        if let Some(ids) = self.stdlib_ids.as_ref().cloned() {
-            let mut eval_env = eval::Environment::new();
-            ids.iter().for_each(|(module, file_id)| {
-                // The internals module needs special treatment: it's required to be a record
-                // literal, and its bindings are added directly to the environment
-                if let nickel_stdlib::StdlibModule::Internals = module {
-                    let result = eval::env_add_record(
-                        eval_cache,
-                        &mut eval_env,
-                        Closure::atomic_closure(self.get_owned(*file_id).expect(
-                            "cache::mk_eval_env(): can't build environment, stdlib not parsed",
-                        )),
-                    );
-                    if let Err(eval::EnvBuildError::NotARecord(rt)) = result {
-                        panic!(
-                            "cache::load_stdlib(): \
+        let mut eval_env = eval::Environment::new();
+        self.files.stdlib_modules().for_each(|(module, file_id)| {
+            // The internals module needs special treatment: it's required to be a record
+            // literal, and its bindings are added directly to the environment
+            if let nickel_stdlib::StdlibModule::Internals = module {
+                let result = eval::env_add_record(
+                    eval_cache,
+                    &mut eval_env,
+                    Closure::atomic_closure(self.get_owned(file_id).expect(
+                        "cache::mk_eval_env(): can't build environment, stdlib not parsed",
+                    )),
+                );
+                if let Err(eval::EnvBuildError::NotARecord(rt)) = result {
+                    panic!(
+                        "cache::load_stdlib(): \
                             expected the stdlib module {} to be a record, got {:?}",
-                            self.name(*file_id).to_string_lossy().as_ref(),
-                            rt
-                        )
-                    }
-                } else {
-                    eval::env_add(
-                        eval_cache,
-                        &mut eval_env,
-                        module.name().into(),
-                        self.get_owned(*file_id).expect(
-                            "cache::mk_eval_env(): can't build environment, stdlib not parsed",
-                        ),
-                        eval::Environment::new(),
-                    );
+                        self.name(file_id).to_string_lossy().as_ref(),
+                        rt
+                    )
                 }
-            });
+            } else {
+                eval::env_add(
+                    eval_cache,
+                    &mut eval_env,
+                    module.name().into(),
+                    self.get_owned(file_id)
+                        .expect("cache::mk_eval_env(): can't build environment, stdlib not parsed"),
+                    eval::Environment::new(),
+                );
+            }
+        });
 
-            Ok(eval_env)
-        } else {
-            Err(CacheError::NotParsed)
-        }
+        Ok(eval_env)
     }
 }
 
@@ -1622,7 +1590,7 @@ pub mod resolvers {
     /// when needed: don't use this resolver with source code that import non UTF-8 paths.
     #[derive(Clone, Default)]
     pub struct SimpleResolver {
-        files: Files<String>,
+        files: Files,
         file_cache: HashMap<String, FileId>,
         term_cache: HashMap<FileId, RichTerm>,
     }

--- a/core/src/error/report.rs
+++ b/core/src/error/report.rs
@@ -70,7 +70,7 @@ pub fn report<E: IntoDiagnostics>(
 
     report_with(
         &mut StandardStream::stderr(color_opt.for_terminal(stderr().is_terminal())).lock(),
-        cache.files_mut(),
+        &mut cache.files().clone(),
         error,
         format,
     )
@@ -92,7 +92,7 @@ pub fn report_to_stdout<E: IntoDiagnostics>(
 
     report_with(
         &mut StandardStream::stdout(color_opt.for_terminal(stdout().is_terminal())).lock(),
-        cache.files_mut(),
+        &mut cache.files().clone(),
         error,
         format,
     )

--- a/core/src/error/report.rs
+++ b/core/src/error/report.rs
@@ -60,7 +60,7 @@ impl Default for ColorOpt {
 ///
 /// - `cache` is the file cache used during the evaluation, which is required by the reporting
 ///   infrastructure to point at specific locations and print snippets when needed.
-pub fn report<E: IntoDiagnostics<FileId>>(
+pub fn report<E: IntoDiagnostics>(
     cache: &mut Cache,
     error: E,
     format: ErrorFormat,
@@ -68,11 +68,9 @@ pub fn report<E: IntoDiagnostics<FileId>>(
 ) {
     use std::io::{stderr, IsTerminal};
 
-    let stdlib_ids = cache.get_all_stdlib_modules_file_id();
     report_with(
         &mut StandardStream::stderr(color_opt.for_terminal(stderr().is_terminal())).lock(),
         cache.files_mut(),
-        stdlib_ids.as_ref(),
         error,
         format,
     )
@@ -84,7 +82,7 @@ pub fn report<E: IntoDiagnostics<FileId>>(
 ///
 /// - `cache` is the file cache used during the evaluation, which is required by the reporting
 ///   infrastructure to point at specific locations and print snippets when needed.
-pub fn report_to_stdout<E: IntoDiagnostics<FileId>>(
+pub fn report_to_stdout<E: IntoDiagnostics>(
     cache: &mut Cache,
     error: E,
     format: ErrorFormat,
@@ -92,26 +90,23 @@ pub fn report_to_stdout<E: IntoDiagnostics<FileId>>(
 ) {
     use std::io::{stdout, IsTerminal};
 
-    let stdlib_ids = cache.get_all_stdlib_modules_file_id();
     report_with(
         &mut StandardStream::stdout(color_opt.for_terminal(stdout().is_terminal())).lock(),
         cache.files_mut(),
-        stdlib_ids.as_ref(),
         error,
         format,
     )
 }
 
 /// Report an error on `stderr`, provided a file database and a list of stdlib file ids.
-pub fn report_with<E: IntoDiagnostics<FileId>>(
+pub fn report_with<E: IntoDiagnostics>(
     writer: &mut dyn WriteColor,
-    files: &mut Files<String>,
-    stdlib_ids: Option<&Vec<FileId>>,
+    files: &mut Files,
     error: E,
     format: ErrorFormat,
 ) {
     let config = codespan_reporting::term::Config::default();
-    let diagnostics = error.into_diagnostics(files, stdlib_ids);
+    let diagnostics = error.into_diagnostics(files);
     let stderr = std::io::stderr();
 
     let result = match format {

--- a/core/src/eval/callstack.rs
+++ b/core/src/eval/callstack.rs
@@ -2,10 +2,10 @@
 //! application is evaluated. Additional information about the history of function calls is thus
 //! stored in a call stack solely for better error reporting.
 use crate::{
+    files::Files,
     identifier::LocIdent,
     position::{RawSpan, TermPos},
 };
-use codespan::FileId;
 
 /// A call stack, saving the history of function calls.
 #[derive(PartialEq, Eq, Clone, Default, Debug)]
@@ -128,10 +128,7 @@ impl CallStack {
     ///
     /// - `stdlib_ids`: the `FileId`s of the sources containing standard contracts, to filter their
     ///   calls out.
-    pub fn group_by_calls(
-        self: &CallStack,
-        stdlib_ids: &[FileId],
-    ) -> (Vec<CallDescr>, Option<CallDescr>) {
+    pub fn group_by_calls(self: &CallStack, files: &Files) -> (Vec<CallDescr>, Option<CallDescr>) {
         // We filter out calls and accesses made from within the builtin contracts, as well as
         // generated variables introduced by program transformations.
         let it = self.0.iter().filter(|elem| match elem {
@@ -145,7 +142,7 @@ impl CallStack {
             // We avoid applications (Fun/App) with inherited positions. Such calls include
             // contracts applications which add confusing call items whose positions don't point to
             // an actual call in the source.
-                if !stdlib_ids.contains(src_id) =>
+                if !files.is_stdlib(*src_id) =>
             {
                 true
             }

--- a/core/src/eval/mod.rs
+++ b/core/src/eval/mod.rs
@@ -78,6 +78,7 @@ use crate::{
     closurize::{closurize_rec_record, Closurize},
     environment::Environment as GenericEnvironment,
     error::{Error, EvalError},
+    files::FileId,
     identifier::Ident,
     identifier::LocIdent,
     match_sharedterm,
@@ -105,7 +106,6 @@ pub mod operation;
 pub mod stack;
 
 use callstack::*;
-use codespan::FileId;
 use operation::OperationCont;
 use stack::{Stack, StrAccData};
 

--- a/core/src/eval/tests.rs
+++ b/core/src/eval/tests.rs
@@ -2,6 +2,7 @@ use super::cache::CacheImpl;
 use super::*;
 use crate::cache::resolvers::{DummyResolver, SimpleResolver};
 use crate::error::ImportError;
+use crate::files::Files;
 use crate::label::Label;
 use crate::parser::{grammar, lexer, ErrorTolerantParser};
 use crate::term::make as mk_term;
@@ -10,7 +11,6 @@ use crate::term::{BinaryOp, StrChunk, UnaryOp};
 use crate::transform::import_resolution::strict::resolve_imports;
 use crate::{mk_app, mk_fun, mk_record};
 use assert_matches::assert_matches;
-use codespan::Files;
 
 /// Evaluate a term without import support.
 fn eval_no_import(t: RichTerm) -> Result<Term, EvalError> {

--- a/core/src/files.rs
+++ b/core/src/files.rs
@@ -1,0 +1,212 @@
+use std::{
+    ffi::{OsStr, OsString},
+    path::PathBuf,
+    rc::Rc,
+};
+
+use codespan::ByteIndex;
+use codespan_reporting::files::Error;
+use nickel_lang_vector::Vector;
+
+use crate::{position::RawSpan, stdlib::StdlibModule};
+
+#[derive(
+    Copy, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, serde::Serialize, serde::Deserialize,
+)]
+pub struct FileId(u32);
+
+#[derive(Debug, Clone)]
+pub struct File {
+    /// The name of the file.
+    name: OsString,
+    /// The source code of the file.
+    source: Rc<str>,
+    /// The starting byte indices in the source code.
+    line_starts: Rc<[ByteIndex]>,
+}
+
+impl File {
+    pub fn new(name: impl Into<OsString>, source: impl Into<Rc<str>>) -> Self {
+        let source = source.into();
+        let line_starts: Vec<_> = std::iter::once(ByteIndex(0))
+            .chain(
+                source
+                    .match_indices('\n')
+                    .map(|(i, _)| ByteIndex(i as u32 + 1)),
+            )
+            .collect();
+
+        File {
+            name: name.into(),
+            line_starts: line_starts.into(),
+            source,
+        }
+    }
+
+    fn line_index(&self, byte_index: ByteIndex) -> usize {
+        match self.line_starts.binary_search(&byte_index) {
+            Ok(line) => line,
+            // unwrap: we always start off the `line_starts` array with a zero,
+            // so next_line must be at least 1.
+            Err(next_line) => next_line.checked_sub(1).unwrap(),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct Files {
+    files: Vector<File, 8>,
+    first_non_stdlib: usize,
+}
+
+impl Files {
+    pub fn new() -> Self {
+        let files: Vector<_, 8> = crate::stdlib::modules()
+            .iter()
+            .map(|m| File::new(m.file_name().to_owned(), m.content()))
+            .collect();
+
+        Files {
+            first_non_stdlib: files.len(),
+            files,
+        }
+    }
+
+    pub fn is_stdlib(&self, id: FileId) -> bool {
+        (id.0 as usize) < self.first_non_stdlib
+    }
+
+    pub fn stdlib_modules(&self) -> impl Iterator<Item = (StdlibModule, FileId)> {
+        crate::stdlib::modules()
+            .into_iter()
+            .zip(0..)
+            .map(|(m, id)| (m, FileId(id)))
+    }
+
+    pub fn add(&mut self, name: impl Into<OsString>, source: impl Into<Rc<str>>) -> FileId {
+        let file_id = FileId(self.files.len() as u32);
+        self.files.push(File::new(name, source));
+        file_id
+    }
+
+    /// Updates a source file in place.
+    ///
+    /// Panics if `file_id` is invalid.
+    pub fn update(&mut self, file_id: FileId, source: impl Into<Rc<str>>) {
+        // This implementation would be a little nicer if `Vector` supported mutable access.
+        // unwrap: we're allowed to panic if file_id is invalid
+        let mut old = self.get(file_id).unwrap().clone();
+        old.source = source.into();
+        self.files.set(file_id.0 as usize, old);
+    }
+
+    /// Returns a span containing all of a source.
+    ///
+    /// Panics if `file_id` is invalid.
+    pub fn source_span(&self, file_id: FileId) -> RawSpan {
+        // unwrap: we're allowed to panic if file_id is invalid
+        let len = self.get(file_id).unwrap().source.len();
+
+        RawSpan {
+            src_id: file_id,
+            start: ByteIndex(0),
+            end: ByteIndex(len as u32),
+        }
+    }
+
+    /// Returns the source's name.
+    ///
+    /// Panics if `file_id` is invalid.
+    pub fn name(&self, id: FileId) -> &OsStr {
+        &self.get(id).unwrap().name
+    }
+
+    pub fn source(&self, id: FileId) -> &str {
+        self.get(id).unwrap().source.as_ref()
+    }
+
+    pub fn source_slice(&self, span: RawSpan) -> &str {
+        let start: usize = span.start.into();
+        let end: usize = span.end.into();
+        &self.source(span.src_id)[start..end]
+    }
+
+    pub fn location(
+        &self,
+        id: FileId,
+        byte_index: impl Into<ByteIndex>,
+    ) -> Result<codespan::Location, Error> {
+        let file = self.get(id)?;
+        let byte_index = byte_index.into();
+        let idx = byte_index.to_usize();
+
+        if idx >= file.source.len() {
+            return Err(Error::IndexTooLarge {
+                given: idx,
+                max: file.source.len() - 1,
+            });
+        }
+
+        let line_idx = file.line_index(byte_index);
+        let line_start_idx = file.line_starts[line_idx];
+        let line = file
+            .source
+            .get(line_start_idx.to_usize()..idx)
+            .ok_or(Error::InvalidCharBoundary { given: idx })?;
+
+        Ok(codespan::Location {
+            line: codespan::LineIndex::from(line_idx as u32),
+            column: codespan::ColumnIndex::from(line.chars().count() as u32),
+        })
+    }
+
+    fn get(&self, id: FileId) -> Result<&File, Error> {
+        self.files.get(id.0 as usize).ok_or(Error::FileMissing)
+    }
+}
+
+impl Default for Files {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<'a> codespan_reporting::files::Files<'a> for Files {
+    type FileId = FileId;
+    type Name = String;
+    type Source = &'a str;
+
+    fn name(&'a self, id: Self::FileId) -> Result<String, Error> {
+        Ok(PathBuf::from(&self.get(id)?.name).display().to_string())
+    }
+
+    fn source(
+        &'a self,
+        id: Self::FileId,
+    ) -> Result<Self::Source, codespan_reporting::files::Error> {
+        Ok(self.get(id)?.source.as_ref())
+    }
+
+    fn line_index(
+        &'a self,
+        id: Self::FileId,
+        byte_index: usize,
+    ) -> Result<usize, codespan_reporting::files::Error> {
+        let file = self.get(id)?;
+        Ok(file.line_index(ByteIndex(byte_index as u32)))
+    }
+
+    fn line_range(
+        &'a self,
+        id: Self::FileId,
+        line_index: usize,
+    ) -> Result<std::ops::Range<usize>, codespan_reporting::files::Error> {
+        let file = self.get(id)?;
+        let starts = &file.line_starts;
+        let end = starts
+            .get(line_index + 1)
+            .copied()
+            .unwrap_or(ByteIndex(file.source.len() as u32));
+        Ok(starts[line_index].into()..end.into())
+    }
+}

--- a/core/src/label.rs
+++ b/core/src/label.rs
@@ -6,6 +6,7 @@ use std::{collections::HashMap, rc::Rc};
 
 use crate::{
     eval::cache::{Cache as EvalCache, CacheIndex},
+    files::Files,
     identifier::LocIdent,
     mk_uty_enum, mk_uty_record,
     position::{RawSpan, TermPos},
@@ -16,8 +17,6 @@ use crate::{
     typ::{Type, TypeF},
     typecheck::{ReifyAsUnifType, UnifType},
 };
-
-use codespan::Files;
 
 pub mod ty_path {
     //! Type paths.

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -7,6 +7,7 @@ pub mod deserialize;
 pub mod environment;
 pub mod error;
 pub mod eval;
+pub mod files;
 pub mod identifier;
 pub mod label;
 #[cfg(feature = "nix-experimental")]

--- a/core/src/parser/error.rs
+++ b/core/src/parser/error.rs
@@ -1,7 +1,6 @@
-use codespan::FileId;
 use codespan_reporting::diagnostic::Label;
 
-use crate::{identifier::LocIdent, position::RawSpan};
+use crate::{files::FileId, identifier::LocIdent, position::RawSpan};
 use std::ops::Range;
 
 #[derive(Clone, PartialEq, Eq, Debug)]

--- a/core/src/parser/grammar.lalrpop
+++ b/core/src/parser/grammar.lalrpop
@@ -39,7 +39,6 @@ use std::{
     convert::TryFrom,
 };
 
-use codespan::FileId;
 use lalrpop_util::ErrorRecovery;
 
 use super::{
@@ -51,6 +50,7 @@ use super::{
 };
 
 use crate::{
+    files::FileId,
     mk_app,
     mk_opn,
     mk_fun,

--- a/core/src/parser/mod.rs
+++ b/core/src/parser/mod.rs
@@ -1,9 +1,9 @@
 use crate::error::{ParseError, ParseErrors};
+use crate::files::FileId;
 use crate::identifier::LocIdent;
 use crate::position::RawSpan;
 use crate::term::RichTerm;
 use crate::typ::Type;
-use codespan::FileId;
 use lalrpop_util::lalrpop_mod;
 
 lalrpop_mod!(

--- a/core/src/parser/tests.rs
+++ b/core/src/parser/tests.rs
@@ -1,6 +1,7 @@
 use super::lexer::{Lexer, MultiStringToken, NormalToken, StringToken, SymbolicStringStart, Token};
 use super::utils::{build_record, FieldPathElem};
 use crate::error::ParseError;
+use crate::files::Files;
 use crate::identifier::LocIdent;
 use crate::parser::{error::ParseError as InternalParseError, ErrorTolerantParser};
 use crate::term::Number;
@@ -10,7 +11,6 @@ use crate::term::{record, BinaryOp, RichTerm, StrChunk, UnaryOp};
 
 use crate::mk_app;
 use assert_matches::assert_matches;
-use codespan::Files;
 
 fn parse(s: &str) -> Result<RichTerm, ParseError> {
     let id = Files::new().add("<test>", String::from(s));

--- a/core/src/parser/utils.rs
+++ b/core/src/parser/utils.rs
@@ -5,8 +5,6 @@ use std::ffi::OsString;
 use std::rc::Rc;
 use std::{collections::HashSet, fmt::Debug};
 
-use codespan::FileId;
-
 use self::pattern::bindings::Bindings as _;
 
 use super::error::ParseError;
@@ -18,6 +16,7 @@ use crate::{
         merge::{merge_doc, split},
         operation::RecPriority,
     },
+    files::FileId,
     identifier::LocIdent,
     label::{Label, MergeKind, MergeLabel},
     mk_app, mk_fun,

--- a/core/src/position.rs
+++ b/core/src/position.rs
@@ -3,7 +3,8 @@
 //! The positions defined in this module are represented by the id of the corresponding source and
 //! raw byte indices.  They are prefixed with Raw to differentiate them from codespan's types and
 //! indicate that they do not store human friendly data like lines and columns.
-use codespan::{self, ByteIndex, FileId};
+use crate::files::FileId;
+use codespan::{self, ByteIndex};
 use std::cmp::{max, min, Ordering};
 
 /// A position identified by a byte offset in a file.

--- a/core/src/pretty.rs
+++ b/core/src/pretty.rs
@@ -1377,12 +1377,12 @@ pub trait PrettyPrintCap: ToString {
 
 #[cfg(test)]
 mod tests {
+    use crate::files::Files;
     use crate::parser::lexer::Lexer;
     use crate::parser::{
         grammar::{FixedTypeParser, TermParser},
         ErrorTolerantParser,
     };
-    use codespan::Files;
     use pretty::Doc;
 
     use super::*;

--- a/core/src/program.rs
+++ b/core/src/program.rs
@@ -587,7 +587,7 @@ impl<EC: EvalCache> Program<EC> {
             &mut with_color
         };
 
-        report_with(writer, cache.files_mut(), error, ErrorFormat::Text);
+        report_with(writer, &mut cache.files().clone(), error, ErrorFormat::Text);
         // unwrap(): report_with() should only print valid utf8 to the the buffer
         String::from_utf8(buffer).unwrap()
     }

--- a/core/src/program.rs
+++ b/core/src/program.rs
@@ -28,6 +28,7 @@ use crate::{
         Error, EvalError, IOError, IntoDiagnostics, ParseError,
     },
     eval::{cache::Cache as EvalCache, Closure, VirtualMachine},
+    files::FileId,
     identifier::LocIdent,
     label::Label,
     metrics::increment,
@@ -40,7 +41,6 @@ use crate::{
 };
 
 use clap::ColorChoice;
-use codespan::FileId;
 use codespan_reporting::term::termcolor::{Ansi, NoColor, WriteColor};
 
 use std::{
@@ -160,10 +160,7 @@ impl FieldOverride {
                 )
             })?;
 
-        let value = cache
-            .files()
-            .source_slice(span_value.src_id, span_value)
-            .expect("the span coming from the parser must be valid");
+        let value = cache.files().source_slice(span_value);
 
         Ok(FieldOverride {
             path: FieldPath(path),
@@ -559,7 +556,7 @@ impl<EC: EvalCache> Program<EC> {
     /// Wrapper for [`report`].
     pub fn report<E>(&mut self, error: E, format: ErrorFormat)
     where
-        E: IntoDiagnostics<FileId>,
+        E: IntoDiagnostics,
     {
         report(self.vm.import_resolver_mut(), error, format, self.color_opt)
     }
@@ -567,7 +564,7 @@ impl<EC: EvalCache> Program<EC> {
     /// Wrapper for [`report_to_stdout`].
     pub fn report_to_stdout<E>(&mut self, error: E, format: ErrorFormat)
     where
-        E: IntoDiagnostics<FileId>,
+        E: IntoDiagnostics,
     {
         report_to_stdout(self.vm.import_resolver_mut(), error, format, self.color_opt)
     }
@@ -575,10 +572,9 @@ impl<EC: EvalCache> Program<EC> {
     /// Build an error report as a string and return it.
     pub fn report_as_str<E>(&mut self, error: E) -> String
     where
-        E: IntoDiagnostics<FileId>,
+        E: IntoDiagnostics,
     {
         let cache = self.vm.import_resolver_mut();
-        let stdlib_ids = cache.get_all_stdlib_modules_file_id();
 
         let mut buffer = Vec::new();
         let mut with_color;
@@ -591,13 +587,7 @@ impl<EC: EvalCache> Program<EC> {
             &mut with_color
         };
 
-        report_with(
-            writer,
-            cache.files_mut(),
-            stdlib_ids.as_ref(),
-            error,
-            ErrorFormat::Text,
-        );
+        report_with(writer, cache.files_mut(), error, ErrorFormat::Text);
         // unwrap(): report_with() should only print valid utf8 to the the buffer
         String::from_utf8(buffer).unwrap()
     }

--- a/core/src/repl/mod.rs
+++ b/core/src/repl/mod.rs
@@ -13,6 +13,7 @@ use crate::error::{
 };
 use crate::eval::cache::Cache as EvalCache;
 use crate::eval::{Closure, VirtualMachine};
+use crate::files::FileId;
 use crate::identifier::LocIdent;
 use crate::parser::{grammar, lexer, ErrorTolerantParser, ExtendedTerm};
 use crate::program::FieldPath;
@@ -22,7 +23,6 @@ use crate::transform::import_resolution;
 use crate::typ::Type;
 use crate::typecheck::TypecheckMode;
 use crate::{eval, transform, typecheck};
-use codespan::FileId;
 use simple_counter::*;
 use std::convert::Infallible;
 use std::ffi::{OsStr, OsString};
@@ -217,7 +217,7 @@ impl<EC: EvalCache> ReplImpl<EC> {
         }
     }
 
-    fn report(&mut self, err: impl IntoDiagnostics<FileId>, color_opt: ColorOpt) {
+    fn report(&mut self, err: impl IntoDiagnostics, color_opt: ColorOpt) {
         report::report(self.cache_mut(), err, ErrorFormat::Text, color_opt);
     }
 }

--- a/core/src/serialize.rs
+++ b/core/src/serialize.rs
@@ -474,6 +474,7 @@ pub fn to_string(format: ExportFormat, rt: &RichTerm) -> Result<String, ExportEr
 /// any new dependencies, because it's used by `toml` internally anyway.
 pub mod toml_deser {
     use crate::{
+        files::FileId,
         identifier::LocIdent,
         position::{RawSpan, TermPos},
         term::{
@@ -482,7 +483,7 @@ pub mod toml_deser {
             RichTerm, Term,
         },
     };
-    use codespan::{ByteIndex, FileId};
+    use codespan::ByteIndex;
     use malachite::{num::conversion::traits::ExactFrom as _, Rational};
     use std::ops::Range;
     use toml_edit::Value;

--- a/core/src/term/mod.rs
+++ b/core/src/term/mod.rs
@@ -24,6 +24,7 @@ use crate::{
     cache::InputFormat,
     error::{EvalError, ParseError},
     eval::{cache::CacheIndex, Environment},
+    files::FileId,
     identifier::LocIdent,
     impl_display_from_pretty,
     label::{Label, MergeLabel},
@@ -35,8 +36,6 @@ use crate::{
 };
 
 use crate::metrics::increment;
-
-use codespan::FileId;
 
 pub use malachite::{
     num::{

--- a/core/src/transform/import_resolution.rs
+++ b/core/src/transform/import_resolution.rs
@@ -7,8 +7,8 @@ use super::ImportResolver;
 pub mod strict {
     use super::{tolerant, ImportResolver};
     use crate::error::ImportError;
+    use crate::files::FileId;
     use crate::term::RichTerm;
-    use codespan::FileId;
 
     /// The result of an import resolution transformation.
     #[derive(Debug)]
@@ -78,8 +78,8 @@ pub mod strict {
 pub mod tolerant {
     use super::ImportResolver;
     use crate::error::ImportError;
+    use crate::files::FileId;
     use crate::term::{RichTerm, Term, Traverse, TraverseOrder};
-    use codespan::FileId;
 
     /// The result of an error tolerant import resolution.
     #[derive(Debug)]

--- a/core/src/typ.rs
+++ b/core/src/typ.rs
@@ -1913,7 +1913,7 @@ mod tests {
 
     /// Parse a type represented as a string.
     fn parse_type(s: &str) -> Type {
-        use codespan::Files;
+        use crate::files::Files;
         let id = Files::new().add("<test>", s);
 
         FixedTypeParser::new()

--- a/core/src/typecheck/mod.rs
+++ b/core/src/typecheck/mod.rs
@@ -2846,7 +2846,7 @@ pub fn apparent_type(
     env: Option<&Environment>,
     resolver: Option<&dyn ImportResolver>,
 ) -> ApparentType {
-    use codespan::FileId;
+    use crate::files::FileId;
 
     // Check the apparent type while avoiding cycling through direct imports loops. Indeed,
     // `apparent_type` tries to see through imported terms. But doing so can lead to an infinite

--- a/core/tests/integration/contract_label_path.rs
+++ b/core/tests/integration/contract_label_path.rs
@@ -1,6 +1,6 @@
 use assert_matches::assert_matches;
-use codespan::Files;
 use nickel_lang_core::error::{Error, EvalError, IntoDiagnostics};
+use nickel_lang_core::files::Files;
 
 use nickel_lang_utils::test_program::eval;
 
@@ -23,7 +23,7 @@ fn array_contracts_label_path_is_set_correctly() {
     // Check that reporting doesn't panic. Provide a dummy file database, as we won't report
     // the error message but just check that it can be built.
     let mut files = Files::new();
-    res.unwrap_err().into_diagnostics(&mut files, None);
+    res.unwrap_err().into_diagnostics(&mut files);
 
     let res = eval(
         "(%array/at% (\
@@ -41,7 +41,7 @@ fn array_contracts_label_path_is_set_correctly() {
         ),
         err => panic!("expected blame error, got {err:?}"),
     }
-    res.unwrap_err().into_diagnostics(&mut files, None);
+    res.unwrap_err().into_diagnostics(&mut files);
 }
 
 #[test]

--- a/core/tests/manual/main.rs
+++ b/core/tests/manual/main.rs
@@ -156,9 +156,8 @@ fn check_repl(content: String) {
                 (Ok(EvalResult::Bound(_)), ReplResult::Empty) => (),
                 (Err(e), ReplResult::Error(expected)) => {
                     let mut error = NoColor::new(Vec::<u8>::new());
-                    let stdlib_ids = repl.cache_mut().get_all_stdlib_modules_file_id();
                     let files = repl.cache_mut().files_mut();
-                    report_with(&mut error, files, stdlib_ids.as_ref(), e, ErrorFormat::Text);
+                    report_with(&mut error, files, e, ErrorFormat::Text);
 
                     check_error_report(String::from_utf8(error.into_inner()).unwrap(), expected);
                 }

--- a/core/tests/manual/main.rs
+++ b/core/tests/manual/main.rs
@@ -156,8 +156,8 @@ fn check_repl(content: String) {
                 (Ok(EvalResult::Bound(_)), ReplResult::Empty) => (),
                 (Err(e), ReplResult::Error(expected)) => {
                     let mut error = NoColor::new(Vec::<u8>::new());
-                    let files = repl.cache_mut().files_mut();
-                    report_with(&mut error, files, e, ErrorFormat::Text);
+                    let mut files = repl.cache_mut().files().clone();
+                    report_with(&mut error, &mut files, e, ErrorFormat::Text);
 
                     check_error_report(String::from_utf8(error.into_inner()).unwrap(), expected);
                 }

--- a/lsp/nls/src/analysis.rs
+++ b/lsp/nls/src/analysis.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
-use codespan::FileId;
 use nickel_lang_core::{
+    files::FileId,
     identifier::Ident,
     position::RawSpan,
     term::{BinaryOp, RichTerm, Term, Traverse, TraverseControl, UnaryOp},
@@ -434,8 +434,9 @@ impl TypeCollector {
 #[cfg(test)]
 mod tests {
     use assert_matches::assert_matches;
-    use codespan::{ByteIndex, Files};
+    use codespan::ByteIndex;
     use nickel_lang_core::{
+        files::Files,
         identifier::Ident,
         parser::{grammar, lexer, ErrorTolerantParser as _},
         term::Term,

--- a/lsp/nls/src/background.rs
+++ b/lsp/nls/src/background.rs
@@ -5,13 +5,13 @@ use std::{
 };
 
 use anyhow::anyhow;
-use codespan::FileId;
 use crossbeam::channel::{bounded, Receiver, RecvTimeoutError, Sender};
 use log::warn;
 use lsp_types::Url;
 use nickel_lang_core::{
     cache::{InputFormat, SourcePath},
     eval::{cache::CacheImpl, VirtualMachine},
+    files::FileId,
 };
 use serde::{Deserialize, Serialize};
 

--- a/lsp/nls/src/cache.rs
+++ b/lsp/nls/src/cache.rs
@@ -1,10 +1,11 @@
-use codespan::{ByteIndex, FileId};
+use codespan::ByteIndex;
 use lsp_types::{TextDocumentPositionParams, Url};
 use nickel_lang_core::cache::InputFormat;
 use nickel_lang_core::term::{RichTerm, Term, Traverse};
 use nickel_lang_core::{
     cache::{Cache, CacheError, CacheOp, EntryState, SourcePath, TermEntry},
     error::{Error, ImportError},
+    files::FileId,
     position::RawPos,
     typecheck::{self},
 };

--- a/lsp/nls/src/diagnostic.rs
+++ b/lsp/nls/src/diagnostic.rs
@@ -93,11 +93,7 @@ pub trait DiagnosticCompat: Sized {
     //
     // We do use the `related_information` field for cross-file diagnostics, because the main
     // diagnostics notification assumes all the diagnostics are for the same file.
-    fn from_codespan(
-        file_id: FileId,
-        diagnostic: Diagnostic<FileId>,
-        files: &mut Files,
-    ) -> Vec<Self>;
+    fn from_codespan(file_id: FileId, diagnostic: Diagnostic<FileId>, files: &Files) -> Vec<Self>;
 }
 
 /// Determine the position of a [codespan_reporting::diagnostic::Label] by looking it up
@@ -133,11 +129,7 @@ impl LocationCompat for lsp_types::Location {
 }
 
 impl DiagnosticCompat for SerializableDiagnostic {
-    fn from_codespan(
-        file_id: FileId,
-        diagnostic: Diagnostic<FileId>,
-        files: &mut Files,
-    ) -> Vec<Self> {
+    fn from_codespan(file_id: FileId, diagnostic: Diagnostic<FileId>, files: &Files) -> Vec<Self> {
         let severity = Some(match diagnostic.severity {
             diagnostic::Severity::Bug => lsp_types::DiagnosticSeverity::WARNING,
             diagnostic::Severity::Error => lsp_types::DiagnosticSeverity::ERROR,
@@ -218,11 +210,7 @@ impl DiagnosticCompat for SerializableDiagnostic {
 }
 
 impl DiagnosticCompat for lsp_types::Diagnostic {
-    fn from_codespan(
-        file_id: FileId,
-        diagnostic: Diagnostic<FileId>,
-        files: &mut Files,
-    ) -> Vec<Self> {
+    fn from_codespan(file_id: FileId, diagnostic: Diagnostic<FileId>, files: &Files) -> Vec<Self> {
         SerializableDiagnostic::from_codespan(file_id, diagnostic, files)
             .into_iter()
             .map(From::from)

--- a/lsp/nls/src/diagnostic.rs
+++ b/lsp/nls/src/diagnostic.rs
@@ -1,8 +1,8 @@
 use std::ops::Range;
 
-use codespan::{FileId, Files};
 use codespan_reporting::diagnostic::{self, Diagnostic, LabelStyle};
 use lsp_types::{DiagnosticRelatedInformation, NumberOrString};
+use nickel_lang_core::files::{FileId, Files};
 use nickel_lang_core::{error::UNKNOWN_SOURCE_NAME, position::RawSpan};
 use serde::{Deserialize, Serialize};
 
@@ -96,16 +96,16 @@ pub trait DiagnosticCompat: Sized {
     fn from_codespan(
         file_id: FileId,
         diagnostic: Diagnostic<FileId>,
-        files: &mut Files<String>,
+        files: &mut Files,
     ) -> Vec<Self>;
 }
 
 /// Determine the position of a [codespan_reporting::diagnostic::Label] by looking it up
 /// in the file cache
 pub trait LocationCompat: Sized {
-    fn from_codespan(file_id: &FileId, range: &Range<usize>, files: &Files<String>) -> Self;
+    fn from_codespan(file_id: &FileId, range: &Range<usize>, files: &Files) -> Self;
 
-    fn from_span(span: &RawSpan, files: &Files<String>) -> Self {
+    fn from_span(span: &RawSpan, files: &Files) -> Self {
         Self::from_codespan(
             &span.src_id,
             &(span.start.to_usize()..span.end.to_usize()),
@@ -115,7 +115,7 @@ pub trait LocationCompat: Sized {
 }
 
 impl LocationCompat for lsp_types::Range {
-    fn from_codespan(file_id: &FileId, range: &Range<usize>, files: &Files<String>) -> Self {
+    fn from_codespan(file_id: &FileId, range: &Range<usize>, files: &Files) -> Self {
         byte_span_to_range(files, *file_id, range.clone()).unwrap_or(lsp_types::Range {
             start: Default::default(),
             end: Default::default(),
@@ -124,7 +124,7 @@ impl LocationCompat for lsp_types::Range {
 }
 
 impl LocationCompat for lsp_types::Location {
-    fn from_codespan(file_id: &FileId, range: &Range<usize>, files: &Files<String>) -> Self {
+    fn from_codespan(file_id: &FileId, range: &Range<usize>, files: &Files) -> Self {
         lsp_types::Location {
             uri: lsp_types::Url::from_file_path(files.name(*file_id)).unwrap(),
             range: lsp_types::Range::from_codespan(file_id, range, files),
@@ -136,7 +136,7 @@ impl DiagnosticCompat for SerializableDiagnostic {
     fn from_codespan(
         file_id: FileId,
         diagnostic: Diagnostic<FileId>,
-        files: &mut Files<String>,
+        files: &mut Files,
     ) -> Vec<Self> {
         let severity = Some(match diagnostic.severity {
             diagnostic::Severity::Bug => lsp_types::DiagnosticSeverity::WARNING,
@@ -221,7 +221,7 @@ impl DiagnosticCompat for lsp_types::Diagnostic {
     fn from_codespan(
         file_id: FileId,
         diagnostic: Diagnostic<FileId>,
-        files: &mut Files<String>,
+        files: &mut Files,
     ) -> Vec<Self> {
         SerializableDiagnostic::from_codespan(file_id, diagnostic, files)
             .into_iter()

--- a/lsp/nls/src/position.rs
+++ b/lsp/nls/src/position.rs
@@ -204,8 +204,9 @@ fn search<T>(vec: &[(Range<u32>, T)], index: ByteIndex) -> Option<&T> {
 #[cfg(test)]
 pub(crate) mod tests {
     use assert_matches::assert_matches;
-    use codespan::{ByteIndex, FileId, Files};
+    use codespan::ByteIndex;
     use nickel_lang_core::{
+        files::{FileId, Files},
         parser::{grammar, lexer, ErrorTolerantParser},
         term::{RichTerm, Term, UnaryOp},
     };

--- a/lsp/nls/src/requests/formatting.rs
+++ b/lsp/nls/src/requests/formatting.rs
@@ -18,7 +18,7 @@ pub fn handle_format_document(
         .cache
         .id_of(&SourcePath::Path(path, InputFormat::Nickel))
         .unwrap();
-    let text = server.world.cache.files().source(file_id).clone();
+    let text = server.world.cache.files().source(file_id);
     let document_length = text.lines().count() as u32;
 
     let mut formatted: Vec<u8> = Vec::new();

--- a/lsp/nls/src/server.rs
+++ b/lsp/nls/src/server.rs
@@ -1,5 +1,4 @@
 use anyhow::Result;
-use codespan::FileId;
 use crossbeam::select;
 use log::{debug, trace, warn};
 use lsp_server::{Connection, ErrorCode, Message, Notification, RequestId, Response};
@@ -14,6 +13,7 @@ use lsp_types::{
     TextDocumentSyncCapability, TextDocumentSyncKind, TextDocumentSyncOptions, Url,
     WorkDoneProgressOptions,
 };
+use nickel_lang_core::files::FileId;
 
 use crate::{
     actions,

--- a/lsp/nls/src/term.rs
+++ b/lsp/nls/src/term.rs
@@ -1,7 +1,7 @@
 use std::{hash::Hash, ops::Range};
 
-use codespan::FileId;
 use nickel_lang_core::{
+    files::FileId,
     position::RawSpan,
     term::{RichTerm, SharedTerm, Term},
 };

--- a/lsp/nls/src/usage.rs
+++ b/lsp/nls/src/usage.rs
@@ -250,8 +250,7 @@ impl UsageLookup {
 #[cfg(test)]
 pub(crate) mod tests {
     use assert_matches::assert_matches;
-    use codespan::FileId;
-    use nickel_lang_core::{identifier::Ident, position::RawSpan, term::Term};
+    use nickel_lang_core::{files::FileId, identifier::Ident, position::RawSpan, term::Term};
 
     use crate::{
         identifier::LocIdent,

--- a/lsp/nls/src/world.rs
+++ b/lsp/nls/src/world.rs
@@ -4,13 +4,13 @@ use std::{
     path::PathBuf,
 };
 
-use codespan::FileId;
 use log::warn;
 use lsp_server::{ErrorCode, ResponseError};
 use lsp_types::Url;
 use nickel_lang_core::{
     cache::{Cache, CacheError, ErrorTolerance, InputFormat, SourcePath},
     error::{ImportError, IntoDiagnostics},
+    files::FileId,
     position::{RawPos, RawSpan},
     term::{pattern::bindings::Bindings, record::FieldMetadata, RichTerm, Term, UnaryOp},
     typecheck::Context,
@@ -136,10 +136,9 @@ impl World {
     pub fn lsp_diagnostics(
         &mut self,
         file_id: FileId,
-        err: impl IntoDiagnostics<FileId>,
+        err: impl IntoDiagnostics,
     ) -> Vec<SerializableDiagnostic> {
-        let stdlib_ids = self.cache.get_all_stdlib_modules_file_id();
-        err.into_diagnostics(self.cache.files_mut(), stdlib_ids.as_ref())
+        err.into_diagnostics(self.cache.files_mut())
             .into_iter()
             .flat_map(|d| SerializableDiagnostic::from_codespan(file_id, d, self.cache.files_mut()))
             .collect()

--- a/lsp/nls/src/world.rs
+++ b/lsp/nls/src/world.rs
@@ -138,9 +138,10 @@ impl World {
         file_id: FileId,
         err: impl IntoDiagnostics,
     ) -> Vec<SerializableDiagnostic> {
-        err.into_diagnostics(self.cache.files_mut())
+        let mut files = self.cache.files().clone();
+        err.into_diagnostics(&mut files)
             .into_iter()
-            .flat_map(|d| SerializableDiagnostic::from_codespan(file_id, d, self.cache.files_mut()))
+            .flat_map(|d| SerializableDiagnostic::from_codespan(file_id, d, &files))
             .collect()
     }
 

--- a/utils/src/test_program.rs
+++ b/utils/src/test_program.rs
@@ -1,8 +1,7 @@
-use codespan::Files;
-
 use nickel_lang_core::{
     error::{Error, ParseError},
     eval::cache::CacheImpl,
+    files::Files,
     parser::{grammar, lexer, ErrorTolerantParser, ExtendedTerm},
     program::Program,
     term::{RichTerm, Term},

--- a/vector/src/slice.rs
+++ b/vector/src/slice.rs
@@ -114,6 +114,20 @@ where
         self.start.checked_add(idx).and_then(|i| self.vec.get(i))
     }
 
+    /// Gets an element at a given index, panicking if `idx` is out-of-bounds.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use nickel_lang_vector::Slice;
+    /// let mut arr = Slice::<_, 32>::from_iter([0, 1, 2, 3, 4, 5]);
+    /// arr.set(2, 6);
+    /// assert_eq!(arr.into_iter().collect::<Vec<_>>(), vec![0, 1, 6, 3, 4, 5]);
+    /// ```
+    pub fn set(&mut self, idx: usize, elt: T) {
+        self.vec.set(self.start.checked_add(idx).unwrap(), elt);
+    }
+
     /// Adds an element to the end of this array.
     ///
     /// Morally runs in time `O(log self.len())`, but see [`Slice::slice`]

--- a/vector/src/slice.rs
+++ b/vector/src/slice.rs
@@ -114,7 +114,7 @@ where
         self.start.checked_add(idx).and_then(|i| self.vec.get(i))
     }
 
-    /// Gets an element at a given index, panicking if `idx` is out-of-bounds.
+    /// Sets an element at a given index, panicking if `idx` is out-of-bounds.
     ///
     /// # Examples
     ///

--- a/vector/src/vector.rs
+++ b/vector/src/vector.rs
@@ -597,6 +597,19 @@ where
         self.root.as_ref().and_then(|r| r.get(self.height, idx))
     }
 
+    /// Sets an element at a given index.
+    ///
+    /// Panics if the index is out of bounds.
+    pub fn set(&mut self, idx: usize, elt: T) {
+        if idx >= self.length {
+            panic!("index {idx} out of bounds, length is {}", self.length);
+        }
+
+        if let Some(root) = self.root.as_mut() {
+            Rc::make_mut(root).set(self.height, idx, elt);
+        }
+    }
+
     // Increases the height of the tree by one, temporarily breaking the invariant that
     // the root must have at least two children.
     fn add_level(&mut self) {


### PR DESCRIPTION
This introduces our own `Files` database, and uses it instead of the one in `codespan`. The main point of this change is that our `Files` is cheaply clonable and copy-on-write (using `Vector` under the hood). Also, the loading of the stdlib text has been moved from `Cache` to `Files`. Together, this means that errors needing files for reporting can take a cloned `Files` instead of a `Program`. (I haven't actually made this change to the errors yet.)

There are a lot of changes caused by the fact that we're moving from `codespan::{Files, FileId}` to `nickel_lang_core::files::{Files, FileId}` everywhere, but most of the interesting changes are to `core/src/cache.rs`.