### PR TITLE
[RFC007] Clean the AST alloc interface

### DIFF
--- a/core/src/bytecode/ast/builder.rs
+++ b/core/src/bytecode/ast/builder.rs
@@ -187,7 +187,7 @@ impl<'ast> Field<'ast, Record<'ast>> {
         self.finalize_contracts(alloc);
 
         self.state.field_defs.push(record::FieldDef {
-            path: alloc.alloc_iter(
+            path: alloc.alloc_many(
                 self.path
                     .into_iter()
                     .map(|id| FieldPathElem::Ident(id.into())),
@@ -204,7 +204,7 @@ impl<'ast> Field<'ast, Record<'ast>> {
         self.finalize_contracts(alloc);
 
         self.state.field_defs.push(record::FieldDef {
-            path: alloc.alloc_iter(
+            path: alloc.alloc_many(
                 self.path
                     .into_iter()
                     .map(|id| FieldPathElem::Ident(id.into())),
@@ -221,7 +221,7 @@ impl<'ast> Field<'ast, Record<'ast>> {
     /// filling the field `self.metadata.annotation.contracts` with it. After this call,
     /// `self.contracts` is empty and shouldn't be used anymore (it will have no effect).
     fn finalize_contracts(&mut self, alloc: &'ast AstAlloc) {
-        self.metadata.annotation.contracts = alloc.types(self.contracts.drain(..));
+        self.metadata.annotation.contracts = alloc.alloc_many(self.contracts.drain(..));
     }
 }
 
@@ -290,7 +290,7 @@ impl<'ast> Record<'ast> {
     pub fn build(self, alloc: &'ast AstAlloc) -> Ast<'ast> {
         alloc
             .record(record::Record {
-                field_defs: alloc.alloc_iter(self.field_defs),
+                field_defs: alloc.alloc_many(self.field_defs),
                 open: self.open,
             })
             .into()
@@ -393,7 +393,7 @@ mod tests {
     {
         alloc
             .record(record::Record {
-                field_defs: alloc.alloc_iter(fields.into_iter().map(|(id, metadata, node)| {
+                field_defs: alloc.alloc_many(fields.into_iter().map(|(id, metadata, node)| {
                     record::FieldDef {
                         path: FieldPathElem::single_ident_path(alloc, id.into()),
                         value: node.map(Ast::from),
@@ -578,9 +578,9 @@ mod tests {
             ast,
             alloc
                 .record(record::Record {
-                    field_defs: alloc.alloc_iter(vec![
+                    field_defs: alloc.alloc_many(vec![
                         record::FieldDef {
-                            path: alloc.alloc_iter(vec![
+                            path: alloc.alloc_many(vec![
                                 FieldPathElem::Ident("terraform".into()),
                                 FieldPathElem::Ident("required_providers".into())
                             ]),
@@ -588,7 +588,7 @@ mod tests {
                             value: Some(
                                 alloc
                                     .record(record::Record {
-                                        field_defs: alloc.alloc_iter(vec![
+                                        field_defs: alloc.alloc_many(vec![
                                             record::FieldDef {
                                                 path: FieldPathElem::single_ident_path(
                                                     &alloc,
@@ -615,7 +615,7 @@ mod tests {
                             pos: TermPos::None,
                         },
                         record::FieldDef {
-                            path: alloc.alloc_iter(vec![
+                            path: alloc.alloc_many(vec![
                                 FieldPathElem::Ident("terraform".into()),
                                 FieldPathElem::Ident("required_providers".into()),
                                 FieldPathElem::Ident("foo".into())
@@ -684,10 +684,10 @@ mod tests {
                 iter::once((
                     "foo",
                     record::FieldMetadata::from(Annotation {
-                        contracts: alloc.types(std::iter::once(Type {
+                        contracts: alloc.alloc_singleton(Type {
                             typ: TypeF::String,
                             pos: TermPos::None
-                        })),
+                        }),
                         ..Default::default()
                     }),
                     None
@@ -728,10 +728,10 @@ mod tests {
                                 typ: TypeF::Number,
                                 pos: TermPos::None,
                             }),
-                            contracts: alloc.types(iter::once(Type {
+                            contracts: alloc.alloc_singleton(Type {
                                 typ: TypeF::String,
                                 pos: TermPos::None
-                            })),
+                            }),
                         },
                     },
                     None,

--- a/core/src/bytecode/ast/record.rs
+++ b/core/src/bytecode/ast/record.rs
@@ -35,12 +35,12 @@ impl<'ast> FieldPathElem<'ast> {
         alloc: &'ast AstAlloc,
         ident: LocIdent,
     ) -> &'ast [FieldPathElem<'ast>] {
-        alloc.alloc_iter(std::iter::once(FieldPathElem::Ident(ident)))
+        alloc.alloc_singleton(FieldPathElem::Ident(ident))
     }
 
     /// Crate a path composed of a single dynamic expression.
     pub fn single_expr_path(alloc: &'ast AstAlloc, expr: Ast<'ast>) -> &'ast [FieldPathElem<'ast>] {
-        alloc.alloc_iter(std::iter::once(FieldPathElem::Expr(expr)))
+        alloc.alloc_singleton(FieldPathElem::Expr(expr))
     }
 
     /// Try to interpret this element element as a static identifier. Returns `None` if the the

--- a/core/src/parser/grammar.lalrpop
+++ b/core/src/parser/grammar.lalrpop
@@ -147,7 +147,7 @@ AnnotSeries<AnnotAtom>: AnnotAtom = <AnnotAtom+> => {
 // `FixedType` (see `FixedType` and `parser::utils::fix_type_vars`).
 AnnotAtom<TypeRule>: Annotation<'ast> = {
     "|" <TypeRule> => Annotation {
-        contracts: alloc.types(iter::once(<>)),
+        contracts: alloc.alloc_singleton(<>),
         ..Default::default()
     },
     ":" <TypeRule> => Annotation {
@@ -467,7 +467,7 @@ RecordField: FieldDef<'ast> = {
     <value: ("=" <Term>)?>
     <r: @R> => {
         FieldDef {
-            path: alloc.alloc_iter(path),
+            path: alloc.alloc_many(path),
             metadata: ann.unwrap_or_default(),
             value,
             pos: TermPos::Original(mk_span(src_id, l, r)),
@@ -476,7 +476,7 @@ RecordField: FieldDef<'ast> = {
     <err: Error> => {
         FieldDef {
           pos: err.pos,
-          path: alloc.alloc_iter(iter::once(FieldPathElem::Expr(err.clone()))),
+          path: alloc.alloc_singleton(FieldPathElem::Expr(err.clone())),
           metadata: Default::default(),
           value: None,
         }
@@ -715,7 +715,7 @@ ConstantPattern: ConstantPattern<'ast> = {
 
 ConstantPatternData: ConstantPatternData<'ast> = {
     Bool => ConstantPatternData::Bool(<>),
-    NumberLiteral => ConstantPatternData::Number(alloc.number_move(<>)),
+    NumberLiteral => ConstantPatternData::Number(alloc.alloc_number(<>)),
     // We could accept multiline strings here, but it's unlikely that this will
     // result in very readable match expressions. For now we restrict ourselves
     // to standard string; we can always extend to multiline later if needed
@@ -740,7 +740,7 @@ RecordPattern: RecordPattern<'ast> = {
         };
 
         let pattern = RecordPattern {
-            patterns: alloc.field_patterns(field_pats),
+            patterns: alloc.alloc_many(field_pats),
             tail,
             pos: mk_pos(src_id, start, end)
         };
@@ -767,7 +767,7 @@ ArrayPattern: ArrayPattern<'ast> = {
         };
 
         ArrayPattern {
-            patterns: alloc.patterns(patterns),
+            patterns: alloc.alloc_many(patterns),
             tail,
             pos: mk_pos(src_id, start, end)
         }
@@ -878,7 +878,7 @@ OrPatternBranch: Pattern<'ast> = {
         Pattern {
             pos,
             alias: None,
-            data: PatternData::Enum(alloc.enum_pattern(EnumPattern {
+            data: PatternData::Enum(alloc.alloc(EnumPattern {
                 tag: <>.tag,
                 pattern: None,
                 pos,
@@ -900,7 +900,7 @@ OrPatternUnparens: OrPattern<'ast> = {
           patterns.into_iter().chain(iter::once(last)).collect();
 
         OrPattern {
-            patterns: alloc.patterns(patterns),
+            patterns: alloc.alloc_many(patterns),
             pos: mk_pos(src_id, start, end),
         }
     },


### PR DESCRIPTION
A previous PR introduced generic `alloc` and `alloc_iter` methods, instead of needing a myriad of `xxx_move` functions for each and every AST component type. However, this poses a risk of memory leak because this method allocates in the generic bumpalo arena, which doesn't run destructors.

This commit makes this approach safer by using a marker trait which forbids some AST components from being allocated through this method, when they need to be dropped. Anecdotally, `alloc_iter` is renamed to `alloc_many` and a specialized version `alloc_singleton` is added to eliminate a lot of `alloc.alloc_many(iter::once(x))`.

In a second time, all the legacy `xxx_move` variants or the like are removed, and replaced with `alloc` and `alloc_many` whenever possible, making the interface of `AstAlloc` quite smaller.