### PR TITLE
Optional field types

### DIFF
--- a/core/src/bytecode/ast/compat.rs
+++ b/core/src/bytecode/ast/compat.rs
@@ -1042,6 +1042,7 @@ impl<'ast> FromAst<RecordRow<'ast>> for mline_type::RecordRow {
     fn from_ast(rrow: &RecordRow<'ast>) -> Self {
         mline_type::RecordRowF {
             id: rrow.id,
+            opt: false,
             typ: Box::new(rrow.typ.to_mainline()),
         }
     }

--- a/core/src/bytecode/ast/mod.rs
+++ b/core/src/bytecode/ast/mod.rs
@@ -271,7 +271,7 @@ pub struct Annotation<'ast> {
     pub contracts: &'ast [Type<'ast>],
 }
 
-impl Annotation<'_> {
+impl<'ast> Annotation<'ast> {
     /// Returns a string representation of the contracts (without the static type annotation) as a
     /// comma-separated list.
     pub fn contracts_to_string(&self) -> Option<String> {
@@ -289,6 +289,18 @@ impl Annotation<'_> {
     /// contracts annotations.
     pub fn is_empty(&self) -> bool {
         self.typ.is_none() && self.contracts.is_empty()
+    }
+
+    /// If this annotation represents a single type (and not a user-defined contract), return it.
+    ///
+    /// This returns `Some(Number)` for either `| Number` or `: Number`, although it currently
+    /// returns `None` for `: Number | Number`. Should it?
+    pub fn simple_type(&self) -> Option<&Type<'ast>> {
+        match (&self.typ, self.contracts) {
+            (None, [ctr]) if !matches!(&ctr.typ, TypeF::Contract(_)) => Some(ctr),
+            (Some(ty), []) => Some(ty),
+            _ => None,
+        }
     }
 }
 

--- a/core/src/bytecode/typecheck/eq.rs
+++ b/core/src/bytecode/typecheck/eq.rs
@@ -373,6 +373,35 @@ where
     }
 }
 
