### PR TITLE
[RFC007] Make function node multi-ary by default

### DIFF
--- a/cli/tests/snapshot/snapshots/snapshot__eval_stderr_naked_contract_parametrized.ncl.snap
+++ b/cli/tests/snapshot/snapshots/snapshot__eval_stderr_naked_contract_parametrized.ncl.snap
@@ -6,7 +6,7 @@ warning: plain functions as contracts are deprecated
   ┌─ [INPUTS_PATH]/warnings/naked_contract_parametrized.ncl:6:3
   │
 3 │ let C = fun arg label value => value in
-  │         ---------------------------- this function
+  │                 -------------------- this function
   ·
 6 │   [1, 2] | Array (C "hi")
   │   ^^^^^^ applied to this term
@@ -17,7 +17,7 @@ warning: plain functions as contracts are deprecated
   ┌─ [INPUTS_PATH]/warnings/naked_contract_parametrized.ncl:5:3
   │
 3 │ let C = fun arg label value => value in
-  │         ---------------------------- this function
+  │                 -------------------- this function
 4 │ [
 5 │   1 | C "hi",
   │   ^ applied to this term

--- a/cli/tests/snapshot/snapshots/snapshot__export_stderr_non_serializable_print_path.ncl.snap
+++ b/cli/tests/snapshot/snapshots/snapshot__export_stderr_non_serializable_print_path.ncl.snap
@@ -14,10 +14,10 @@ warning: plain functions as contracts are deprecated
    = wrap this function using one of the constructors in `std.contract` instead, like `std.contract.from_validator` or `std.contract.custom`
 
 error: non serializable term
-  ┌─ [INPUTS_PATH]/errors/non_serializable_print_path.ncl:8:30
+  ┌─ [INPUTS_PATH]/errors/non_serializable_print_path.ncl:8:50
   │
 8 │ let SomeParametricContract = fun parameter label value => value
-  │                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  │                                                  ^^^^^^^^^^^^^^
   │
   = When exporting field `foo.bar.baz[3].inner.qux_miss_param`
   = Nickel only supports serializing to and from strings, booleans, numbers, enum tags, `null` (depending on the format), as well as records and arrays of serializable values.

--- a/core/src/bytecode/ast/compat.rs
+++ b/core/src/bytecode/ast/compat.rs
@@ -277,8 +277,33 @@ impl<'ast> FromMainline<'ast, term::Term> for Node<'ast> {
                     }
                 }))
             }
