### PR TITLE
[Feat] Support annotations on included expressions

### DIFF
--- a/cli/src/query.rs
+++ b/cli/src/query.rs
@@ -81,7 +81,7 @@ impl From<Field> for QueryResult {
                 }
                 Term::RecRecord(record, includes, dyn_fields, ..) if !record.fields.is_empty() => {
                     let mut fields: Vec<_> = record.fields.keys().map(LocIdent::ident).collect();
-                    fields.extend(includes.iter().map(LocIdent::ident));
+                    fields.extend(includes.iter().map(|incl| incl.ident.ident()));
                     fields.sort();
                     let dynamic = Ident::from("<dynamic>");
                     fields.extend(dyn_fields.iter().map(|_| dynamic));

--- a/cli/tests/snapshot/inputs/query/query_included_field.ncl
+++ b/cli/tests/snapshot/inputs/query/query_included_field.ncl
@@ -1,0 +1,5 @@
+# capture = 'stdout'
+# command = [ 'query', '--field', 'x.y', '--format', 'json' ]
+let y = 1 in
+let x = { include y | doc "Doc of y" | default } in
+{ include x }

--- a/cli/tests/snapshot/snapshots/snapshot__query_stdout_query_included_field.ncl.snap
+++ b/cli/tests/snapshot/snapshots/snapshot__query_stdout_query_included_field.ncl.snap
@@ -1,0 +1,11 @@
+---
+source: cli/tests/snapshot/main.rs
+expression: out
+---
+{
+  "doc": "Doc of y",
+  "optional": false,
+  "not_exported": false,
+  "priority": "default",
+  "value": "1"
+}

--- a/core/src/bytecode/ast/alloc.rs
+++ b/core/src/bytecode/ast/alloc.rs
@@ -25,6 +25,7 @@ impl Allocable for Record<'_> {}
 impl Allocable for record::FieldPathElem<'_> {}
 impl Allocable for record::FieldDef<'_> {}
 impl Allocable for record::FieldMetadata<'_> {}
+impl Allocable for record::Include<'_> {}
 
 impl Allocable for Pattern<'_> {}
 impl Allocable for EnumPattern<'_> {}
@@ -215,7 +216,7 @@ impl AstAlloc {
     ) -> &'ast Record<'ast>
     where
         Ds: IntoIterator<Item = FieldDef<'ast>>,
-        Is: IntoIterator<Item = LocIdent>,
+        Is: IntoIterator<Item = Include<'ast>>,
         Ds::IntoIter: ExactSizeIterator,
         Is::IntoIter: ExactSizeIterator,
     {
@@ -499,12 +500,28 @@ impl CloneTo for LetMetadata<'_> {
     }
 }
 
+impl CloneTo for Include<'_> {
+    type Data<'ast> = Include<'ast>;
+
+    fn clone_to<'to>(data: Self::Data<'_>, dest: &'to AstAlloc) -> Self::Data<'to> {
+        Include {
+            ident: data.ident,
+            metadata: FieldMetadata::clone_to(data.metadata, dest),
+        }
+    }
+}
+
 impl CloneTo for Record<'_> {
     type Data<'ast> = Record<'ast>;
 
     fn clone_to<'to>(data: Self::Data<'_>, dest: &'to AstAlloc) -> Self::Data<'to> {
         Record {
-            includes: dest.alloc_many(data.includes.iter().cloned()),
+            includes: dest.alloc_many(
+                data.includes
+                    .iter()
+                    .cloned()
+                    .map(|include| Include::clone_to(include, dest)),
+            ),
             field_defs: dest.alloc_many(
                 data.field_defs
                     .iter()

--- a/core/src/bytecode/ast/builder.rs
+++ b/core/src/bytecode/ast/builder.rs
@@ -27,7 +27,7 @@
 use crate::identifier::Ident;
 
 use super::{
-    record::{FieldMetadata, FieldPathElem, MergePriority},
+    record::{FieldMetadata, FieldPathElem, Include, MergePriority},
     typ::Type,
     *,
 };
@@ -239,7 +239,7 @@ impl<'ast> Field<'ast, Record<'ast>> {
 #[derive(Debug, Default)]
 pub struct Record<'ast> {
     field_defs: Vec<record::FieldDef<'ast>>,
-    includes: Vec<LocIdent>,
+    includes: Vec<Include<'ast>>,
     open: bool,
 }
 
@@ -273,8 +273,13 @@ impl<'ast> Record<'ast> {
     }
 
     /// Adds an `include` expression (define a field by taking it from the outer environment).
-    pub fn include(mut self, id: LocIdent) -> Self {
-        self.includes.push(id);
+    pub fn include(mut self, ident: LocIdent) -> Self {
+        self.include_with_metadata(ident, Default::default())
+    }
+
+    /// Adds an `include` expression with associated metadata.
+    pub fn include_with_metadata(mut self, ident: LocIdent, metadata: FieldMetadata<'ast>) -> Self {
+        self.includes.push(Include { ident, metadata });
         self
     }
 

--- a/core/src/bytecode/ast/builder.rs
+++ b/core/src/bytecode/ast/builder.rs
@@ -273,7 +273,7 @@ impl<'ast> Record<'ast> {
     }
 
     /// Adds an `include` expression (define a field by taking it from the outer environment).
-    pub fn include(mut self, ident: LocIdent) -> Self {
+    pub fn include(self, ident: LocIdent) -> Self {
         self.include_with_metadata(ident, Default::default())
     }
 

--- a/core/src/bytecode/ast/compat.rs
+++ b/core/src/bytecode/ast/compat.rs
@@ -1405,7 +1405,7 @@ impl<'ast> FromAst<Node<'ast>> for term::Term {
                     data,
                     record
                         .includes
-                        .into_iter()
+                        .iter()
                         .map(|incl| incl.to_mainline())
                         .collect(),
                     dyn_fields,

--- a/core/src/bytecode/ast/compat.rs
+++ b/core/src/bytecode/ast/compat.rs
@@ -198,6 +198,15 @@ impl<'ast> FromMainline<'ast, term::record::FieldMetadata> for record::FieldMeta
     }
 }
 
+impl<'ast> FromMainline<'ast, term::record::Include> for record::Include<'ast> {
+    fn from_mainline(alloc: &'ast AstAlloc, mainline: &term::record::Include) -> Self {
+        record::Include {
+            ident: mainline.ident,
+            metadata: mainline.metadata.to_ast(alloc),
+        }
+    }
+}
+
 impl<'ast> FromMainline<'ast, mline_type::Type> for Type<'ast> {
     fn from_mainline(alloc: &'ast AstAlloc, mainline: &mline_type::Type) -> Self {
         Type {
@@ -399,7 +408,7 @@ impl<'ast> FromMainline<'ast, term::Term> for Node<'ast> {
 
                 alloc.record(Record {
                     field_defs: alloc.alloc_many(field_defs),
-                    includes: alloc.alloc_many(includes.iter().copied()),
+                    includes: alloc.alloc_many(includes.iter().map(|incl| incl.to_ast(alloc))),
                     open: data.attrs.open,
                 })
             }
@@ -983,6 +992,15 @@ impl<'ast> FromAst<record::FieldMetadata<'ast>> for term::record::FieldMetadata 
     }
 }
 
+impl<'ast> FromAst<record::Include<'ast>> for term::record::Include {
+    fn from_ast(incl: &record::Include<'ast>) -> Self {
+        term::record::Include {
+            ident: incl.ident,
+            metadata: incl.metadata.to_mainline(),
+        }
+    }
+}
+
 impl<'ast> FromAst<Type<'ast>> for mline_type::Type {
     fn from_ast(typ: &Type<'ast>) -> Self {
         mline_type::Type {
@@ -1383,7 +1401,16 @@ impl<'ast> FromAst<Node<'ast>> for term::Term {
             }
             Node::Record(record) => {
                 let (data, dyn_fields) = (*record).to_mainline();
-                Term::RecRecord(data, record.includes.to_vec(), dyn_fields, None)
+                Term::RecRecord(
+                    data,
+                    record
+                        .includes
+                        .into_iter()
+                        .map(|incl| incl.to_mainline())
+                        .collect(),
+                    dyn_fields,
+                    None,
+                )
             }
             Node::IfThenElse {
                 cond,

--- a/core/src/bytecode/ast/record.rs
+++ b/core/src/bytecode/ast/record.rs
@@ -159,11 +159,20 @@ impl<'ast> From<Annotation<'ast>> for FieldMetadata<'ast> {
     }
 }
 
+/// An include expression.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Include<'ast> {
+    /// The included identifier.
+    pub ident: LocIdent,
+    /// The field metadata.
+    pub metadata: FieldMetadata<'ast>,
+}
+
 /// A nickel record literal.
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct Record<'ast> {
-    /// `include` statements.
-    pub includes: &'ast [LocIdent],
+    /// `include` expressions.
+    pub includes: &'ast [Include<'ast>],
     /// Field definitions.
     pub field_defs: &'ast [FieldDef<'ast>],
     /// If the record is open, i.e. if it ended with `..`.

