### PR TITLE
Support pull diagnostics and use them for testing

### DIFF
--- a/lsp/lsp-harness/src/output.rs
+++ b/lsp/lsp-harness/src/output.rs
@@ -234,6 +234,33 @@ impl LspDebug for WorkspaceEdit {
 
 impl LspDebug for Diagnostic {
     fn debug(&self, mut w: impl Write) -> std::io::Result<()> {
-        write!(w, "{}: {}", self.range.debug_str(), self.message)
+        write!(w, "{}: {:?}", self.range.debug_str(), self.message)
+    }
+}
+
+impl LspDebug for Option<serde_json::Value> {
+    fn debug(&self, mut w: impl Write) -> std::io::Result<()> {
+        if let Some(v) = self {
+            write!(w, "{v:?}")
+        } else {
+            Ok(())
+        }
+    }
+}
+
+impl LspDebug for lsp_types::DocumentDiagnosticReportResult {
+    fn debug(&self, w: impl Write) -> std::io::Result<()> {
+        let lsp_types::DocumentDiagnosticReportResult::Report(
+            lsp_types::DocumentDiagnosticReport::Full(
+                lsp_types::RelatedFullDocumentDiagnosticReport {
+                    full_document_diagnostic_report,
+                    ..
+                },
+            ),
+        ) = self
+        else {
+            panic!("unexpected report {self:?}");
+        };
+        full_document_diagnostic_report.items.debug(w)
     }
 }

--- a/lsp/nls/src/config.rs
+++ b/lsp/nls/src/config.rs
@@ -29,6 +29,8 @@ impl Default for LspEvalLimits {
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(default)]
 pub struct LspEvalConfig {
+    /// Disable background evaluation altogether.
+    pub disable: bool,
     pub eval_limits: LspEvalLimits,
     /// The duration during which a file that broke the background evaluator will be blacklisted
     /// from it
@@ -38,6 +40,7 @@ pub struct LspEvalConfig {
 impl Default for LspEvalConfig {
     fn default() -> Self {
         LspEvalConfig {
+            disable: false,
             eval_limits: Default::default(),
             blacklist_duration: Duration::from_secs(30),
         }

--- a/lsp/nls/tests/snapshots/main__lsp__nls__tests__inputs__diagnostics-array.ncl.snap
+++ b/lsp/nls/tests/snapshots/main__lsp__nls__tests__inputs__diagnostics-array.ncl.snap
@@ -2,12 +2,4 @@
 source: lsp/nls/tests/main.rs
 expression: output
 ---
-(file:///diagnostics-array.ncl, 2:4-2:7: applied to this expression)
-(file:///diagnostics-array.ncl, 2:4-2:7: contract broken by a value)
-(file:///diagnostics-array.ncl, 3:12-3:18: expected array element type)
-(file:///diagnostics-array.ncl, 5:12-5:17: applied to this expression)
-(file:///diagnostics-array.ncl, 5:12-5:17: contract broken by the value of `num`)
-(file:///diagnostics-array.ncl, 6:20-6:26: expected type)
-(file:///diagnostics-array.ncl, 8:6-8:9: applied to this expression)
-(file:///diagnostics-array.ncl, 8:6-8:9: contract broken by a value)
-(file:///diagnostics-array.ncl, 9:19-9:25: expected array element type)
+[2:4-2:7: "contract broken by a value", 2:4-2:7: "applied to this expression", 3:12-3:18: "expected array element type", 5:12-5:17: "contract broken by the value of `num`", 5:12-5:17: "applied to this expression", 6:20-6:26: "expected type", 8:6-8:9: "contract broken by a value", 8:6-8:9: "applied to this expression", 9:19-9:25: "expected array element type"]

--- a/lsp/nls/tests/snapshots/main__lsp__nls__tests__inputs__diagnostics-basic.ncl.snap
+++ b/lsp/nls/tests/snapshots/main__lsp__nls__tests__inputs__diagnostics-basic.ncl.snap
@@ -2,9 +2,4 @@
 source: lsp/nls/tests/main.rs
 expression: output
 ---
-(file:///diagnostics-basic.ncl, 1:8-1:14: expected type)
-(file:///diagnostics-basic.ncl, 1:17-1:20: applied to this expression)
-(file:///diagnostics-basic.ncl, 1:17-1:20: contract broken by the value of `num`)
-(file:///diagnostics-basic.ncl, 2:9-2:12: applied to this expression)
-(file:///diagnostics-basic.ncl, 2:9-2:12: contract broken by the value of `num2`)
-(file:///diagnostics-basic.ncl, 3:13-3:19: expected type)
+[1:8-1:14: "expected type", 1:17-1:20: "contract broken by the value of `num`", 1:17-1:20: "applied to this expression", 2:9-2:12: "contract broken by the value of `num2`", 2:9-2:12: "applied to this expression", 3:13-3:19: "expected type"]

--- a/lsp/nls/tests/snapshots/main__lsp__nls__tests__inputs__diagnostics-recursion.ncl.snap
+++ b/lsp/nls/tests/snapshots/main__lsp__nls__tests__inputs__diagnostics-recursion.ncl.snap
@@ -2,10 +2,4 @@
 source: lsp/nls/tests/main.rs
 expression: output
 ---
-(file:///diagnostics-recursion.ncl, 0:14-0:46: this record lacks the field `baz`)
-(file:///diagnostics-recursion.ncl, 0:34-0:40: expected type)
-(file:///diagnostics-recursion.ncl, 0:43-0:44: applied to this expression)
-(file:///diagnostics-recursion.ncl, 0:43-0:44: contract broken by the value of `quux`)
-(file:///diagnostics-recursion.ncl, 3:2-3:29: missing field `baz`
-Did you mean `bar`?)
-(file:///diagnostics-recursion.ncl, 3:2-3:29: this requires the field `baz` to exist)
+[0:14-0:46: "this record lacks the field `baz`", 0:34-0:40: "expected type", 0:43-0:44: "contract broken by the value of `quux`", 0:43-0:44: "applied to this expression", 3:2-3:29: "missing field `baz`\nDid you mean `bar`?", 3:2-3:29: "this requires the field `baz` to exist"]

--- a/lsp/nls/tests/snapshots/main__lsp__nls__tests__inputs__diagnostics-typecheck.ncl.snap
+++ b/lsp/nls/tests/snapshots/main__lsp__nls__tests__inputs__diagnostics-typecheck.ncl.snap
@@ -2,8 +2,4 @@
 source: lsp/nls/tests/main.rs
 expression: output
 ---
-(file:///diagnostics.ncl, 0:0-0:1: incompatible types
-Expected an expression of type `String`
-Found an expression of type `Number`
-These types are not compatible)
-(file:///diagnostics.ncl, 0:0-0:1: this expression)
+[0:0-0:1: "incompatible types\nExpected an expression of type `String`\nFound an expression of type `Number`\nThese types are not compatible", 0:0-0:1: "this expression"]

--- a/lsp/nls/tests/snapshots/main__lsp__nls__tests__inputs__diagnostics-undefined-fields.ncl.snap
+++ b/lsp/nls/tests/snapshots/main__lsp__nls__tests__inputs__diagnostics-undefined-fields.ncl.snap
@@ -2,4 +2,4 @@
 source: lsp/nls/tests/main.rs
 expression: output
 ---
-
+[]

--- a/lsp/nls/tests/snapshots/main__lsp__nls__tests__inputs__no-crash-on-pretty-print.ncl.snap
+++ b/lsp/nls/tests/snapshots/main__lsp__nls__tests__inputs__no-crash-on-pretty-print.ncl.snap
@@ -2,10 +2,4 @@
 source: lsp/nls/tests/main.rs
 expression: output
 ---
-(file:///main.ncl, 2:63-2:64: )
-(file:///main.ncl, 2:63-2:64: unexpected token)
-(file:///main.ncl, 3:6-3:7: incompatible types
-Expected an expression of type `Number -> Dyn -> [| 'Ok, 'Error { message | String, <parse error>, } |]`
-Found an expression of type `Number`
-These types are not compatible)
-(file:///main.ncl, 3:6-3:7: this expression)
+[2:63-2:64: "unexpected token", 2:63-2:64: "", 3:6-3:7: "incompatible types\nExpected an expression of type `Number -> Dyn -> [| 'Ok, 'Error { message | String, <parse error>, } |]`\nFound an expression of type `Number`\nThese types are not compatible", 3:6-3:7: "this expression"]


### PR DESCRIPTION
Push diagnostics (where the LSP decides when to publish, and sends notifications) are hard to test reliably, because the harness doesn't know when and how many diagnostics to expect.

This PR adds support for "pull" diagnostics, where there's a diagnostic request and the server responds to it. This simplifies the testing, and hopefully stops it from timing out at random.

This will probably conflict with the typechecker changes. I'm happy to wait and rebase.