### PR TITLE
Traverse enum variants

### DIFF
--- a/core/src/eval/mod.rs
+++ b/core/src/eval/mod.rs
@@ -1047,6 +1047,9 @@ impl<R: ImportResolver, C: Cache> VirtualMachine<R, C> {
                             }
                         }
                     }
+                    Term::EnumVariant { arg, .. } => {
+                        inner(slf, acc, arg.clone(), recursion_limit.saturating_sub(1));
+                    }
                     _ => {}
                 },
             }

--- a/core/src/term/mod.rs
+++ b/core/src/term/mod.rs
@@ -2402,6 +2402,10 @@ impl Traverse<RichTerm> for RichTerm {
 
                 RichTerm::new(Term::Type { typ, contract }, pos)
             }
+            Term::EnumVariant { tag, arg, attrs } => {
+                let arg = arg.traverse(f, order)?;
+                RichTerm::new(Term::EnumVariant { tag, attrs, arg }, pos)
+            }
             _ => rt,
         });
 

--- a/core/tests/integration/inputs/adts/enum_contract_propagation.ncl
+++ b/core/tests/integration/inputs/adts/enum_contract_propagation.ncl
@@ -1,0 +1,8 @@
+# test.type = 'error'
+# eval = 'full'
+#
+# [test.metadata]
+# error = 'EvalError::BlameError'
+
+# Check that contracts in enums are evaluated
+'Foo { bar = "hi" } | [| 'Foo { bar | Number } |]

--- a/core/tests/integration/inputs/adts/enum_wildcard_substitution.ncl
+++ b/core/tests/integration/inputs/adts/enum_wildcard_substitution.ncl
@@ -1,0 +1,7 @@
+# test.type = 'error'
+#
+# [test.metadata]
+# error = 'EvalError::BlameError'
+
+# Check that wildcards inside enum variants are substituted for their inferred type
+let f : [| 'Foo _ |] -> Number = match { 'Foo n => n } in f ('Foo "a")


### PR DESCRIPTION
This fixes an issue where contracts inside enum variants wouldn't get turned into runtime contracts. This PR also modifies nls's permissive evaluator to recurse into enum variants. (I was trying to fix #2180 but got distracted...)