### PR TITLE
[RFC007] Improve/simplify record representation in the new AST

### DIFF
--- a/core/src/bytecode/ast/record.rs
+++ b/core/src/bytecode/ast/record.rs
@@ -1,10 +1,77 @@
-use super::{Annotation, Ast};
+use super::{Annotation, Ast, AstAlloc, StrChunk};
 
-use crate::identifier::LocIdent;
+use crate::{identifier::LocIdent, position::TermPos};
 
 pub use crate::term::MergePriority;
 
 use std::rc::Rc;
+
+/// Element of a record field path in a record field definition. For example, in  `{ a."%{"hello-"
+/// ++ "world"}".c = true }`, the path `a."%{b}".c` is composed of three elements: an identifier
+/// `a`, an expression `"hello" ++ "world"`, and another identifier `c`.
+#[derive(Clone, Debug, PartialEq)]
+pub enum FieldPathElem<'ast> {
+    /// A statically known identifier.
+    Ident(LocIdent),
+    /// A dynamic field name written as a quoted expression, e.g. `"%{protocol}" = .. `.
+    Expr(&'ast [StrChunk<Ast<'ast>>], TermPos),
+}
+
+impl<'ast> FieldPathElem<'ast> {
+    /// Returns the position of the field path element.
+    pub fn pos(&self) -> TermPos {
+        match self {
+            FieldPathElem::Ident(ident) => ident.pos,
+            FieldPathElem::Expr(_, pos) => *pos,
+        }
+    }
+
+    /// Crate a path composed of a single static identifier.
+    pub fn single_ident_path(
+        alloc: &'ast AstAlloc,
+        ident: LocIdent,
+    ) -> &'ast [FieldPathElem<'ast>] {
+        alloc.alloc_iter(std::iter::once(FieldPathElem::Ident(ident)))
+    }
+
+    /// Crate a path composed of a single dynamic expression.
+    pub fn single_expr_path(
+        alloc: &'ast AstAlloc,
+        expr: &'ast [StrChunk<Ast<'ast>>],
+        pos: TermPos,
+    ) -> &'ast [FieldPathElem<'ast>] {
+        alloc.alloc_iter(std::iter::once(FieldPathElem::Expr(expr, pos)))
+    }
+}
+
+/// A field definition. A field is defined by a dot-separated path of identifier or interpolated
+/// strings, a potential value, and associated metadata.
+#[derive(Clone, Debug, PartialEq)]
+pub struct FieldDef<'ast> {
+    /// A sequence of field path elements, composing the left hand side (with respect to the `=`)
+    /// of the field definition.
+    pub path: &'ast [FieldPathElem<'ast>],
+    /// The metadata and the optional value bundled as a field.
+    pub metadata: FieldMetadata<'ast>,
+    pub value: Option<Ast<'ast>>,
+    /// The position of the whole field definition.
+    pub pos: TermPos,
+}
+
+impl<'ast> FieldDef<'ast> {
+    /// Returns the identifier corresponding to this definition if the path is composed of exactly
+    /// one element which is a static identifier. Returns `None` otherwise.
+    pub fn path_as_ident(&self) -> Option<LocIdent> {
+        if self.path.len() > 1 {
+            return None;
+        }
+
+        self.path.first().and_then(|path_elem| match path_elem {
+            FieldPathElem::Expr(..) => None,
+            FieldPathElem::Ident(ident) => Some(*ident),
+        })
+    }
+}
 
 /// The metadata attached to record fields.
 #[derive(Debug, PartialEq, Clone, Default)]
@@ -12,7 +79,7 @@ pub struct FieldMetadata<'ast> {
     /// The documentation of the field. This is allocated once and for all and shared through a
     /// reference-counted pointer.
     pub doc: Option<Rc<str>>,
-    /// Potential type and contract annotations.
+    /// Type and contract annotations.
     pub annotation: Annotation<'ast>,
     /// If the field is optional.
     pub opt: bool,
@@ -45,46 +112,11 @@ impl<'ast> From<Annotation<'ast>> for FieldMetadata<'ast> {
     }
 }
 
