### PR TITLE
Make sure to keep Records Records while preparing test

### DIFF
--- a/cli/tests/snapshot/inputs/doctest/record_regression.ncl
+++ b/cli/tests/snapshot/inputs/doctest/record_regression.ncl
@@ -1,0 +1,13 @@
+# capture = 'all'
+# command = ['test']
+
+# Regression test for #2248
+let types = {
+  ServiceKind = [| 'Dns |],
+  mk_Server | ServiceKind -> { kind }
+    = fun kind_  => { kind = kind_ },
+}
+in
+{
+  MyDnsServer = types.mk_Server 'Dns
+}

--- a/cli/tests/snapshot/snapshots/snapshot__test_stderr_record_regression.ncl.snap
+++ b/cli/tests/snapshot/snapshots/snapshot__test_stderr_record_regression.ncl.snap
@@ -1,0 +1,5 @@
+---
+source: cli/tests/snapshot/main.rs
+expression: err
+---
+

--- a/cli/tests/snapshot/snapshots/snapshot__test_stdout_record_regression.ncl.snap
+++ b/cli/tests/snapshot/snapshots/snapshot__test_stdout_record_regression.ncl.snap
@@ -1,0 +1,5 @@
+---
+source: cli/tests/snapshot/main.rs
+expression: out
+---
+


### PR DESCRIPTION
Fixes #2248.

The test preparation transform had the side effect of turning Records into RecRecords. This should be fine most of the time, but pattern compilation creates records and then match eval assumes that it has records.