### PR TITLE
Automatically convert interpolated values to string

### DIFF
--- a/cli/tests/snapshot/inputs/errors/interpolation_non_stringable.ncl
+++ b/cli/tests/snapshot/inputs/errors/interpolation_non_stringable.ncl
@@ -1,0 +1,5 @@
+# capture = 'stderr'
+# command = ['eval']
+
+let data = {foo = 1, bar = "string"} in
+"hello, I am %{data}"

--- a/cli/tests/snapshot/snapshots/snapshot__eval_stderr_interpolation_non_stringable.ncl.snap
+++ b/cli/tests/snapshot/snapshots/snapshot__eval_stderr_interpolation_non_stringable.ncl.snap
@@ -1,0 +1,13 @@
+---
+source: cli/tests/snapshot/main.rs
+expression: err
+---
+error: dynamic type error
+  ┌─ [INPUTS_PATH]/errors/interpolation_non_stringable.ncl:5:16
+  │
+4 │ let data = {foo = 1, bar = "string"} in
+  │            ------------------------- evaluated to this
+5 │ "hello, I am %{data}"
+  │                ^^^^ this expression has type Record, but Stringable was expected
+  │
+  = interpolated values must be Stringable (string, number, boolean, enum tag or null)

--- a/cli/tests/snapshot/snapshots/snapshot__eval_stderr_subcontract_nested_custom_diagnostics.ncl.snap
+++ b/cli/tests/snapshot/snapshots/snapshot__eval_stderr_subcontract_nested_custom_diagnostics.ncl.snap
@@ -21,9 +21,9 @@ warning: plain functions as contracts are deprecated
    = wrap this function using one of the constructors in `std.contract` instead, like `std.contract.from_validator` or `std.contract.custom`
 
 warning: plain functions as contracts are deprecated
-     ┌─ <stdlib/std.ncl>:1708:9
+     ┌─ <stdlib/std.ncl>:1707:9
      │
-1708 │         %contract/apply% contract (%label/push_diag% label) value,
+1707 │         %contract/apply% contract (%label/push_diag% label) value,
      │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ applied to this term
      │
      ┌─ [INPUTS_PATH]/errors/subcontract_nested_custom_diagnostics.ncl:3:21

--- a/core/src/term/mod.rs
+++ b/core/src/term/mod.rs
@@ -52,8 +52,8 @@ pub use malachite::{
 
 use serde::{Deserialize, Serialize, Serializer};
 
-// Because we use `IndexMap` for recors, consumer of Nickel (as a library) might have to
-// manipulate values of this type, so we re-export this type.
+// Because we use `IndexMap` for recorsd, consumer of Nickel (as a library) might have to
+// manipulate values of this type, so we re-export it.
 pub use indexmap::IndexMap;
 
 use std::{
@@ -1240,6 +1240,19 @@ impl Term {
     pub fn try_as_closure(&self) -> Option<CacheIndex> {
         match self {
             Term::Closure(idx) => Some(idx.clone()),
+            _ => None,
+        }
+    }
+
+    /// Converts a primitive value (number, string, boolean, enum tag or null) to a Nickel string,
+    /// or returns `None` if the term isn't primitive.
+    pub fn to_nickel_string(&self) -> Option<NickelString> {
+        match self {
+            Term::Num(n) => Some(format!("{}", n.to_sci()).into()),
+            Term::Str(s) => Some(s.clone()),
+            Term::Bool(b) => Some(b.to_string().into()),
+            Term::Enum(id) => Some((*id).into()),
+            Term::Null => Some("null".into()),
             _ => None,
         }
     }

--- a/core/src/term/mod.rs
+++ b/core/src/term/mod.rs
@@ -52,7 +52,7 @@ pub use malachite::{
 
 use serde::{Deserialize, Serialize, Serializer};
 
-// Because we use `IndexMap` for recorsd, consumer of Nickel (as a library) might have to
+// Because we use `IndexMap` for records, consumer of Nickel (as a library) might have to
 // manipulate values of this type, so we re-export it.
 pub use indexmap::IndexMap;
 

--- a/core/stdlib/internals.ncl
+++ b/core/stdlib/internals.ncl
@@ -166,7 +166,7 @@
           'Ok value
         else
           'Error {
-            message = "expected `'%{%to_string% tag}`, got `'%{%to_string% value_tag}`"
+            message = "expected `'%{tag}`, got `'%{value_tag}`"
           }
       else
         'Error { message = "expected an enum variant" },

--- a/core/stdlib/std.ncl
+++ b/core/stdlib/std.ncl
@@ -1127,7 +1127,7 @@
               value
             else
               ctr_label
-              |> label.with_message "expected `%{%to_string% constant_type}`, got `%{%to_string% value_type}`"
+              |> label.with_message "expected `%{constant_type}`, got `%{value_type}`"
               |> label.append_note "`std.contract.Equal some_value` requires that the checked value is equal to `some_value`, but they don't have the same type."
               |> blame
           in
@@ -1171,7 +1171,7 @@
                     )
                 else
                   ctr_label
-                  |> label.with_message "array length mismatch (expected `%{%to_string% (%array/length% constant)}`, got `%{%to_string% value_length})`"
+                  |> label.with_message "array length mismatch (expected `%{%array/length% constant}`, got `%{value_length})`"
                   |> label.append_note "`std.contract.Equal some_array` requires that the checked value is equal to the array `some_array`, but their lengths differ."
                   |> blame,
 
@@ -1378,12 +1378,11 @@
             0 => 'Ok,
             n if std.is_number n =>
               'Error {
-                message = "expected 0, got %{std.to_string n}",
+                message = "expected 0, got %{n}",
                 notes = ["The value is a number, but it isn't 0"],
               },
             v =>
-              let vtype = v |> std.typeof |> std.to_string in
-              'Error { message = "expected a number, got a %{vtype}" }
+              'Error { message = "expected a number, got a %{std.typeof v}" }
           })
           in
 
