### PR TITLE
Build windows and macos binaries on release

### DIFF
--- a/.github/workflows/release-artifacts.yaml
+++ b/.github/workflows/release-artifacts.yaml
@@ -77,6 +77,7 @@ jobs:
           cat response.json
 
   release-artifacts:
+    if: false
     name: "Build Nickel binary and Docker image"
     strategy:
       matrix:
@@ -150,3 +151,46 @@ jobs:
         run: |
           docker buildx imagetools create -t ghcr.io/tweag/nickel:$RELEASE_TAG ghcr.io/tweag/nickel:$RELEASE_TAG-x86_64 ghcr.io/tweag/nickel:$RELEASE_TAG-arm64
           docker buildx imagetools inspect ghcr.io/tweag/nickel:$RELEASE_TAG 
+
+  release-artifacts-macos:
+    name: "Build MacOS Nickel binaries"
+    runs-on: [self-hosted, macOS, ARM64]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'release' && '' || github.event.inputs.release_tag }}
+      - name: Build binaries
+        run: |
+          set +e
+          nix build --log-format raw-with-logs .#nickel-lang-cli
+          cp ./result/bin/nickel nickel-arm64-macos
+          nix build --log-format raw-with-logs .#nickel-lang-lsp
+          cp ./result/bin/nls nls-arm64-macos
+      - name: "Upload binaries as release assets"
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ github.event_name == 'release' && github.event.release.tag_name || github.event.inputs.release_tag }}
+        run: |
+          gh release upload --clobber $RELEASE_TAG nickel-arm64-macos
+          gh release upload --clobber $RELEASE_TAG nls-arm64-macos
+
+  release-artifacts-windows:
+    name: "Build Windows Nickel binaries"
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'release' && '' || github.event.inputs.release_tag }}
+      - name: Build binaries
+        run: |
+          cargo build --release --package nickel-lang-cli
+          cargo build --release --package nickel-lang-lsp
+          cp ./target/release/nickel nickel-x86_64-windows
+          cp ./target/release/nls nls-x86_64-windows
+      - name: "Upload binaries as release assets"
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ github.event_name == 'release' && github.event.release.tag_name || github.event.inputs.release_tag }}
+        run: |
+          gh release upload --clobber $RELEASE_TAG nickel-x86_64-windows
+          gh release upload --clobber $RELEASE_TAG nls-x86_64-windows

--- a/.github/workflows/release-artifacts.yaml
+++ b/.github/workflows/release-artifacts.yaml
@@ -1,4 +1,4 @@
-name: Test Docker manifest
+name: Build release binaries
 on:
   release:
     types: [published]
@@ -14,7 +14,6 @@ permissions:
 
 jobs:
   start-runner:
-    if: false
     name: Start EC2 runner
     runs-on: ubuntu-latest
     outputs:
@@ -49,7 +48,7 @@ jobs:
     name: Stop EC2 runner
     runs-on: ubuntu-latest
     # Ensure that `stop-runner` will always stop the EC2 instance, even if other jobs failed or were canceled
-    if: false
+    if: ${{ always() }}
     needs:
       - start-runner
       - docker-multiplatform-image
@@ -78,7 +77,6 @@ jobs:
           cat response.json
 
   release-artifacts:
-    if: false
     name: "Build Nickel binary and Docker image"
     strategy:
       matrix:

--- a/.github/workflows/release-artifacts.yaml
+++ b/.github/workflows/release-artifacts.yaml
@@ -186,8 +186,8 @@ jobs:
         run: |
           cargo build --release --package nickel-lang-cli
           cargo build --release --package nickel-lang-lsp
-          cp ./target/release/nickel nickel-x86_64-windows
-          cp ./target/release/nls nls-x86_64-windows
+          cp ./target/release/nickel.exe nickel-x86_64-windows.exe
+          cp ./target/release/nls.exe nls-x86_64-windows.exe
       - name: "Upload binaries as release assets"
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/release-artifacts.yaml
+++ b/.github/workflows/release-artifacts.yaml
@@ -193,5 +193,5 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           RELEASE_TAG: ${{ github.event_name == 'release' && github.event.release.tag_name || github.event.inputs.release_tag }}
         run: |
-          gh release upload --clobber $RELEASE_TAG nickel-x86_64-windows
-          gh release upload --clobber $RELEASE_TAG nls-x86_64-windows
+          gh release upload --clobber $RELEASE_TAG nickel-x86_64-windows.exe
+          gh release upload --clobber $RELEASE_TAG nls-x86_64-windows.exe

--- a/.github/workflows/release-artifacts.yaml
+++ b/.github/workflows/release-artifacts.yaml
@@ -193,5 +193,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           RELEASE_TAG: ${{ github.event_name == 'release' && github.event.release.tag_name || github.event.inputs.release_tag }}
         run: |
+          echo $RELEASE_TAG
+          ls
           gh release upload --clobber $RELEASE_TAG nickel-x86_64-windows.exe
           gh release upload --clobber $RELEASE_TAG nls-x86_64-windows.exe

--- a/.github/workflows/release-artifacts.yaml
+++ b/.github/workflows/release-artifacts.yaml
@@ -14,6 +14,7 @@ permissions:
 
 jobs:
   start-runner:
+    if: false
     name: Start EC2 runner
     runs-on: ubuntu-latest
     outputs:
@@ -48,7 +49,7 @@ jobs:
     name: Stop EC2 runner
     runs-on: ubuntu-latest
     # Ensure that `stop-runner` will always stop the EC2 instance, even if other jobs failed or were canceled
-    if: ${{ always() }}
+    if: false
     needs:
       - start-runner
       - docker-multiplatform-image

--- a/.github/workflows/release-artifacts.yaml
+++ b/.github/workflows/release-artifacts.yaml
@@ -193,7 +193,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           RELEASE_TAG: ${{ github.event_name == 'release' && github.event.release.tag_name || github.event.inputs.release_tag }}
         run: |
-          echo $RELEASE_TAG
+          echo $Env:RELEASE_TAG
           ls
-          gh release upload --clobber $RELEASE_TAG nickel-x86_64-windows.exe
-          gh release upload --clobber $RELEASE_TAG nls-x86_64-windows.exe
+          gh release upload --clobber $Env:RELEASE_TAG nickel-x86_64-windows.exe
+          gh release upload --clobber $Env:RELEASE_TAG nls-x86_64-windows.exe


### PR DESCRIPTION
Adds mac and windows binaries to the release workflow.

This hasn't been tested end-to-end yet -- the release upload failed because I never tagged a release. But everything worked up to the upload step (which failed with the expected error message about not finding a release).