### PR TITLE
Fix spawning of too many LSP `TestHarness`es

### DIFF
--- a/lsp/lsp-harness/src/lib.rs
+++ b/lsp/lsp-harness/src/lib.rs
@@ -211,6 +211,14 @@ impl TestHarness {
         Self::new_with_options(None)
     }
 
+    /// Shut down the underlying language server by calling `kill` on its `proc`.
+    ///
+    /// This is used when benchmarking to avoid exhausting the computer's PID pool when
+    /// thousands of servers are created.
+    pub fn finish(self) -> anyhow::Result<()> {
+        self.srv.die()
+    }
+
     pub fn request<T: LspRequest>(&mut self, params: T::Params)
     where
         T::Result: LspDebug,

--- a/lsp/nls/benches/main.rs
+++ b/lsp/nls/benches/main.rs
@@ -66,7 +66,9 @@ fn benchmark_one_test(c: &mut Criterion, path: &str) {
             // If the input is big, nls will be blocked generating diagnostics. Let that
             // finish before we try to benchmark a request.
             harness.wait_for_diagnostics();
-            b.iter(|| harness.request_dyn(req.clone()))
+            b.iter(|| harness.request_dyn(req.clone()));
+
+            harness.finish().unwrap();
         });
     }
 }


### PR DESCRIPTION
During benchmarking, each criterion run would spawn `TestHarness`, each with its own `lsp` process. They weren't cleaned up between criterion runs, so eventually they would exhaust the system’s process pool. Fixed this by explicitly killing and cleaning up the lsp at the end of a criterion run.