### PR TITLE
Fix panic with multiple contracts on field

### DIFF
--- a/core/src/eval/contract_eq.rs
+++ b/core/src/eval/contract_eq.rs
@@ -161,8 +161,8 @@ fn contract_eq_bounded(
                     let had_gas = state.use_gas();
                     state.use_gas();
 
-                    let closure1 = idx1.borrow_orig();
-                    let closure2 = idx2.borrow_orig();
+                    let closure1 = idx1.borrow();
+                    let closure2 = idx2.borrow();
 
                     had_gas
                         && contract_eq_bounded(
@@ -184,8 +184,14 @@ fn contract_eq_bounded(
             let had_gas = state.use_gas();
             state.use_gas();
 
-            let closure1 = idx1.borrow();
-            let closure2 = idx2.borrow();
+            // If we find a closure that isn't coming from a variable, it might be the content of a
+            // recursive field. When deduplicating contracts at merge time, those fields have been
+            // reverted to a state where they don't have a cached value built yet. This state is
+            // not observable by the rest of the evaluator, but we do have to consider it here. We
+            // make use of `borrow_orig` built for this purpose, to get the original closure in
+            // this case instead of panicking as `borrow()` would.
+            let closure1 = idx1.borrow_orig();
+            let closure2 = idx2.borrow_orig();
 
             had_gas
                 && contract_eq_bounded(

--- a/core/src/eval/merge.rs
+++ b/core/src/eval/merge.rs
@@ -427,14 +427,15 @@ fn merge_fields<'a, C: Cache, I: DoubleEndedIterator<Item = &'a LocIdent> + Clon
         _ => unreachable!(),
     };
 
-    let mut pending_contracts = pending_contracts1.revert_closurize(cache);
-
     // Since contracts are closurized, they don't need another local environment
     let empty = Environment::new();
 
-    for ctr2 in pending_contracts2.revert_closurize(cache) {
-        RuntimeContract::push_dedup(&mut pending_contracts, &empty, ctr2, &empty);
-    }
+    let pending_contracts = RuntimeContract::combine_dedup(
+        pending_contracts1.revert_closurize(cache),
+        &empty,
+        pending_contracts2.revert_closurize(cache),
+        &empty,
+    );
 
     Ok(Field {
         metadata: FieldMetadata {
@@ -495,6 +496,7 @@ impl Saturate for RichTerm {
                 .saturate(idx.clone(), fields.map(LocIdent::ident))
                 .with_pos(self.pos))
         } else {
+            debug_assert!(self.as_ref().is_constant());
             Ok(self)
         }
     }

--- a/core/tests/integration/inputs/contracts/dedup_multiple.ncl
+++ b/core/tests/integration/inputs/contracts/dedup_multiple.ncl
@@ -1,0 +1,19 @@
+# test.type = 'pass'
+
+# Regression test for https://github.com/tweag/nickel/issues/2189
+let Linktype = {
+  source,
+  target
+    | Dyn
+    | { file | default = source }
+}
+in
+(
+  {
+    source = "",
+    target | Dyn | Dyn = {},
+  } | Linktype
+) == {
+  source = "",
+  target.file = "",
+}


### PR DESCRIPTION
Closes #2189.

This commit fixes two defects when deduplicating the contracts on a merged field:

1. Do not uselessly run contract equality on contracts coming from the same side of the merge. Those are assumed to be already deduped.
2. Properly use `borrow_orig` when comparing two closures, instead of using it when comparing two variables. I think for the case of two variables and two closures, the `borrow` and `borrow_orig` usages are swapped when comparing to older versions of Nickel, before we extracted the contract equality code out of  `typecheck` and simplified it. It's most likely a migration error.

Beside tests, I checked on the private benchmark that there are no less deduplicated contracts with the new version, which is indeed the case. We do reduce the number of contract equality checks, although on this particular benchmark, this isn't really a game changer (98934 contract equality checks on master vs 98315 with this branch).