### PR TITLE
Move 'clap' crate dependency behind feature flag in core

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -453,6 +453,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
+name = "colorchoice-clap"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96a804da36d925510ac4d61a0ee8edfdba6ae00c7d5c93c8bf58f25915966956"
+dependencies = [
+ "clap 4.5.2",
+ "colorchoice",
+]
+
+[[package]]
 name = "comrak"
 version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1806,6 +1816,8 @@ dependencies = [
  "clap 4.5.2",
  "codespan",
  "codespan-reporting",
+ "colorchoice",
+ "colorchoice-clap",
  "comrak",
  "criterion 0.4.0",
  "cxx",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -453,16 +453,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
-name = "colorchoice-clap"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96a804da36d925510ac4d61a0ee8edfdba6ae00c7d5c93c8bf58f25915966956"
-dependencies = [
- "clap 4.5.2",
- "colorchoice",
-]
-
-[[package]]
 name = "comrak"
 version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1817,7 +1807,6 @@ dependencies = [
  "codespan",
  "codespan-reporting",
  "colorchoice",
- "colorchoice-clap",
  "comrak",
  "criterion 0.4.0",
  "cxx",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,6 @@ clap_complete = "4.3.2"
 codespan = { version = "0.11", features = ["serialization"] }
 codespan-reporting = { version = "0.11", features = ["serialization"] }
 colorchoice = "1.0.0"
-colorchoice-clap = "1.0.6"
 comrak = "0.24.0"
 criterion = "0.4"
 crossbeam = "0.8.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,8 @@ clap = "4.3"
 clap_complete = "4.3.2"
 codespan = { version = "0.11", features = ["serialization"] }
 codespan-reporting = { version = "0.11", features = ["serialization"] }
+colorchoice = "1.0.0"
+colorchoice-clap = "1.0.6"
 comrak = "0.24.0"
 criterion = "0.4"
 crossbeam = "0.8.4"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -23,7 +23,7 @@ format = ["nickel-lang-core/format", "dep:tempfile"]
 metrics = ["dep:metrics", "dep:metrics-util", "nickel-lang-core/metrics"]
 
 [dependencies]
-nickel-lang-core = { workspace = true, features = [ "markdown" ], default-features = false }
+nickel-lang-core = { workspace = true, features = [ "markdown", "clap" ], default-features = false }
 
 clap = { workspace = true, features = ["derive", "string"] }
 serde = { workspace = true, features = ["derive"] }

--- a/cli/src/input.rs
+++ b/cli/src/input.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 
 use nickel_lang_core::{eval::cache::lazy::CBNCache, program::Program};
 
-use crate::{cli::GlobalOptions, customize::Customize, error::CliResult};
+use crate::{cli::GlobalOptions, color_opt_from_clap, customize::Customize, error::CliResult};
 
 #[derive(clap::Parser, Debug)]
 pub struct InputOptions<Customize: clap::Args> {
@@ -40,7 +40,7 @@ impl<C: clap::Args + Customize> Prepare for InputOptions<C> {
             files => Program::new_from_files(files, std::io::stderr()),
         }?;
 
-        program.color_opt = global.color.into();
+        program.color_opt = color_opt_from_clap(global.color);
 
         program.add_import_paths(self.import_path.iter());
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -67,8 +67,17 @@ fn main() -> ExitCode {
         // user's point of view.
         Ok(()) | Err(error::Error::CustomizeInfoPrinted) => ExitCode::SUCCESS,
         Err(error) => {
-            error.report(error_format, color.into());
+            error.report(error_format, color_opt_from_clap(color));
             ExitCode::FAILURE
         }
+    }
+}
+
+fn color_opt_from_clap(c: clap::ColorChoice) -> nickel_lang_core::error::report::ColorOpt {
+    use nickel_lang_core::error::report::ColorOpt;
+    match c {
+        clap::ColorChoice::Auto => ColorOpt::Auto,
+        clap::ColorChoice::Always => ColorOpt::Always,
+        clap::ColorChoice::Never => ColorOpt::Never,
     }
 }

--- a/cli/src/repl.rs
+++ b/cli/src/repl.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 use directories::BaseDirs;
 use nickel_lang_core::repl::rustyline_frontend;
 
-use crate::{cli::GlobalOptions, error::CliResult};
+use crate::{cli::GlobalOptions, color_opt_from_clap, error::CliResult};
 
 #[derive(clap::Parser, Debug)]
 pub struct ReplCommand {
@@ -21,6 +21,9 @@ impl ReplCommand {
                 .home_dir()
                 .join(".nickel_history")
         };
-        Ok(rustyline_frontend::repl(histfile, global.color.into())?)
+        Ok(rustyline_frontend::repl(
+            histfile,
+            color_opt_from_clap(global.color),
+        )?)
     }
 }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -19,7 +19,7 @@ links = "nix"
 bench = false
 
 [features]
-default = ["markdown", "repl", "doc", "format", "clap"]
+default = ["markdown", "repl", "doc", "format"]
 clap = ["dep:clap", "dep:colorchoice-clap"]
 markdown = ["dep:termimad"]
 repl = ["dep:rustyline", "dep:rustyline-derive", "dep:ansi_term"]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -19,7 +19,8 @@ links = "nix"
 bench = false
 
 [features]
-default = ["markdown", "repl", "doc", "format"]
+default = ["markdown", "repl", "doc", "format", "clap"]
+clap = ["dep:clap", "dep:colorchoice-clap"]
 markdown = ["dep:termimad"]
 repl = ["dep:rustyline", "dep:rustyline-derive", "dep:ansi_term"]
 repl-wasm = ["dep:wasm-bindgen", "dep:js-sys", "dep:serde_repr", "dep:serde-wasm-bindgen"]
@@ -39,9 +40,11 @@ pkg-config = { workspace = true, optional = true }
 lalrpop-util.workspace = true
 regex.workspace = true
 simple-counter.workspace = true
-clap = { workspace = true, features = ["derive"] }
+clap = { workspace = true, features = ["derive"], optional = true }
 codespan.workspace = true
 codespan-reporting.workspace = true
+colorchoice.workspace = true
+colorchoice-clap = { workspace = true, optional = true }
 cxx = { workspace = true, optional = true }
 logos.workspace = true
 nickel-lang-vector.workspace = true

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -20,7 +20,7 @@ bench = false
 
 [features]
 default = ["markdown", "repl", "doc", "format"]
-clap = ["dep:clap", "dep:colorchoice-clap"]
+clap = ["dep:clap"]
 markdown = ["dep:termimad"]
 repl = ["dep:rustyline", "dep:rustyline-derive", "dep:ansi_term"]
 repl-wasm = ["dep:wasm-bindgen", "dep:js-sys", "dep:serde_repr", "dep:serde-wasm-bindgen"]
@@ -44,7 +44,6 @@ clap = { workspace = true, features = ["derive"], optional = true }
 codespan.workspace = true
 codespan-reporting.workspace = true
 colorchoice.workspace = true
-colorchoice-clap = { workspace = true, optional = true }
 cxx = { workspace = true, optional = true }
 logos.workspace = true
 nickel-lang-vector.workspace = true

--- a/core/src/error/report.rs
+++ b/core/src/error/report.rs
@@ -24,42 +24,20 @@ pub enum ErrorFormat {
     Toml,
 }
 
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
-pub struct ColorOpt(pub(crate) colorchoice::ColorChoice);
+pub type ColorOpt = colorchoice::ColorChoice;
 
-impl ColorOpt {
-    fn for_terminal(self, is_terminal: bool) -> ColorChoice {
-        match self.0 {
-            colorchoice::ColorChoice::Auto => {
-                if is_terminal {
-                    ColorChoice::Auto
-                } else {
-                    ColorChoice::Never
-                }
+fn colors_for_terminal(color_opt: ColorOpt, is_terminal: bool) -> ColorChoice {
+    match color_opt {
+        colorchoice::ColorChoice::Auto => {
+            if is_terminal {
+                ColorChoice::Auto
+            } else {
+                ColorChoice::Never
             }
-            colorchoice::ColorChoice::Always => ColorChoice::Always,
-            colorchoice::ColorChoice::AlwaysAnsi => ColorChoice::AlwaysAnsi,
-            colorchoice::ColorChoice::Never => ColorChoice::Never,
         }
-    }
-}
-
-#[cfg(feature = "clap")]
-impl From<clap::ColorChoice> for ColorOpt {
-    fn from(color: clap::ColorChoice) -> Self {
-        Self(colorchoice_clap::Color { color }.as_choice())
-    }
-}
-
-impl From<colorchoice::ColorChoice> for ColorOpt {
-    fn from(color_choice: colorchoice::ColorChoice) -> Self {
-        Self(color_choice)
-    }
-}
-
-impl Default for ColorOpt {
-    fn default() -> Self {
-        Self(colorchoice::ColorChoice::Auto)
+        colorchoice::ColorChoice::Always => ColorChoice::Always,
+        colorchoice::ColorChoice::AlwaysAnsi => ColorChoice::AlwaysAnsi,
+        colorchoice::ColorChoice::Never => ColorChoice::Never,
     }
 }
 
@@ -78,7 +56,7 @@ pub fn report<E: IntoDiagnostics>(
     use std::io::{stderr, IsTerminal};
 
     report_with(
-        &mut StandardStream::stderr(color_opt.for_terminal(stderr().is_terminal())).lock(),
+        &mut StandardStream::stderr(colors_for_terminal(color_opt, stderr().is_terminal())).lock(),
         &mut cache.files().clone(),
         error,
         format,
@@ -100,7 +78,7 @@ pub fn report_to_stdout<E: IntoDiagnostics>(
     use std::io::{stdout, IsTerminal};
 
     report_with(
-        &mut StandardStream::stdout(color_opt.for_terminal(stdout().is_terminal())).lock(),
+        &mut StandardStream::stdout(colors_for_terminal(color_opt, stdout().is_terminal())).lock(),
         &mut cache.files().clone(),
         error,
         format,

--- a/core/src/error/report.rs
+++ b/core/src/error/report.rs
@@ -14,7 +14,8 @@ impl From<Vec<Diagnostic<FileId>>> for DiagnosticsWrapper {
 }
 
 /// Available export formats for error diagnostics.
-#[derive(Copy, Clone, Eq, PartialEq, Debug, Default, clap::ValueEnum)]
+#[derive(Copy, Clone, Eq, PartialEq, Debug, Default)]
+#[cfg_attr(feature = "clap", derive(clap::ValueEnum))]
 pub enum ErrorFormat {
     #[default]
     Text,
@@ -24,33 +25,41 @@ pub enum ErrorFormat {
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
-pub struct ColorOpt(pub(crate) clap::ColorChoice);
+pub struct ColorOpt(pub(crate) colorchoice::ColorChoice);
 
 impl ColorOpt {
     fn for_terminal(self, is_terminal: bool) -> ColorChoice {
         match self.0 {
-            clap::ColorChoice::Auto => {
+            colorchoice::ColorChoice::Auto => {
                 if is_terminal {
                     ColorChoice::Auto
                 } else {
                     ColorChoice::Never
                 }
             }
-            clap::ColorChoice::Always => ColorChoice::Always,
-            clap::ColorChoice::Never => ColorChoice::Never,
+            colorchoice::ColorChoice::Always => ColorChoice::Always,
+            colorchoice::ColorChoice::AlwaysAnsi => ColorChoice::AlwaysAnsi,
+            colorchoice::ColorChoice::Never => ColorChoice::Never,
         }
     }
 }
 
+#[cfg(feature = "clap")]
 impl From<clap::ColorChoice> for ColorOpt {
-    fn from(color_choice: clap::ColorChoice) -> Self {
+    fn from(color: clap::ColorChoice) -> Self {
+        Self(colorchoice_clap::Color { color }.as_choice())
+    }
+}
+
+impl From<colorchoice::ColorChoice> for ColorOpt {
+    fn from(color_choice: colorchoice::ColorChoice) -> Self {
         Self(color_choice)
     }
 }
 
 impl Default for ColorOpt {
     fn default() -> Self {
-        Self(clap::ColorChoice::Auto)
+        Self(colorchoice::ColorChoice::Auto)
     }
 }
 

--- a/core/src/program.rs
+++ b/core/src/program.rs
@@ -40,8 +40,8 @@ use crate::{
     typecheck::TypecheckMode,
 };
 
-use clap::ColorChoice;
 use codespan_reporting::term::termcolor::{Ansi, NoColor, WriteColor};
+use colorchoice::ColorChoice;
 
 use std::{
     ffi::OsString,
@@ -233,7 +233,7 @@ impl<EC: EvalCache> Program<EC> {
         Ok(Self {
             main_id,
             vm,
-            color_opt: clap::ColorChoice::Auto.into(),
+            color_opt: colorchoice::ColorChoice::Auto.into(),
             overrides: Vec::new(),
             field: FieldPath::new(),
         })
@@ -282,7 +282,7 @@ impl<EC: EvalCache> Program<EC> {
         Ok(Self {
             main_id,
             vm,
-            color_opt: clap::ColorChoice::Auto.into(),
+            color_opt: colorchoice::ColorChoice::Auto.into(),
             overrides: Vec::new(),
             field: FieldPath::new(),
         })

--- a/core/src/program.rs
+++ b/core/src/program.rs
@@ -233,7 +233,7 @@ impl<EC: EvalCache> Program<EC> {
         Ok(Self {
             main_id,
             vm,
-            color_opt: colorchoice::ColorChoice::Auto.into(),
+            color_opt: colorchoice::ColorChoice::Auto,
             overrides: Vec::new(),
             field: FieldPath::new(),
         })
@@ -282,7 +282,7 @@ impl<EC: EvalCache> Program<EC> {
         Ok(Self {
             main_id,
             vm,
-            color_opt: colorchoice::ColorChoice::Auto.into(),
+            color_opt: colorchoice::ColorChoice::Auto,
             overrides: Vec::new(),
             field: FieldPath::new(),
         })
@@ -579,7 +579,7 @@ impl<EC: EvalCache> Program<EC> {
         let mut buffer = Vec::new();
         let mut with_color;
         let mut no_color;
-        let writer: &mut dyn WriteColor = if self.color_opt.0 == ColorChoice::Never {
+        let writer: &mut dyn WriteColor = if self.color_opt == ColorChoice::Never {
             no_color = NoColor::new(&mut buffer);
             &mut no_color
         } else {

--- a/core/src/repl/rustyline_frontend.rs
+++ b/core/src/repl/rustyline_frontend.rs
@@ -13,20 +13,18 @@ pub fn config(color_opt: ColorOpt) -> Config {
     Config::builder()
         .history_ignore_space(true)
         .edit_mode(EditMode::Emacs)
-        .color_mode(color_opt.into())
+        .color_mode(color_mode_from_opt(color_opt))
         .auto_add_history(true)
         .build()
 }
 
-impl From<ColorOpt> for rustyline::config::ColorMode {
-    fn from(c: ColorOpt) -> Self {
-        use rustyline::config::ColorMode;
-        match c.0 {
-            colorchoice::ColorChoice::Always => ColorMode::Forced,
-            colorchoice::ColorChoice::AlwaysAnsi => ColorMode::Enabled,
-            colorchoice::ColorChoice::Auto => ColorMode::Enabled,
-            colorchoice::ColorChoice::Never => ColorMode::Disabled,
-        }
+fn color_mode_from_opt(c: ColorOpt) -> rustyline::config::ColorMode {
+    use rustyline::config::ColorMode;
+    match c {
+        colorchoice::ColorChoice::Always => ColorMode::Forced,
+        colorchoice::ColorChoice::AlwaysAnsi => ColorMode::Enabled,
+        colorchoice::ColorChoice::Auto => ColorMode::Enabled,
+        colorchoice::ColorChoice::Never => ColorMode::Disabled,
     }
 }
 

--- a/core/src/repl/rustyline_frontend.rs
+++ b/core/src/repl/rustyline_frontend.rs
@@ -22,9 +22,10 @@ impl From<ColorOpt> for rustyline::config::ColorMode {
     fn from(c: ColorOpt) -> Self {
         use rustyline::config::ColorMode;
         match c.0 {
-            clap::ColorChoice::Always => ColorMode::Forced,
-            clap::ColorChoice::Auto => ColorMode::Enabled,
-            clap::ColorChoice::Never => ColorMode::Disabled,
+            colorchoice::ColorChoice::Always => ColorMode::Forced,
+            colorchoice::ColorChoice::AlwaysAnsi => ColorMode::Enabled,
+            colorchoice::ColorChoice::Auto => ColorMode::Enabled,
+            colorchoice::ColorChoice::Never => ColorMode::Disabled,
         }
     }
 }

--- a/core/src/serialize.rs
+++ b/core/src/serialize.rs
@@ -27,11 +27,12 @@ use once_cell::sync::Lazy;
 use std::{fmt, io};
 
 /// Available export formats.
-#[derive(Copy, Clone, Eq, PartialEq, Debug, Default, clap::ValueEnum)]
+#[derive(Copy, Clone, Eq, PartialEq, Debug, Default)]
+#[cfg_attr(feature = "clap", derive(clap::ValueEnum))]
 pub enum ExportFormat {
     /// Evalute a Nickel expression to a string and write that text to the output
     /// Note: `raw` is a deprecated alias for `text`; prefer `text` instead.
-    #[value(alias("raw"))]
+    #[cfg_attr(feature = "clap", value(alias("raw")))]
     Text,
     #[default]
     Json,
@@ -51,7 +52,8 @@ impl fmt::Display for ExportFormat {
 }
 
 /// Available metadata export formats.
-#[derive(Copy, Clone, Eq, PartialEq, Debug, Default, clap::ValueEnum)]
+#[derive(Copy, Clone, Eq, PartialEq, Debug, Default)]
+#[cfg_attr(feature = "clap", derive(clap::ValueEnum))]
 pub enum MetadataExportFormat {
     #[default]
     Markdown,


### PR DESCRIPTION
As a developer of an app embedding Nickel as a scripting language, I don't want to be forced to incur the overhead of a third-party commandline-parsing library (clap) with core Nickel.

The change keeps the new "clap" feature enabled by default in Cargo.toml, to minimize impact on any users.

See also: https://github.com/tweag/nickel/discussions/2088