### PR TITLE
Add support for packages to nickel-lang-core

### DIFF
--- a/core/src/bytecode/ast/compat.rs
+++ b/core/src/bytecode/ast/compat.rs
@@ -414,7 +414,10 @@ impl<'ast> FromMainline<'ast, term::Term> for Node<'ast> {
             Term::Annotated(annot, term) => {
                 alloc.annotated(annot.to_ast(alloc), term.to_ast(alloc))
             }
-            Term::Import { path, format } => alloc.import(path.clone(), *format),
+            Term::Import(term::Import::Path { path, format }) => {
+                alloc.import_path(path.clone(), *format)
+            }
+            Term::Import(term::Import::Package { id }) => alloc.import_package(*id),
             Term::ResolvedImport(_) => panic!("didn't expect a resolved import at parsing stage"),
             Term::Type { typ, .. } => alloc.typ(typ.to_ast(alloc)),
             Term::CustomContract(_) => panic!("didn't expect a custom contract at parsing stage"),
@@ -1170,10 +1173,11 @@ impl<'ast> FromAst<Node<'ast>> for term::Term {
             Node::Annotated { annot, inner } => {
                 Term::Annotated((*annot).to_mainline(), inner.to_mainline())
             }
-            Node::Import { path, format } => Term::Import {
-                path: (*path).clone(),
+            Node::Import(Import::Path { path, format }) => Term::Import(term::Import::Path {
+                path: (*path).to_owned(),
                 format: *format,
-            },
+            }),
+            Node::Import(Import::Package { id }) => Term::Import(term::Import::Package { id: *id }),
             Node::Type(typ) => {
                 let typ: mline_type::Type = (*typ).to_mainline();
 

--- a/core/src/deserialize.rs
+++ b/core/src/deserialize.rs
@@ -59,6 +59,10 @@ impl<'de> serde::Deserializer<'de> for RichTerm {
                 variant: v.into_label(),
                 rich_term: None,
             }),
+            Term::EnumVariant { tag, arg, .. } => visitor.visit_enum(EnumDeserializer {
+                variant: tag.into_label(),
+                rich_term: Some(arg),
+            }),
             Term::Record(record) => visit_record(record.fields, visitor),
             Term::Array(v, _) => visit_array(v, visitor),
             // unreachable(): `unwrap_term` recursively unwraps `Annotated` nodes until it
@@ -107,6 +111,7 @@ impl<'de> serde::Deserializer<'de> for RichTerm {
     {
         let (variant, rich_term) = match unwrap_term(self)? {
             Term::Enum(ident) => (ident.into_label(), None),
+            Term::EnumVariant { tag, arg, .. } => (tag.into_label(), Some(arg)),
             Term::Record(record) => {
                 let mut iter = record.fields.into_iter();
                 let (variant, value) = match iter.next() {

--- a/core/src/eval/mod.rs
+++ b/core/src/eval/mod.rs
@@ -79,8 +79,7 @@ use crate::{
     environment::Environment as GenericEnvironment,
     error::{Error, EvalError},
     files::FileId,
-    identifier::Ident,
-    identifier::LocIdent,
+    identifier::{Ident, LocIdent},
     match_sharedterm,
     metrics::{increment, measure_runtime},
     position::TermPos,
@@ -91,7 +90,7 @@ use crate::{
         pattern::compile::Compile,
         record::{Field, RecordData},
         string::NickelString,
-        BinaryOp, BindingType, LetAttrs, MatchBranch, MatchData, RecordOpKind, RichTerm,
+        BinaryOp, BindingType, Import, LetAttrs, MatchBranch, MatchData, RecordOpKind, RichTerm,
         RuntimeContract, StrChunk, Term, UnaryOp,
     },
 };
@@ -799,15 +798,15 @@ impl<R: ImportResolver, C: Cache> VirtualMachine<R, C> {
                         ));
                     }
                 }
-                Term::Import { path, .. } => {
+                Term::Import(Import::Path { path, .. }) => {
                     break Err(EvalError::InternalError(
                         format!("Unresolved import ({})", path.to_string_lossy()),
                         pos,
                     ));
                 }
-                Term::ImportPkg(pkg) => {
+                Term::Import(Import::Package { id }) => {
                     return Err(EvalError::InternalError(
-                        format!("Unresolved package import ({})", pkg),
+                        format!("Unresolved package import ({})", id),
                         pos,
                     ));
                 }
@@ -1196,8 +1195,7 @@ pub fn subst<C: Cache>(
         | v @ Term::ForeignId(_)
         | v @ Term::SealingKey(_)
         | v @ Term::Enum(_)
-        | v @ Term::Import{..}
-        | v @ Term::ImportPkg(_)
+        | v @ Term::Import(_)
         | v @ Term::ResolvedImport(_)
         // We could recurse here, because types can contain terms which would then be subject to
         // substitution. Not recursing should be fine, though, because a type in term position

--- a/core/src/eval/mod.rs
+++ b/core/src/eval/mod.rs
@@ -805,6 +805,12 @@ impl<R: ImportResolver, C: Cache> VirtualMachine<R, C> {
                         pos,
                     ));
                 }
+                Term::ImportPkg(pkg) => {
+                    return Err(EvalError::InternalError(
+                        format!("Unresolved package import ({})", pkg),
+                        pos,
+                    ));
+                }
                 // Closurize the array if it's not already done.
                 // This *should* make it unnecessary to call closurize in [operation].
                 // See the comment on the `BinaryOp::ArrayConcat` match arm.
@@ -1191,6 +1197,7 @@ pub fn subst<C: Cache>(
         | v @ Term::SealingKey(_)
         | v @ Term::Enum(_)
         | v @ Term::Import{..}
+        | v @ Term::ImportPkg(_)
         | v @ Term::ResolvedImport(_)
         // We could recurse here, because types can contain terms which would then be subject to
         // substitution. Not recursing should be fine, though, because a type in term position

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -12,6 +12,7 @@ pub mod identifier;
 pub mod label;
 #[cfg(feature = "nix-experimental")]
 pub mod nix_ffi;
+pub mod package;
 pub mod parser;
 pub mod position;
 pub mod pretty;

--- a/core/src/package.rs
+++ b/core/src/package.rs
@@ -1,0 +1,85 @@
+//! This module contains the part of package management that's needed by the evaluator.
+//!
+//! In particular, it doesn't contain any support for version resolution or
+//! dependency fetching, but defines package maps and allows them to be used to
+//! resolve package dependencies to paths.
+
+use std::{
+    collections::HashMap,
+    path::{Path, PathBuf},
+};
+
+use crate::{error::ImportError, identifier::Ident, position::TermPos};
+
+/// Maps package imports to filesystem locations.
+///
+/// Providing one of these to the import resolver enables importing named
+/// packages, like `import foo`; this map tells the import resolver where
+/// to find the `foo` package on the filesystem.
+///
+/// Package names are package-local, in the sense that if you import `foo`
+/// and `bar`, and then `foo` also imports `bar`, then those two `bar`s
+/// are not necessarily the same package.
+#[derive(Clone, Debug, Default)]
+pub struct PackageMap {
+    /// The top-level name-to-path map. If the main file imports the name `foo`,
+    /// it gets looked up here.
+    pub top_level: HashMap<Ident, PathBuf>,
+    /// The name-to-path map for imported packages. If the package located at
+    /// `/my-path` imports `foo`, we look up `("/my-path", foo)` in this map.
+    pub packages: HashMap<(PathBuf, Ident), PathBuf>,
+}
+
+impl PackageMap {
+    /// Look up a package in the map.
+    ///
+    /// `parent` is the path of the package doing the import (if `None`, it was
+    /// the top-level package doing the import).
+    pub fn get(
+        &self,
+        parent: Option<&Path>,
+        name: Ident,
+        pos: TermPos,
+    ) -> Result<&Path, ImportError> {
+        let result = match parent {
+            Some(parent) => self.packages.get(&(parent.to_owned(), name)),
+            None => self.top_level.get(&name),
+        };
+        result
+            .map(PathBuf::as_path)
+            .ok_or_else(|| ImportError::MissingDependency {
+                parent: parent.map(Path::to_owned),
+                missing: name,
+                pos,
+            })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Cursor;
+
+    use super::*;
+    use crate::{eval::cache::CacheImpl, program::Program, term::Term};
+    use nickel_lang_utils::project_root::project_root;
+
+    // Test basic package map functionality by building one manually out of
+    // files in our integration test folder. More thorough integration tests
+    // will be possible once the cli is wired up with lock-files.
+    #[test]
+    fn package_import() {
+        let pkg1 = project_root().join("core/tests/integration/inputs/imports/imported/pkg1");
+        let pkg2 = project_root().join("core/tests/integration/inputs/imports/imported/pkg2");
+
+        let map = PackageMap {
+            top_level: std::iter::once((Ident::new("pkg"), pkg1.clone())).collect(),
+            packages: std::iter::once(((pkg1, Ident::new("dep")), pkg2)).collect(),
+        };
+
+        let mut p: Program<CacheImpl> =
+            Program::new_from_source(Cursor::new("import pkg"), "<test>", std::io::sink()).unwrap();
+        p.set_package_map(map);
+
+        assert_eq!(p.eval_full().unwrap().as_ref(), &Term::Num(44.into()));
+    }
+}

--- a/core/src/parser/grammar.lalrpop
+++ b/core/src/parser/grammar.lalrpop
@@ -258,6 +258,9 @@ UniTerm: UniTerm = {
     "import" <s: StandardStaticString> "as" <l: @L> <t: EnumTag> <r: @R> =>? {
         Ok(UniTerm::from(mk_import_explicit(s, t, mk_span(src_id, l, r))?))
     },
+    "import" <pkg: Ident> => {
+        UniTerm::from(Term::ImportPkg(pkg.ident()))
+    }
 };
 
 AnnotatedInfixExpr: UniTerm = {

--- a/core/src/parser/grammar.lalrpop
+++ b/core/src/parser/grammar.lalrpop
@@ -259,7 +259,7 @@ UniTerm: UniTerm = {
         Ok(UniTerm::from(mk_import_explicit(s, t, mk_span(src_id, l, r))?))
     },
     "import" <pkg: Ident> => {
-        UniTerm::from(Term::ImportPkg(pkg.ident()))
+        UniTerm::from(Term::Import(Import::Package { id: pkg.ident() }))
     }
 };
 

--- a/core/src/parser/utils.rs
+++ b/core/src/parser/utils.rs
@@ -708,7 +708,7 @@ pub fn mk_import_based_on_filename(path: String, _span: RawSpan) -> Result<Term,
     // Fall back to InputFormat::Nickel in case of unknown filename extension for backwards compatiblilty.
     let format = format.unwrap_or_default();
 
-    Ok(Term::Import { path, format })
+    Ok(Term::Import(Import::Path { path, format }))
 }
 
 pub fn mk_import_explicit(
@@ -720,7 +720,7 @@ pub fn mk_import_explicit(
     let Some(format) = InputFormat::from_tag(format.label()) else {
         return Err(ParseError::InvalidImportFormat { span });
     };
-    Ok(Term::Import { path, format })
+    Ok(Term::Import(Import::Path { path, format }))
 }
 
 /// Determine the minimal level of indentation of a multi-line string.

--- a/core/src/pretty.rs
+++ b/core/src/pretty.rs
@@ -1132,6 +1132,7 @@ impl<'a> Pretty<'a, Allocator> for &Term {
                     },
                 ]
             }
+            ImportPkg(pkg) => allocator.text("import ").append(pkg.to_string()),
             ResolvedImport(id) => allocator.text(format!("import <file_id: {id:?}>")),
             // This type is in term position, so we don't need to add parentheses.
             Type { typ, contract: _ } => typ.pretty(allocator),

--- a/core/src/pretty.rs
+++ b/core/src/pretty.rs
@@ -9,7 +9,7 @@ use crate::term::{
     record::{Field, FieldMetadata, RecordData},
     *,
 };
-use crate::typ::*;
+use crate::{term, typ::*};
 
 use malachite::num::{basic::traits::Zero, conversion::traits::ToSci};
 use once_cell::sync::Lazy;
@@ -1110,7 +1110,7 @@ impl<'a> Pretty<'a, Allocator> for &Term {
             SealingKey(sym) => allocator.text(format!("%<sealing key: {sym}>")),
             Sealed(_i, _rt, _lbl) => allocator.text("%<sealed>"),
             Annotated(annot, rt) => allocator.atom(rt).append(annot.pretty(allocator)),
-            Import { path, format } => {
+            Import(term::Import::Path { path, format }) => {
                 docs![
                     allocator,
                     "import",
@@ -1132,7 +1132,9 @@ impl<'a> Pretty<'a, Allocator> for &Term {
                     },
                 ]
             }
-            ImportPkg(pkg) => allocator.text("import ").append(pkg.to_string()),
+            Import(term::Import::Package { id }) => {
+                allocator.text("import ").append(id.to_string())
+            }
             ResolvedImport(id) => allocator.text(format!("import <file_id: {id:?}>")),
             // This type is in term position, so we don't need to add parentheses.
             Type { typ, contract: _ } => typ.pretty(allocator),

--- a/core/src/program.rs
+++ b/core/src/program.rs
@@ -37,7 +37,7 @@ use crate::{
     term::{
         make::{self as mk_term, builder},
         record::Field,
-        BinaryOp, MergePriority, RichTerm, RuntimeContract, Term,
+        BinaryOp, Import, MergePriority, RichTerm, RuntimeContract, Term,
     },
     typecheck::TypecheckMode,
 };
@@ -260,19 +260,19 @@ impl<EC: EvalCache> Program<EC> {
         let merge_term = inputs
             .into_iter()
             .map(|input| match input {
-                Input::Path(path) => RichTerm::from(Term::Import {
+                Input::Path(path) => RichTerm::from(Term::Import(Import::Path {
                     path: path.into(),
                     format: InputFormat::Nickel,
-                }),
+                })),
                 Input::Source(source, name) => {
                     let path = PathBuf::from(name.into());
                     cache
                         .add_source(SourcePath::Path(path.clone(), InputFormat::Nickel), source)
                         .unwrap();
-                    RichTerm::from(Term::Import {
+                    RichTerm::from(Term::Import(Import::Path {
                         path: path.into(),
                         format: InputFormat::Nickel,
-                    })
+                    }))
                 }
             })
             .reduce(|acc, f| mk_term::op2(BinaryOp::Merge(Label::default().into()), acc, f))

--- a/core/src/program.rs
+++ b/core/src/program.rs
@@ -32,10 +32,12 @@ use crate::{
     identifier::LocIdent,
     label::Label,
     metrics::increment,
+    package::PackageMap,
+    position::TermPos,
     term::{
         make::{self as mk_term, builder},
         record::Field,
-        BinaryOp, MergePriority, RichTerm, Term,
+        BinaryOp, MergePriority, RichTerm, RuntimeContract, Term,
     },
     typecheck::TypecheckMode,
 };
@@ -192,6 +194,9 @@ pub struct Program<EC: EvalCache> {
     /// be evaluated, but it can be set by the user (for example by the `--field` argument of the
     /// CLI) to evaluate only a specific field.
     pub field: FieldPath,
+    /// Extra contracts to apply to the main program source. Note that the contract is applied to
+    /// the whole value before fields are extracted.
+    pub contracts: Vec<RuntimeContract>,
 }
 
 /// The Possible Input Sources, anything that a Nickel program can be created from
@@ -236,6 +241,7 @@ impl<EC: EvalCache> Program<EC> {
             color_opt: colorchoice::ColorChoice::Auto,
             overrides: Vec::new(),
             field: FieldPath::new(),
+            contracts: Vec::new(),
         })
     }
 
@@ -285,6 +291,7 @@ impl<EC: EvalCache> Program<EC> {
             color_opt: colorchoice::ColorChoice::Auto,
             overrides: Vec::new(),
             field: FieldPath::new(),
+            contracts: Vec::new(),
         })
     }
 
@@ -367,12 +374,20 @@ impl<EC: EvalCache> Program<EC> {
         self.overrides.extend(overrides);
     }
 
+    pub fn add_contract(&mut self, contract: RuntimeContract) {
+        self.contracts.push(contract);
+    }
+
     /// Adds import paths to the end of the list.
     pub fn add_import_paths<P>(&mut self, paths: impl Iterator<Item = P>)
     where
         PathBuf: From<P>,
     {
         self.vm.import_resolver_mut().add_import_paths(paths);
+    }
+
+    pub fn set_package_map(&mut self, map: PackageMap) {
+        self.vm.import_resolver_mut().set_package_map(map)
     }
 
     /// Only parse the program, don't typecheck or evaluate. returns the [`RichTerm`] AST
@@ -427,7 +442,7 @@ impl<EC: EvalCache> Program<EC> {
     fn prepare_eval_impl(&mut self, for_query: bool) -> Result<Closure, Error> {
         // If there are no overrides, we avoid the boilerplate of creating an empty record and
         // merging it with the current program
-        let prepared_body = if self.overrides.is_empty() {
+        let mut prepared_body = if self.overrides.is_empty() {
             self.vm.prepare_eval(self.main_id)?
         } else {
             let mut record = builder::Record::new();
@@ -455,6 +470,14 @@ impl<EC: EvalCache> Program<EC> {
             // without referring to any source position.
             mk_term::op2(BinaryOp::Merge(Label::default().into()), t, built_record)
         };
+
+        if !self.contracts.is_empty() {
+            prepared_body = RuntimeContract::apply_all(
+                prepared_body,
+                self.contracts.iter().cloned(),
+                TermPos::None,
+            );
+        }
 
         let prepared = Closure::atomic_closure(prepared_body);
 

--- a/core/src/term/mod.rs
+++ b/core/src/term/mod.rs
@@ -25,7 +25,7 @@ use crate::{
     error::{EvalError, ParseError},
     eval::{cache::CacheIndex, Environment},
     files::FileId,
-    identifier::LocIdent,
+    identifier::{Ident, LocIdent},
     impl_display_from_pretty,
     label::{Label, MergeLabel},
     match_sharedterm,
@@ -209,6 +209,9 @@ pub enum Term {
     #[serde(skip)]
     Import { path: OsString, format: InputFormat },
 
+    #[serde(skip)]
+    ImportPkg(Ident),
+
     /// A resolved import (which has already been loaded and parsed).
     #[serde(skip)]
     ResolvedImport(FileId),
@@ -375,6 +378,7 @@ impl PartialEq for Term {
                     format: r1,
                 },
             ) => l0 == r0 && l1 == r1,
+            (Self::ImportPkg(l0), Self::ImportPkg(r0)) => l0 == r0,
             (Self::ResolvedImport(l0), Self::ResolvedImport(r0)) => l0 == r0,
             (
                 Self::Type {
@@ -1001,6 +1005,7 @@ impl Term {
             | Term::Op2(_, _, _)
             | Term::OpN(..)
             | Term::Import { .. }
+            | Term::ImportPkg(_)
             | Term::ResolvedImport(_)
             | Term::StrChunks(_)
             | Term::ParseError(_)
@@ -1054,6 +1059,7 @@ impl Term {
             | Term::Sealed(..)
             | Term::Annotated(..)
             | Term::Import{..}
+            | Term::ImportPkg(_)
             | Term::ResolvedImport(_)
             | Term::StrChunks(_)
             | Term::RecRecord(..)
@@ -1116,6 +1122,7 @@ impl Term {
             | Term::Sealed(..)
             | Term::Annotated(..)
             | Term::Import { .. }
+            | Term::ImportPkg(_)
             | Term::ResolvedImport(_)
             | Term::StrChunks(_)
             | Term::RecRecord(..)
@@ -1172,6 +1179,7 @@ impl Term {
             | Term::Sealed(..)
             | Term::Annotated(..)
             | Term::Import{..}
+            | Term::ImportPkg(_)
             | Term::ResolvedImport(..)
             | Term::Closure(_)
             | Term::ParseError(_)
@@ -2419,6 +2427,7 @@ impl Traverse<RichTerm> for RichTerm {
             | Term::Closure(_)
             | Term::Enum(_)
             | Term::Import { .. }
+            | Term::ImportPkg(_)
             | Term::ResolvedImport(_)
             | Term::SealingKey(_)
             | Term::ForeignId(_)

--- a/core/src/transform/free_vars.rs
+++ b/core/src/transform/free_vars.rs
@@ -43,6 +43,7 @@ impl CollectFreeVars for RichTerm {
             | Term::SealingKey(_)
             | Term::Enum(_)
             | Term::Import { .. }
+            | Term::ImportPkg(_)
             | Term::ResolvedImport(_) => (),
             Term::Fun(id, t) => {
                 let mut fresh = HashSet::new();

--- a/core/src/transform/free_vars.rs
+++ b/core/src/transform/free_vars.rs
@@ -43,7 +43,6 @@ impl CollectFreeVars for RichTerm {
             | Term::SealingKey(_)
             | Term::Enum(_)
             | Term::Import { .. }
-            | Term::ImportPkg(_)
             | Term::ResolvedImport(_) => (),
             Term::Fun(id, t) => {
                 let mut fresh = HashSet::new();

--- a/core/src/transform/import_resolution.rs
+++ b/core/src/transform/import_resolution.rs
@@ -77,7 +77,6 @@ pub mod strict {
 /// together with a (partially) resolved term.
 pub mod tolerant {
     use super::ImportResolver;
-    use crate::cache::PathOrPackage;
     use crate::error::ImportError;
     use crate::files::FileId;
     use crate::term::{RichTerm, Term, Traverse, TraverseOrder};
@@ -145,22 +144,10 @@ pub mod tolerant {
     {
         let term = rt.as_ref();
         match term {
-            Term::Import { path, format } => {
-                match resolver.resolve(PathOrPackage::Path(path, *format), parent, &rt.pos) {
-                    Ok((_, file_id)) => {
-                        (RichTerm::new(Term::ResolvedImport(file_id), rt.pos), None)
-                    }
-                    Err(err) => (rt, Some(err)),
-                }
-            }
-            Term::ImportPkg(pkg) => {
-                match resolver.resolve(PathOrPackage::Package(*pkg), parent, &rt.pos) {
-                    Ok((_, file_id)) => {
-                        (RichTerm::new(Term::ResolvedImport(file_id), rt.pos), None)
-                    }
-                    Err(err) => (rt, Some(err)),
-                }
-            }
+            Term::Import(import) => match resolver.resolve(import, parent, &rt.pos) {
+                Ok((_, file_id)) => (RichTerm::new(Term::ResolvedImport(file_id), rt.pos), None),
+                Err(err) => (rt, Some(err)),
+            },
             _ => (rt, None),
         }
     }

--- a/core/src/typecheck/mod.rs
+++ b/core/src/typecheck/mod.rs
@@ -1446,8 +1446,7 @@ fn walk<V: TypecheckVisitor>(
         | Term::SealingKey(_)
         // This function doesn't recursively typecheck imports: this is the responsibility of the
         // caller.
-        | Term::Import{..}
-        | Term::ImportPkg(_)
+        | Term::Import(_)
         | Term::ResolvedImport(_) => Ok(()),
         Term::Var(x) => ctxt.type_env
             .get(&x.ident())
@@ -2403,7 +2402,7 @@ fn check<V: TypecheckVisitor>(
             .unify(mk_uniftype::sym(), state, &ctxt)
             .map_err(|err| err.into_typecheck_err(state, rt.pos)),
         Term::Sealed(_, t, _) => check(state, ctxt, visitor, t, ty),
-        Term::Import { .. } | Term::ImportPkg(_) => ty
+        Term::Import(_) => ty
             .unify(mk_uniftype::dynamic(), state, &ctxt)
             .map_err(|err| err.into_typecheck_err(state, rt.pos)),
         // We use the apparent type of the import for checking. This function doesn't recursively

--- a/core/src/typecheck/mod.rs
+++ b/core/src/typecheck/mod.rs
@@ -1447,6 +1447,7 @@ fn walk<V: TypecheckVisitor>(
         // This function doesn't recursively typecheck imports: this is the responsibility of the
         // caller.
         | Term::Import{..}
+        | Term::ImportPkg(_)
         | Term::ResolvedImport(_) => Ok(()),
         Term::Var(x) => ctxt.type_env
             .get(&x.ident())
@@ -2402,7 +2403,7 @@ fn check<V: TypecheckVisitor>(
             .unify(mk_uniftype::sym(), state, &ctxt)
             .map_err(|err| err.into_typecheck_err(state, rt.pos)),
         Term::Sealed(_, t, _) => check(state, ctxt, visitor, t, ty),
-        Term::Import { .. } => ty
+        Term::Import { .. } | Term::ImportPkg(_) => ty
             .unify(mk_uniftype::dynamic(), state, &ctxt)
             .map_err(|err| err.into_typecheck_err(state, rt.pos)),
         // We use the apparent type of the import for checking. This function doesn't recursively

--- a/core/tests/integration/inputs/imports/imported/pkg1/main.ncl
+++ b/core/tests/integration/inputs/imports/imported/pkg1/main.ncl
@@ -1,0 +1,2 @@
+# test.type = 'skip'
+1 + (import dep)

--- a/core/tests/integration/inputs/imports/imported/pkg2/main.ncl
+++ b/core/tests/integration/inputs/imports/imported/pkg2/main.ncl
@@ -1,0 +1,2 @@
+# test.type = 'skip'
+43

--- a/lsp/nls/src/requests/completion.rs
+++ b/lsp/nls/src/requests/completion.rs
@@ -7,7 +7,7 @@ use nickel_lang_core::{
     identifier::Ident,
     position::RawPos,
     pretty::Allocator,
-    term::{record::FieldMetadata, RichTerm, Term, UnaryOp},
+    term::{record::FieldMetadata, Import, RichTerm, Term, UnaryOp},
     typ::Type,
 };
 use pretty::{DocBuilder, Pretty};
@@ -300,7 +300,9 @@ pub fn handle_completion(
     let term = server.world.lookup_term_by_position(pos)?.cloned();
     let ident = server.world.lookup_ident_by_position(pos)?;
 
-    if let Some(Term::Import { path: import, .. }) = term.as_ref().map(|t| t.term.as_ref()) {
+    if let Some(Term::Import(Import::Path { path: import, .. })) =
+        term.as_ref().map(|t| t.term.as_ref())
+    {
         // Don't respond with anything if trigger is a `.`, as that may be the
         // start of a relative file path `./`, or the start of a file extension
         if !matches!(trigger, Some(".")) {


### PR DESCRIPTION
These are the changes to the core crate, picked out from the `npm` branch.

Essentially, this enables the `import pkg` syntax, and introduces `PackageMap` for figuring out how to interpret those import statements.

It also includes deserialization support for enum variants, because I ran into that while working on manifest files. That's unrelated to most of the changes here, so I could break it out as a separate PR if you want.