### PR TITLE
Build the workspace in the flake

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -54,7 +54,7 @@ jobs:
         nix flake check --accept-flake-config --print-build-logs
 
     - name: Typecheck benchmarks
-      run: nix shell --inputs-from . .#nickel-lang-cli nixpkgs#findutils --command find core/benches -type f -name "*.ncl" -exec nickel typecheck '{}' \;
+      run: nix shell --inputs-from . .#nickel-lang nixpkgs#findutils --command find core/benches -type f -name "*.ncl" -exec nickel typecheck '{}' \;
 
   build-and-test-windows:
     name: "build-and-test (windows-latest)"

--- a/.github/workflows/release-artifacts.yaml
+++ b/.github/workflows/release-artifacts.yaml
@@ -42,10 +42,9 @@ jobs:
         run: |
           nix build --log-format raw-with-logs .#nickel-static
           cp ./result/bin/nickel nickel-${{ matrix.os.architecture }}-linux
+          cp ./result/bin/nls nls-${{ matrix.os.architecture }}-linux
           nix build --log-format raw-with-logs .#nickel-pkg-static
           cp ./result/bin/nickel nickel-pkg-${{ matrix.os.architecture }}-linux
-          nix build --log-format raw-with-logs .#nickel-lang-lsp-static
-          cp ./result/bin/nls nls-${{ matrix.os.architecture }}-linux
       - name: "Upload static binary as release asset"
         env:
           GH_TOKEN: ${{ github.token }}
@@ -103,12 +102,11 @@ jobs:
       - name: Build binaries
         run: |
           set +e
-          nix build --log-format raw-with-logs .#nickel-lang-cli
+          nix build --log-format raw-with-logs .#nickel-lang
           cp ./result/bin/nickel nickel-arm64-macos
-          nix build --log-format raw-with-logs .#nickel-lang-cli-pkg
-          cp ./result/bin/nickel nickel-pkg-arm64-macos
-          nix build --log-format raw-with-logs .#nickel-lang-lsp
           cp ./result/bin/nls nls-arm64-macos
+          nix build --log-format raw-with-logs .#nickel-lang-pkg
+          cp ./result/bin/nickel nickel-pkg-arm64-macos
       - name: "Upload binaries as release assets"
         env:
           GH_TOKEN: ${{ github.token }}

