### PR TITLE
Add support for environment variables sigil @env on the command line

### DIFF
--- a/cli/src/customize/mod.rs
+++ b/cli/src/customize/mod.rs
@@ -69,6 +69,12 @@ struct CustomizeOptions {
     /// prevent shell interpretation.
     ///
     /// Example: `nickel eval config.ncl -- 'http.enabled="yes"' protocol=\'ftp`
+    ///
+    /// In addition to Nickel values, the left hand side of the assignment can be a special
+    /// expression introduced by the `@` sigil, with the syntax
+    /// `@<selector>[/<attribute>]:<argument>`.
+    ///
+    /// Example: `nickel eval config.ncl -- vars.home=@env:HOME vars.path=@env:PATH`
     #[clap(value_name = ASSIGNMENT_SYNTAX)]
     assignment: Vec<String>,
 

--- a/cli/tests/snapshot/inputs/customize-mode/sigil_env.ncl
+++ b/cli/tests/snapshot/inputs/customize-mode/sigil_env.ncl
@@ -1,0 +1,13 @@
+# capture = 'stdout'
+# command = ['export']
+# extra_args = [
+#  '--',
+#  'env.pkg=@env:CARGO_PKG_NAME',
+# ]
+
+# We bet that CARGO_PKG_NAME is always set in the test environment by cargo, and
+# that it's unlikely to change often, which should fit the bill for this
+# snapshot test.
+{
+  env.pkg | String,
+} 

--- a/cli/tests/snapshot/inputs/customize-mode/sigil_missing_colon.ncl
+++ b/cli/tests/snapshot/inputs/customize-mode/sigil_missing_colon.ncl
@@ -1,0 +1,9 @@
+# capture = 'stderr'
+# command = ['export']
+# extra_args = [
+#  '--',
+#  'input=@env_missing_value',
+# ]
+{
+  input
+}

--- a/cli/tests/snapshot/inputs/customize-mode/unknown_sigil_attr.ncl
+++ b/cli/tests/snapshot/inputs/customize-mode/unknown_sigil_attr.ncl
@@ -1,0 +1,9 @@
+# capture = 'stderr'
+# command = ['export']
+# extra_args = [
+#  '--',
+#  'input."foo bar".baz=@env/attr:PATH',
+# ]
+{
+  input."foo bar".baz,
+} 

--- a/cli/tests/snapshot/inputs/customize-mode/unknown_sigil_expr.ncl
+++ b/cli/tests/snapshot/inputs/customize-mode/unknown_sigil_expr.ncl
@@ -1,0 +1,9 @@
+# capture = 'stderr'
+# command = ['export']
+# extra_args = [
+#  '--',
+#  'input."foo bar".baz=@what/attr:value',
+# ]
+{
+  input."foo bar".baz,
+} 

--- a/cli/tests/snapshot/snapshots/snapshot__export_stderr_sigil_missing_colon.ncl.snap
+++ b/cli/tests/snapshot/snapshots/snapshot__export_stderr_sigil_missing_colon.ncl.snap
@@ -1,0 +1,12 @@
+---
+source: cli/tests/snapshot/main.rs
+expression: err
+---
+error: missing sigil expression separator `:`
+  ┌─ <override input>:1:1
+  │
+1 │ @env_missing_value
+  │ ^^^^^^^^^^^^^^^^^^
+  │
+  = The CLI sigil expression syntax is `@<sigil>:<argument>` or `@<sigil>/<attribute>:<argument>`
+  = The given sigil expression is missing the `:` separator.

--- a/cli/tests/snapshot/snapshots/snapshot__export_stderr_sigil_missing_colon.ncl.snap
+++ b/cli/tests/snapshot/snapshots/snapshot__export_stderr_sigil_missing_colon.ncl.snap
@@ -8,5 +8,5 @@ error: missing sigil expression separator `:`
 1 │ @env_missing_value
   │ ^^^^^^^^^^^^^^^^^^
   │
-  = The CLI sigil expression syntax is `@<sigil>:<argument>` or `@<sigil>/<attribute>:<argument>`
-  = The given sigil expression is missing the `:` separator.
+  = The CLI sigil expression syntax is `@<selector>:<argument>` or `@<selector>/<attribute>:<argument>`
+  = The provided sigil expression is missing the `:` separator.

--- a/cli/tests/snapshot/snapshots/snapshot__export_stderr_unknown_sigil_attr.ncl.snap
+++ b/cli/tests/snapshot/snapshots/snapshot__export_stderr_unknown_sigil_attr.ncl.snap
@@ -1,0 +1,11 @@
+---
+source: cli/tests/snapshot/main.rs
+expression: err
+---
+error: unknown sigil attribute `attr`
+  ┌─ <override input."foo bar".baz>:1:6
+  │
+1 │ @env/attr:PATH
+  │      ^^^^ unknown attribute for sigil selector `env`
+  │
+  = No attributes are available for sigil selector `env`. Use the selector directly as in `@env:<argument>`

--- a/cli/tests/snapshot/snapshots/snapshot__export_stderr_unknown_sigil_expr.ncl.snap
+++ b/cli/tests/snapshot/snapshots/snapshot__export_stderr_unknown_sigil_expr.ncl.snap
@@ -1,0 +1,11 @@
+---
+source: cli/tests/snapshot/main.rs
+expression: err
+---
+error: unknown sigil selector `what`
+  ┌─ <override input."foo bar".baz>:1:2
+  │
+1 │ @what/attr:value
+  │  ^^^^
+  │
+  = Available selectors are currently: `env`

--- a/cli/tests/snapshot/snapshots/snapshot__export_stdout_help.ncl.snap
+++ b/cli/tests/snapshot/snapshots/snapshot__export_stdout_help.ncl.snap
@@ -23,6 +23,12 @@ Arguments:
           prevent shell interpretation.
           
           Example: `nickel eval config.ncl -- 'http.enabled="yes"' protocol=\'ftp`
+          
+          In addition to Nickel values, the left hand side of the assignment can be a special
+          expression introduced by the `@` sigil, with the syntax
+          `@<selector>[/<attribute>]:<argument>`.
+          
+          Example: `nickel eval config.ncl -- vars.home=@env:HOME vars.path=@env:PATH`
 
 Options:
       --override <FIELD_PATH=NICKEL_EXPRESSION>
@@ -38,4 +44,3 @@ Options:
           Print help (see a summary with '-h')
 
 WARNING: Customize mode is experimental. Its interface is subject to breaking changes.
-

--- a/cli/tests/snapshot/snapshots/snapshot__export_stdout_sigil_env.ncl.snap
+++ b/cli/tests/snapshot/snapshots/snapshot__export_stdout_sigil_env.ncl.snap
@@ -1,0 +1,9 @@
+---
+source: cli/tests/snapshot/main.rs
+expression: out
+---
+{
+  "env": {
+    "pkg": "nickel-lang-cli"
+  }
+}

--- a/core/src/error/mod.rs
+++ b/core/src/error/mod.rs
@@ -2169,8 +2169,8 @@ impl IntoDiagnostics for ParseError {
                 .with_message("missing sigil expression separator `:`")
                 .with_labels(vec![primary(&span)])
                 .with_notes(vec![
-                    "The CLI sigil expression syntax is `@<sigil>:<argument>` or `@<sigil>/<attribute>:<argument>`".to_owned(),
-                    "The given sigil expression is missing the `:` separator.".to_owned(),
+                    "The CLI sigil expression syntax is `@<selector>:<argument>` or `@<selector>/<attribute>:<argument>`".to_owned(),
+                    "The provided sigil expression is missing the `:` separator.".to_owned(),
                 ])
             }
         };


### PR DESCRIPTION
Closes #2043. This is starting from #2068, for environment variables only, which is the most useful and less controversial part.