-/// A record field with its metadata.
-#[derive(Clone, Default, PartialEq, Debug)]
-pub struct Field<'ast> {
-    /// The value is optional because record field may not have a definition (e.g. optional fields).
-    pub value: Option<Ast<'ast>>,
-    /// The metadata attached to the field.
-    pub metadata: FieldMetadata<'ast>,
-}
-
-impl<'ast> From<Ast<'ast>> for Field<'ast> {
-    fn from(ast: Ast<'ast>) -> Self {
-        Field {
-            value: Some(ast),
-            ..Default::default()
-        }
-    }
-}
-
-impl<'ast> From<Annotation<'ast>> for Field<'ast> {
-    fn from(ann: Annotation<'ast>) -> Self {
-        Field::from(FieldMetadata::from(ann))
-    }
-}
-
-impl<'ast> From<FieldMetadata<'ast>> for Field<'ast> {
-    fn from(metadata: FieldMetadata<'ast>) -> Self {
-        Field {
-            metadata,
-            ..Default::default()
-        }
-    }
-}
-
-/// The base structure of a Nickel record.
+/// A nickel record literal.
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct Record<'ast> {
-    /// Fields whose names are known statically.
-    pub stat_fields: &'ast [(LocIdent, Field<'ast>)],
-    /// Fields whose names is a Nickel expression computed at runtime.
-    pub dyn_fields: &'ast [(Ast<'ast>, Field<'ast>)],
+    /// Field definitions.
+    pub field_defs: &'ast [FieldDef<'ast>],
     /// If the record is open, i.e. if it ended with `..`.
     pub open: bool,
 }
@@ -93,5 +125,10 @@ impl<'ast> Record<'ast> {
     /// A record with no fields and the default set of attributes.
     pub fn empty() -> Self {
         Default::default()
+    }
+
+    /// Returns self with the open flag set to true.
+    pub fn open(self) -> Self {
+        Record { open: true, ..self }
     }
 }

--- a/core/src/bytecode/ast/record.rs
+++ b/core/src/bytecode/ast/record.rs
@@ -62,14 +62,11 @@ impl<'ast> FieldDef<'ast> {
     /// Returns the identifier corresponding to this definition if the path is composed of exactly
     /// one element which is a static identifier. Returns `None` otherwise.
     pub fn path_as_ident(&self) -> Option<LocIdent> {
-        if self.path.len() > 1 {
-            return None;
+        if let [FieldPathElem::Ident(ident)] = self.path {
+            Some(*ident)
+        } else {
+            None
         }
-
-        self.path.first().and_then(|path_elem| match path_elem {
-            FieldPathElem::Expr(..) => None,
-            FieldPathElem::Ident(ident) => Some(*ident),
-        })
     }
 }
 


### PR DESCRIPTION
Instead of elaborating piecewise definitions (such as `{foo.bar = 1, foo.baz = 2}`) directly at the parsing stage, this commit makes the new AST closer to the source language by making record a list of field definitions, where the field "name" (left hand side of `=`) can be a sequence of identifiers and dynamic strings. This representation is used internally by the parser; we now make it the default in the new AST, such that the migration of the parser in #2083  won't have to do this elaboration at all. The elaboration is offloaded to the conversion to `RichTerm`, which happens in the `ast::compat` module.

This makes the AST closer to the source language.

The first motivation is that it'll be better for the LSP, where some open issues on the tracker are caused by the inability to trace what the LSP get back to the original piecewise definitions.

The second reason is that we can't actually elaborate a piecewise definition while staying in the new AST correctly as of today: the new AST only has one record variant, which is recursive by default, but this doesn't match the way recursion and scoping work for piecewise definition. For example, `{foo.bar = 1, baz.foo = foo + 1}` works fine in today's Nickel (evaluate to `{foo = {bar = 1}, baz {foo = 2}}`), but if we elaborate it in the new AST naively, we'll get an infinite recursion: `{foo = {bar = 1}, baz = {foo = foo + 1}}`.

Mailine Nickel currently uses a non recursive `Record` for that, but we don't want to introduce such "runtime dictionary" in the new AST as they can't be expressed in the source language. Instead, we rather keep records as piecewise defined without transformation and will do further elaboration when needed later in the pipeline, during typechecking, future compilation, or in the meantime when converting the new AST representation to mainline Nickel.