### PR TITLE
[Feat] Add `--apply-contract` argument to the CLI

### DIFF
--- a/cli/src/input.rs
+++ b/cli/src/input.rs
@@ -13,14 +13,10 @@ pub struct InputOptions<Customize: clap::Args> {
     /// Nickel expressions are merged (combined with `&`) to produce the result.
     pub files: Vec<PathBuf>,
 
-    /// Validates the final configuration against a contract specified as a Nickel file.
-    ///
-    /// Note that the main input files can be any supported input format, such as JSON or YAML. In
-    /// conjunction with `--contract`, it's possible to use the Nickel CLI to merge existing
-    /// non-Nickel configurations and validate the result using Nickel contracts in a non-invasive
-    /// way.
-    #[arg(long = "contract")]
-    contracts: Vec<PathBuf>,
+    /// Validates the final configuration against a contract specified as a Nickel file. If this
+    /// argument is used multiple times, all specified contracts will be applied sequentially.
+    #[arg(long)]
+    apply_contract: Vec<PathBuf>,
 
     #[cfg(debug_assertions)]
     /// Skips the standard library import. For debugging only
@@ -88,7 +84,7 @@ impl<C: clap::Args + Customize> Prepare for InputOptions<C> {
         }?;
 
         program
-            .add_contract_paths(self.contracts.iter())
+            .add_contract_paths(self.apply_contract.iter())
             .map_err(|error| {
                 PrepareError::Error(crate::error::Error::Program {
                     error,

--- a/cli/tests/snapshot/README.md
+++ b/cli/tests/snapshot/README.md
@@ -22,6 +22,10 @@ nix dev shell, `cargo-insta` is already on your path. Most of this guide will
 assume you have `cargo-insta` installed. If you'd prefer not to install it,
 please read [this section](#without-cargo-insta).
 
+Since some tests requiring specifying paths from the command line, `main.rs`
+sets the current working directory of the Nickel process to be the directory
+where this README lies.
+
 ## What to do if a snapshot test fails
 
 1. Run `cargo insta review`.

--- a/cli/tests/snapshot/README.md
+++ b/cli/tests/snapshot/README.md
@@ -22,9 +22,9 @@ nix dev shell, `cargo-insta` is already on your path. Most of this guide will
 assume you have `cargo-insta` installed. If you'd prefer not to install it,
 please read [this section](#without-cargo-insta).
 
-Since some tests requiring specifying paths from the command line, `main.rs`
-sets the current working directory of the Nickel process to be the directory
-where this README lies.
+Since some tests require specifying paths from the command line, `main.rs` sets
+the current working directory of the Nickel process to be the directory where
+this README lies.
 
 ## What to do if a snapshot test fails
 

--- a/cli/tests/snapshot/imports/additional_contract1.ncl
+++ b/cli/tests/snapshot/imports/additional_contract1.ncl
@@ -1,0 +1,5 @@
+{
+  foo | Number,
+  baz | Bool,
+  ..
+}

--- a/cli/tests/snapshot/imports/additional_contract2.ncl
+++ b/cli/tests/snapshot/imports/additional_contract2.ncl
@@ -1,0 +1,5 @@
+{
+  foo | Number,
+  bar | String,
+  ..
+}

--- a/cli/tests/snapshot/inputs/eval/fail_additional_contract.ncl
+++ b/cli/tests/snapshot/inputs/eval/fail_additional_contract.ncl
@@ -1,5 +1,5 @@
 # capture = 'stderr'
-# command = ['eval', '--contract', '../../imports/additional_contract2.ncl']
+# command = ['eval', '--apply-contract', '../../imports/additional_contract2.ncl']
 {
   foo = 1,
   bar = "hello, world!",

--- a/cli/tests/snapshot/inputs/eval/fail_additional_contract.ncl
+++ b/cli/tests/snapshot/inputs/eval/fail_additional_contract.ncl
@@ -1,5 +1,5 @@
 # capture = 'stderr'
-# command = ['eval', '--apply-contract', '../../imports/additional_contract2.ncl']
+# command = ['eval', '--apply-contract', 'imports/additional_contract1.ncl']
 {
   foo = 1,
   bar = "hello, world!",

--- a/cli/tests/snapshot/inputs/eval/fail_additional_contract.ncl
+++ b/cli/tests/snapshot/inputs/eval/fail_additional_contract.ncl
@@ -1,0 +1,6 @@
+# capture = 'stderr'
+# command = ['eval', '--contract', '../../imports/additional_contract2.ncl']
+{
+  foo = 1,
+  bar = "hello, world!",
+}

--- a/cli/tests/snapshot/inputs/eval/fail_additional_two_contracts1.ncl
+++ b/cli/tests/snapshot/inputs/eval/fail_additional_two_contracts1.ncl
@@ -1,5 +1,5 @@
 # capture = 'stderr'
-# command = ['eval', '--contract', '../../imports/additional_contract1.ncl', '--contract', '../../imports/additional_contract2.ncl']
+# command = ['eval', '--apply-contract', '../../imports/additional_contract1.ncl', '--apply-contract', '../../imports/additional_contract2.ncl']
 {
   foo = 1,
   bar = "hello, world!",

--- a/cli/tests/snapshot/inputs/eval/fail_additional_two_contracts1.ncl
+++ b/cli/tests/snapshot/inputs/eval/fail_additional_two_contracts1.ncl
@@ -1,0 +1,6 @@
+# capture = 'stderr'
+# command = ['eval', '--contract', '../../imports/additional_contract1.ncl', '--contract', '../../imports/additional_contract2.ncl']
+{
+  foo = 1,
+  bar = "hello, world!",
+}

--- a/cli/tests/snapshot/inputs/eval/fail_additional_two_contracts1.ncl
+++ b/cli/tests/snapshot/inputs/eval/fail_additional_two_contracts1.ncl
@@ -1,5 +1,5 @@
 # capture = 'stderr'
-# command = ['eval', '--apply-contract', '../../imports/additional_contract1.ncl', '--apply-contract', '../../imports/additional_contract2.ncl']
+# command = ['eval', '--apply-contract', 'imports/additional_contract1.ncl', '--apply-contract', 'imports/additional_contract2.ncl']
 {
   foo = 1,
   bar = "hello, world!",

--- a/cli/tests/snapshot/inputs/eval/fail_additional_two_contracts2.ncl
+++ b/cli/tests/snapshot/inputs/eval/fail_additional_two_contracts2.ncl
@@ -1,5 +1,5 @@
 # capture = 'stderr'
-# command = ['eval', '--contract', '../../imports/additional_contract1.ncl', '--contract', '../../imports/additional_contract2.ncl']
+# command = ['eval', '--apply-contract', '../../imports/additional_contract1.ncl', '--apply-contract', '../../imports/additional_contract2.ncl']
 {
   foo = 1,
   baz = false,

--- a/cli/tests/snapshot/inputs/eval/fail_additional_two_contracts2.ncl
+++ b/cli/tests/snapshot/inputs/eval/fail_additional_two_contracts2.ncl
@@ -1,0 +1,6 @@
+# capture = 'stderr'
+# command = ['eval', '--contract', '../../imports/additional_contract1.ncl', '--contract', '../../imports/additional_contract2.ncl']
+{
+  foo = 1,
+  baz = false,
+}

--- a/cli/tests/snapshot/inputs/eval/fail_additional_two_contracts2.ncl
+++ b/cli/tests/snapshot/inputs/eval/fail_additional_two_contracts2.ncl
@@ -1,5 +1,5 @@
 # capture = 'stderr'
-# command = ['eval', '--apply-contract', '../../imports/additional_contract1.ncl', '--apply-contract', '../../imports/additional_contract2.ncl']
+# command = ['eval', '--apply-contract', 'imports/additional_contract1.ncl', '--apply-contract', 'imports/additional_contract2.ncl']
 {
   foo = 1,
   baz = false,

--- a/cli/tests/snapshot/main.rs
+++ b/cli/tests/snapshot/main.rs
@@ -129,6 +129,8 @@ impl<'a> NickelInvocation<'a> {
         let nickel_loc = env!("CARGO_BIN_EXE_nickel");
         let mut cmd = Command::new(nickel_loc);
         cmd.args(["--color", "never"]);
+        // We set a deterministic working directory for CLI arguments that accept file paths.
+        cmd.current_dir(project_root().join("cli/tests/snapshot"));
         Self {
             cmd,
             file: None,

--- a/cli/tests/snapshot/snapshots/snapshot__eval_stderr_fail_additional_contract.ncl.snap
+++ b/cli/tests/snapshot/snapshots/snapshot__eval_stderr_fail_additional_contract.ncl.snap
@@ -1,0 +1,23 @@
+---
+source: cli/tests/snapshot/main.rs
+expression: err
+---
+error: missing definition for `baz`
+  ┌─ [IMPORTS_PATH]/additional_contract1.ncl:3:3
+  │
+3 │   baz | Bool,
+  │   ^^^ required here
+  │
+  ┌─ [INPUTS_PATH]/eval/fail_additional_contract.ncl:3:1
+  │  
+3 │ ╭ {
+4 │ │   foo = 1,
+5 │ │   bar = "hello, world!",
+6 │ │ }
+  │ ╰─' in this record
+
+note: 
+  ┌─ [IMPORTS_PATH]/additional_contract1.ncl:3:9
+  │
+3 │   baz | Bool,
+  │         ^^^^ bound here

--- a/cli/tests/snapshot/snapshots/snapshot__eval_stderr_fail_additional_two_contracts1.ncl.snap
+++ b/cli/tests/snapshot/snapshots/snapshot__eval_stderr_fail_additional_two_contracts1.ncl.snap
@@ -1,0 +1,23 @@
+---
+source: cli/tests/snapshot/main.rs
+expression: err
+---
+error: missing definition for `baz`
+  ┌─ [IMPORTS_PATH]/additional_contract1.ncl:3:3
+  │
+3 │   baz | Bool,
+  │   ^^^ required here
+  │
+  ┌─ [INPUTS_PATH]/eval/fail_additional_two_contracts1.ncl:3:1
+  │  
+3 │ ╭ {
+4 │ │   foo = 1,
+5 │ │   bar = "hello, world!",
+6 │ │ }
+  │ ╰─' in this record
+
+note: 
+  ┌─ [IMPORTS_PATH]/additional_contract1.ncl:3:9
+  │
+3 │   baz | Bool,
+  │         ^^^^ bound here

--- a/cli/tests/snapshot/snapshots/snapshot__eval_stderr_fail_additional_two_contracts2.ncl.snap
+++ b/cli/tests/snapshot/snapshots/snapshot__eval_stderr_fail_additional_two_contracts2.ncl.snap
@@ -1,0 +1,23 @@
+---
+source: cli/tests/snapshot/main.rs
+expression: err
+---
+error: missing definition for `bar`
+  ┌─ [IMPORTS_PATH]/additional_contract2.ncl:3:3
+  │
+3 │   bar | String,
+  │   ^^^ required here
+  │
+  ┌─ [INPUTS_PATH]/eval/fail_additional_two_contracts2.ncl:3:1
+  │  
+3 │ ╭ {
+4 │ │   foo = 1,
+5 │ │   baz = false,
+6 │ │ }
+  │ ╰─' in this record
+
+note: 
+  ┌─ [IMPORTS_PATH]/additional_contract2.ncl:3:9
+  │
+3 │   bar | String,
+  │         ^^^^^^ bound here

--- a/core/src/eval/mod.rs
+++ b/core/src/eval/mod.rs
@@ -365,11 +365,8 @@ impl<R: ImportResolver, C: Cache> VirtualMachine<R, C> {
 
             prev_pos = current_value.pos;
 
-            let curr_value_with_ctr = RuntimeContract::apply_all(
-                current_value,
-                field.pending_contracts.into_iter(),
-                prev_pos,
-            );
+            let curr_value_with_ctr =
+                RuntimeContract::apply_all(current_value, field.pending_contracts, prev_pos);
 
             let current_evaled = self.eval_closure(Closure {
                 body: curr_value_with_ctr,
@@ -933,7 +930,7 @@ impl<R: ImportResolver, C: Cache> VirtualMachine<R, C> {
                     };
 
                     let inner_with_ctr =
-                        RuntimeContract::apply_all(inner_with_static, contracts.into_iter(), pos);
+                        RuntimeContract::apply_all(inner_with_static, contracts, pos);
 
                     Closure {
                         body: inner_with_ctr,

--- a/core/src/eval/operation.rs
+++ b/core/src/eval/operation.rs
@@ -1217,11 +1217,7 @@ impl<R: ImportResolver, C: Cache> VirtualMachine<R, C> {
                         .map(|(id, field)| {
                             let value = field.value.map(|value| {
                                 let pos = value.pos;
-                                RuntimeContract::apply_all(
-                                    value,
-                                    field.pending_contracts.into_iter(),
-                                    pos,
-                                )
+                                RuntimeContract::apply_all(value, field.pending_contracts, pos)
                             });
 
                             let field = Field {
@@ -3884,16 +3880,10 @@ fn eq<C: Cache>(
                             let pos1 = value1.pos;
                             let pos2 = value2.pos;
 
-                            let value1_with_ctr = RuntimeContract::apply_all(
-                                value1,
-                                pending_contracts1.into_iter(),
-                                pos1,
-                            );
-                            let value2_with_ctr = RuntimeContract::apply_all(
-                                value2,
-                                pending_contracts2.into_iter(),
-                                pos2,
-                            );
+                            let value1_with_ctr =
+                                RuntimeContract::apply_all(value1, pending_contracts1, pos1);
+                            let value2_with_ctr =
+                                RuntimeContract::apply_all(value2, pending_contracts2, pos2);
                             Some(Ok((value1_with_ctr, value2_with_ctr)))
                         }
                         (Field { value: None, .. }, Field { value: None, .. }) => None,

--- a/core/src/program.rs
+++ b/core/src/program.rs
@@ -219,7 +219,7 @@ pub enum ProgramContract {
     /// wrapped programmatically.
     Term(RuntimeContract),
     /// Contract specified as a source. They will be parsed and typechecked alongside the rest of
-    /// the program.
+    /// the program. Typically coming form the CLI `--apply-contract` argument.
     Source(FileId),
 }
 
@@ -239,11 +239,6 @@ pub struct Program<EC: EvalCache> {
     /// an import referring to the corresponding isolated value. This stub is finally merged with
     /// the current program before being evaluated for import.
     overrides: Vec<FieldOverride>,
-    /// A list of additional contracts to apply to the main.
-    ///
-    /// Those come from the `--contract` argument of the CLI, which is handy to validate non-Nickel
-    /// configurations against Nickel contracts on-the-fly. Those contracts are applied to the
-    /// result of the potentially overridden program (See [Self::overrides]).
     /// A specific field to act on. It is empty by default, which means that the whole program will
     /// be evaluated, but it can be set by the user (for example by the `--field` argument of the
     /// CLI) to evaluate only a specific field.
@@ -688,7 +683,7 @@ impl<EC: EvalCache> Program<EC> {
                         let source_name = cache.sources.name(*file_id).to_string_lossy();
                         let arg_id = cache.sources.add_string(
                             SourcePath::CliFieldAssignment,
-                            format!("--contract {source_name}"),
+                            format!("--apply-contract {source_name}"),
                         );
 
                         let span = cache.sources.files().source_span(arg_id);

--- a/core/src/program.rs
+++ b/core/src/program.rs
@@ -219,7 +219,7 @@ pub enum ProgramContract {
     /// wrapped programmatically.
     Term(RuntimeContract),
     /// Contract specified as a source. They will be parsed and typechecked alongside the rest of
-    /// the program. Typically coming form the CLI `--apply-contract` argument.
+    /// the program. Typically coming from the CLI `--apply-contract` argument.
     Source(FileId),
 }
 

--- a/core/src/program.rs
+++ b/core/src/program.rs
@@ -816,7 +816,7 @@ impl<EC: EvalCache> Program<EC> {
                 ProgramContract::Source(file_id) => {
                     self.vm
                         .import_resolver_mut()
-                        .typecheck(*file_id, TypecheckMode::Walk)
+                        .typecheck(*file_id, initial_mode)
                         .map_err(|cache_err| {
                             cache_err.unwrap_error(
                                 "program::typecheck(): expected contract to be parsed",

--- a/core/src/term/mod.rs
+++ b/core/src/term/mod.rs
@@ -498,9 +498,11 @@ impl RuntimeContract {
     /// Apply a series of contracts to a term, in order.
     pub fn apply_all<I>(rt: RichTerm, contracts: I, pos: TermPos) -> RichTerm
     where
-        I: Iterator<Item = Self>,
+        I: IntoIterator<Item = Self>,
     {
-        contracts.fold(rt, |acc, ctr| ctr.apply(acc, pos))
+        contracts
+            .into_iter()
+            .fold(rt, |acc, ctr| ctr.apply(acc, pos))
     }
 
     /// Push a pending contract to a vector of contracts if the contract to add isn't already

--- a/core/src/term/record.rs
+++ b/core/src/term/record.rs
@@ -430,7 +430,7 @@ impl RecordData {
                     let pos = v.pos;
                     Some(Ok((
                         id.ident(),
-                        RuntimeContract::apply_all(v, field.pending_contracts.into_iter(), pos),
+                        RuntimeContract::apply_all(v, field.pending_contracts, pos),
                     )))
                 }
                 None if !field.metadata.opt => Some(Err(MissingFieldDefError {

--- a/package/src/manifest.rs
+++ b/package/src/manifest.rs
@@ -11,7 +11,7 @@ use nickel_lang_core::{
     eval::cache::CacheImpl,
     identifier::Ident,
     label::Label,
-    program::Program,
+    program::{Program, ProgramContract},
     term::{make, RichTerm, RuntimeContract, Term},
 };
 use serde::Deserialize;
@@ -182,7 +182,10 @@ impl ManifestFile {
             RecordAccess("Manifest".into()),
             make::op1(RecordAccess("package".into()), Term::Var("std".into())),
         );
-        prog.add_contract(RuntimeContract::new(contract, Label::default()));
+        prog.add_contract(ProgramContract::Term(RuntimeContract::new(
+            contract,
+            Label::default(),
+        )));
 
         let manifest_term = prog.eval_full().map_err(|e| Error::ManifestEval {
             package: None,


### PR DESCRIPTION
Closes #2216.

This PR adds an argument `--apply-contract <path-to-contract>` to the CLI which applies the provided contract to the main program (initially `--contract` but that conflicted with the existing argument for `nickel query`, used to toggle the display of some part of the metadata, here the contract annotations). The name of the argument is open to bikeshedding.

`Program` already had infrastructure to store and apply additional contracts after merging multiple source files. However, this part was introduced by the package manager, which has different requirements: the package manager creates wrappers on the fly, programmatically. On the other hand, the CLI interface accepts a file path. So we need to parse, typecheck and whatnot the provided contracts.

One possibility is to do this right away, when `add_contract_files` is called, but this causes issues because the stdlib hasn't been loaded yet (typechecking fails). In the end, I think it's simpler and more solid to consider those additional sources - the contract provided on the CLI - as being part of the main program. They are thus stored as file ids, and parsed, typechecked or transformed at the same time as the rest of the program, instead of having a separate special treatment.

This also has the advantage that, if for any reason some workload doesn't want to perform all the steps (e.g. ignore typechecking for performance reasons), this will be uniformly applied to the additional contracts as well.