### PR TITLE
pass thru feature `nix-experimental`

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -21,6 +21,7 @@ repl = ["nickel-lang-core/repl"]
 doc = ["nickel-lang-core/doc", "comrak"]
 format = ["nickel-lang-core/format", "dep:tempfile"]
 metrics = ["dep:metrics", "dep:metrics-util", "nickel-lang-core/metrics"]
+nix-experimental = ["nickel-lang-core/nix-experimental"]
 
 [dependencies]
 nickel-lang-core = { workspace = true, features = [ "markdown", "clap" ], default-features = false }

--- a/core/src/nix_ffi/cpp/nix.cc
+++ b/core/src/nix_ffi/cpp/nix.cc
@@ -11,10 +11,7 @@ using namespace nix;
 #include <nix/value-to-json.hh>
 #include <nix/command.hh>
 #include <nix/value.hh>
-// We will need this include when we update to latest Nix, but for now it's
-// pinned to a previous version where `initGC()` is still exported by already
-// imported headers, so we don't need it yet.
-// #include <nix/eval-gc.hh>
+#include <nix/eval-gc.hh>
 
 #include "nickel-lang-core/src/nix_ffi/mod.rs.h"
 

--- a/lsp/nls/Cargo.toml
+++ b/lsp/nls/Cargo.toml
@@ -56,3 +56,6 @@ lsp-harness.workspace = true
 nickel-lang-utils.workspace = true
 pretty_assertions.workspace = true
 test-generator.workspace = true
+
+[features]
+nix-experimental = ["nickel-lang-core/nix-experimental"]

--- a/pyckel/Cargo.toml
+++ b/pyckel/Cargo.toml
@@ -21,3 +21,6 @@ pyo3-build-config.workspace = true
 [lib]
 crate-type = ["cdylib", "rlib"]
 bench = false
+
+[features]
+nix-experimental = ["nickel-lang-core/nix-experimental"]


### PR DESCRIPTION
I found that the [`nickel` package in nixpkgs](https://github.com/NixOS/nixpkgs/blob/master/pkgs/by-name/ni/nickel/package.nix) had yet to add support for nickel's [`nix-experimental`](https://github.com/tweag/nickel/commit/91d63ed611f2f86e245b696b34b4cf09f637ee91) feature flag.

in an [in-progress attempt](https://github.com/NixOS/nixpkgs/compare/master...KiaraGrouwstra:nixpkgs:nickel-enable-nix-import?expand=1) to add this, i bumped into a few hurdles for this on the nickel side.
this PR tries to address these, on the Cargo side erring toward passing thru the feature for a few extra packages for consistency.

whereas i'm not sure this would be sufficient on the nickel side (yet having to get it to work at run-time), i felt maybe i could get a bit of feedback on this direction already.
