### PR TITLE
Add missing implementation of from_ast for Record

### DIFF
--- a/core/src/bytecode/ast/compat.rs
+++ b/core/src/bytecode/ast/compat.rs
@@ -1136,7 +1136,34 @@ impl<'ast> FromAst<Node<'ast>> for term::Term {
                     Term::Enum(*tag)
                 }
             }
-            Node::Record(_) => todo!(),
+            Node::Record(Record {
+                stat_fields,
+                dyn_fields,
+                open,
+            }) => {
+                let fields = stat_fields
+                    .iter()
+                    .map(|(id, field)| (*id, field.to_mainline()))
+                    .collect();
+
+                let dyn_fields = dyn_fields
+                    .iter()
+                    .map(|(dyn_name, field)| (dyn_name.to_mainline(), field.to_mainline()))
+                    .collect();
+
+                Term::RecRecord(
+                    term::record::RecordData {
+                        fields,
+                        attrs: term::record::RecordAttrs {
+                            open: *open,
+                            ..Default::default()
+                        },
+                        sealed_tail: None,
+                    },
+                    dyn_fields,
+                    None,
+                )
+            }
             Node::IfThenElse {
                 cond,
                 then_branch,

--- a/core/src/bytecode/ast/record.rs
+++ b/core/src/bytecode/ast/record.rs
@@ -1,26 +1,10 @@
 use super::{Annotation, Ast};
 
-use crate::{combine::Combine, identifier::LocIdent};
+use crate::identifier::LocIdent;
 
 pub use crate::term::MergePriority;
 
 use std::rc::Rc;
-
-/// Additional attributes for record.
-#[derive(Debug, Default, Eq, PartialEq, Copy, Clone)]
-pub struct RecordAttrs {
-    /// If the record is an open record, ie ending with `..`. Open records have a different
-    /// behavior when used as a record contract: they allow additional fields to be present.
-    pub open: bool,
-}
-
-impl Combine for RecordAttrs {
-    fn combine(left: Self, right: Self) -> Self {
-        RecordAttrs {
-            open: left.open || right.open,
-        }
-    }
-}
 
 /// The metadata attached to record fields.
 #[derive(Debug, PartialEq, Clone, Default)]


### PR DESCRIPTION
While testing #2083 I realized that I left a `todo!()` in the translation of the new AST to mainline `Term`. This PR adds the missing case. I also removed `RecordAttrs` that were copy pasted when introducing the new AST, but since we only store an `open` flag, I ended up using a simple `bool` field so this type is just unused now.