+impl<'ast, S, T> TypeEqBounded<'ast> for (S, T)
+where
+    S: TypeEqBounded<'ast>,
+    T: TypeEqBounded<'ast>,
+{
+    fn type_eq_bounded(
+        &self,
+        other: &Self,
+        state: &mut State,
+        env1: &TermEnv<'ast>,
+        env2: &TermEnv<'ast>,
+    ) -> bool {
+        self.0.type_eq_bounded(&other.0, state, env1, env2)
+            && self.1.type_eq_bounded(&other.1, state, env1, env2)
+    }
+}
+
+impl<'ast> TypeEqBounded<'ast> for bool {
+    fn type_eq_bounded(
+        &self,
+        other: &Self,
+        _state: &mut State,
+        _env1: &TermEnv<'ast>,
+        _env2: &TermEnv<'ast>,
+    ) -> bool {
+        *self == *other
+    }
+}
+
 impl<'ast> TypeEqBounded<'ast> for UnifEnumRows<'ast> {
     fn type_eq_bounded(
         &self,
@@ -416,7 +445,11 @@ impl<'ast> TypeEqBounded<'ast> for UnifRecordRows<'ast> {
         let map_self: Option<IndexMap<LocIdent, _>> = self
             .iter()
             .map(|item| match item {
-                RecordRowsElt::Row(RecordRowF { id, typ: types }) => Some((id, types)),
+                RecordRowsElt::Row(RecordRowF {
+                    id,
+                    opt,
+                    typ: types,
+                }) => Some((id, (opt, types))),
                 _ => None,
             })
             .collect();
@@ -424,7 +457,11 @@ impl<'ast> TypeEqBounded<'ast> for UnifRecordRows<'ast> {
         let map_other: Option<IndexMap<LocIdent, _>> = other
             .iter()
             .map(|item| match item {
-                RecordRowsElt::Row(RecordRowF { id, typ: types }) => Some((id, types)),
+                RecordRowsElt::Row(RecordRowF {
+                    id,
+                    opt,
+                    typ: types,
+                }) => Some((id, (opt, types))),
                 _ => None,
             })
             .collect();

--- a/core/src/bytecode/typecheck/mk_uniftype.rs
+++ b/core/src/bytecode/typecheck/mk_uniftype.rs
@@ -77,6 +77,7 @@ macro_rules! mk_buty_record_row {
             $crate::typ::RecordRowsF::Extend {
                 row: $crate::typ::RecordRowF {
                     id: $crate::identifier::LocIdent::from($id),
+                    opt: false,
                     typ: Box::new($ty.into()),
                 },
                 tail: Box::new($crate::mk_buty_record_row!($(($ids, $tys)),* $(; $tail)?)),

--- a/core/src/bytecode/typecheck/mod.rs
+++ b/core/src/bytecode/typecheck/mod.rs
@@ -335,7 +335,7 @@ impl VarLevelUpperBound for UnifRecordRowsUnr<'_> {
             // A var that hasn't be instantiated yet isn't a unification variable
             RecordRowsF::Empty | RecordRowsF::TailVar(_) | RecordRowsF::TailDyn => VarLevel::NO_VAR,
             RecordRowsF::Extend {
-                row: RecordRowF { id: _, typ },
+                row: RecordRowF { id: _, opt: _, typ },
                 tail,
             } => max(tail.var_level_upper_bound(), typ.var_level_upper_bound()),
         }
@@ -1155,6 +1155,7 @@ impl<'a, 'ast> Iterator for RecordRowsIterator<'a, UnifType<'ast>, UnifRecordRow
                     self.rrows = Some(tail);
                     Some(RecordRowsElt::Row(RecordRowF {
                         id: row.id,
+                        opt: row.opt,
                         typ: row.typ.as_ref(),
                     }))
                 }
@@ -3072,6 +3073,7 @@ pub fn infer_record_type<'ast>(
                         RecordRowsF::Extend {
                             row: UnifRecordRow {
                                 id,
+                                opt: false,
                                 typ: Box::new(uty),
                             },
                             tail: Box::new(rtype.into()),

--- a/core/src/bytecode/typecheck/pattern.rs
+++ b/core/src/bytecode/typecheck/pattern.rs
@@ -492,6 +492,7 @@ impl<'ast> PatternTypes<'ast> for FieldPattern<'ast> {
 
         Ok(UnifRecordRow {
             id: self.matched_id,
+            opt: false,
             typ: Box::new(ty_row),
         })
     }

--- a/core/src/bytecode/typecheck/reporting.rs
+++ b/core/src/bytecode/typecheck/reporting.rs
@@ -263,6 +263,7 @@ impl<'ast> ToType<'ast> for UnifRecordRow<'ast> {
     ) -> Self::Target {
         RecordRow {
             id: self.id,
+            opt: self.opt,
             typ: alloc.alloc(self.typ.to_type(alloc, reg, table)),
         }
     }

--- a/core/src/bytecode/typecheck/unif.rs
+++ b/core/src/bytecode/typecheck/unif.rs
@@ -1734,6 +1734,7 @@ impl<'ast> RemoveRow<'ast> for UnifRecordRows<'ast> {
 
                 let row_to_insert = UnifRecordRow {
                     id: *target,
+                    opt: false,
                     typ: Box::new(target_content.clone()),
                 };
 

--- a/core/src/eval/contract_eq.rs
+++ b/core/src/eval/contract_eq.rs
@@ -348,11 +348,11 @@ where
 ///
 /// Require the rows to be closed (i.e. the last element must be `RowEmpty`), otherwise `None` is
 /// returned. `None` is returned as well if a type encountered is not row, or if it is a enum row.
