### PR TITLE
[Infra] Fix PyPI workflow

### DIFF
--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -16,9 +16,6 @@ on:
 permissions:
   contents: read
 
-env:
-  DRY_RUN: ${{ github.event.inputs.dry_run || 'false' }}
-
 jobs:
   linux:
     runs-on: ${{ matrix.platform.runner }}
@@ -151,7 +148,7 @@ jobs:
   publish-to-pypi:
     name: Publish distribution to PyPI
     runs-on: ubuntu-latest
-    if: env.DRY_RUN == 'false'
+    if: ${{ github.event.inputs.dry_run == 'false' }}
     needs: [linux, musllinux, windows, macos, sdist]
     environment:
       name: pypi


### PR DESCRIPTION
Depends #2168

The workflow didn't work on release. This PR tries to fix it up by getting rid of the misused `env` (its usage is not allowed in the context where it's used).