### PR TITLE
[RFC007] Add Seal and Unseal to the new AST primops

### DIFF
--- a/core/src/bytecode/ast/compat.rs
+++ b/core/src/bytecode/ast/compat.rs
@@ -596,9 +596,12 @@ impl From<&term::BinaryOp> for PrimOp {
             term::BinaryOp::LabelAppendNote => PrimOp::LabelAppendNote,
             term::BinaryOp::LabelLookupTypeVar => PrimOp::LabelLookupTypeVar,
 
-            op @ (term::BinaryOp::RecordInsert { .. }
-            | term::BinaryOp::Unseal
-            | term::BinaryOp::Seal) => panic!("didn't expect {op} at the parsing stage"),
+            term::BinaryOp::Seal => PrimOp::Seal,
+            term::BinaryOp::Unseal => PrimOp::Unseal,
+
+            term::BinaryOp::RecordInsert { .. } => {
+                panic!("didn't expect %record/insert% at the parsing stage")
+            }
         }
     }
 }
@@ -1020,6 +1023,8 @@ impl FromAst<PrimOp> for TermPrimOp {
             PrimOp::StringSplit => TermPrimOp::Binary(term::BinaryOp::StringSplit),
             PrimOp::StringContains => TermPrimOp::Binary(term::BinaryOp::StringContains),
             PrimOp::StringCompare => TermPrimOp::Binary(term::BinaryOp::StringCompare),
+            PrimOp::Seal => TermPrimOp::Binary(term::BinaryOp::Seal),
+            PrimOp::Unseal => TermPrimOp::Binary(term::BinaryOp::Unseal),
             PrimOp::ContractArrayLazyApp => {
                 TermPrimOp::Binary(term::BinaryOp::ContractArrayLazyApp)
             }

--- a/core/src/bytecode/ast/primop.rs
+++ b/core/src/bytecode/ast/primop.rs
@@ -771,6 +771,22 @@ pub enum PrimOp {
     /// 2. The right string.
     StringCompare,
 
+    /// Seal a term with a sealing key (used by the implementation of polymorphic contracts).
+    ///
+    /// # Argumens
+    ///
+    /// 1. The sealing key.
+    /// 2. The term to seal.
+    Seal,
+
+    /// Unseal a term given the right sealing key. See [Self::Seal].
+    ///
+    /// # Arguments
+    ///
+    /// 1. The sealing key.
+    /// 2. The term to unseal.
+    Unseal,
+
     /// Lazily apply a contract to an Array.
     ///
     /// This simply inserts a contract into the array attributes.
@@ -1015,6 +1031,8 @@ impl fmt::Display for PrimOp {
             StringSplit => write!(f, "string/split"),
             StringContains => write!(f, "string/contains"),
             StringCompare => write!(f, "string/compare"),
+            Seal => write!(f, "seal"),
+            Unseal => write!(f, "unseal"),
             ContractArrayLazyApp => write!(f, "contract/array_lazy_apply"),
             ContractRecordLazyApp => write!(f, "contract/record_lazy_apply"),
             LabelWithMessage => write!(f, "label/with_message"),
@@ -1126,6 +1144,8 @@ impl PrimOp {
             | StringSplit
             | StringContains
             | StringCompare
+            | Seal
+            | Unseal
             | ContractArrayLazyApp
             | ContractRecordLazyApp
             | LabelWithMessage


### PR DESCRIPTION
While working on #2083, I realized that we do need the `seal` and `unseal` primitives (which were initially discarded as only a run time thing), since the implementation of the builtin contracts is written in pure Nickel and use those operations.

This PR adds the missing variants to `Primop` and missing conversion as well in `bytecode::ast::compat`.