### PR TITLE
Removed errant `proc.kill()`

### DIFF
--- a/lsp/lsp-harness/src/jsonrpc.rs
+++ b/lsp/lsp-harness/src/jsonrpc.rs
@@ -133,8 +133,7 @@ impl Server {
     /// exhausting the PID pool when thousands of servers are created.
     pub fn die(mut self) -> Result<()> {
         self.shutdown()?;
-        self.proc.kill()?;
-        self.proc.wait()?; // force cleanup of process (kill alone is insufficient)
+        self.proc.wait()?;
         Ok(())
     }
 

--- a/lsp/lsp-harness/src/jsonrpc.rs
+++ b/lsp/lsp-harness/src/jsonrpc.rs
@@ -96,6 +96,24 @@ pub struct Response {
     error: Option<ResponseError>,
 }
 
+impl Drop for Server {
+    fn drop(&mut self) {
+        /// Shut down the language server gracefully.
+        pub fn shutdown(this: &mut Server) -> Result<()> {
+            this.send_request::<Shutdown>(())?;
+            this.send_notification::<Exit>(())?;
+
+            // needed to clean up the process, and in particular to return PIDs to the
+            // process pool to avoid having the system run out of processes during
+            // benchmarking
+            this.proc.wait()?;
+
+            Ok(())
+        }
+        shutdown(self).unwrap()
+    }
+}
+
 impl Server {
     /// Similar to `new`, but allows passing custom stuff
     pub fn new_with_options(
@@ -125,16 +143,6 @@ impl Server {
     /// that's what LSes do).
     pub fn new(cmd: std::process::Command) -> Result<Server> {
         Server::new_with_options(cmd, None)
-    }
-
-    /// Shut down the language server by calling `kill` on its `proc`.
-    ///
-    /// This isn't ordinarily necessary, but is needed when benchmarking to avoid
-    /// exhausting the PID pool when thousands of servers are created.
-    pub fn die(mut self) -> Result<()> {
-        self.shutdown()?;
-        self.proc.wait()?;
-        Ok(())
     }
 
     /// Make the language server aware of a file.
@@ -171,12 +179,6 @@ impl Server {
             work_done_progress_params: Default::default(),
             partial_result_params: Default::default(),
         })
-    }
-
-    /// Shut down the language server gracefully.
-    pub fn shutdown(&mut self) -> Result<()> {
-        self.send_request::<Shutdown>(())?;
-        self.send_notification::<Exit>(())
     }
 
     fn initialize(&mut self, initialization_options: Option<serde_json::Value>) -> Result<()> {

--- a/lsp/lsp-harness/src/lib.rs
+++ b/lsp/lsp-harness/src/lib.rs
@@ -211,14 +211,6 @@ impl TestHarness {
         Self::new_with_options(None)
     }
 
-    /// Shut down the underlying language server by calling `kill` on its `proc`.
-    ///
-    /// This is used when benchmarking to avoid exhausting the computer's PID pool when
-    /// thousands of servers are created.
-    pub fn finish(self) -> anyhow::Result<()> {
-        self.srv.die()
-    }
-
     pub fn request<T: LspRequest>(&mut self, params: T::Params)
     where
         T::Result: LspDebug,

--- a/lsp/nls/benches/main.rs
+++ b/lsp/nls/benches/main.rs
@@ -67,8 +67,6 @@ fn benchmark_one_test(c: &mut Criterion, path: &str) {
             // finish before we try to benchmark a request.
             harness.wait_for_diagnostics();
             b.iter(|| harness.request_dyn(req.clone()));
-
-            harness.finish().unwrap();
         });
     }
 }
@@ -109,8 +107,6 @@ fn benchmark_diagnostics(c: &mut Criterion, path: &str) {
                     }
                 }
             });
-
-            harness.finish().unwrap();
         });
     }
 }

--- a/lsp/nls/benches/main.rs
+++ b/lsp/nls/benches/main.rs
@@ -96,6 +96,7 @@ fn benchmark_diagnostics(c: &mut Criterion, path: &str) {
         let name = format!("init-diagnostics-{path}-{i:03}");
         c.bench_function(&name, |b| {
             let mut harness = TestHarness::new();
+
             b.iter(|| {
                 harness.send_file(f.uri.clone(), &f.contents);
                 loop {
@@ -108,6 +109,8 @@ fn benchmark_diagnostics(c: &mut Criterion, path: &str) {
                     }
                 }
             });
+
+            harness.finish().unwrap();
         });
     }
 }


### PR DESCRIPTION
In #2098 I tried `kill`ing the process. It turns out that doing this before `wait`ing leads to out of order IO, leading to IO errors when Bincode tries to deserialize. It also turns out that killing isn't even necessary; waiting is sufficient.

So this PR removes that `kill` line, getting rid of the IO errors introduced in #2098.

Also Added `finish` to `benchmark_diagnostics` as well (should have been there all along). Thought: do we want to just `impl Drop for TestHarness`? This might make the panicking situation tricky (generally, you shouldn't panic in `drop`), whereas explicitly calling `harness.finish()`, while possible to forget, makes handling panics just work.