### PR TITLE
Update behavior of debugLog flag in VSCode extension

### DIFF
--- a/lsp/vscode-extension/src/extension.ts
+++ b/lsp/vscode-extension/src/extension.ts
@@ -24,8 +24,8 @@ export async function activate(context: ExtensionContext) {
 	console.log(serverPath);
 
 	// Pass the process.env to nls. Fixes direnv integration
-	const options = { env: process.env };
-	const debugOptions = { env: Object.assign(options.env, { "RUST_LOG": "trace" }) };
+	const options = { env: {...process.env, "RUST_LOG": "warn" } };
+	const debugOptions = { env: {...options.env, "RUST_LOG": "trace" } };
 
 	// If the extension is launched in debug mode then the debug server options are used
 	// Otherwise the run options are used


### PR DESCRIPTION
Fixes #2233.

Since options.env is set as the target of Objects.assign, RUST_LOG=trace is being set on options.env, and not just debugOptions.env. This results in nls starting up with trace logging, regardless of the value of nls.server.debugLog. This is fixed to set trace logging only when debugLog is true as originally intended.

Additionally, I've set a value of RUST_LOG for the case in which debugLog is false. Users might have the RUST_LOG variable set for any number of reasons when running VSCode, and it's unlikely they intended for it to affect the behavior of the language server, but since the environment is passed through, nls would use that log level. It seemed to me that the info level logs would not be useful to most users so I've set the log level to warn in this case.