### PR TITLE
Add a freeze primop and stdlib wrapper

### DIFF
--- a/core/src/bytecode/ast/compat.rs
+++ b/core/src/bytecode/ast/compat.rs
@@ -540,6 +540,7 @@ impl From<&term::UnaryOp> for PrimOp {
                 ignore_not_exported: *ignore_not_exported,
             },
             term::UnaryOp::RecordEmptyWithTail => PrimOp::RecordEmptyWithTail,
+            term::UnaryOp::RecordFreeze => PrimOp::RecordFreeze,
             term::UnaryOp::Trace => PrimOp::Trace,
             term::UnaryOp::LabelPushDiag => PrimOp::LabelPushDiag,
             #[cfg(feature = "nix-experimental")]
@@ -1081,6 +1082,7 @@ impl FromAst<PrimOp> for TermPrimOp {
                 ignore_not_exported: *ignore_not_exported,
             }),
             PrimOp::RecordEmptyWithTail => TermPrimOp::Unary(term::UnaryOp::RecordEmptyWithTail),
+            PrimOp::RecordFreeze => TermPrimOp::Unary(term::UnaryOp::RecordFreeze),
             PrimOp::Trace => TermPrimOp::Unary(term::UnaryOp::Trace),
             PrimOp::LabelPushDiag => TermPrimOp::Unary(term::UnaryOp::LabelPushDiag),
             PrimOp::EnumGetArg => TermPrimOp::Unary(term::UnaryOp::EnumGetArg),

