### PR TITLE
Update release script to accomodate new crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3424,7 +3424,7 @@ dependencies = [
 
 [[package]]
 name = "nickel-lang-package"
-version = "1.10.0"
+version = "0.1.0"
 dependencies = [
  "anyhow",
  "directories",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ readme = "README.md"
 nickel-lang-core = { version = "0.11.0", path = "./core", default-features = false }
 nickel-lang-flock = { version = "0.1.0", path = "./flock" }
 nickel-lang-git = { version = "0.1.0", path = "./git" }
-nickel-lang-package = { version = "1.9.0", path = "./package" }
+nickel-lang-package = { version = "0.1.0", path = "./package" }
 nickel-lang-vector = { version = "0.1.0", path = "./vector" }
 nickel-lang-utils = { version = "0.1.0", path = "./utils" }
 lsp-harness = { version = "0.1.0", path = "./lsp/lsp-harness" }

--- a/package/Cargo.toml
+++ b/package/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "nickel-lang-package"
-description = "The Nickel Package Manager (npm)"
-version.workspace = true
+description = "Utility library for the Nickel Package Manager"
+version = "0.1.0"
 
 authors.workspace = true
 edition.workspace = true


### PR DESCRIPTION
Preparing for the 1.11 release.

With the package manager come new crates in the workspace.

This commit updates the release script to properly include them (untested), and also fixes the versioning of `nickel-lang-package` which was following the workspace version (maybe because it was originally intended as a separate tool?), but should probably follow its own versioning, as all the other Nickel libraries do (`git`, `flock`, `vector`)