-            Term::Fun(id, body) => alloc.fun(Pattern::any(*id), body.to_ast(alloc)),
-            Term::FunPattern(pat, body) => alloc.fun(pat.to_ast(alloc), body.to_ast(alloc)),
+            t @ (Term::Fun(_, body) | Term::FunPattern(_, body)) => {
+                let fst_arg = match t {
+                    Term::Fun(id, _) => Pattern::any(*id),
+                    Term::FunPattern(pat, _) => pat.to_ast(alloc),
+                    // unreachable!(): we are in a match arm that matches either Fun or FunPattern
+                    _ => unreachable!(),
+                };
+
+                let mut args = vec![fst_arg];
+                let mut maybe_next_fun = body;
+
+                let final_body = loop {
+                    match maybe_next_fun.as_ref() {
+                        Term::Fun(next_id, next_body) => {
+                            args.push(Pattern::any(*next_id));
+                            maybe_next_fun = next_body;
+                        }
+                        Term::FunPattern(next_pat, next_body) => {
+                            args.push(next_pat.to_ast(alloc));
+                            maybe_next_fun = next_body;
+                        }
+                        _ => break maybe_next_fun,
+                    }
+                };
+
+                alloc.fun(args, final_body.to_ast(alloc))
+            }
             Term::Let(bindings, body, attrs) => alloc.let_block(
                 bindings.iter().map(|(id, value)| LetBinding {
                     pattern: Pattern::any(*id),
@@ -327,7 +352,11 @@ impl<'ast> FromMainline<'ast, term::Term> for Node<'ast> {
                     maybe_next_app = next_fun.as_ref();
                 }
 
-                alloc.app(fun.to_ast(alloc), args.into_iter().rev())
+                // Application is left-associative: `f x y` is parsed as `(f x) y`. So we see the
+                // outer argument `y` first, and `args` will be `[y, x]`. We need to reverse it to
+                // match the expected order of a flat application node.
+                args.reverse();
+                alloc.app(fun.to_ast(alloc), args)
             }
             Term::Var(id) => Node::Var(*id),
             Term::Enum(id) => alloc.enum_variant(*id, None),
@@ -1205,10 +1234,31 @@ impl<'ast> FromAst<Node<'ast>> for term::Term {
 
                 Term::StrChunks(chunks)
             }
-            Node::Fun { arg, body } => match arg.data {
-                PatternData::Any(id) => Term::Fun(id, body.to_mainline()),
-                _ => Term::FunPattern((*arg).to_mainline(), body.to_mainline()),
-            },
+            Node::Fun { args, body } => {
+                let body_pos = body.pos;
+
+                // We transform a n-ary function representation to a chain of nested unary
+                // functions, the latter being the representation used in the mainline AST.
+                args.iter()
+                    .rev()
+                    .fold(term::RichTerm::from_ast(body), |acc, arg| {
+                        let term = match arg.data {
+                            PatternData::Any(id) => Term::Fun(id, acc),
+                            _ => term::Term::FunPattern((*arg).to_mainline(), acc),
+                        };
+
+                        // [^nary-constructors-unrolling]: this case is a bit annoying: we need to
+                        // extract the position of the intermediate created functions to satisfy
+                        // the old AST structure, but this information isn't available directly.
+                        //
+                        // What we do here is to fuse the span of the term being built and the one
+                        // of the current argument, which should be a reasonable approximation (if
+                        // not exactly the same thing).
+                        term::RichTerm::new(term, arg.pos.fuse(body_pos))
+                    })
+                    .term
+                    .into_owned()
+            }
             Node::Let {
                 bindings,
                 body,
@@ -1272,22 +1322,22 @@ impl<'ast> FromAst<Node<'ast>> for term::Term {
                     Term::LetPattern(bindings, body, attrs)
                 }
             }
-            Node::App { head: fun, args } => {
-                let fun_pos = fun.pos;
+            Node::App { head, args } => {
+                let head_pos = head.pos;
 
-                let rterm = args.iter().fold(fun.to_mainline(), |result, arg| {
-                    // This case is a bit annoying: we need to extract the position of the sub
-                    // application to satisfy the old AST structure, but this information isn't
-                    // available directly.
-                    //
-                    // What we do here is to fuse the span of the term being built and the one of
-                    // the current argument, which should be a reasonable approximation (if not
-                    // exactly the same thing).
-                    let arg_pos = arg.pos;
-                    term::RichTerm::new(Term::App(result, arg.to_mainline()), fun_pos.fuse(arg_pos))
-                });
-
-                rterm.term.into_owned()
+                // We transform a n-ary application representation to a chain of nested unary
+                // applications, the latter being the representation used in the mainline AST.
+                args.iter()
+                    .fold(head.to_mainline(), |result, arg| {
+                        // see [^nary-constructors-unrolling]
+                        let arg_pos = arg.pos;
+                        term::RichTerm::new(
+                            Term::App(result, arg.to_mainline()),
+                            head_pos.fuse(arg_pos),
+                        )
+                    })
+                    .term
+                    .into_owned()
             }
             Node::Var(loc_ident) => Term::Var(*loc_ident),
             Node::EnumVariant { tag, arg } => {

--- a/core/src/parser/grammar.lalrpop
+++ b/core/src/parser/grammar.lalrpop
@@ -288,17 +288,8 @@ UniTerm: UniTerm<'ast> = {
             body,
         )?))
     },
-    <l: @L> "fun" <pats: PatternFun+> "=>" <body: Term> <r: @R> => {
-        let pos = mk_pos(src_id, l, r);
-
-        let expr = pats
-            .into_iter()
-            .rev()
-            .fold(body, |built, next_arg|
-                alloc.fun(next_arg, built).spanned(pos)
-            );
-
-        UniTerm::from(expr)
+    "fun" <pats: PatternFun+> "=>" <body: Term> => {
+        UniTerm::from(alloc.fun(pats, body))
     },
     "if" <cond: Term> "then" <e1: Term> "else" <e2: Term> =>
         UniTerm::from(alloc.if_then_else(cond, e1, e2)),

--- a/core/src/parser/utils.rs
+++ b/core/src/parser/utils.rs
@@ -185,7 +185,7 @@ impl EtaExpand for InfixOp {
                 let fun_args: Vec<_> = vars.iter().map(|arg| pattern::Pattern::any(*arg)).collect();
                 let args: Vec<_> = vars.into_iter().map(builder::var).collect();
 
-                alloc.nary_fun(fun_args, alloc.prim_op(op, args).spanned(pos))
+                alloc.fun(fun_args, alloc.prim_op(op, args).spanned(pos))
             }
         }
     }


### PR DESCRIPTION
Depends on #2111.

In the new AST, the representation function application has been changed to be multi-ary by default (as is primop application as well). It just matches the syntax better and it avoids having to desugar a n-ary application to nested unary applications as before, saving space and time (for the time being we still have  this desugaring to do when converting to the mainline AST). The only cost is that unary applications are slighty larger in memory (basically one word for the size of the slice), but we expect the gain from n-ary applications for `n > 1` to dwarf this. It also avoids having to come up with dubious position for the generated intermediate nodes.

This commit applies the same treatment to function abstraction since the same arguments apply. Passing by, we also specialize macros like `fun` and `app` for one argument to avoid vec allocation.