### PR TITLE
Fix crash in nls

### DIFF
--- a/lsp/nls/src/requests/goto.rs
+++ b/lsp/nls/src/requests/goto.rs
@@ -16,7 +16,7 @@ fn ids_to_locations(ids: impl IntoIterator<Item = RawSpan>, world: &World) -> Ve
     spans.dedup();
     spans
         .iter()
-        .map(|loc| Location::from_span(loc, world.cache.files()))
+        .filter_map(|loc| Location::from_span(loc, world.cache.files()))
         .collect()
 }
 

--- a/lsp/nls/src/requests/hover.rs
+++ b/lsp/nls/src/requests/hover.rs
@@ -208,7 +208,7 @@ pub fn handle(
                 contents: HoverContents::Array(contents),
                 range: hover
                     .span
-                    .map(|s| Range::from_span(&s, server.world.cache.files())),
+                    .and_then(|s| Range::from_span(&s, server.world.cache.files())),
             },
         ));
     } else {

--- a/lsp/nls/src/requests/rename.rs
+++ b/lsp/nls/src/requests/rename.rs
@@ -45,10 +45,12 @@ pub fn handle_rename(
     let mut changes = HashMap::<Url, Vec<TextEdit>>::new();
     for pos in all_positions {
         let url = Url::from_file_path(server.world.cache.files().name(pos.src_id)).unwrap();
-        changes.entry(url).or_default().push(TextEdit {
-            range: Range::from_span(&pos, server.world.cache.files()),
-            new_text: params.new_name.clone(),
-        });
+        if let Some(range) = Range::from_span(&pos, server.world.cache.files()) {
+            changes.entry(url).or_default().push(TextEdit {
+                range,
+                new_text: params.new_name.clone(),
+            });
+        }
     }
 
     server.reply(Response::new_ok(

--- a/lsp/nls/tests/inputs/hover-stdlib-type.ncl
+++ b/lsp/nls/tests/inputs/hover-stdlib-type.ncl
@@ -10,3 +10,7 @@ foo.bar.baz "0" + std.string.to_number "1"
 ### type = "Hover"
 ### textDocument.uri = "file:///main.ncl"
 ### position = { line = 2, character = 30 }
+### [[request]]
+### type = "GotoDefinition"
+### textDocument.uri = "file:///main.ncl"
+### position = { line = 2, character = 30 }


### PR DESCRIPTION
Nls would crash when it failed to convert a nickel location to an lsp location. But this could actually happen in realistic situations, such as when trying to go to a location in the standard library. Now, we just ignore locations that fail to convert.