-fn rrows_as_map(erows: &RecordRows) -> Option<IndexMap<LocIdent, &Type>> {
+fn rrows_as_map(erows: &RecordRows) -> Option<IndexMap<LocIdent, (bool, &Type)>> {
     let map: Option<IndexMap<LocIdent, _>> = erows
         .iter()
         .map(|item| match item {
-            RecordRowsIteratorItem::Row(RecordRowF { id, typ }) => Some((id, typ)),
+            RecordRowsIteratorItem::Row(RecordRowF { id, opt, typ }) => Some((id, (opt, typ))),
             _ => None,
         })
         .collect();
@@ -493,12 +493,12 @@ fn type_eq_bounded(
         (TypeF::Record(uty1), TypeF::Record(uty2)) => {
             fn type_eq_bounded_wrapper(
                 state: &mut State,
-                uty1: &&Type,
+                (opt1, uty1): &(bool, &Type),
                 env1: &Environment,
-                uty2: &&Type,
+                (opt2, uty2): &(bool, &Type),
                 env2: &Environment,
             ) -> bool {
-                type_eq_bounded(state, uty1, env1, uty2, env2)
+                opt1 == opt2 && type_eq_bounded(state, uty1, env1, uty2, env2)
             }
 
             let map1 = rrows_as_map(uty1);

--- a/core/src/eval/operation.rs
+++ b/core/src/eval/operation.rs
@@ -3026,10 +3026,17 @@ impl<R: ImportResolver, C: Cache> VirtualMachine<R, C> {
                 };
 
                 let split::SplitResult {
-                    left,
+                    mut left,
                     center,
                     right,
                 } = split::split(record1.fields, record2.fields);
+
+                // This doesn't seem very... principled. But at least it's sort of reasonable
+                // current usages of %record/split_pair%? $record_type wants this behavior
+                // because the contract is on the left and we allow optional fields to be
+                // ignored. The other user is std.contract.Equal, and ignoring of optionals
+                // means that `{ } | std.contract.Equal { foo | optional = 1 }` will succeed.
+                left.retain(|_name, value| !value.metadata.opt);
 
                 let left_only = Term::Record(RecordData {
                     fields: left,

--- a/core/src/label.rs
+++ b/core/src/label.rs
@@ -177,7 +177,11 @@ pub mod ty_path {
             (TypeF::Record(rows), next @ Some(Elem::Field(ident))) => {
                 for row_item in rows.iter() {
                     match row_item {
-                        RecordRowsIteratorItem::Row(RecordRowF { id, typ: ty }) if id == *ident => {
+                        RecordRowsIteratorItem::Row(RecordRowF {
+                            id,
+                            typ: ty,
+                            opt: _,
+                        }) if id == *ident => {
                             let path_span = span(path_it, ty)?;
 
                             return Some(PathSpan {

--- a/core/src/pretty.rs
+++ b/core/src/pretty.rs
@@ -1218,7 +1218,8 @@ where
         docs![
             allocator,
             ident_quoted(&self.id),
-            " : ",
+            // FIXME: we don't actually have a surface syntax for optional fields in types
+            if self.opt { " ?: " } else { " : " },
             allocator.type_part(self.typ.deref()),
         ]
     }

--- a/core/src/typecheck/eq.rs
+++ b/core/src/typecheck/eq.rs
@@ -513,13 +513,15 @@ where
 /// returned. `None` is returned as well if a type encountered is not row, or if it is a enum row.
 fn rrows_as_map<E: TermEnvironment>(
     erows: &GenericUnifRecordRows<E>,
-) -> Option<IndexMap<LocIdent, &GenericUnifType<E>>> {
+) -> Option<IndexMap<LocIdent, (bool, &GenericUnifType<E>)>> {
     let map: Option<IndexMap<LocIdent, _>> = erows
         .iter()
         .map(|item| match item {
-            GenericUnifRecordRowsIteratorItem::Row(RecordRowF { id, typ: types }) => {
-                Some((id, types))
-            }
+            GenericUnifRecordRowsIteratorItem::Row(RecordRowF {
+                id,
+                typ: types,
+                opt,
+            }) => Some((id, (opt, types))),
             _ => None,
         })
         .collect();
@@ -685,12 +687,12 @@ fn type_eq_bounded<E: TermEnvironment>(
                 (TypeF::Record(uty1), TypeF::Record(uty2)) => {
                     fn type_eq_bounded_wrapper<E: TermEnvironment>(
                         state: &mut State,
-                        uty1: &&GenericUnifType<E>,
+                        (opt1, uty1): &(bool, &GenericUnifType<E>),
                         env1: &E,
-                        uty2: &&GenericUnifType<E>,
+                        (opt2, uty2): &(bool, &GenericUnifType<E>),
                         env2: &E,
                     ) -> bool {
-                        type_eq_bounded(state, *uty1, env1, *uty2, env2)
+                        opt1 == opt2 && type_eq_bounded(state, *uty1, env1, *uty2, env2)
                     }
 
                     let map1 = rrows_as_map(uty1);

--- a/core/src/typecheck/mk_uniftype.rs
+++ b/core/src/typecheck/mk_uniftype.rs
@@ -77,6 +77,7 @@ macro_rules! mk_uty_record_row {
             $crate::typ::RecordRowsF::Extend {
                 row: $crate::typ::RecordRowF {
                     id: $crate::identifier::LocIdent::from($id),
+                    opt: false,
                     typ: Box::new($ty.into()),
                 },
                 tail: Box::new($crate::mk_uty_record_row!($(($ids, $tys)),* $(; $tail)?)),

--- a/core/src/typecheck/mod.rs
+++ b/core/src/typecheck/mod.rs
@@ -297,7 +297,7 @@ impl<E: TermEnvironment> VarLevelUpperBound for GenericUnifRecordRowsUnrolling<E
             // A var that hasn't be instantiated yet isn't a unification variable
             RecordRowsF::Empty | RecordRowsF::TailVar(_) | RecordRowsF::TailDyn => VarLevel::NO_VAR,
             RecordRowsF::Extend {
-                row: RecordRowF { id: _, typ },
+                row: RecordRowF { id: _, opt: _, typ },
                 tail,
             } => max(tail.var_level_upper_bound(), typ.var_level_upper_bound()),
         }
@@ -1125,6 +1125,7 @@ impl<'a, E: TermEnvironment> Iterator
                     self.rrows = Some(tail);
                     Some(GenericUnifRecordRowsIteratorItem::Row(RecordRowF {
                         id: row.id,
+                        opt: row.opt,
                         typ: row.typ.as_ref(),
                     }))
                 }
@@ -2942,6 +2943,7 @@ pub fn infer_record_type(
                     RecordRowsF::Extend {
                         row: UnifRecordRow {
                             id: *id,
+                            opt: false,
                             typ: Box::new(uty),
                         },
                         tail: Box::new(r.into()),

--- a/core/src/typecheck/pattern.rs
+++ b/core/src/typecheck/pattern.rs
@@ -484,6 +484,7 @@ impl PatternTypes for FieldPattern {
 
         Ok(UnifRecordRow {
             id: self.matched_id,
+            opt: false,
             typ: Box::new(ty_row),
         })
     }

--- a/core/src/typecheck/reporting.rs
+++ b/core/src/typecheck/reporting.rs
@@ -232,6 +232,7 @@ impl ToType for UnifRecordRow {
     fn to_type(self, reg: &mut NameReg, table: &UnifTable) -> Self::Target {
         RecordRow {
             id: self.id,
+            opt: self.opt,
             typ: Box::new(self.typ.to_type(reg, table)),
         }
     }

--- a/core/src/typecheck/subtyping.rs
+++ b/core/src/typecheck/subtyping.rs
@@ -47,8 +47,6 @@ impl SubsumedBy for UnifType {
         let inferred = instantiate_foralls(state, &mut ctxt, self, ForallInst::UnifVar);
         let checked = t2.into_root(state.table);
 
-        dbg!(&inferred, &checked);
-
         match (inferred, checked) {
             // {a1 : T1,...,an : Tn} <: {_ : U} if for every n `Tn <: U`
             (
@@ -191,12 +189,11 @@ impl SubsumedBy for UnifRecordRows {
                 | (RecordRowsF::TailDyn, RecordRowsF::TailDyn) => Ok(()),
                 (RecordRowsF::Empty, RecordRowsF::TailDyn)
                 | (RecordRowsF::TailDyn, RecordRowsF::Empty) => Err(RowUnifError::ExtraDynTail),
-                (RecordRowsF::Empty | RecordRowsF::TailDyn, RecordRowsF::Extend { row, tail }) => {
-                    dbg!(&row);
+                (RecordRowsF::Empty | RecordRowsF::TailDyn, RecordRowsF::Extend { row, .. }) => {
+                    // TODO: shouldn't we need to handle optional rows here too?
                     Err(RowUnifError::MissingRow(row.id))
                 }
-                (RecordRowsF::Extend { row, tail }, RecordRowsF::TailDyn | RecordRowsF::Empty) => {
-                    dbg!(&row);
+                (RecordRowsF::Extend { row, .. }, RecordRowsF::TailDyn | RecordRowsF::Empty) => {
                     Err(RowUnifError::ExtraRow(row.id))
                 }
             },

--- a/core/src/typecheck/subtyping.rs
+++ b/core/src/typecheck/subtyping.rs
@@ -47,6 +47,8 @@ impl SubsumedBy for UnifType {
         let inferred = instantiate_foralls(state, &mut ctxt, self, ForallInst::UnifVar);
         let checked = t2.into_root(state.table);
 
+        dbg!(&inferred, &checked);
+
         match (inferred, checked) {
             // {a1 : T1,...,an : Tn} <: {_ : U} if for every n `Tn <: U`
             (
@@ -121,7 +123,7 @@ impl SubsumedBy for UnifType {
                     ..
                 },
             ) => a.subsumed_by(*b, state, ctxt),
-            // {a1 : T1,...,an : Tn} <: {b1 : U1,...,bn : Un} if for every n `Tn <: Un`
+            // {a1 : T1,...,an : Tn} <: {b1 : U1,...,bn : Un} if for every n `Tn <: Un` or `an` is optional and `bn` is missing
             (
                 UnifType::Concrete {
                     typ: TypeF::Record(rrows1),
@@ -145,7 +147,7 @@ impl SubsumedBy for UnifRecordRows {
     type Error = RowUnifError;
 
     fn subsumed_by(self, t2: Self, state: &mut State, ctxt: Context) -> Result<(), Self::Error> {
-        // This code is almost taken verbatim fro `unify`, but where some recursive calls are
+        // This code is almost taken verbatim from `unify`, but where some recursive calls are
         // changed to be `subsumed_by` instead of `unify`. We can surely factorize both into a
         // generic function, but this is left for future work.
         let inferred = self.into_root(state.table);
@@ -189,34 +191,14 @@ impl SubsumedBy for UnifRecordRows {
                 | (RecordRowsF::TailDyn, RecordRowsF::TailDyn) => Ok(()),
                 (RecordRowsF::Empty, RecordRowsF::TailDyn)
                 | (RecordRowsF::TailDyn, RecordRowsF::Empty) => Err(RowUnifError::ExtraDynTail),
-                (
-                    RecordRowsF::Empty,
-                    RecordRowsF::Extend {
-                        row: UnifRecordRow { id, .. },
-                        ..
-                    },
-                )
-                | (
-                    RecordRowsF::TailDyn,
-                    RecordRowsF::Extend {
-                        row: UnifRecordRow { id, .. },
-                        ..
-                    },
-                ) => Err(RowUnifError::MissingRow(id)),
-                (
-                    RecordRowsF::Extend {
-                        row: UnifRecordRow { id, .. },
-                        ..
-                    },
-                    RecordRowsF::TailDyn,
-                )
-                | (
-                    RecordRowsF::Extend {
-                        row: UnifRecordRow { id, .. },
-                        ..
-                    },
-                    RecordRowsF::Empty,
-                ) => Err(RowUnifError::ExtraRow(id)),
+                (RecordRowsF::Empty | RecordRowsF::TailDyn, RecordRowsF::Extend { row, tail }) => {
+                    dbg!(&row);
+                    Err(RowUnifError::MissingRow(row.id))
+                }
+                (RecordRowsF::Extend { row, tail }, RecordRowsF::TailDyn | RecordRowsF::Empty) => {
+                    dbg!(&row);
+                    Err(RowUnifError::ExtraRow(row.id))
+                }
             },
             (UnifRecordRows::UnifVar { id, .. }, urrows)
             | (urrows, UnifRecordRows::UnifVar { id, .. }) => {


### PR DESCRIPTION
This was an attempt at #2050 

- makes fields optional in record types
- adds a unification rule for optional record fields
- adds automatic UniTerm -> Type conversions for records with "simple enough" contract annotations

I think the last one was a mistake, though. It's not backwards compatible (e.g. it breaks one test), and it leads to some weird special cases. I'm going to try doing the contract -> type conversion later (like maybe just in the typechecker itself) and see if that's better.

I also didn't figure out how to trigger subtype checking. I tried some variants of the existing subtype tests but I only ever hit the unification code.