### PR TITLE
Disabled default benches throughout the workspace

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -113,9 +113,9 @@ harness = false
 name = "arrays"
 harness = false
 
-# [[bench]]
-# name = "records"
-# harness = false
+[[bench]]
+name = "records"
+harness = false
 
 [[bench]]
 name = "serialization"

--- a/git/Cargo.toml
+++ b/git/Cargo.toml
@@ -4,6 +4,9 @@ description = "Git utility functions for internal use in nickel"
 version = "0.1.0"
 edition = "2021"
 
+[lib]
+bench = false
+
 [dependencies]
 anyhow.workspace = true
 gix = { workspace = true, features = ["blocking-network-client", "serde"] }

--- a/lsp/lsp-harness/Cargo.toml
+++ b/lsp/lsp-harness/Cargo.toml
@@ -3,6 +3,9 @@ name = "lsp-harness"
 version = "0.1.0"
 edition = "2021"
 
+[lib]
+bench = false
+
 [dependencies]
 anyhow.workspace = true
 env_logger.workspace = true

--- a/lsp/nls/Cargo.toml
+++ b/lsp/nls/Cargo.toml
@@ -13,6 +13,7 @@ version.workspace = true
 [[bin]]
 name = "nls"
 path = "src/main.rs"
+bench = false
 
 [[bench]]
 name = "main"

--- a/pyckel/Cargo.toml
+++ b/pyckel/Cargo.toml
@@ -20,3 +20,4 @@ pyo3-build-config.workspace = true
 
 [lib]
 crate-type = ["cdylib", "rlib"]
+bench = false

--- a/vector/Cargo.toml
+++ b/vector/Cargo.toml
@@ -9,6 +9,9 @@ keywords.workspace = true
 license.workspace = true
 repository.workspace = true
 
+[lib]
+bench = false
+
 [dependencies]
 imbl-sized-chunks = "0.1.2"
 serde.workspace = true
@@ -18,6 +21,10 @@ arbitrary = { version = "1.3.2", features = ["derive"] }
 arbtest = "0.3.1"
 criterion = "0.5.1"
 rpds = "1.1.0"
+
+[[bench]]
+name = "array"
+harness = false
 
 [[bench]]
 name = "rpds_comparison"

--- a/wasm-repl/Cargo.toml
+++ b/wasm-repl/Cargo.toml
@@ -14,3 +14,4 @@ nickel-lang-core = { workspace = true, default-features = false, features = ["re
 
 [lib]
 crate-type = ["cdylib", "rlib"]
+bench = false


### PR DESCRIPTION
This allows running `cargo bench -- --criterion-specific-arg` without erroring due to `error: Unrecognized option: 'criterion-specific-arg'`.

https://bheisler.github.io/criterion.rs/book/faq.html#cargo-bench-gives-unrecognized-option-errors-for-valid-command-line-options explains why this is necessary; I've copied it below for posterity.

> By default, Cargo implicitly adds a `libtest` benchmark harness to your crate when benchmarking, to handle any `#[bench]` functions, even if you have none. It compiles and runs this executable first, before any of the other benchmarks. Normally, this is fine - it detects that there are no `libtest`benchmarks to execute and exits, allowing Cargo to move on to the real benchmarks. Unfortunately, it checks the command-line arguments first, and panics when it finds one it doesn't understand. This causes Cargo to stop benchmarking early, and it never executes the Criterion.rs benchmarks.
>
> This will occur when running `cargo bench` with any argument that Criterion.rs supports but `libtest` does not. For example, `--verbose` and `--save-baseline` will cause this issue, while `--help` will not. There are two ways to work around this at present:
>
> You could run only your Criterion benchmark, like so:
>
> `cargo bench --bench my_benchmark -- --verbose`
>
> Note that `my_benchmark` here corresponds to the name of your benchmark in your `Cargo.toml` file.
>
> Another option is to disable benchmarks for your lib or app crate. For example, for library crates, you could add this to your `Cargo.toml` file:
>
> ```
> [lib] 
> bench = false
> ```
>
> If your crate produces one or more binaries as well as a library, you may need to add additional records to `Cargo.toml` like this:
>
> ```
> [[bin]]
> name = "my-binary" 
> path = "src/bin/my-binary.rs" 
> bench = false
> ```
>
> This is because Cargo automatically discovers some kinds of binaries and it will enable the default benchmark harness for these as well.
>
> Of course, this only works if you define all of your benchmarks in the `benches` directory.
>
> See [Rust Issue #47241](https://github.com/rust-lang/rust/issues/47241) for more details.