### PR TITLE
Fix nls crash when typechecking parse errors

### DIFF
--- a/core/src/pretty.rs
+++ b/core/src/pretty.rs
@@ -522,6 +522,7 @@ impl Allocator {
         match id_expr.as_ref() {
             // Nickel will not parse a multiline string literal in this position
             Term::StrChunks(chunks) => self.chunks(chunks, StringRenderStyle::ForceMonoline),
+            Term::ParseError(_) => docs![self, "<parse error>"],
             _ => unimplemented!("Dynamic record fields must be StrChunks currently"),
         }
         .append(self.field_body(field))

--- a/lsp/nls/tests/inputs/no-crash-on-pretty-print.ncl
+++ b/lsp/nls/tests/inputs/no-crash-on-pretty-print.ncl
@@ -1,0 +1,7 @@
+### /main.ncl
+{
+  multipleOf
+    : Number -> Dyn -> [| 'Ok, 'Error { message | String, notes] } |]
+    = 1
+}
+### diagnostic = ["file:///main.ncl"]

--- a/lsp/nls/tests/inputs/no-crash-on-pretty-print.ncl
+++ b/lsp/nls/tests/inputs/no-crash-on-pretty-print.ncl
@@ -1,6 +1,6 @@
 ### /main.ncl
 {
-  multipleOf
+  multiple_of
     : Number -> Dyn -> [| 'Ok, 'Error { message | String, notes] } |]
     = 1
 }

--- a/lsp/nls/tests/snapshots/main__lsp__nls__tests__inputs__no-crash-on-pretty-print.ncl.snap
+++ b/lsp/nls/tests/snapshots/main__lsp__nls__tests__inputs__no-crash-on-pretty-print.ncl.snap
@@ -1,0 +1,11 @@
+---
+source: lsp/nls/tests/main.rs
+expression: output
+---
+(file:///main.ncl, 2:63-2:64: )
+(file:///main.ncl, 2:63-2:64: unexpected token)
+(file:///main.ncl, 3:6-3:7: incompatible types
+Expected an expression of type `Number -> Dyn -> [| 'Ok, 'Error { message | String, <parse error>, } |]`
+Found an expression of type `Number`
+These types are not compatible)
+(file:///main.ncl, 3:6-3:7: this expression)


### PR DESCRIPTION
Fixes #2153.

Nls attempts to typecheck the input even if parsing fails (as long as the failure is non-fatal). The problem is that the pretty-printing code (for diagnosing a type error) assumes that all dynamic fields of all records are `Term::StrChunks`. This may be true for successful parses, but if the parse fails then you can also have a `Term::ParseError` as a dynamic field.