### PR TITLE
Backport nls crash fix

### DIFF
--- a/core/src/files.rs
+++ b/core/src/files.rs
@@ -117,7 +117,7 @@ impl Files {
         // This implementation would be a little nicer if `Vector` supported mutable access.
         // unwrap: we're allowed to panic if file_id is invalid
         let mut old = self.get(file_id).unwrap().clone();
-        old.source = source.into();
+        old = File::new(old.name, source);
         self.files.set(file_id.0 as usize, old);
     }
 


### PR DESCRIPTION
In case this is the cause of #2125 here's a backport of the fix. I can't actually reproduce the exact issue, but it sounds like the same problem (especially the part about how it doesn't trigger if you copy-paste, because the issue is caused by a stale cache and so it might not get hit if you enter the input all at once). Also, I did double-check that the files refactor was in 1.9.0 but the warnings PR (which originally contained this fix) wasn't.

Probably targeting the 1.9.0-release branch isn't quite right; I guess we should branch out a 1.9.1-release first?