### PR TITLE
Refactor Environment.

### DIFF
--- a/core/src/environment.rs
+++ b/core/src/environment.rs
@@ -1,5 +1,5 @@
 //! An environment for storing variables with scopes.
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::hash::Hash;
 use std::iter::FromIterator;
 use std::rc::Rc;
@@ -173,30 +173,6 @@ impl<'a, K: 'a + Hash + Eq, V: 'a + PartialEq> Iterator for EnvLayerIter<'a, K, 
             self.env = env.previous.as_deref();
             res
         })
-    }
-}
-
-/// An iterator over the elements of an `Environment`, from current layer to oldest one.
-/// Keys are guaranteed to appear only once, with actual value.
-///
-/// Created by the [`iter`] method on [`Environment`].
-///
-/// [`iter`]: Environment::iter
-///
-pub struct EnvIter<'a, K: 'a + Hash + Eq, V: 'a + PartialEq> {
-    seen: HashSet<&'a K>,
-    elems: std::iter::Flatten<EnvLayerIter<'a, K, V>>,
-}
-
-impl<'a, K: 'a + Hash + Eq, V: 'a + PartialEq> Iterator for EnvIter<'a, K, V> {
-    type Item = (&'a K, &'a V);
-
-    fn next(&mut self) -> Option<Self::Item> {
-        let mut elt = self.elems.next()?;
-        while !self.seen.insert(elt.0) {
-            elt = self.elems.next()?;
-        }
-        Some(elt)
     }
 }
 

--- a/core/src/eval/mod.rs
+++ b/core/src/eval/mod.rs
@@ -617,7 +617,6 @@ impl<R: ImportResolver, C: Cache> VirtualMachine<R, C> {
                         env.insert(x.ident(), idx);
                     }
 
-                    let names = env.iter_elems().map(|(k, _v)| k).collect::<Vec<_>>();
                     for idx in indices {
                         self.cache.patch(idx, |cl| cl.env = env.clone());
                     }


### PR DESCRIPTION
Removes unsafe code, and also makes Environment covariant.

When trying to use ouroboros in nls, I ran into the problem that Environment isn't covariant, because it uses a RefCell internally to do copy-on-write. I don't really understand why though: it seems more natural to do the copy-on-writing during `insert`, where we have a mutable reference already and don't need interior mutability.

So this PR makes that change, and also removes some unsafe code that doesn't seem necessary. Local benchmarks suggest a small speed-up, if we can believe them.