@@ -1940,7 +1939,7 @@
               if %typeof% value == 'Number && value < 0 then
                 'Error {
                   message = "invalid range step",
-                  notes = ["Expected a positive number, got %{%to_string% value}"],
+                  notes = ["Expected a positive number, got %{value}"],
                 }
               else
                 'Ok value
@@ -1967,13 +1966,10 @@
                 if %typeof% start == 'Number
                 && %typeof% value == 'Number
                 && start > value then
-                  let start_as_str = %to_string% start in
-                  let end_as_str = %to_string% value in
-
                   'Error {
                     message = "invalid range",
                     notes = [
-                      "Expected a range end greater than %{start_as_str} (range start), got %{end_as_str}"
+                      "Expected a range end greater than %{start} (range start), got %{value}"
                     ]
                   }
                 else
@@ -2021,7 +2017,7 @@
                     let label =
                       label
                       |> attach_message
-                      |> label_module.append_note "Expected array index to be a positive integer, got %{%to_string% value} "
+                      |> label_module.append_note "Expected array index to be a positive integer, got %{value} "
                     in
                     std.contract.check std.number.Nat label value
                   else
@@ -2039,13 +2035,11 @@
                     in
 
                     if min_size > max_idx then
-                      let index_as_str = %to_string% min_size in
-                      let max_as_str = %to_string% max_idx in
                       let note =
                         if %array/length% value == 0 then
                           "Can't index into an empty array"
                         else
-                          "Expected an array index between 0 and %{max_as_str} (included), got %{index_as_str}"
+                          "Expected an array index between 0 and %{max_idx} (included), got %{min_size}"
                       in
 
                       'Error {
@@ -2093,7 +2087,7 @@
                     let label =
                       label
                       |> attach_message
-                      |> label_module.append_note "Expected the array slice start index to be a positive integer, got %{%to_string% value}"
+                      |> label_module.append_note "Expected the array slice start index to be a positive integer, got %{value}"
                     in
                     std.contract.check std.number.Nat label value
                   else
@@ -2106,14 +2100,14 @@
                       'Error {
                         message = "invalid array slice indexing",
                         notes = [
-                          "Expected the array slice indices to satisfy `start <= end`, but got %{%to_string% start} (start) and %{%to_string% value} (end)"
+                          "Expected the array slice indices to satisfy `start <= end`, but got %{start} (start) and %{value} (end)"
                         ],
                       }
                     else
                       let label =
                         label
                         |> attach_message
