### PR TITLE
Fix formatting of doc/manual/package-management.md

### DIFF
--- a/doc/manual/package-management.md
+++ b/doc/manual/package-management.md
@@ -117,7 +117,7 @@ on tooling to improve it:
 2. Clone your fork onto your local machine.
 3. The package you want to publish must be at the root of a git repository.
    `cd` into that repository (or supply `--manifest-path` in the next step).
-4. Run `nickel publish --index <directory-of-your-clone> --package-id github:you/your-package`
+4. Run `nickel package publish --index <directory-of-your-clone> --package-id github:you/your-package`
 5. You should see that your local machine's index was modified. Commit that
    modification.
 6. Push your package to the `you/your-package` repository on github. These

--- a/doc/manual/package-management.md
+++ b/doc/manual/package-management.md
@@ -119,7 +119,7 @@ on tooling to improve it:
    `cd` into that repository (or supply `--manifest-path` in the next step).
 4. Run `nickel publish --index <directory-of-your-clone> --package-id github:you/your-package`
 5. You should see that your local machine's index was modified. Commit that
-  modification.
+   modification.
 6. Push your package to the `you/your-package` repository on github. These
    names *must* match the package id in the index, and you must ensure that
    the version you push to github matches the SHA-1 hash in the index.


### PR DESCRIPTION
This fixes the rendering of the package management chapter of the manual which is broken on the Nickel website.

![image](https://github.com/user-attachments/assets/45da784f-bb29-46bc-80ac-9980b2675914)
