### PR TITLE
Add regression test for #2124

### DIFF
--- a/core/tests/integration/inputs/typecheck/mismatch_dict_dynamic_field.ncl
+++ b/core/tests/integration/inputs/typecheck/mismatch_dict_dynamic_field.ncl
@@ -1,0 +1,12 @@
+# test.type = 'error'
+# eval = 'typecheck'
+# 
+# [test.metadata]
+# error = 'TypecheckError::TypeMismatch'
+#
+# [test.metadata.expectation]
+# expected = 'Bool'
+# inferred = 'Number'
+
+# Regression test for https://github.com/tweag/nickel/issues/2124
+let x = "a" in {"%{x}" = 1, bar = false} : {_ : Bool}


### PR DESCRIPTION
Closes #2124. The actual fix was indeed shipped by the migration of the typechecker to the new AST. This PR simply adds a regression test for the issue.