### PR TITLE
Negation error messages

### DIFF
--- a/cli/tests/snapshot/inputs/errors/no_internals_when_currying.ncl
+++ b/cli/tests/snapshot/inputs/errors/no_internals_when_currying.ncl
@@ -1,0 +1,4 @@
+# capture = 'stderr'
+# command = ['eval']
+let add : Number -> Number -> Number = fun x y => x + y in
+add 1 - 1

--- a/cli/tests/snapshot/snapshots/snapshot__eval_stderr_no_internals_when_currying.ncl.snap
+++ b/cli/tests/snapshot/snapshots/snapshot__eval_stderr_no_internals_when_currying.ncl.snap
@@ -1,0 +1,15 @@
+---
+source: cli/tests/snapshot/main.rs
+expression: err
+---
+error: dynamic type error
+  ┌─ [INPUTS_PATH]/errors/no_internals_when_currying.ncl:4:1
+  │
+4 │ add 1 - 1
+  │ ^^^^^----
+  │ │
+  │ this expression was parsed as a binary subtraction
+  │ this expression has type Function, but Number was expected
+  │
+  = (-) expects its 1st argument to be a Number
+  = for unary negation, add parentheses: write `(-42)` instead of `-42`

--- a/core/src/error/mod.rs
+++ b/core/src/error/mod.rs
@@ -1238,13 +1238,13 @@ impl IntoDiagnostics for EvalError {
                     (Some(span_orig), Some(span_t)) if span_orig == span_t => {
                         vec![primary(&span_orig).with_message(label)]
                     }
-                    (Some(span_orig), Some(_)) => {
+                    (Some(span_orig), Some(t_pos)) if !files.is_stdlib(t_pos.src_id) => {
                         vec![
                             primary(&span_orig).with_message(label),
                             secondary_term(&t, files).with_message("evaluated to this"),
                         ]
                     }
-                    (Some(span), None) => {
+                    (Some(span), _) => {
                         vec![primary(&span).with_message(label)]
                     }
                     (None, Some(span)) => {

--- a/core/src/eval/operation.rs
+++ b/core/src/eval/operation.rs
@@ -1293,12 +1293,12 @@ impl<R: ImportResolver, C: Cache> VirtualMachine<R, C> {
                     ))
                 } else {
                     // Not using mk_type_error! because of a non-uniform message
-                    Err(EvalError::TypeError(
-                        String::from("String"),
-                        String::from("eval_nix takes a string of nix code as an argument"),
-                        arg_pos,
-                        RichTerm { term: t, pos },
-                    ))
+                    Err(EvalError::TypeError {
+                        expected: String::from("String"),
+                        message: String::from("eval_nix takes a string of nix code as an argument"),
+                        orig_pos: arg_pos,
+                        term: RichTerm { term: t, pos },
+                    })
                 }
             }
             UnaryOp::EnumGetArg => {

--- a/core/src/eval/operation.rs
+++ b/core/src/eval/operation.rs
@@ -202,6 +202,7 @@ impl<R: ImportResolver, C: Cache> VirtualMachine<R, C> {
                     arg_number: $arg_number,
                     arg_pos,
                     arg_evaluated: RichTerm { term: t, pos },
+                    op_pos: pos_op,
                 })
             };
         }
@@ -1600,6 +1601,7 @@ impl<R: ImportResolver, C: Cache> VirtualMachine<R, C> {
                         term: $term,
                         pos: $pos,
                     },
+                    op_pos: pos_op,
                 })
             };
             ($expected:expr, $arg_number:expr, $term:expr, $pos:expr) => {
@@ -3158,6 +3160,7 @@ impl<R: ImportResolver, C: Cache> VirtualMachine<R, C> {
                 arg_number,
                 arg_pos,
                 arg_evaluated: RichTerm { term, pos },
+                op_pos: pos_op,
             })
         };
 