--- a/core/src/bytecode/ast/primop.rs
+++ b/core/src/bytecode/ast/primop.rs
@@ -335,6 +335,15 @@ pub enum PrimOp {
     /// 1. The model record to take the tail from.
     RecordEmptyWithTail,
 
+    /// Freezes a recursive record to make it a static dictionary. Apply all pending lazy contracts
+    /// (and flush them), and remove all dependency information, so that the value of the fields is
+    /// fixed in time and subsequent overrides will only impact the overriden field.
+    ///
+    /// # Arguments
+    ///
+    /// 1. The record to freeze.
+    RecordFreeze,
+
     /// Print a message when encountered during evaluation and proceed with the evaluation of the
     /// argument on the top of the stack. Operationally the same as the identity function
     ///
@@ -964,6 +973,7 @@ impl fmt::Display for PrimOp {
             StringFindAll => write!(f, "string/find_all"),
             Force { .. } => write!(f, "force"),
             RecordEmptyWithTail => write!(f, "record/empty_with_tail"),
+            RecordFreeze => write!(f, "record/freeze"),
             Trace => write!(f, "trace"),
             LabelPushDiag => write!(f, "label/push_diag"),
 
@@ -1091,6 +1101,7 @@ impl PrimOp {
             | StringFindAll
             | Force { .. }
             | RecordEmptyWithTail
+            | RecordFreeze
             | Trace
             | LabelPushDiag
             | EnumGetArg

--- a/core/src/error/mod.rs
+++ b/core/src/error/mod.rs
@@ -251,7 +251,8 @@ pub enum IllegalPolymorphicTailAction {
     FieldAccess { field: String },
     Map,
     Merge,
-    RecordRemove { field: String },
+    FieldRemove { field: String },
+    Freeze,
 }
 
 impl IllegalPolymorphicTailAction {
@@ -264,9 +265,10 @@ impl IllegalPolymorphicTailAction {
             }
             Map => "cannot map over a record sealed by a polymorphic contract".to_owned(),
             Merge => "cannot merge a record sealed by a polymorphic contract".to_owned(),
-            RecordRemove { field } => {
+            FieldRemove { field } => {
                 format!("cannot remove field `{field}` sealed by a polymorphic contract")
             }
+            Freeze => "cannot freeze a record sealed by a polymorphic contract".to_owned(),
         }
     }
 }

--- a/core/src/parser/grammar.lalrpop
+++ b/core/src/parser/grammar.lalrpop
@@ -1170,6 +1170,7 @@ UOp: PrimOp = {
     // "op rec_force" => PrimOp::RecForce,
     // "op rec_default" => PrimOp::RecDefault,
     "record/empty_with_tail" => PrimOp::RecordEmptyWithTail,
+    "record/freeze" => PrimOp::RecordFreeze,
     "trace" => PrimOp::Trace,
     "label/push_diag" => PrimOp::LabelPushDiag,
     <l: @L> "eval_nix" <r: @R> =>? {
@@ -1617,6 +1618,7 @@ extern {
         "record/split_pair" => Token::Normal(NormalToken::RecordSplitPair),
         "record/disjoint_merge" => Token::Normal(NormalToken::RecordDisjointMerge),
         "record/merge_contract" => Token::Normal(NormalToken::RecordMergeContract),
+        "record/freeze" => Token::Normal(NormalToken::RecordFreeze),
         "array/map" => Token::Normal(NormalToken::ArrayMap),
         "array/generate" => Token::Normal(NormalToken::ArrayGen),
         "array/at" => Token::Normal(NormalToken::ArrayAt),

--- a/core/src/parser/lexer.rs
+++ b/core/src/parser/lexer.rs
@@ -311,6 +311,8 @@ pub enum NormalToken<'input> {
     RecordDisjointMerge,
     #[token("%record/merge_contract%")]
     RecordMergeContract,
+    #[token("%record/freeze%")]
+    RecordFreeze,
 
     #[token("merge")]
     Merge,

--- a/core/src/term/mod.rs
+++ b/core/src/term/mod.rs
@@ -1538,6 +1538,11 @@ pub enum UnaryOp {
     /// function that preserves the sealed polymorphic tail of its argument.
     RecordEmptyWithTail,
 
+    /// Freezes a recursive record to make it a static dictionary. Apply all pending lazy contracts
+    /// (and flush them), and remove all dependency information, so that the value of the fields is
+    /// fixed in time and subsequent overrides will only impact the overriden field.
+    RecordFreeze,
+
     /// Print a message when encountered during evaluation and proceed with the evaluation of the
     /// argument on the top of the stack. Operationally the same as the identity function
     Trace,
@@ -1655,6 +1660,7 @@ impl fmt::Display for UnaryOp {
             RecDefault => write!(f, "rec_default"),
             RecForce => write!(f, "rec_force"),
             RecordEmptyWithTail => write!(f, "record/empty_with_tail"),
+            RecordFreeze => write!(f, "record/freeze"),
             Trace => write!(f, "trace"),
             LabelPushDiag => write!(f, "label/push_diag"),
 

--- a/core/src/typecheck/operation.rs
+++ b/core/src/typecheck/operation.rs
@@ -231,7 +231,11 @@ pub fn get_uop_type(
             (ty.clone(), ty)
         }
         UnaryOp::RecordEmptyWithTail => (mk_uniftype::dynamic(), mk_uniftype::dynamic()),
-
+        // forall a. { _ : a} -> { _ : a }
+        UnaryOp::RecordFreeze => {
+            let dict = mk_uniftype::dict(state.table.fresh_type_uvar(var_level));
+            (dict.clone(), dict)
+        }
         // forall a. Str -> a -> a
         UnaryOp::Trace => {
             let ty = state.table.fresh_type_uvar(var_level);

--- a/core/stdlib/std.ncl
+++ b/core/stdlib/std.ncl
@@ -3317,6 +3317,44 @@
         record
         |> fields
         |> std.array.length,
+
+    freeze
+      : forall a. { _ : a } -> { _ : a }
+      | doc m%"
+        Freezes a recursive record:
+
+        - The values of recursive fields are frozen at the current values, and
+          the dependencies are forgotten. **This means that subsequent overrides
+          through merging will only affect the overriden fields, but will no
+          longer update reverse dependencies**.
+        - All lazy pending contracts accumulated through merging and annotations
+          will be applied and flushed. **This means that the contracts of this
+          record won't propagate through future merges anymore after freezing**.
+
+        Note that the documentation and the priority of the fields aren't
+        affected.
+
+        `freeze` is used internally in the stdlib when applying dictionary
+        operations, such as `std.record.insert` or `std.record.remove`. Indeed,
+        interleaving dictionary operations and recursive records can lean to
+        surprising and unintuitive results. The Nickel stdlib tries to avoid
+        using records in both recursive and dictionary modes at the same time.
+
+        Freezing is idempotent: freezing an already frozen record has no effect.
+
+        # Examples
+
+        ```nickel multiline
+        let frozen = std.record.freeze { x = "old", y = x } in
+        frozen & { x | force = "new" }
+        # => { x = "new", y = "old" }
+
+        let frozen = std.record.freeze { x | Number = 1 } in
+        frozen & { x | force = "bypass number contract" }
+        # => { x = "bypass number contract" }
+        ```
+      "%
+      = fun record => %record/freeze% record,
   },
 
   string = {

--- a/core/tests/integration/inputs/records/freezing.ncl
+++ b/core/tests/integration/inputs/records/freezing.ncl
@@ -1,0 +1,14 @@
+# test.type = 'pass'
+[
+  (%record/freeze% { x = 1, y = x }) & { x | force = 2 } == { x = 2, y = 1 },
+  (%record/freeze% { x | default = 1, y = x }) & { x = 2 } == { x = 2, y = 1 },
+  (%record/freeze% { x | default = 1, y = x })
+  & (%record/freeze% { x = 2, z = x })
+  & { x | force = 3 } == { x = 3, y = 1, z = 2 },
+
+  # freezing, as record mapping, flushes pending contracts and make them not
+  # propagate anymore
+  (%record/freeze% {x | String = "a"}) & {x | force = 1} == {x = 1},
+
+ ]
+|> std.test.assert_all

--- a/core/tests/integration/inputs/records/merge_unfreezes.ncl
+++ b/core/tests/integration/inputs/records/merge_unfreezes.ncl
@@ -1,0 +1,12 @@
+# test.type = 'error'
+#
+# [test.metadata]
+# error = 'EvalError::BlameError'
+
+# Test that even if freezing makes the initial `String` contract to not
+# propagate, it doesn't prevent other contracts coming from unfrozen records to
+# propagate.
+%force% ((%record/freeze% { x | String = "a" })
+& { x | priority 1 | Number = 2 }
+& { x | priority 2 = false })
+


### PR DESCRIPTION
Following a confusing behavior around the interaction of recursive fields and dictionary operations reported in #1866 (insert, remove, update), it was proposed in #1877 to freeze recursive records before applying dictionary operations.

This PR adds a primitive operation to do so, which applies pending contracts, flushes them, and remove any dependency data, effectively freezing recursive fields to their current value.

A flag is also added to record attributes, in order to remember that some record has already been frozen. Indeed, freezing is linear in the number of fields and pending contracts: freezing at every dictionary operation thus could be costly. Instead, as for closurization, we do it once and then remember that it's been done in flag. It helps dictionary operations preserve frozenness. Only merging or lazy contract applications might require freezing again.

What's missing to close #1877 is to just add a call to `%record/freeze%` in preamble of every dictionary operations. This will be addressed in a follow-up PR.