### PR TITLE
Fixed `Debug` impl of `EvalOrDeserError` printing entire source of files

### DIFF
--- a/core/src/deserialize.rs
+++ b/core/src/deserialize.rs
@@ -35,13 +35,27 @@ macro_rules! deserialize_number {
     };
 }
 
-#[derive(Debug)]
 pub enum EvalOrDeserError {
     Nickel {
         error: error::Error,
         files: Option<crate::files::Files>,
     },
     Deser(RustDeserializationError),
+}
+
+impl std::fmt::Debug for EvalOrDeserError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Nickel { error, files } => {
+                let filenames = files.as_ref().map(|f| f.filenames().collect::<Vec<_>>());
+                f.debug_struct("Nickel")
+                    .field("error", error)
+                    .field("files", &filenames)
+                    .finish()
+            }
+            Self::Deser(arg0) => f.debug_tuple("Deser").field(arg0).finish(),
+        }
+    }
 }
 
 impl EvalOrDeserError {

--- a/core/src/files.rs
+++ b/core/src/files.rs
@@ -191,6 +191,10 @@ impl Files {
     fn get(&self, id: FileId) -> Result<&File, Error> {
         self.files.get(id.0 as usize).ok_or(Error::FileMissing)
     }
+
+    pub(crate) fn filenames(&self) -> impl Iterator<Item = &OsStr> {
+        self.files.iter().map(|f| &*f.name)
+    }
 }
 
 impl Default for Files {


### PR DESCRIPTION
Now it just prints filenames, which is much more useful.