### PR TITLE
Add regression test for #1971

### DIFF
--- a/lsp/nls/tests/inputs/hover-double-def.ncl
+++ b/lsp/nls/tests/inputs/hover-double-def.ncl
@@ -1,0 +1,10 @@
+### /main.ncl
+{ foo, foo } | { foo | doc "The field Foo" }
+### [[request]]
+### type = "Hover"
+### textDocument.uri = "file:///main.ncl"
+### position = { line = 0, character = 3 }
+### [[request]]
+### type = "Hover"
+### textDocument.uri = "file:///main.ncl"
+### position = { line = 0, character = 8 }

--- a/lsp/nls/tests/snapshots/main__lsp__nls__tests__inputs__hover-double-def.ncl.snap
+++ b/lsp/nls/tests/snapshots/main__lsp__nls__tests__inputs__hover-double-def.ncl.snap
@@ -1,0 +1,10 @@
+---
+source: lsp/nls/tests/main.rs
+expression: output
+---
+<0:2-0:5>[```nickel
+Dyn
+```, The field Foo]
+<0:7-0:10>[```nickel
+Dyn
+```, The field Foo]


### PR DESCRIPTION
Closes #1971. The latter was automagically fixed by the migration of NLS to the new AST, which is more faithful. This PR just adds a regression test.