### PR TITLE
Add context to error opening trace file in nls

### DIFF
--- a/lsp/nls/src/main.rs
+++ b/lsp/nls/src/main.rs
@@ -1,4 +1,8 @@
-use std::{fs, io, path::PathBuf, thread};
+use std::{
+    fs, io,
+    path::{self, PathBuf},
+    thread,
+};
 
 use anyhow::Result;
 
@@ -81,12 +85,16 @@ fn run() -> Result<()> {
     }
 
     if let Some(file) = options.trace {
-        debug!("Writing trace to {:?}", file.canonicalize()?);
+        let absolute_path = path::absolute(&file)?;
+        debug!("Writing trace to {:?}", absolute_path);
         Trace::set_writer(csv::Writer::from_writer(io::BufWriter::new(
             fs::OpenOptions::new()
                 .append(true)
                 .create(true)
-                .open(file)?,
+                .open(file)
+                .map_err(|e| {
+                    anyhow::anyhow!("Failed to open trace file {:?}: {}", absolute_path, e)
+                })?,
         )))?;
     }
 


### PR DESCRIPTION
This improves the error logging when nls is started with an invalid trace option. Right now the output of nls when starting it with a path that doesn't exist is:
```
$ nls --trace MissingDir/trace
Error: No such file or directory (os error 2) 
```
I ran into an issue where I had accidentally entered some input into the trace setting in the VSCode extension and it was pretty difficult to figure out what was going on from that message.

This PR improves the logging in a couple of ways:
- ```file.canonicalize()``` uses filesystem access to resolve symlinks, meaning that nls crashes there without ever printing the debug statement. I've changed that to path::absolute which does not access the filesystem.
- If nls fails to open the trace file, it will return the attempted file path along with the error.