--- a/core/src/eval/operation.rs
+++ b/core/src/eval/operation.rs
@@ -225,12 +225,14 @@ impl<R: ImportResolver, C: Cache> VirtualMachine<R, C> {
                     }
                 } else {
                     // Not using mk_type_error! because of a non-uniform message
-                    Err(EvalError::TypeError(
-                        String::from("Bool"),
-                        String::from("the condition in an if expression must have type Bool"),
-                        arg_pos,
-                        RichTerm { term: t, pos },
-                    ))
+                    Err(EvalError::TypeError {
+                        expected: String::from("Bool"),
+                        message: String::from(
+                            "the condition in an if expression must have type Bool",
+                        ),
+                        orig_pos: arg_pos,
+                        term: RichTerm { term: t, pos },
+                    })
                 }
             }
             UnaryOp::Typeof => {
@@ -474,12 +476,12 @@ impl<R: ImportResolver, C: Cache> VirtualMachine<R, C> {
                     }
                 } else {
                     // Not using mk_type_error! because of a non-uniform message
-                    Err(EvalError::TypeError(
-                        String::from("Record"),
-                        String::from("field access only makes sense for records"),
-                        arg_pos,
-                        RichTerm { term: t, pos },
-                    ))
+                    Err(EvalError::TypeError {
+                        expected: String::from("Record"),
+                        message: String::from("field access only makes sense for records"),
+                        orig_pos: arg_pos,
+                        term: RichTerm { term: t, pos },
+                    })
                 }
             }
             UnaryOp::RecordFields(op_kind) => match_sharedterm!(match (t) {
@@ -802,12 +804,12 @@ impl<R: ImportResolver, C: Cache> VirtualMachine<R, C> {
                     // the remaining string chunks.
                     //
                     // Not using mk_type_error! because of a non-uniform message
-                    Err(EvalError::TypeError(
-                        String::from("Stringable"),
-                        String::from("interpolated values must be Stringable (string, number, boolean, enum tag or null)"),
-                        curr_pos,
-                        RichTerm { term: t, pos },
-                    ))
+                    Err(EvalError::TypeError {
+                        expected: String::from("Stringable"),
+                        message: String::from("interpolated values must be Stringable (string, number, boolean, enum tag or null)"),
+                        orig_pos: curr_pos,
+                        term: RichTerm { term: t, pos },
+                    })
                 }
             }
             UnaryOp::StringTrim => {
@@ -2301,15 +2303,15 @@ impl<R: ImportResolver, C: Cache> VirtualMachine<R, C> {
                             }
                         } else {
                             // Not using mk_type_error! because of a non-uniform message
-                            Err(EvalError::TypeError(
-                                String::from("Record"),
-                                String::from("field access only makes sense for records"),
-                                snd_pos,
-                                RichTerm {
+                            Err(EvalError::TypeError {
+                                expected: String::from("Record"),
+                                message: String::from("field access only makes sense for records"),
+                                orig_pos: snd_pos,
+                                term: RichTerm {
                                     term: t2,
                                     pos: pos2,
                                 },
-                            ))
+                            })
                         }
                     }
                     // This error should be impossible to trigger. The parser

--- a/core/tests/integration/main.rs
+++ b/core/tests/integration/main.rs
@@ -242,7 +242,7 @@ impl PartialEq<Error> for ErrorExpectation {
                 EvalIllegalPolymorphicTailAccess,
                 Error::EvalError(EvalError::IllegalPolymorphicTailAccess { .. }),
             )
-            | (EvalTypeError, Error::EvalError(EvalError::TypeError(..)))
+            | (EvalTypeError, Error::EvalError(EvalError::TypeError { .. }))
             | (EvalIncomparableValues, Error::EvalError(EvalError::IncomparableValues { .. }))
             | (EvalNAryPrimopTypeError, Error::EvalError(EvalError::NAryPrimopTypeError { .. }))
             | (


### PR DESCRIPTION
This improves error messages in two ways:

- it suppresses the evaluated form for type errors, if that evaluated form points to internals.
- it adds a special-case note for subtraction type errors, if the first argument is a function. The hope is that this case is mostly triggered by errors like `add 1 -1`, parsed as `(add 1) - 1`.

The second point could have  fewer false positives if we had access to the span of the `-`, because then we could only add the hint if there was no space between `-` and its right argument. Unfortunately, that span is dropped during parsing so it would be a bit invasive to thread it through.

Before:
```
   ┌─ /home/jneeman/tweag/nickel/test.ncl:2:1
   │
 2 │ add 1 -1
   │ ^^^^^ this expression has type Function, but Number was expected
   │
   ┌─ <stdlib/internals.ncl>:80:13
   │
80 │           'Ok (fun x =>
   │ ╭─────────────'
81 │ │           value (
82 │ │             %contract/apply%
83 │ │               Domain
   · │
86 │ │           )
87 │ │         )
   │ ╰─────────' evaluated to this
   │
   = (-) expects its 1st argument to be a Number
```

After:
```
error: dynamic type error
  ┌─ /home/jneeman/tweag/nickel/test.ncl:2:1
  │
2 │ add 1 -1
  │ ^^^^^---
  │ │
  │ this expression was parsed as a binary subtraction
  │ this expression has type Function, but Number was expected
  │
  = (-) expects its 1st argument to be a Number
  = for unary negation, add parentheses: write `(-42)` instead of `-42`
```