--- a/flake.nix
+++ b/flake.nix
@@ -397,6 +397,7 @@
           # A version of the Nickel CLI with the experimental package management
           # feature enabled.
           nickel-lang-pkg = fixupGitRevision (buildWorkspace {
+            pnameSuffix = "-pkg";
             extraBuildArgs = "--features package-experimental";
             extraArgs = {
               inherit env;
@@ -649,6 +650,7 @@
       packages = {
         inherit (mkCraneArtifacts { })
           nickel-lang
+          nickel-lang-pkg
           benchmarks
           cargoArtifacts;
         default = packages.nickel-lang;

--- a/flake.nix
+++ b/flake.nix
@@ -371,33 +371,33 @@
           # In addition to external dependencies, we build the lalrpop file in a
           # separate derivation because it's expensive to build but needs to be
           # rebuilt infrequently.
-          cargoArtifacts = buildPackage {
+          cargoArtifacts = craneLib.buildPackage {
+            inherit pname version;
             pnameSuffix = "-core-lalrpop";
-            cargoPackage = "${pname}-core";
-            extraArgs = {
-              cargoArtifacts = cargoArtifactsDeps;
-              src = craneLib.mkDummySrc {
-                inherit src;
+            src = craneLib.mkDummySrc {
+              inherit src;
 
-                # after stubbing out, reset things back just enough for lalrpop build
-                extraDummyScript = ''
-                  mkdir -p $out/core/src/parser
-                  cp ${./core/build.rs} $out/core/build.rs
-                  cp ${./core/src/parser/grammar.lalrpop} $out/core/src/parser/grammar.lalrpop
+              # after stubbing out, reset things back just enough for lalrpop build
+              extraDummyScript = ''
+                mkdir -p $out/core/src/parser
+                cp ${./core/build.rs} $out/core/build.rs
+                cp ${./core/src/parser/grammar.lalrpop} $out/core/src/parser/grammar.lalrpop
                 '' +
-                # package.build gets set to a dummy file. Reset it to use local build.rs
+                # package.build gets set to a dummy file. reset it to use local build.rs
                 # tomlq -i broken (https://github.com/kislyuk/yq/issues/130 not in nixpkgs yet)
                 ''
-                  ${pkgs.yq}/bin/tomlq -t 'del(.package.build)' $out/core/Cargo.toml > tmp
-                  mv tmp $out/core/Cargo.toml
-                '';
-              };
-              # the point of this is to cache lalrpop compilation
-              doInstallCargoArtifacts = true;
-              # we need the target/ directory to be writable
-              installCargoArtifactsMode = "use-zstd";
-              CARGO_PROFILE = profile;
+                ${pkgs.yq}/bin/tomlq -t 'del(.package.build)' $out/core/Cargo.toml > tmp
+                mv tmp $out/core/Cargo.toml
+              '';
             };
+
+            cargoArtifacts = cargoArtifactsDeps;
+            cargoExtraArgs = "--package nickel-lang-core";
+            # the point of this is to cache lalrpop compilation
+            doInstallCargoArtifacts = true;
+            # we need the target/ directory to be writable
+            installCargoArtifactsMode = "use-zstd";
+            CARGO_PROFILE = profile;
           };
         in
         rec {

--- a/flake.nix
+++ b/flake.nix
@@ -348,7 +348,7 @@
                 # C++ libraries. The `cc-rs` crate is typically used in
                 # upstream build.rs scripts.
                 CXXSTDLIB = "static=c++";
-                stdenv = pkgs.pkgsMusl.libcxxStdenv;
+                stdenv = p: p.pkgsMusl.libcxxStdenv;
                 doCheck = false;
                 CARGO_PROFILE = profile;
               } // extraArgs;
@@ -368,10 +368,10 @@
                 mkdir -p $out/core/src/parser
                 cp ${./core/build.rs} $out/core/build.rs
                 cp ${./core/src/parser/grammar.lalrpop} $out/core/src/parser/grammar.lalrpop
-                '' +
-                # package.build gets set to a dummy file. reset it to use local build.rs
-                # tomlq -i broken (https://github.com/kislyuk/yq/issues/130 not in nixpkgs yet)
-                ''
+              '' +
+              # package.build gets set to a dummy file. reset it to use local build.rs
+              # tomlq -i broken (https://github.com/kislyuk/yq/issues/130 not in nixpkgs yet)
+              ''
                 ${pkgs.yq}/bin/tomlq -t 'del(.package.build)' $out/core/Cargo.toml > tmp
                 mv tmp $out/core/Cargo.toml
               '';
@@ -410,7 +410,6 @@
           # call ABIs aren't stable. This output shouldn't be used on MacOS.
           nickel-static =
             fixupGitRevision (buildStaticWorkspace {
-              cargoPackage = "nickel-lang-cli";
               pnameSuffix = "-static";
               extraArgs = { meta.mainProgram = "nickel"; };
             });
@@ -418,7 +417,6 @@
           # See nickel-static
           nickel-pkg-static =
             fixupGitRevision (buildStaticWorkspace {
-              cargoPackage = "nickel-lang-cli";
               pnameSuffix = "-pkg-static";
               extraBuildArgs = "--features package-experimental";
               extraArgs = { meta.mainProgram = "nickel"; };

--- a/flake.nix
+++ b/flake.nix
@@ -309,7 +309,7 @@
             NICKEL_NIX_BUILD_REV = dummyRev;
           };
 
-          buildWorkspace = { pnameSuffix, extraBuildArgs ? "", extraArgs ? { } }:
+          buildWorkspace = { pnameSuffix ? "", extraBuildArgs ? "", extraArgs ? { } }:
             craneLib.buildPackage ({
               inherit
                 pname
@@ -389,7 +389,6 @@
         rec {
           inherit cargoArtifacts cargoArtifactsDeps;
           nickel-lang = fixupGitRevision (buildWorkspace {
-            pnameSuffix = "-cli";
             extraArgs = {
               inherit env;
               meta.mainProgram = "nickel";
@@ -398,7 +397,6 @@
           # A version of the Nickel CLI with the experimental package management
           # feature enabled.
           nickel-lang-pkg = fixupGitRevision (buildWorkspace {
-            pnameSuffix = "-cli";
             extraBuildArgs = "--features package-experimental";
             extraArgs = {
               inherit env;


### PR DESCRIPTION
This changes the nix packages so that they build the whole workspace instead of going package-by-package. Because of the way feature unification works in cargo, this should reduce the number of times we need to build dependencies.

As a consequence, this also runs more tests in CI: `nix flake check` now runs the tests for all crates, not just the few that we selected.

It may be possible to get back to package-by-package builds in the future, since cargo would like to improve this on their end: https://rust-lang.github.io/rfcs/3692-feature-unification.html