### PR TITLE
ADT and package management improvements in nls

### DIFF
--- a/lsp/nls/src/analysis.rs
+++ b/lsp/nls/src/analysis.rs
@@ -158,6 +158,20 @@ impl<'ast> ParentLookup<'ast> {
 
                     TraverseControl::SkipBranch
                 }
+                Node::EnumVariant {
+                    tag,
+                    arg: Some(elt),
+                } => {
+                    let parent = Parent {
+                        ast,
+                        child_path: vec![EltId::Tag(tag.ident())],
+                    };
+                    elt.traverse_ref(
+                        &mut |ast, parent| traversal(ast, parent, acc),
+                        &Some(parent),
+                    );
+                    TraverseControl::SkipBranch
+                }
                 _ => TraverseControl::ContinueWithScope(Some(ast.into())),
             }
         }
@@ -239,7 +253,10 @@ impl<'ast> ParentChainIter<'ast, '_> {
 
             if !matches!(
                 &next.ast.node,
-                Node::Record(_) | Node::Annotated { .. } | Node::Array(..)
+                Node::Record(_)
+                    | Node::Annotated { .. }
+                    | Node::Array(..)
+                    | Node::EnumVariant { .. }
             ) && !matches!(&next.ast.node, Node::PrimOpApp { op, ..} if op.arity() == 2)
             {
                 self.rev_path = None;

--- a/lsp/nls/src/requests/completion.rs
+++ b/lsp/nls/src/requests/completion.rs
@@ -265,6 +265,7 @@ fn field_completion<'ast>(
     world: &'ast World,
     path: &[Ident],
 ) -> Vec<CompletionItem<'ast>> {
+    log::info!("field completion for {ast}");
     let resolver = FieldResolver::new(world);
     let mut records = resolver.resolve_record(ast);
 
@@ -291,6 +292,7 @@ fn field_completion<'ast>(
 }
 
 fn env_completion<'ast>(ast: &'ast Ast<'ast>, world: &'ast World) -> Vec<CompletionItem<'ast>> {
+    log::info!("env completion for {ast}");
     let env = world.analysis_reg.get_env(ast);
     env.map(|env| {
         env.iter_elems()

--- a/lsp/nls/tests/inputs/completion-inside-enum.ncl
+++ b/lsp/nls/tests/inputs/completion-inside-enum.ncl
@@ -1,0 +1,20 @@
+### /file.ncl
+{
+  a = 'Ok { ba },
+  b = 'Error { ba },
+  c = 'Nested { a = { inn } },
+} | { _ : [| 'Ok { bar }, 'Error { baz }, 'Nested { a | { inner } } |] }
+### [[request]]
+### type = "Completion"
+### textDocument.uri = "file:///file.ncl"
+### position = { line = 1, character = 14 }
+###
+### [[request]]
+### type = "Completion"
+### textDocument.uri = "file:///file.ncl"
+### position = { line = 2, character = 17 }
+###
+### [[request]]
+### type = "Completion"
+### textDocument.uri = "file:///file.ncl"
+### position = { line = 3, character = 25 }

--- a/lsp/nls/tests/inputs/package-manifest.ncl
+++ b/lsp/nls/tests/inputs/package-manifest.ncl
@@ -1,0 +1,16 @@
+### /main.ncl
+{
+  minimal_nickel_version = "1.10.0",
+  dependencies = {
+    foo = 'Index { pack, version = "1.2.0" },
+  }
+} | std.package.Manifest
+### [[request]]
+### type = "Completion"
+### textDocument.uri = "file:///main.ncl"
+### position = { line = 3, character = 23 }
+###
+### [[request]]
+### type = "Hover"
+### textDocument.uri = "file:///main.ncl"
+### position = { line = 1, character = 10 }

--- a/lsp/nls/tests/snapshots/main__lsp__nls__tests__inputs__completion-inside-enum.ncl.snap
+++ b/lsp/nls/tests/snapshots/main__lsp__nls__tests__inputs__completion-inside-enum.ncl.snap
@@ -1,0 +1,7 @@
+---
+source: lsp/nls/tests/main.rs
+expression: output
+---
+[bar]
+[baz]
+[inner]

--- a/lsp/nls/tests/snapshots/main__lsp__nls__tests__inputs__package-manifest.ncl.snap
+++ b/lsp/nls/tests/snapshots/main__lsp__nls__tests__inputs__package-manifest.ncl.snap
@@ -1,6 +1,5 @@
 ---
 source: lsp/nls/tests/main.rs
-assertion_line: 31
 expression: output
 ---
 [package (PackageId) [The dependency's identifier within the package index, in the format "github:<organization>/<repository>".], version (SemverReq) [The required version of the package.

--- a/lsp/nls/tests/snapshots/main__lsp__nls__tests__inputs__package-manifest.ncl.snap.new
+++ b/lsp/nls/tests/snapshots/main__lsp__nls__tests__inputs__package-manifest.ncl.snap.new
@@ -1,0 +1,26 @@
+---
+source: lsp/nls/tests/main.rs
+assertion_line: 31
+expression: output
+---
+[package (PackageId) [The dependency's identifier within the package index, in the format "github:<organization>/<repository>".], version (SemverReq) [The required version of the package.
+
+Nickel supports two kinds of requirements: semver-compatible
+requirements and exact version requirements. Semver-compatible
+requirements take the form "major.minor.patch", where minor and patch
+are optional. Their semantics are:
+
+- "1.2.3" will match all versions having major version 1, minor version 2,
+  and patch version at least 3.
+- "1.2" will match all versions having major version 1 and minor version
+  at least 2.
+- "1" will match all versions having major version 1.
+- a semver-compatible requirement will never match a prerelease version.
+
+Exact version requirements take the form "=major.minor.patch-pre", where
+the prerelease tag is optional, but major, minor, and patch are all required.]]
+<1:2-1:24>[```nickel
+SemverPrefix
+```, ```nickel
+String
+```, The minimal nickel version required for this package.]


### PR DESCRIPTION
This PR combines two things that together improve the experience of editing package manifests (and other things too, probably).

The first improvement allows enum tags in parent/child paths. This means that the two "foo"s in `'Ok { foo } | [| 'Ok { foo } |]` are considered "cousin defs", which allows completions and metadata to propagate between them.

The second improvement fixes the resolution (in nls's analysis) of the name "std" from within the standard library. Previously it would fail to resolve, breaking the various parts of `std.package.Manifest` that refer to other things in `std`.