### PR TITLE
ci: Stream logs from nix flake check

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -51,14 +51,7 @@ jobs:
 
     - name: Run all checks
       run: |
-          # see https://github.com/NixOS/nix/issues/8949 for why we redirect to
-          # an output file. Everything else is just capturing the error code
-          # while still printing the logs
-          set +e
-          nix flake check --accept-flake-config --print-build-logs > logs 2>&1
-          errcode=$?
-          cat logs
-          exit $errcode
+        nix flake check --accept-flake-config --print-build-logs
 
     - name: Typecheck benchmarks
       run: nix shell --inputs-from . .#nickel-lang-cli nixpkgs#findutils --command find core/benches -type f -name "*.ncl" -exec nickel typecheck '{}' \;


### PR DESCRIPTION
The issue https://github.com/NixOS/nix/issues/8949 referenced in the comment seems to be resolved, and such redirect reduces visibility of the build process considerably. Remove the redirect.
