### PR TITLE
Don't quote enum tag keywords

### DIFF
--- a/cli/tests/snapshot/inputs/pretty/id_quoting.ncl
+++ b/cli/tests/snapshot/inputs/pretty/id_quoting.ncl
@@ -1,0 +1,10 @@
+# capture = 'stdout'
+# command = ['pprint-ast']
+{
+  "a field" = 1,
+  "Number" = 1,
+  bar = 'if,
+  foo = bar |> match { 'if => 1, '"has space" => 0 },
+  has_space = '"hi there",
+  annotated | [| 'if, 'then, '"has space" |],
+}."a field"

--- a/cli/tests/snapshot/snapshots/snapshot__pprint-ast_stdout_id_quoting.ncl.snap
+++ b/cli/tests/snapshot/snapshots/snapshot__pprint-ast_stdout_id_quoting.ncl.snap
@@ -1,0 +1,12 @@
+---
+source: cli/tests/snapshot/main.rs
+expression: out
+---
+{
+  "Number" = 1,
+  "a field" = 1,
+  annotated | [| 'if, 'then, '"has space" |],
+  bar = 'if,
+  foo = (match { 'if => 1, '"has space" => 0, }) bar,
+  has_space = '"hi there",
+}."a field"

--- a/doc/manual/contracts.md
+++ b/doc/manual/contracts.md
@@ -1159,10 +1159,10 @@ will check if the provided value has a matching `tag` immediately.
   ]
 
 > { tag = 'Number, value = 1+1 } | NumberOrString
-{ tag = '"Number", value | Number = 2, }
+{ tag = 'Number, value | Number = 2, }
 
 > { tag = 'String, value = "hello"} | NumberOrString
-{ tag = '"String", value | String = "hello", }
+{ tag = 'String, value | String = "hello", }
 
 > { tag = 'Number, value = "hello"} | NumberOrString
 error: contract broken by the value of `value`


### PR DESCRIPTION
Enum tags are allowed to be Nickel keywords without any special quoting: `'if` and `'then` are totally fine, for example. This PR relaxes the pretty-printer to avoid quoting enum tags unless they actually need it.

I noticed this extra quoting in the [stdlib](https://nickel-lang.org/stdlib/std) docs for `std.cast`, which looks like
```nickel
cast : Dyn -> [| '"Number" Number, '"Bool" Bool, '"String" String, 'Enum Dyn, 'Label Dyn, 'Function ( Dyn -> Dyn ), '"Array" ( Array Dyn ), 'Record ( { _ : Dyn } ), 'ForeignId Dyn, 'CustomContract Dyn, 'Type Dyn, 'Other Dyn |]
```
(note the unnecessary quotes around, e.g. `Number`)