-                        |> label_module.append_note "Expected the array slice end index to be a positive integer, got %{%to_string% value}"
+                        |> label_module.append_note "Expected the array slice end index to be a positive integer, got %{value}"
                       in
                       std.contract.check std.number.Nat label value
                   else
@@ -2124,13 +2118,10 @@
                   if %typeof% end_index == 'Number
                   && %typeof% value == 'Array
                   && end_index > %array/length% value then
-                    let index_as_str = %to_string% end_index in
-                    let size_as_str = %to_string% (%array/length% value) in
-
                     'Error {
                       message = "invalid array slice indexing",
                       notes = [
-                        "Expected the slice end index to be between 0 and %{size_as_str} (array's length), got %{index_as_str}"
+                        "Expected the slice end index to be between 0 and %{%array/length% value} (array's length), got %{end_index}"
                       ],
                     }
                   else
@@ -3288,8 +3279,10 @@
             let value_validator =
               std.contract.from_validator (fun s =>
                 if (std.string.length s) != 40 then
-                  let len = std.string.length s |> std.to_string in
-                  'Error { message = "expected 40 characters, got %{len}", notes = ["use the full commit id; short ids are not supported"] }
+                  'Error {
+                    message = "expected 40 characters, got %{std.string.length s}",
+                    notes = ["use the full commit id; short ids are not supported"]
+                  }
                 else if !(hex_chars s) then
                   'Error { message = "contains an invalid character", notes = ["only 0-9 and a-f are allowed"] }
                 else

--- a/core/tests/integration/inputs/strings/string_interpolation.ncl
+++ b/core/tests/integration/inputs/strings/string_interpolation.ncl
@@ -54,4 +54,7 @@
   let actual = m%%"XYZ "%%%{"CBA"}""%% in
   let expected = "XYZ \"%CBA\"" in
   actual == expected,
+
+  "%{1}+%{1} is %{2}? %{1+1==2}, of %{'course}" == "1+1 is 2? true, of course",
+  "%{null}" == "null",
 ] |> std.test.assert_all

--- a/core/tests/integration/inputs/strings/string_interpolation_record.ncl
+++ b/core/tests/integration/inputs/strings/string_interpolation_record.ncl
@@ -2,4 +2,4 @@
 #
 # [test.metadata]
 # error = 'EvalError::TypeError'
-"bad type %{1 + 1}"
+"bad type %{{}}"

--- a/doc/manual/contracts.md
+++ b/doc/manual/contracts.md
@@ -169,9 +169,8 @@ reporting:
         message = "expected \"foo\", got \"%{value}\"",
       },
     value =>
-      let typeof = value |> std.typeof |> std.to_string in
       'Error {
-        message = "expected a String, got a %{typeof}",
+        message = "expected a String, got a %{std.typeof value}",
         notes = ["The value must be a string equal to \"foo\"."],
       },
   }

--- a/doc/manual/modular-configurations.md
+++ b/doc/manual/modular-configurations.md
@@ -382,7 +382,7 @@ a reusable configuration module. For example:
 
   some_config_option = inputs.bar + 1,
   other_option = std.string.join " " ["Hello", local.computed],
-  last_option = "values are %{local.computed} and %{std.to_string inputs.bar}",
+  last_option = "values are %{local.computed} and %{inputs.bar}",
 }
 ```
 

--- a/doc/manual/syntax.md
+++ b/doc/manual/syntax.md
@@ -134,7 +134,9 @@ In fact, as far as at all practicable, Nickel treats strings as sequences of
 Unicode extended grapheme clusters and refuses to break them apart.
 
 The string interpolation syntax is
-`"%{ < expression that evaluates to a string > }"`.
+`"%{ < expression that evaluates to a string > }"`. You can interpolate any
+primitive value that can be converted to a string, that is numbers, booleans,
+enum tags, strings and the `null` value (see `std.string.Stringable`).
 
 Here are some examples of string handling in Nickel:
 
@@ -153,10 +155,6 @@ Here are some examples of string handling in Nickel:
 "Hello World"
 
 > let n = 5 in "The number %{n}."
-error: dynamic type error
-[...]
-
-> let n = 5 in "The number %{std.string.from_number n}."
 "The number 5."
 ```
 