--- a/core/src/bytecode/pretty.rs
+++ b/core/src/bytecode/pretty.rs
@@ -315,7 +315,14 @@ impl Allocator {
                             // For now we don't need to escape the included id, as it must be a
                             // valid variable name, and thus can't contain non-identifier
                             // characters such as spaces.
-                            .map(|id| { docs![alloc, "include ", id.to_string()] }),
+                            .map(|include| {
+                                docs![
+                                    alloc,
+                                    "include ",
+                                    include.ident.to_string(),
+                                    self.field_metadata(&include.metadata, true)
+                                ]
+                            }),
                         docs![alloc, ",", alloc.line()]
                     ),
                     if !record.includes.is_empty() {

--- a/core/src/bytecode/pretty.rs
+++ b/core/src/bytecode/pretty.rs
@@ -318,7 +318,8 @@ impl Allocator {
                             .map(|include| {
                                 docs![
                                     alloc,
-                                    "include ",
+                                    "include",
+                                    alloc.space(),
                                     include.ident.to_string(),
                                     self.field_metadata(&include.metadata, true)
                                 ]
@@ -326,7 +327,7 @@ impl Allocator {
                         docs![alloc, ",", alloc.line()]
                     ),
                     if !record.includes.is_empty() {
-                        alloc.line()
+                        docs![alloc, ",", alloc.line()]
                     } else {
                         alloc.nil()
                     },

--- a/core/src/eval/mod.rs
+++ b/core/src/eval/mod.rs
@@ -1139,7 +1139,7 @@ impl<C: Cache> VirtualMachine<ImportCaches, C> {
         Ok(())
     }
 
-    /// Generate an initial evaluation environment from the stdlib from  the underlying import
+    /// Generate an initial evaluation environment from the stdlib from the underlying import
     /// cache and eval cache.
     pub fn mk_eval_env(&mut self) -> Environment {
         self.import_resolver.mk_eval_env(&mut self.cache)

--- a/core/src/parser/grammar.lalrpop
+++ b/core/src/parser/grammar.lalrpop
@@ -429,9 +429,9 @@ UniRecord: UniRecord<'ast> = {
         //
         // Note that `LocIdent`'s hash function doesn't take the location into
         // account, only the identifier, which is what we want. This means
-        // retrieving the same `LocIdent` from one one set or the other will
-        // actually idents with different positions, which is meaningful for
-        // error reporting.
+        // retrieving the same `LocIdent` from one set or the other will
+        // actually return idents with different positions, and this difference
+        // is meaningful for error reporting.
         let mut defs_seen = HashSet::new();
         let mut includes_seen : HashSet<LocIdent> = HashSet::new();
 

--- a/core/src/parser/grammar.lalrpop
+++ b/core/src/parser/grammar.lalrpop
@@ -60,7 +60,7 @@ use crate::{
     bytecode::ast::{
         Ast, Node, Annotation, LetMetadata, AstAlloc, LetBinding, MatchBranch,
         builder, StringChunk, MergePriority, Number, TryConvert,
-        record::{FieldMetadata, FieldDef, FieldPathElem},
+        record::{FieldMetadata, FieldDef, FieldPathElem, Include},
         pattern::*,
         typ::*,
         primop::{PrimOp, RecordOpKind},
@@ -423,27 +423,33 @@ UniRecord: UniRecord<'ast> = {
         let mut includes = Vec::new();
 
         // For now, we don't accept piecewise definitions involving both an
-        // include and a field definition. We maintain a set of definition and
+        // include and a field definition. We maintain a set of definitions and
         // includes that we've seen and check at the end that the intersection
         // is empty.
-        let mut def_fields = HashSet::new();
-        let mut include_fields : HashSet<LocIdent> = HashSet::new();
+        //
+        // Note that `LocIdent`'s hash function doesn't take the location into
+        // account, only the identifier, which is what we want. This means
+        // retrieving the same `LocIdent` from one one set or the other will
+        // actually idents with different positions, which is meaningful for
+        // error reporting.
+        let mut defs_seen = HashSet::new();
+        let mut includes_seen : HashSet<LocIdent> = HashSet::new();
 
-        let mut handle_include = |id: LocIdent| -> Result<(), _> {
-            if let Some(prev_id) = include_fields.get(&id) {
+        let mut handle_include = |include: Include<'ast>| -> Result<(), _> {
+            if let Some(prev_id) = includes_seen.get(&include.ident) {
                 return Err(lalrpop_util::ParseError::User {
                     error: ParseError::MultipleFieldDecls {
-                        ident: id.ident(),
+                        ident: include.ident.ident(),
                         // unwrap(): we expect positions to be defined for
                         // freshly parsed ident
                         include_span: prev_id.pos.unwrap(),
-                        other_span: id.pos.unwrap(),
+                        other_span: include.ident.pos.unwrap(),
                     }
                 });
             }
 
-            include_fields.insert(id);
-            includes.push(id);
+            includes_seen.insert(include.ident);
+            includes.push(include);
             Ok(())
         };
 
@@ -453,7 +459,7 @@ UniRecord: UniRecord<'ast> = {
         {
             match decl {
                 FieldDecl::Def(field_def) => {
-                    def_fields.extend(field_def.root_as_ident());
+                    defs_seen.extend(field_def.root_as_ident());
                     fields.push(field_def);
                 },
                 FieldDecl::Include(id) => {
@@ -467,7 +473,7 @@ UniRecord: UniRecord<'ast> = {
             }
         }
 
-        if let Some(id) = def_fields.intersection(&include_fields).next() {
+        if let Some(id) = defs_seen.intersection(&includes_seen).next() {
             Err(lalrpop_util::ParseError::User {
                 error: ParseError::MultipleFieldDecls {
                     ident: id.ident(),
@@ -475,8 +481,8 @@ UniRecord: UniRecord<'ast> = {
                     // sets since it's in the intersection
                     // unwrap(): we expect positions to be defined for
                     // freshly parsed ident
-                    include_span: include_fields.get(id).unwrap().pos.unwrap(),
-                    other_span: def_fields.get(id).unwrap().pos.unwrap(),
+                    include_span: includes_seen.get(id).unwrap().pos.unwrap(),
+                    other_span: defs_seen.get(id).unwrap().pos.unwrap(),
                 }
             })
         }
@@ -519,10 +525,16 @@ Atom: UniTerm<'ast> = {
 };
 
 // An `include` expression in a record literal.
-RecordInclude: LocIdent = "include" <ExtendedIdent>;
+RecordInclude: Include<'ast> =
+    "include" <ident: ExtendedIdent> <ann: FieldAnnot<Type>?> =>
+        Include { ident, metadata: ann.unwrap_or_default() };
 
 // Multiple `include` expressions using the list syntax in a record literal.
-RecordIncludeList: Vec<LocIdent> = "include" <List<ExtendedIdent>>;
+RecordIncludeList: Vec<Include<'ast>> = "include" <List<ExtendedIdent>> =>
+    <>
+        .into_iter()
+        .map(|ident| Include { ident, metadata: FieldMetadata::default() })
+        .collect();
 
 
 // A record field declaration, that can be either a standard field definition or

--- a/core/src/parser/grammar.lalrpop
+++ b/core/src/parser/grammar.lalrpop
@@ -526,7 +526,10 @@ Atom: UniTerm<'ast> = {
 
 // An `include` expression in a record literal.
 RecordInclude: Include<'ast> =
-    "include" <ident: ExtendedIdent> <ann: FieldAnnot<Type>?> =>
+    // Note that we use a fixed type here: a record literal with an include
+    // expressions will never be interpreted as a record type, so we can fix its
+    // annotation right away.
+    "include" <ident: ExtendedIdent> <ann: FieldAnnot<FixedType>?> =>
         Include { ident, metadata: ann.unwrap_or_default() };
 
 // Multiple `include` expressions using the list syntax in a record literal.

--- a/core/src/parser/uniterm.rs
+++ b/core/src/parser/uniterm.rs
@@ -6,7 +6,7 @@ use indexmap::{map::Entry, IndexMap};
 use crate::{
     bytecode::ast::{
         self,
-        record::{FieldDef, FieldMetadata, FieldPathElem},
+        record::{FieldDef, FieldMetadata, FieldPathElem, Include},
         typ::{EnumRow, EnumRows, RecordRow, RecordRows, Type},
         *,
     },
@@ -202,7 +202,7 @@ where
 pub struct UniRecord<'ast> {
     pub fields: Vec<FieldDef<'ast>>,
     pub tail: Option<(RecordRows<'ast>, TermPos)>,
-    pub includes: Vec<LocIdent>,
+    pub includes: Vec<Include<'ast>>,
     pub open: bool,
     pub pos: TermPos,
     /// The position of the final ellipsis `..`, if any. Used for error reporting. `pos_ellipsis`
@@ -405,7 +405,7 @@ impl<'ast> UniRecord<'ast> {
             return Err(InvalidRecordTypeError::IsOpen(raw_span));
         }
 
-        if let Some(raw_span) = self.includes.first().map(|id| id.pos.unwrap()) {
+        if let Some(raw_span) = self.includes.first().map(|incl| incl.ident.pos.unwrap()) {
             return Err(InvalidRecordTypeError::InterpolatedField(raw_span));
         }
 

--- a/core/src/parser/uniterm.rs
+++ b/core/src/parser/uniterm.rs
@@ -526,6 +526,9 @@ impl<'ast> TryConvert<'ast, UniRecord<'ast>> for Ast<'ast> {
             Ok(alloc
                 .record(ast::record::Record {
                     field_defs: alloc.alloc_many(field_defs_fixed),
+                    // Note that we don't need to fix field types for includes: the parser does it
+                    // already, because when it sees an include expression, it knows the current
+                    // literal must be a record value and not a record type.
                     includes: alloc.alloc_many(ur.includes),
                     open,
                 })
@@ -659,9 +662,9 @@ where
     /// that are not actually bound by a `forall` to be term variables. This is the role of
     /// `fix_type_vars()`.
     ///
-    /// Since `forall`s only bind type variables locally and cross contract boundaries, we don't
-    /// have to recurse into contracts and this pass will only visit each node of the AST at most
-    /// once in total (and most probably much less so). In some sense, we just visit the type
+    /// Since `forall`s only bind type variables locally and don't cross contract boundaries, we
+    /// don't have to recurse into contracts and this pass will only visit each node of the AST at
+    /// most once in total (and most probably much less so). In some sense, we just visit the type
     /// layer, or type spine, composed only of type constructors.
     ///
     /// There is one subtlety with unirecords, though. A unirecord can still be in interpreted as a

--- a/core/src/parser/utils.rs
+++ b/core/src/parser/utils.rs
@@ -12,7 +12,7 @@ use crate::{
     app,
     bytecode::ast::{
         pattern::bindings::Bindings as _,
-        record::{FieldDef, FieldMetadata},
+        record::{FieldDef, FieldMetadata, Include},
         *,
     },
     cache::InputFormat,
@@ -102,8 +102,8 @@ pub enum LastField<'ast> {
 #[derive(Clone, Debug)]
 pub enum FieldDecl<'ast> {
     Def(FieldDef<'ast>),
-    Include(LocIdent),
-    IncludeList(Vec<LocIdent>),
+    Include(Include<'ast>),
+    IncludeList(Vec<Include<'ast>>),
 }
 
 /// The last match in a data structure pattern. This can either be a normal match, or an ellipsis

--- a/core/src/pretty.rs
+++ b/core/src/pretty.rs
@@ -301,7 +301,8 @@ impl Allocator {
                             .map(|incl| {
                                 docs![
                                     alloc,
-                                    "include ",
+                                    "include",
+                                    alloc.space(),
                                     incl.ident.to_string(),
                                     self.field_metadata(&incl.metadata, true)
                                 ]
@@ -309,7 +310,7 @@ impl Allocator {
                         docs![alloc, ",", alloc.line()]
                     ),
                     if !includes.is_empty() {
-                        alloc.line()
+                        docs![alloc, ",", alloc.line()]
                     } else {
                         alloc.nil()
                     },

--- a/core/src/repl/query_print.rs
+++ b/core/src/repl/query_print.rs
@@ -222,7 +222,7 @@ fn render_query_result<R: QueryPrinter>(
             }
             Term::RecRecord(record, includes, dyn_fields, ..) if !record.fields.is_empty() => {
                 let mut fields: Vec<_> = record.fields.keys().map(LocIdent::ident).collect();
-                fields.extend(includes.iter().map(LocIdent::ident));
+                fields.extend(includes.iter().map(|incl| incl.ident.ident()));
                 fields.sort();
                 let dynamic = Ident::from("<dynamic>");
                 fields.extend(dyn_fields.iter().map(|_| dynamic));

--- a/core/src/term/mod.rs
+++ b/core/src/term/mod.rs
@@ -16,7 +16,7 @@ pub mod string;
 
 use array::{Array, ArrayAttrs};
 use pattern::Pattern;
-use record::{Field, FieldDeps, FieldMetadata, RecordData, RecordDeps};
+use record::{Field, FieldDeps, FieldMetadata, Include, RecordData, RecordDeps};
 use smallvec::SmallVec;
 use string::NickelString;
 
@@ -150,7 +150,7 @@ pub enum Term {
     #[serde(skip)]
     RecRecord(
         RecordData,
-        Vec<LocIdent>,          /* fields defined through `include` expressions */
+        Vec<Include>,           /* fields defined through `include` expressions */
         Vec<(RichTerm, Field)>, /* field whose name is defined by interpolation */
         Option<RecordDeps>, /* dependency tracking between fields. None before the free var pass */
     ),

--- a/core/src/term/record.rs
+++ b/core/src/term/record.rs
@@ -114,14 +114,26 @@ impl From<HashSet<Ident>> for FieldDeps {
     }
 }
 
-/// Store field interdependencies in a recursive record. Map each static and dynamic field to the
-/// set of recursive fields that syntactically appears in their definition as free variables.
+/// Store field interdependencies in a recursive record. Map each static, dynamic and included
+/// field to the set of recursive fields that syntactically appear in their definition as free
+/// variables.
 #[derive(Debug, Default, Eq, PartialEq, Clone)]
 pub struct RecordDeps {
     /// Must have exactly the same keys as the static fields map of the recursive record.
     pub stat_fields: IndexMap<Ident, FieldDeps>,
     /// Must have exactly the same length as the dynamic fields list of the recursive record.
     pub dyn_fields: Vec<FieldDeps>,
+    /// Must have exactly the same length as the included fields list of the recursive record.
+    pub incl_fields: Vec<FieldDeps>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+/// An include expression (see [crate::bytecode::ast::record::Include]).
+pub struct Include {
+    /// The included identifier.
+    pub ident: LocIdent,
+    /// The field metadata.
+    pub metadata: FieldMetadata,
 }
 
 /// The metadata attached to record fields.

--- a/core/src/term/record.rs
+++ b/core/src/term/record.rs
@@ -119,12 +119,13 @@ impl From<HashSet<Ident>> for FieldDeps {
 /// variables.
 #[derive(Debug, Default, Eq, PartialEq, Clone)]
 pub struct RecordDeps {
-    /// Must have exactly the same keys as the static fields map of the recursive record.
+    /// Must have exactly the same keys as the static fields map of the recursive record and the
+    /// include expressions. Static fields and include expressions are combined because at the time
+    /// the evaluator uses the dependencies, include expressions don't exist anymore: they have
+    /// already been elaborated to static fields and inserted.
     pub stat_fields: IndexMap<Ident, FieldDeps>,
     /// Must have exactly the same length as the dynamic fields list of the recursive record.
     pub dyn_fields: Vec<FieldDeps>,
-    /// Must have exactly the same length as the included fields list of the recursive record.
-    pub incl_fields: Vec<FieldDeps>,
 }
 
 #[derive(Clone, Debug, PartialEq)]

--- a/core/src/transform/free_vars.rs
+++ b/core/src/transform/free_vars.rs
@@ -7,7 +7,7 @@ use crate::{
     identifier::Ident,
     term::pattern::*,
     term::{
-        record::{Field, FieldDeps, RecordDeps},
+        record::{Field, FieldDeps, Include, RecordDeps},
         IndexMap, MatchBranch, RichTerm, SharedTerm, StrChunk, Term,
     },
     typ::{RecordRowF, RecordRows, RecordRowsF, Type, TypeF},
@@ -137,17 +137,25 @@ impl CollectFreeVars for RichTerm {
                 let mut rec_fields: HashSet<Ident> =
                     record.fields.keys().map(|id| id.ident()).collect();
                 // `{include foo, [..]}` is defined to have the semantics of `let foo_ = foo in
-                // {foo = foo_, [..]}`. Hence an include count both as a normal field definition
-                // and as a free variable of the record (for the external `foo` to be plugged in).
-                let includes_as_ident = includes.iter().map(|id| id.ident());
-                rec_fields.extend(includes_as_ident.clone());
-                free_vars.extend(includes_as_ident);
+                // {foo = foo_, [..]}`, hence an included field also counts as a recursive field.
+                rec_fields.extend(includes.iter().map(|incl| incl.ident.ident()));
 
                 let mut fresh = HashSet::new();
                 let mut new_deps = RecordDeps {
                     stat_fields: IndexMap::with_capacity(record.fields.len()),
                     dyn_fields: Vec::with_capacity(dyn_fields.len()),
+                    incl_fields: Vec::with_capacity(includes.len()),
                 };
+
+                for incl in includes.iter_mut() {
+                    fresh.clear();
+
+                    incl.collect_free_vars(&mut fresh);
+                    new_deps
+                        .incl_fields
+                        .push(FieldDeps::from(&fresh & &rec_fields));
+                    free_vars.extend(&fresh - &rec_fields);
+                }
 
                 for (id, t) in record.fields.iter_mut() {
                     fresh.clear();
@@ -159,12 +167,13 @@ impl CollectFreeVars for RichTerm {
 
                     free_vars.extend(&fresh - &rec_fields);
                 }
+
                 for (t1, t2) in dyn_fields.iter_mut() {
                     fresh.clear();
 
-                    // Currently, the identifier part of a dynamic definition is not recursive, i.e.
-                    // one can't write `{foo = "hey", "%{foo}" = 5}`. Hence, we add their free
-                    // variables directly in the final set without taking them into account for
+                    // Currently, the identifier part of a dynamic definition is not recursive,
+                    // i.e. one can't write `{foo = "hey", "%{foo}" = 5}`. Hence, we add their free
+                    // variables directly to the final set without taking them into account for
                     // recursive dependencies.
                     t1.collect_free_vars(free_vars);
                     t2.collect_free_vars(&mut fresh);
@@ -262,6 +271,14 @@ impl CollectFreeVars for Field {
 
         if let Some(ref mut value) = self.value {
             value.collect_free_vars(set);
+        }
+    }
+}
+
+impl CollectFreeVars for Include {
+    fn collect_free_vars(&mut self, set: &mut HashSet<Ident>) {
+        for labeled_ty in self.metadata.annotation.iter_mut() {
+            labeled_ty.typ.collect_free_vars(set)
         }
     }
 }

--- a/core/src/transform/gen_pending_contracts.rs
+++ b/core/src/transform/gen_pending_contracts.rs
@@ -32,8 +32,6 @@ use crate::{
 /// The pending contracts are expected to be initially empty. This function will override any
 /// previous pending contract.
 pub fn with_pending_contracts(field: Field) -> Result<Field, UnboundTypeVariableError> {
-    debug_assert!(field.pending_contracts.is_empty());
-
     // We simply add the contracts to the pending contract fields
     let pending_contracts = field.metadata.annotation.pending_contracts()?;
     // Type annotations are different: the contract is generated statically, because as opposed

--- a/core/src/transform/gen_pending_contracts.rs
+++ b/core/src/transform/gen_pending_contracts.rs
@@ -21,38 +21,50 @@ use crate::{
     typ::UnboundTypeVariableError,
 };
 
-pub fn transform_one(rt: RichTerm) -> Result<RichTerm, UnboundTypeVariableError> {
-    fn attach_to_field(field: Field) -> Result<Field, UnboundTypeVariableError> {
-        // We simply add the contracts to the pending contract fields
-        let pending_contracts = field.metadata.annotation.pending_contracts()?;
-        // Type annotations are different: the contract is generated statically, because as opposed
-        // to contract annotations, type anntotations don't propagate.
-        let value = field
-            .value
-            .map(|v| -> Result<RichTerm, UnboundTypeVariableError> {
-                if let Some(labeled_ty) = &field.metadata.annotation.typ {
-                    let pos = v.pos;
-                    let contract = RuntimeContract::from_static_type(labeled_ty.clone())?;
-                    Ok(contract.apply(v, pos))
-                } else {
-                    Ok(v)
-                }
-            })
-            .transpose()?;
+/// Take a field, generate pending contracts from the annotation and return the field with the
+/// pending contracts filled.
+///
+/// Contracts derived from typed annotations aren't added to the pending contracts, but mapped
+/// directly onto the value, as they don't propagate (see RFC005 for more details).
+///
+/// # Preconditions
+///
+/// The pending contracts are expected to be initially empty. This function will override any
+/// previous pending contract.
+pub fn with_pending_contracts(field: Field) -> Result<Field, UnboundTypeVariableError> {
+    debug_assert!(field.pending_contracts.is_empty());
 
-        Ok(Field {
-            value,
-            pending_contracts,
-            ..field
+    // We simply add the contracts to the pending contract fields
+    let pending_contracts = field.metadata.annotation.pending_contracts()?;
+    // Type annotations are different: the contract is generated statically, because as opposed
+    // to contract annotations, type anntotations don't propagate.
+    let value = field
+        .value
+        .map(|v| -> Result<RichTerm, UnboundTypeVariableError> {
+            if let Some(labeled_ty) = &field.metadata.annotation.typ {
+                let pos = v.pos;
+                let contract = RuntimeContract::from_static_type(labeled_ty.clone())?;
+                Ok(contract.apply(v, pos))
+            } else {
+                Ok(v)
+            }
         })
-    }
+        .transpose()?;
 
+    Ok(Field {
+        value,
+        pending_contracts,
+        ..field
+    })
+}
+
+pub fn transform_one(rt: RichTerm) -> Result<RichTerm, UnboundTypeVariableError> {
     fn attach_to_fields(
         fields: IndexMap<LocIdent, Field>,
     ) -> Result<IndexMap<LocIdent, Field>, UnboundTypeVariableError> {
         fields
             .into_iter()
-            .map(|(id, field)| Ok((id, attach_to_field(field)?)))
+            .map(|(id, field)| Ok((id, with_pending_contracts(field)?)))
             .collect()
     }
 
@@ -68,7 +80,7 @@ pub fn transform_one(rt: RichTerm) -> Result<RichTerm, UnboundTypeVariableError>
             let fields = attach_to_fields(fields)?;
             let dyn_fields = dyn_fields
                 .into_iter()
-                .map(|(id_term, field)| Ok((id_term, attach_to_field(field)?)))
+                .map(|(id_term, field)| Ok((id_term, with_pending_contracts(field)?)))
                 .collect::<Result<_, _>>()?;
 
             RichTerm::new(

--- a/core/src/typecheck/eq.rs
+++ b/core/src/typecheck/eq.rs
@@ -521,9 +521,9 @@ impl<'ast> TypeEqBounded<'ast> for record::Record<'ast> {
         sort_field_defs(&mut sorted_other);
 
         let mut includes_self_sorted = self.includes.to_vec();
-        includes_self_sorted.sort();
+        includes_self_sorted.sort_by_key(|incl| incl.ident);
         let mut includes_other_sorted = other.includes.to_vec();
-        includes_other_sorted.sort();
+        includes_other_sorted.sort_by_key(|incl| incl.ident);
 
         sorted_self
             .as_slice()

--- a/core/src/typecheck/mod.rs
+++ b/core/src/typecheck/mod.rs
@@ -1236,6 +1236,27 @@ pub struct Context<'ast> {
     pub var_level: VarLevel,
 }
 
+/// A pair of environments for a record.
+#[derive(Clone, PartialEq, Debug)]
+pub(super) struct RecordContext<'ast> {
+    /// The outer environment of the record.
+    pub(super) outer: Context<'ast>,
+    /// The inner environment of the record, also dubbed the recursive environment, which is
+    /// composed of [Self::outer] plus the fields of the record.
+    pub(super) inner: Context<'ast>,
+}
+
+impl<'ast> RecordContext<'ast> {
+    /// Creates a new context from the outer environment. The inner environment is cloned from the
+    /// outer, and supposed to be be filled later through mutation.
+    pub(super) fn from_outer(outer: Context<'ast>) -> Self {
+        RecordContext {
+            inner: outer.clone(),
+            outer,
+        }
+    }
+}
+
 impl<'ast> Context<'ast> {
     pub fn new() -> Self {
         Context {
@@ -1978,10 +1999,10 @@ fn walk_with_annot<'ast, 'a, S: AnnotSeqRef<'ast>, V: TypecheckVisitor<'ast>>(
 /// - `t`: the term to check.
 /// - `ty`: the type to check the term against.
 ///
-/// # Linearization (LSP)
+/// # LSP
 ///
-/// `check` is in charge of registering every term with the `visitor` and makes sure to scope
-/// the visitor accordingly
+/// `check` is in charge of registering every term it comes across (and identifiers) with the
+/// `visitor` and makes sure to scope the visitor accordingly.
 ///
 /// [bidirectional-typing]: (https://arxiv.org/abs/1908.05839)
 trait Check<'ast> {
@@ -2527,19 +2548,21 @@ impl<'ast, S: AnnotSeqRef<'ast>> Check<'ast> for &FieldDefCheckView<'ast, S> {
             if let Some(value) = self.value.as_ref() {
                 value.check(state, ctxt, visitor, ty)
             } else {
-                // It might make sense to accept any type for a value without definition (which would
-                // act a bit like a function parameter). But for now, we play safe and implement a more
-                // restrictive rule, which is that a value without a definition has type `Dyn`
+                // It might make sense to accept any type, i.e. generate a unification variable,
+                // for a value without definition (which would act a bit like a function
+                // parameter). But for now, we play safe and implement a more restrictive rule,
+                // which is that a value without a definition has type `Dyn`
                 ty.unify(mk_uniftype::dynamic(), state, &ctxt)
                     .map_err(|err| err.into_typecheck_err(state, self.pos_id))
             }
         } else {
             let pos = self.value.as_ref().map(|v| v.pos).unwrap_or(self.pos_id);
 
-            let inferred = infer_with_annot(state, ctxt.clone(), visitor, self.annots, self.value)?;
+            let outer = ctxt.clone();
+            let inferred = infer_with_annot(state, ctxt, visitor, self.annots, self.value)?;
 
             inferred
-                .subsumed_by(ty, state, ctxt)
+                .subsumed_by(ty, state, outer)
                 .map_err(|err| err.into_typecheck_err(state, pos))
         }
     }
@@ -2563,13 +2586,11 @@ impl<'ast> Check<'ast> for &'ast FieldDef<'ast> {
 }
 
 /// Function handling the common part of inferring the type of terms with type or contract
-/// annotation, with or without definitions. This encompasses both standalone type annotation
+/// annotations, with or without definitions. This encompasses both standalone type annotation
 /// (where `value` is always `Some(_)`) as well as field definitions (where `value` may or may not
 /// be defined).
 ///
-/// As for [check_visited] and [infer_visited], the additional `item_id` is provided when the term
-/// has been added to the visitor before but can still benefit from updating its information
-/// with the inferred type.
+/// The annotations are walked as well.
 fn infer_with_annot<'ast, V: TypecheckVisitor<'ast>, S: AnnotSeqRef<'ast>>(
     state: &mut State<'ast, '_>,
     ctxt: Context<'ast>,

--- a/core/src/typecheck/mod.rs
+++ b/core/src/typecheck/mod.rs
@@ -2558,11 +2558,10 @@ impl<'ast, S: AnnotSeqRef<'ast>> Check<'ast> for &FieldDefCheckView<'ast, S> {
         } else {
             let pos = self.value.as_ref().map(|v| v.pos).unwrap_or(self.pos_id);
 
-            let outer = ctxt.clone();
-            let inferred = infer_with_annot(state, ctxt, visitor, self.annots, self.value)?;
+            let inferred = infer_with_annot(state, ctxt.clone(), visitor, self.annots, self.value)?;
 
             inferred
-                .subsumed_by(ty, state, outer)
+                .subsumed_by(ty, state, ctxt)
                 .map_err(|err| err.into_typecheck_err(state, pos))
         }
     }

--- a/core/src/typecheck/record.rs
+++ b/core/src/typecheck/record.rs
@@ -408,10 +408,13 @@ impl<'ast> Walk<'ast> for &ResolvedRecord<'ast> {
         let mut ctxt = self.content.walk_ctxt(state, ctxt, visitor);
 
         for incl in self.includes.iter() {
-            // If the include expression has a type annotation, we need to add this information to
-            // the recursive environment (inner). Otherwise, other fields referring to the included
+            // If the include expression has an annotation, we need to add this information to the
+            // recursive environment (inner). Otherwise, other fields referring to the included
             // expression will transparently find the identifier in the outer environment (which is
             // included in the inner environment), in which case we don't have to do anything.
+            //
+            // If the annotation is a static type annotation, the call to `Include::walk_split`
+            // below will handle additional checks.
             let ty = if let ApparentType::Annotated(ty) =
                 incl.apparent_type(state.ast_alloc, Some(&ctxt.outer.type_env), None)
             {

--- a/core/tests/integration/free_vars.rs
+++ b/core/tests/integration/free_vars.rs
@@ -1,14 +1,13 @@
 use nickel_lang_core::{
     identifier::Ident,
-    term::{record::{FieldDeps, Include}, IndexMap, Term},
+    term::{
+        record::{FieldDeps, Include},
+        IndexMap, Term,
+    },
     transform::free_vars,
 };
 
-use std::{
-    collections::HashSet,
-    iter::IntoIterator,
-    rc::Rc,
-};
+use std::{collections::HashSet, iter::IntoIterator, rc::Rc};
 
 use nickel_lang_utils::test_program::parse;
 

--- a/core/tests/integration/free_vars.rs
+++ b/core/tests/integration/free_vars.rs
@@ -66,7 +66,7 @@ fn check_stat_and_includes(expr: &str, mut expected: IndexMap<&str, Vec<&str>>) 
             // the inclusion test functions `xxx_free_vars_incl` above take the free variables out
             // of expected as they are matched, so we expect that at the end of the test,
             // `expected` is empty (there was no extra field specified in `expected`)
-            && expected.len() == 0
+            && expected.is_empty()
         }
         _ => panic!("{expr} hasn't been parsed as a record"),
     }

--- a/core/tests/integration/free_vars.rs
+++ b/core/tests/integration/free_vars.rs
@@ -1,9 +1,6 @@
 use nickel_lang_core::{
     identifier::Ident,
-    term::{
-        record::{FieldDeps, Include},
-        IndexMap, Term,
-    },
+    term::{record::FieldDeps, IndexMap, Term},
     transform::free_vars,
 };
 
@@ -16,9 +13,9 @@ fn free_vars_eq(free_vars: &FieldDeps, expected: Vec<&str>) -> bool {
     *free_vars == FieldDeps::Known(Rc::new(expected_set))
 }
 
-/// Check that the dependencies of the static fields of a record match the expected ones. The
-/// matches are removed from `expected`.
-fn stat_free_vars_incl(
+/// Check that the dependencies of the static fields (including include expressions) of a record
+/// are a subset of the expected ones. The matches are removed from `expected`.
+fn stat_free_vars_subset(
     stat_fields: &IndexMap<Ident, FieldDeps>,
     expected: &mut IndexMap<&str, Vec<&str>>,
 ) -> bool {
@@ -27,22 +24,9 @@ fn stat_free_vars_incl(
         .all(|(id, set)| free_vars_eq(set, expected.swap_remove(id.label()).unwrap()))
 }
 
-/// Check that the dependencies of the include expressions of a record match the expected ones.
-/// The matches are removed from `expected`.
-fn includes_free_vars_incl(
-    includes: &[Include],
-    include_deps: &[FieldDeps],
-    expected: &mut IndexMap<&str, Vec<&str>>,
-) -> bool {
-    includes
-        .iter()
-        .zip(include_deps)
-        .all(|(incl, set)| free_vars_eq(set, expected.swap_remove(incl.ident.label()).unwrap()))
-}
-
-/// Check that the dependencies of the dynamic fields of a record match the expected ones. The
-/// match are removed from `expected`.
-fn dyn_free_vars_incl(dyn_fields: &[FieldDeps], mut expected: Vec<Vec<&str>>) -> bool {
+/// Check that the dependencies of the dynamic fields of a record are a subset of the expected
+/// ones. The match are removed from `expected`.
+fn dyn_free_vars_subset(dyn_fields: &[FieldDeps], mut expected: Vec<Vec<&str>>) -> bool {
     dyn_fields
         .iter()
         .enumerate()
@@ -58,16 +42,15 @@ fn check_dyn_vars(expr: &str, expected: Vec<Vec<&str>>) -> bool {
     match rt.term.into_owned() {
         Term::RecRecord(_, _, dyns, deps) => {
             let deps = deps.unwrap();
-            dyns.len() == deps.dyn_fields.len() && dyn_free_vars_incl(&deps.dyn_fields, expected)
+            dyns.len() == deps.dyn_fields.len() && dyn_free_vars_subset(&deps.dyn_fields, expected)
         }
         _ => panic!("{expr} hasn't been parsed as a record"),
     }
 }
 
 /// Takes a string expression, parses it as a record and checks that the dependencies of each
-/// static field and included field match the ones given in the `expected` argument. Include
-/// expressions are looked up by field name.
-fn check_stat_and_incl_vars(expr: &str, mut expected: IndexMap<&str, Vec<&str>>) -> bool {
+/// static field and included field match the ones given in the `expected` argument.
+fn check_stat_and_includes(expr: &str, mut expected: IndexMap<&str, Vec<&str>>) -> bool {
     let mut rt = parse(expr).unwrap();
     free_vars::transform(&mut rt);
 
@@ -78,10 +61,8 @@ fn check_stat_and_incl_vars(expr: &str, mut expected: IndexMap<&str, Vec<&str>>)
                 "-- comparing {:#?} **AND* {:#?}",
                 deps.stat_fields, expected
             );
-            stat_free_vars_incl(&deps.stat_fields, &mut expected)
-            && includes_free_vars_incl(&includes, &deps.incl_fields, &mut expected)
-            && record.fields.len() == deps.stat_fields.len()
-            && includes.len() == deps.incl_fields.len()
+            stat_free_vars_subset(&deps.stat_fields, &mut expected)
+            && record.fields.len() == deps.stat_fields.len() + includes.len()
             // the inclusion test functions `xxx_free_vars_incl` above take the free variables out
             // of expected as they are matched, so we expect that at the end of the test,
             // `expected` is empty (there was no extra field specified in `expected`)
@@ -93,7 +74,7 @@ fn check_stat_and_incl_vars(expr: &str, mut expected: IndexMap<&str, Vec<&str>>)
 
 #[test]
 fn static_record() {
-    assert!(check_stat_and_incl_vars(
+    assert!(check_stat_and_includes(
         "{
           a = b + 1 + h,
           b = f (a + 1) z,
@@ -123,7 +104,7 @@ fn dynamic_record() {
 
 #[test]
 fn simple_let() {
-    assert!(check_stat_and_incl_vars(
+    assert!(check_stat_and_includes(
         "{
           a = let b = 0 in b + a + h,
           b = let a = c in f (a + 1) z,
@@ -139,7 +120,7 @@ fn simple_let() {
 
 #[test]
 fn destruct_let() {
-    assert!(check_stat_and_incl_vars(
+    assert!(check_stat_and_includes(
         "{
           a = let {b={foo, bar}} = null in b + a + h,
           b = let {a, b={c=e@{d}}} = null in f (a + 1 - c) z,
@@ -151,7 +132,7 @@ fn destruct_let() {
 
 #[test]
 fn simple_fun() {
-    assert!(check_stat_and_incl_vars(
+    assert!(check_stat_and_includes(
         "{
           a = let f = fun a b => a + b + c in f null,
           b = (fun a => a + (fun b => b + (fun z => c))) a,
@@ -163,7 +144,7 @@ fn simple_fun() {
 
 #[test]
 fn destruct_fun() {
-    assert!(check_stat_and_incl_vars(
+    assert!(check_stat_and_includes(
         "{
           a = let f = fun {a=foo} {b=b@{}} => a + b + c in f null,
           b = (fun {a={b={a}}} => a + (fun {foo={bar=b@{b=e}}} => b + (fun z => b))) c,
@@ -175,7 +156,7 @@ fn destruct_fun() {
 
 #[test]
 fn nested_records() {
-    assert!(check_stat_and_incl_vars(
+    assert!(check_stat_and_includes(
         "{
           a = {
             foo = {bar = a},
@@ -197,7 +178,7 @@ fn nested_records() {
 
 #[test]
 fn recursive_let() {
-    assert!(check_stat_and_incl_vars(
+    assert!(check_stat_and_includes(
         "{
           a = let rec b = b + a + h in b,
           b = let rec a = a + b in f (a + 1) z,
@@ -213,7 +194,7 @@ fn recursive_let() {
 
 #[test]
 fn include_exprs() {
-    assert!(check_stat_and_incl_vars(
+    assert!(check_stat_and_includes(
         "{
           a,
           include [b],

--- a/core/tests/integration/free_vars.rs
+++ b/core/tests/integration/free_vars.rs
@@ -62,7 +62,7 @@ fn check_stat_and_includes(expr: &str, mut expected: IndexMap<&str, Vec<&str>>) 
                 deps.stat_fields, expected
             );
             stat_free_vars_subset(&deps.stat_fields, &mut expected)
-            && record.fields.len() == deps.stat_fields.len() + includes.len()
+            && record.fields.len() + includes.len() == deps.stat_fields.len()
             // the inclusion test functions `xxx_free_vars_incl` above take the free variables out
             // of expected as they are matched, so we expect that at the end of the test,
             // `expected` is empty (there was no extra field specified in `expected`)

--- a/core/tests/integration/free_vars.rs
+++ b/core/tests/integration/free_vars.rs
@@ -1,12 +1,14 @@
 use nickel_lang_core::{
     identifier::Ident,
-    term::{record::FieldDeps, IndexMap, Term},
+    term::{record::{FieldDeps, Include}, IndexMap, Term},
     transform::free_vars,
 };
 
-use std::collections::HashSet;
-use std::iter::IntoIterator;
-use std::rc::Rc;
+use std::{
+    collections::HashSet,
+    iter::IntoIterator,
+    rc::Rc,
+};
 
 use nickel_lang_utils::test_program::parse;
 
@@ -36,7 +38,7 @@ fn includes_free_vars_incl(
     includes
         .iter()
         .zip(include_deps)
-        .all(|(incl, set)| free_vars_eq(set, expected.swap_remove(incl.ident).unwrap()))
+        .all(|(incl, set)| free_vars_eq(set, expected.swap_remove(incl.ident.label()).unwrap()))
 }
 
 /// Check that the dependencies of the dynamic fields of a record match the expected ones. The

--- a/core/tests/integration/free_vars.rs
+++ b/core/tests/integration/free_vars.rs
@@ -81,7 +81,7 @@ fn check_stat_and_incl_vars(expr: &str, mut expected: IndexMap<&str, Vec<&str>>)
             && includes_free_vars_incl(&includes, &deps.incl_fields, &mut expected)
             && record.fields.len() == deps.stat_fields.len()
             && includes.len() == deps.incl_fields.len()
-            // the inclusion test functions `xxx_free_vars_incl` above takes the free variables out
+            // the inclusion test functions `xxx_free_vars_incl` above take the free variables out
             // of expected as they are matched, so we expect that at the end of the test,
             // `expected` is empty (there was no extra field specified in `expected`)
             && expected.len() == 0

--- a/core/tests/integration/free_vars.rs
+++ b/core/tests/integration/free_vars.rs
@@ -15,15 +15,32 @@ fn free_vars_eq(free_vars: &FieldDeps, expected: Vec<&str>) -> bool {
     *free_vars == FieldDeps::Known(Rc::new(expected_set))
 }
 
+/// Check that the dependencies of the static fields of a record match the expected ones. The
+/// matches are removed from `expected`.
 fn stat_free_vars_incl(
     stat_fields: &IndexMap<Ident, FieldDeps>,
-    mut expected: IndexMap<&str, Vec<&str>>,
+    expected: &mut IndexMap<&str, Vec<&str>>,
 ) -> bool {
     stat_fields
         .iter()
         .all(|(id, set)| free_vars_eq(set, expected.swap_remove(id.label()).unwrap()))
 }
 
+/// Check that the dependencies of the include expressions of a record match the expected ones.
+/// The matches are removed from `expected`.
+fn includes_free_vars_incl(
+    includes: &[Include],
+    include_deps: &[FieldDeps],
+    expected: &mut IndexMap<&str, Vec<&str>>,
+) -> bool {
+    includes
+        .iter()
+        .zip(include_deps)
+        .all(|(incl, set)| free_vars_eq(set, expected.swap_remove(incl.ident).unwrap()))
+}
+
+/// Check that the dependencies of the dynamic fields of a record match the expected ones. The
+/// match are removed from `expected`.
 fn dyn_free_vars_incl(dyn_fields: &[FieldDeps], mut expected: Vec<Vec<&str>>) -> bool {
     dyn_fields
         .iter()
@@ -31,6 +48,8 @@ fn dyn_free_vars_incl(dyn_fields: &[FieldDeps], mut expected: Vec<Vec<&str>>) ->
         .all(|(i, set)| free_vars_eq(set, std::mem::take(&mut expected[i])))
 }
 
+/// Takes a Nickel expression as a string, parses it as a record and checks that the dependencies
+/// of each dynamic field match the ones given in the `expected` argument.
 fn check_dyn_vars(expr: &str, expected: Vec<Vec<&str>>) -> bool {
     let mut rt = parse(expr).unwrap();
     free_vars::transform(&mut rt);
@@ -44,19 +63,28 @@ fn check_dyn_vars(expr: &str, expected: Vec<Vec<&str>>) -> bool {
     }
 }
 
-fn check_stat_vars(expr: &str, expected: IndexMap<&str, Vec<&str>>) -> bool {
+/// Takes a string expression, parses it as a record and checks that the dependencies of each
+/// static field and included field match the ones given in the `expected` argument. Include
+/// expressions are looked up by field name.
+fn check_stat_and_incl_vars(expr: &str, mut expected: IndexMap<&str, Vec<&str>>) -> bool {
     let mut rt = parse(expr).unwrap();
     free_vars::transform(&mut rt);
 
     match rt.term.into_owned() {
-        Term::RecRecord(record, _, _, deps) => {
+        Term::RecRecord(record, includes, _, deps) => {
             let deps = deps.unwrap();
             println!(
                 "-- comparing {:#?} **AND* {:#?}",
                 deps.stat_fields, expected
             );
-            record.fields.len() == deps.stat_fields.len()
-                && stat_free_vars_incl(&deps.stat_fields, expected)
+            stat_free_vars_incl(&deps.stat_fields, &mut expected)
+            && includes_free_vars_incl(&includes, &deps.incl_fields, &mut expected)
+            && record.fields.len() == deps.stat_fields.len()
+            && includes.len() == deps.incl_fields.len()
+            // the inclusion test functions `xxx_free_vars_incl` above takes the free variables out
+            // of expected as they are matched, so we expect that at the end of the test,
+            // `expected` is empty (there was no extra field specified in `expected`)
+            && expected.len() == 0
         }
         _ => panic!("{expr} hasn't been parsed as a record"),
     }
@@ -64,7 +92,7 @@ fn check_stat_vars(expr: &str, expected: IndexMap<&str, Vec<&str>>) -> bool {
 
 #[test]
 fn static_record() {
-    assert!(check_stat_vars(
+    assert!(check_stat_and_incl_vars(
         "{
           a = b + 1 + h,
           b = f (a + 1) z,
@@ -94,7 +122,7 @@ fn dynamic_record() {
 
 #[test]
 fn simple_let() {
-    assert!(check_stat_vars(
+    assert!(check_stat_and_incl_vars(
         "{
           a = let b = 0 in b + a + h,
           b = let a = c in f (a + 1) z,
@@ -110,7 +138,7 @@ fn simple_let() {
 
 #[test]
 fn destruct_let() {
-    assert!(check_stat_vars(
+    assert!(check_stat_and_incl_vars(
         "{
           a = let {b={foo, bar}} = null in b + a + h,
           b = let {a, b={c=e@{d}}} = null in f (a + 1 - c) z,
@@ -122,7 +150,7 @@ fn destruct_let() {
 
 #[test]
 fn simple_fun() {
-    assert!(check_stat_vars(
+    assert!(check_stat_and_incl_vars(
         "{
           a = let f = fun a b => a + b + c in f null,
           b = (fun a => a + (fun b => b + (fun z => c))) a,
@@ -134,7 +162,7 @@ fn simple_fun() {
 
 #[test]
 fn destruct_fun() {
-    assert!(check_stat_vars(
+    assert!(check_stat_and_incl_vars(
         "{
           a = let f = fun {a=foo} {b=b@{}} => a + b + c in f null,
           b = (fun {a={b={a}}} => a + (fun {foo={bar=b@{b=e}}} => b + (fun z => b))) c,
@@ -146,7 +174,7 @@ fn destruct_fun() {
 
 #[test]
 fn nested_records() {
-    assert!(check_stat_vars(
+    assert!(check_stat_and_incl_vars(
         "{
           a = {
             foo = {bar = a},
@@ -168,7 +196,7 @@ fn nested_records() {
 
 #[test]
 fn recursive_let() {
-    assert!(check_stat_vars(
+    assert!(check_stat_and_incl_vars(
         "{
           a = let rec b = b + a + h in b,
           b = let rec a = a + b in f (a + 1) z,
@@ -178,6 +206,28 @@ fn recursive_let() {
             ("a", vec!["a"]),
             ("b", vec!["b"]),
             ("c", vec!["a", "b", "c"])
+        ])
+    ));
+}
+
+#[test]
+fn include_exprs() {
+    assert!(check_stat_and_incl_vars(
+        "{
+          a,
+          include [b],
+          c = a + b + c + d,
+          include x | y,
+          include z | C,
+          C,
+        }",
+        IndexMap::from([
+            ("a", vec![]),
+            ("b", vec![]),
+            ("c", vec!["a", "b", "c"]),
+            ("x", vec![]),
+            ("z", vec!["C"]),
+            ("C", vec![]),
         ])
     ));
 }

--- a/core/tests/integration/inputs/contracts/include_recursive_contract.ncl
+++ b/core/tests/integration/inputs/contracts/include_recursive_contract.ncl
@@ -1,0 +1,11 @@
+# test.type = 'error'
+#
+# [test.metadata]
+# error = 'EvalError::BlameError'
+let x = 1 in
+({
+  include x | Contract,
+  Contract = Dyn,
+} & {
+  Contract | force = std.FailWith "",
+}).x

--- a/core/tests/integration/inputs/typecheck/include_annot_mismatch.ncl
+++ b/core/tests/integration/inputs/typecheck/include_annot_mismatch.ncl
@@ -1,0 +1,11 @@
+# test.type = 'error'
+# eval = 'typecheck'
+# 
+# [test.metadata]
+# error = 'TypecheckError::TypeMismatch'
+#
+# [test.metadata.expectation]
+# expected = 'String'
+# inferred = 'Number'
+let x : Number = 1 in
+{ include x : String }

--- a/core/tests/integration/inputs/typecheck/include_contract_annot.ncl
+++ b/core/tests/integration/inputs/typecheck/include_contract_annot.ncl
@@ -1,0 +1,7 @@
+# test.type = 'pass'
+# eval = 'typecheck'
+let x : Number = 1 in
+{ 
+  include x | String,
+  y = x ++ "b",
+} : _

--- a/core/tests/integration/inputs/typecheck/include_instantiated_dep.ncl
+++ b/core/tests/integration/inputs/typecheck/include_instantiated_dep.ncl
@@ -1,0 +1,20 @@
+# test.type = 'error'
+# eval = 'typecheck'
+# 
+# [test.metadata]
+# error = 'TypecheckError::TypeMismatch'
+#
+# [test.metadata.expectation]
+# expected = 'String'
+# inferred = 'Number'
+
+# This test checks that when adding a type annotation on a include expression,
+# this annotation is used in the recursive environment instead of the original
+# type assigned to the included value (even when, as it is the case here, the
+# annotation is less general).
+let f : forall a b. a -> b -> a = fun x _ => x in
+{ 
+  include f : forall b. String -> b -> String,
+  x = f "hello" 42,
+  y = f 42 "world",
+} : _

--- a/core/tests/integration/inputs/typecheck/include_nonrec_occurrence.ncl
+++ b/core/tests/integration/inputs/typecheck/include_nonrec_occurrence.ncl
@@ -1,0 +1,12 @@
+# test.type = 'pass'
+# eval = 'typecheck'
+
+# Test that the `SomeContract` opaque type affected to `x` is properly coming
+# from the outer environment, and isn't polluted by the local recursive
+# re-definition of `SomeContract` to `Number`.
+let SomeContract = String in
+let x | SomeContract = "hello" in
+{
+  include x,
+  SomeContract = Number,
+} : {x : SomeContract, SomeContract : _}

--- a/core/tests/integration/inputs/typecheck/include_polymorphic_var.ncl
+++ b/core/tests/integration/inputs/typecheck/include_polymorphic_var.ncl
@@ -1,0 +1,9 @@
+# test.type = 'pass'
+# eval = 'typecheck'
+let f : forall a. a -> a = fun x => x in
+{ 
+  include f,
+  x = f 1,
+  y = f "hello",
+  z = f ((+) 1),
+} : _

--- a/core/tests/integration/inputs/typecheck/include_record_type_mismatch.ncl
+++ b/core/tests/integration/inputs/typecheck/include_record_type_mismatch.ncl
@@ -2,9 +2,6 @@
 # eval = 'typecheck'
 # 
 # [test.metadata]
-# error = 'TypecheckError::RecordRowConflict'
-#
-# [test.metadata.expectation]
-# row = 'x'
+# error = 'TypecheckError::RecordRowMismatch'
 let x : Number = 1 in
 { include x } : { x : String }

--- a/core/tests/integration/inputs/typecheck/include_record_type_mismatch.ncl
+++ b/core/tests/integration/inputs/typecheck/include_record_type_mismatch.ncl
@@ -1,0 +1,10 @@
+# test.type = 'error'
+# eval = 'typecheck'
+# 
+# [test.metadata]
+# error = 'TypecheckError::RecordRowConflict'
+#
+# [test.metadata.expectation]
+# row = 'x'
+let x : Number = 1 in
+{ include x } : { x : String }

--- a/lsp/nls/src/position.rs
+++ b/lsp/nls/src/position.rs
@@ -219,15 +219,17 @@ impl<'ast> PositionLookup<'ast> {
                     }));
 
                     // We include the identifier happening as part of `include` expressions.
-                    ident_ranges.extend(data.includes.iter().map(|incl| incl.ident).filter_map(|id| {
-                        Some(Entry {
-                            range: id.pos.into_opt()?.to_range(),
-                            data: IdentData {
-                                ident: id.into(),
-                                field_def: None,
-                            },
-                        })
-                    }));
+                    ident_ranges.extend(data.includes.iter().map(|incl| incl.ident).filter_map(
+                        |id| {
+                            Some(Entry {
+                                range: id.pos.into_opt()?.to_range(),
+                                data: IdentData {
+                                    ident: id.into(),
+                                    field_def: None,
+                                },
+                            })
+                        },
+                    ));
                 }
                 Node::Match(data) => {
                     let ids = data

--- a/lsp/nls/src/position.rs
+++ b/lsp/nls/src/position.rs
@@ -219,7 +219,7 @@ impl<'ast> PositionLookup<'ast> {
                     }));
 
                     // We include the identifier happening as part of `include` expressions.
-                    ident_ranges.extend(data.includes.iter().copied().filter_map(|id| {
+                    ident_ranges.extend(data.includes.iter().map(|incl| incl.ident).filter_map(|id| {
                         Some(Entry {
                             range: id.pos.into_opt()?.to_range(),
                             data: IdentData {


### PR DESCRIPTION
Follow-up of #2241. Related #747.

This PR adds support for metadata annotation on included expressions (only single includes; include lists aren't supported). The parser, transformation pipeline, pretty printer and the typechecker are updated to handle this properly.

The meat of the PR is typechecking. We now need to handle a slightly finer interface for typechecking expressions, differentiating between the outer environment and the recursive environment of a record. Semantically, we follow our simple guideline that `{include x | <annot>}` should be equivalent in behavior to `let _fresh = x in {x | <annot> = _fresh}`.

## Content

- adds a proper `Include` structure to hold an included expression and its related metadata
- extend free variables transformation and recursive dependencies computation to properly handle included expressions. Indeed, from now on, the annotation of an included expression can depend recursively on other fields, and is thus subject to the whole recursive record machinery
- implement proper typechecking for include expressions with annotations