### PR TITLE
Ouroboros nls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3425,6 +3425,7 @@ dependencies = [
  "lsp-types",
  "nickel-lang-core",
  "nickel-lang-utils",
+ "ouroboros",
  "pretty",
  "pretty_assertions",
  "regex",

--- a/lsp/nls/Cargo.toml
+++ b/lsp/nls/Cargo.toml
@@ -38,6 +38,7 @@ log.workspace = true
 lsp-server.workspace = true
 lsp-types.workspace = true
 nickel-lang-core = {workspace = true, default-features = false, features = ["format"]}
+ouroboros.workspace = true
 pretty.workspace = true
 regex.workspace = true
 scopeguard.workspace = true

--- a/lsp/nls/src/world.rs
+++ b/lsp/nls/src/world.rs
@@ -244,7 +244,7 @@ impl World {
     /// Returns `Ok` for recoverable (or no) errors, or `Err` for fatal errors.
     pub fn parse(&mut self, file_id: FileId) -> Vec<SerializableDiagnostic> {
         let mut errs = nickel_lang_core::error::ParseErrors::default();
-        self.analysis_reg.insert(|_| {
+        self.analysis_reg.insert_with(|_| {
             let mut analysis = PackedAnalysis::empty(file_id);
             analysis.parse(&self.sources);
             errs = analysis.parse_errors().clone();
@@ -286,7 +286,7 @@ impl World {
             }); // we don't use `?` here yet, to make sure inserting the analysis back is always
                 // run
 
-        self.analysis_reg.insert(analysis);
+        self.analysis_reg.insert_with(analysis);
 
         let new_imports = new_imports?;
         let new_ids = new_imports
@@ -304,7 +304,7 @@ impl World {
         // Instead, we put everything in the registry first so that it's up to date, and only then
         // typecheck the files one by one.
         for analysis in new_imports {
-            self.analysis_reg.insert(analysis);
+            self.analysis_reg.insert_with(analysis);
         }
 
         let mut typecheck_import_diagnostics: Vec<FileId> = Vec::new();
@@ -411,7 +411,7 @@ impl World {
             .collect();
 
         for analysis in new_imports {
-            self.analysis_reg.insert(analysis);
+            self.analysis_reg.insert_with(analysis);
         }
 
         for id in new_ids {

--- a/lsp/nls/src/world.rs
+++ b/lsp/nls/src/world.rs
@@ -26,7 +26,7 @@ use crate::{
     analysis::{AnalysisRegistry, AnalysisRegistryRef, PackedAnalysis},
     diagnostic::SerializableDiagnostic,
     error::WarningReporter,
-    field_walker::{Def, FieldResolver},
+    field_walker::FieldResolver,
     files::uri_to_path,
     identifier::LocIdent,
     position::IdentData,
@@ -211,11 +211,11 @@ impl World {
         }
     }
 
-    /// Returns `Ok` for recoverable (or no) errors, or `Err` for fatal errors.
+    /// Returns all of the diagnostics encountered during parsing.
     pub fn parse(&mut self, file_id: FileId) -> Vec<SerializableDiagnostic> {
         let mut errs = nickel_lang_core::error::ParseErrors::default();
         self.analysis_reg
-            .insert_with(|_, init_term_env, init_type_ctxt| {
+            .insert_with(|init_term_env, init_type_ctxt| {
                 let analysis = PackedAnalysis::parsed(
                     file_id,
                     &self.sources,


### PR DESCRIPTION
Removes the unsafe from `nls`, with the help of ouroboros.

`PackedAnalysis` grows a lifetime parameter, allowing it to borrow external `Ast`s with that lifetime. The stdlib's analysis is a `PackedAnalysis<'static>` because it doesn't borrow external `Ast`s, and every other analysis is a `PackedAnalysis<'std>`, where `'std` is the lifetime of the stdlib's analysis. The constructor of `AnalysisRegistry` is in charge of tying these lifetimes together.