@@ -1137,7 +1135,7 @@ true
 
 > {foo = 1, bar = "string"} : {_ : Number}
 error: incompatible types
-  ┌─ <repl-input-97>:1:18
+  ┌─ <repl-input-96>:1:18
   │
 1 │  {foo = 1, bar = "string"} : {_ : Number}
   │                  ^^^^^^^^ this expression
@@ -1197,7 +1195,7 @@ annotation but no value are forbidden outside of types.
 ```nickel #repl
 > {foo = 1, bar = "foo" } : {foo : Number, bar : String | optional}
 error: statically typed field without a definition
-  ┌─ <repl-input-101>:1:29
+  ┌─ <repl-input-100>:1:29
   │
 1 │  {foo = 1, bar = "foo" } : {foo : Number, bar : String | optional}
   │                             ^^^   ------ but it has a type annotation

--- a/doc/manual/typing.md
+++ b/doc/manual/typing.md
@@ -254,6 +254,20 @@ The following type constructors are available:
   }
   ```
 
+### String interpolation
+
+Since Nickel 1.11.0 and higher, string interpolation automatically converts
+primitive values like booleans, numbers, etc. to strings as a convenience, so
+that you can write directly `"The length is %{std.array.length array}"` instead
+of `"The length is %{std.string.to_string (std.array.length array)}"` in
+dynamically typed code.
+
+However, this makes type inference more complicated in statically typed code:
+what should be the type of `fun x => "hello, %{x}"`, for example? For now, the
+typechecker is conservative and unconditionally type `x` as `String`, requiring
+you to explicitly convert values to strings when using interpolation in typed
+code. This restriction might be relaxed in future versions.
+
 ### Subtyping
 
 While distinct types are usually incompatible, some types might actually be
@@ -272,7 +286,7 @@ extended
 In this example, there is a silent conversion from `{foo : Number}` to `{_ :
 Number}`. This is safe because `foo` is of type `Number`, and it's the only
 field, which means that a value of type `{foo : Number}` is effectively
-dictionary of numbers. In the typing jargon, `{foo : Number}` is said to be a
+a dictionary of numbers. In the typing jargon, `{foo : Number}` is said to be a
 *subtype* of `{_ : Number}`. We will write `T <: U` to say that `T` is a subtype
 of `U`: whenever a value of type `U` is expected, we can use a value of type `T`
 as well.

--- a/examples/imports/data_nickel_properties.ncl
+++ b/examples/imports/data_nickel_properties.ncl
@@ -5,10 +5,10 @@ let
 in
 
 let
-  melting_celcius = std.string.from_number (kelvin_to_celcius 1728),
-  melting_fahrenheit = std.string.from_number (kelvin_to_fahrenheit 1728),
-  boiling_celcius = std.string.from_number (kelvin_to_celcius 3003),
-  boiling_fahrenheit = std.string.from_number (kelvin_to_fahrenheit 3003),
+  melting_celcius = kelvin_to_celcius 1728,
+  melting_fahrenheit = kelvin_to_fahrenheit 1728,
+  boiling_celcius = kelvin_to_celcius 3003,
+  boiling_fahrenheit = kelvin_to_fahrenheit 3003,
 in
 
 {


### PR DESCRIPTION
This PR implements a feature request (although I can't find the issue for it, but I believe it was requested several times on other channels at least, or maybe as a comment on a different issue) to avoid having to convert manually values to string before interpolating them (at least for primitive values). That is, string interpolation now accepts not only strings, but also numbers, booleans, enum tags and `null`.

This raises the question of what to do about statically typed code. I adopted the most restrictive approach for now, which is to make the typechecker still infer interpolated values to be string; so in a statically typed block, the user has to use `to_string`. This is properly documented in the manual in consequence.

On some-place-I-still-don't-remember (or maybe oral discussion in a weekly), we also discussed a potential follow-up which would be to somehow hardcode typing rules for `std.string.Stringable`: the introduction rule would simply be defined by subtyping, that is `String <: Stringable`, `Number <: Stringable`, `Bool <: Stringable`, etc. This is a bit ad-hoc, but might be ok for something as fundamental as string interpolation. This evolution is compatible with the restrictive approach taken in this PR.