### PR TITLE
[RFC007] Runtime value representation, take 1

### DIFF
--- a/core/src/bytecode/mod.rs
+++ b/core/src/bytecode/mod.rs
@@ -5,3 +5,4 @@
 
 pub mod ast;
 pub mod pretty;
+pub mod value;

--- a/core/src/bytecode/value/mod.rs
+++ b/core/src/bytecode/value/mod.rs
@@ -1,0 +1,307 @@
+//! Runtime representation of Nickel values.
+
+use crate::{
+    eval::cache::CacheIndex,
+    term::{record::RecordData, string::NickelString, ForeignIdPayload},
+};
+use nickel_lang_vector::Slice;
+use std::{num::NonZero, rc::Rc};
+
+/// A tagged pointer to a Nickel value. If the least significant bit is set, the value is an inline
+/// value. If the second least significant bit is set, the value is a thunk, that is a pointer to
+/// code. Finally, if the two least significant bits are clear, the value is a pointer to a
+/// heap-allocated value.
+pub struct NickelValue(usize);
+
+// Since a `NickelValue` can be an reference counted pointer in disguise, we can't just copy it
+// blindly. We need to go through `Rc::clone` to make sure the count is up to date.
+impl Clone for NickelValue {
+    fn clone(&self) -> Self {
+        if self.tag() == ValueTag::Pointer {
+            unsafe {
+                //TODO: the following commented line doesn't work, as an `Rc` of a dynamically
+                // sized type is a fat pointer and thus can't be reconstructed from a raw pointer.
+                // This hints at the fact that we will probably need to abandon the `u8`
+                // representation and just refer to untyped *u8 memory that is manually allocated
+                // through alloc.
+                // let rc = Rc::from_raw(self.0 as *const ContentData);
+                let rc: ValueContent = todo!();
+                NickelValue(Rc::into_raw(rc.clone()))
+            }
+        } else {
+            NickelValue(self)
+        }
+    }
+}
+
+impl NickelValue {
+    pub const fn tag() -> ValueTag {
+        self & VALUE_TAG_MASK
+    }
+}
+
+impl TryFrom<NickelValue> for InlineValue {
+    type Error = ();
+
+    fn try_from(value: NickelValue) -> Result<Self, Self::Error> {
+        (self.tag() == ValueTag::Inline).then_some(self).ok_or(())
+    }
+}
+
+impl TryFrom<NickelValue> for ValueContentPtr {
+    type Error = ();
+
+    fn try_from(value: NickelValue) -> Result<Self, Self::Error> {
+        unsafe {
+            (self.tag() == ValueTag::Pointer)
+                .then_some(Rc::from_raw_parts())
+                .ok_or(())
+        }
+    }
+}
+
+/// We use the lower two bits of a pointer (or an inline value) as a tag. This module defines the
+/// masks corresponding to each tag.
+#[repr(usize)]
+pub enum ValueTag {
+    /// The tag for a general heap-allocated value. The underlying value is to be interpreted as a
+    /// pointer.
+    Pointer = 0,
+    /// The tag for an [super::InlineValue].
+    Inline = 1,
+    /// The tag for a thunk, which is a pointer to code. Currently, this is to be interpreted as a
+    /// pointer to the [old ast](crate::term::RichTerm), but will eventually be a code address.
+    Code = 2,
+}
+
+const VALUE_TAG_MASK: usize = 0b11;
+
+const fn encode_value(content: usize, tag: ValueTag) -> usize {
+    match tag {
+        ValueTag::Pointer => content,
+        _ => (content << 2) | tag,
+    }
+}
+
+const fn decode_value(value: usize) -> usize {
+    match value & VALUE_TAG_MASK {
+        ValueTag::Pointer => tag,
+        _ => value >> 2,
+    }
+}
+
+const fn encode_inline(code: usize) -> usize {
+    encode_vaue(code, ValueTag::Inline)
+}
+
+/// Small values that can be inlined in the one-word representation of a Nickel value. Their numeric
+/// value is directly encoded (tagged), so that no bit shifting is needed
+/// at all for encoding and decoding them.
+#[repr(NonZero<usize>)]
+pub enum InlineValue {
+    Null = encode_inline(0),
+    True = encode_inline(1),
+    False = encode_inline(2),
+    EmptyArray = encode_inline(3),
+    EmptyRecord = encode_inline(4),
+}
+
+#[repr(u8)]
+pub enum ContentTag {
+    Array,
+    Record,
+    String,
+    Thunk,
+    Label,
+    EnumVariant,
+    ForeignId,
+    SealingKey,
+    CustomContract,
+    Type,
+}
+
+#[align(8)]
+pub struct ContentHeader {
+    pub tag: ContentTag,
+    pub closurized: bool,
+    padding: [u8; 6],
+}
+
+impl ContentHeader {
+    pub fn closurized(mut self) -> Self {
+        self.closurized = true;
+        self
+    }
+
+    pub fn with_tag(tag: ContentTag) -> Sef {
+        Self {
+            tag,
+            closurized: false,
+            padding: [0; 6],
+        }
+    }
+}
+
+/// Marker trait for representable values.
+pub trait ValueContent {
+    pub const TAG: ContentTag;
+}
+
+pub trait TaggedContent {
+    /// Get the tag of the value.
+    fn tag(&self) -> ContentTag;
+}
+
+pub type Array = Slice<NickelValue, 32>;
+
+pub type Record = RecordData;
+
+pub type String = NickelString;
+
+pub type Thunk = CacheIndex;
+
+pub type Label = crate::label::Label;
+
+pub struct EnumVariant {
+    pub tag: LocIdent,
+    pub arg: NickelValue,
+    pub attrs: EnumVariantAttrs,
+}
+
+pub type ForeignId = ForeignIdPayload;
+
+pub type CustomContract = crate::term::CustomContract;
+
+impl ValueContent for Array {
+    const TAG: ContentTag = ContentTag::Array;
+}
+
+impl ValueContent for Array {
+    const TAG: ContentTag = ContentTag::Array;
+}
+
+impl ValueContent for Record {
+    const TAG: ContentTag = ContentTag::Record;
+}
+
+impl ValueContent for String {
+    const TAG: ContentTag = ContentTag::String;
+}
+
+impl ContentTag for Thunk {
+    const TAG: ContentTag = ContentTag::Thunk;
+}
+
+impl ValueContent for Label {
+    const TAG: ContentTag = ContentTag::Label;
+}
+
+impl ValueContent for EnumVariant {
+    const TAG: ContentTag = ContentTag::EnumVariant;
+}
+
+impl ValueContent for ForeignId {
+    const TAG: ContentTag = ContentTag::ForeignId;
+}
+
+impl ValueContent for CustomContract {
+    const TAG: ContentTag = ContentTag::CustomContract;
+}
+
+pub trait Decode<T: ValueContent>: TaggedContent {
+    /// Decode a Nickel value from a tagged pointer.
+    fn try_decode(self) -> Option<T> {
+        (self.tag() == T::TAG).then(|| unsafe { self.decode_unchecked() })
+    }
+
+    /// Decode a Nickel value from a tagged pointer, panicking if the value is not of the expected
+    /// type.
+    fn decode(self) -> T {
+        self.try_decode().unwrap()
+    }
+    /// Decode a Nickel value from a tagged pointer without performing any safety checks.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure that the value is of the expected type, that is that the tag of
+    /// `self.tag()` matches `T::tag`, or undefined behavior will follow.
+    unsafe fn decode_unchecked(self) -> T;
+
+    /// Variant of [Self::try_decode] operating on a borrowed value.
+    fn try_decode_ref(&self) -> Option<&T> {
+        (self.tag() == T::TAG).then(|| unsafe { self.decode_ref_unchecked() })
+    }
+    /// Variant of [Self::decode] operating on a borrowed value.
+
+    fn decode_ref(&self) -> &T {
+        self.try_decode_ref().unwrap()
+    }
+
+    /// Variant of [Self::decode_unchecked] operating on a borrowed value.
+    unsafe fn decode_ref_unchecked(&self) -> &T;
+
+    /// Variant of [Self::try_decode] operating on a mutable borrowed value.
+    fn try_decode_mut(&mut self) -> Option<&mut T> {
+        (self.tag() == T::TAG).then(|| unsafe { self.decode_mut_unchecked() })
+    }
+
+    /// Variant of [Self::decode] operating on a mutable borrowed value.
+    fn decode_mut(&mut self) -> &mut T {
+        self.try_decode_mut().unwrap()
+    }
+
+    /// Variant of [Self::decode_unchecked] operating on a mutable borrowed value.
+    unsafe fn decode_mut_unchecked(&mut self) -> &mut T;
+}
+
+pub trait Encode<T: ValueContent>: TaggedContent {
+    /// Creates a [NickelValueData] from a [NickelValueContent].
+    fn encode(value: T) -> Self;
+}
+
+#[align(8)]
+pub struct Bytes(pub [u8]);
+
+pub struct ValueContentPtr(Rc<ContentData>);
+
+/// The content of a heap-allocated Nickel value. The pointee of a `NickelValue` when the latter
+/// isn't an inline value.
+//TODO: we could be even more aggressive and represent this as untyped, unsized `u8*` where we just
+//know that the first byte must be the tag, and then the length is a function of the tag. For now,
+//we'll use `[u8]`, even if it means we waste one word for the length of the slice (which we don't
+//need).
+pub struct ContentData {
+    header: ContentHeader,
+    body: Bytes,
+}
+
+impl ContentData {
+    /// Create a new `NickelValueData` with the given tag and body. Wrapper around
+    /// [Encode::encode].
+    pub fn new<T: ValueContent>(body: T) -> Self {
+        Self::encode(body)
+    }
+}
+
+impl<T: ValueContent> Decode<T> for ContentData {
+    unsafe fn decode_unchecked(self) -> T {
+        std::mem::transmute::<[u8], T>(self.body)
+    }
+
+    unsafe fn decode_ref_unchecked(&self) -> &T {
+        std::mem::transmute::<&[u8], &T>(&self.body)
+    }
+
+    unsafe fn decode_mut_unchecked(&mut self) -> &mut T {
+        std::mem::transmute::<&mut [u8], &mut T>(&mut self.body)
+    }
+}
+
+impl<T: ValueContent> Encode<T> for ContentData {
+    fn encode(value: T) -> Self {
+        Self {
+            header: ContentHeader::with_tag(T::TAG),
+            body: unsafe { std::mem::transmute::<T, [u8]>(value) },
+        }
+    }
+}

--- a/core/src/bytecode/value/mod.rs
+++ b/core/src/bytecode/value/mod.rs
@@ -2,10 +2,11 @@
 
 use crate::{
     eval::cache::CacheIndex,
-    term::{record::RecordData, string::NickelString, ForeignIdPayload},
+    term::{record::RecordData, string::NickelString, ForeignIdPayload, EnumVariantAttrs},
+    identifier::LocIdent,
 };
 use nickel_lang_vector::Slice;
-use std::{num::NonZero, rc::Rc};
+use std::{num::NonZero, rc::Rc, ptr::NonNull};
 
 /// A tagged pointer to a Nickel value. If the least significant bit is set, the value is an inline
 /// value. If the second least significant bit is set, the value is a thunk, that is a pointer to
@@ -25,18 +26,18 @@ impl Clone for NickelValue {
                 // representation and just refer to untyped *u8 memory that is manually allocated
                 // through alloc.
                 // let rc = Rc::from_raw(self.0 as *const ContentData);
-                let rc: ValueContent = todo!();
-                NickelValue(Rc::into_raw(rc.clone()))
+                let rc: ManagedContent = todo!();
+                NickelValue(ManagedContent(Rc::into_raw(rc.clone()) as usize))
             }
         } else {
-            NickelValue(self)
+            NickelValue(self.0)
         }
     }
 }
 
 impl NickelValue {
-    pub const fn tag() -> ValueTag {
-        self & VALUE_TAG_MASK
+    pub const fn tag(&self) -> ValueTag {
+        self.0 & VALUE_TAG_MASK
     }
 }
 
@@ -44,17 +45,18 @@ impl TryFrom<NickelValue> for InlineValue {
     type Error = ();
 
     fn try_from(value: NickelValue) -> Result<Self, Self::Error> {
-        (self.tag() == ValueTag::Inline).then_some(self).ok_or(())
+        (value.tag() == ValueTag::Inline).then_some(value).ok_or(())
     }
 }
 
-impl TryFrom<NickelValue> for ValueContentPtr {
+impl TryFrom<NickelValue> for ManagedContent {
     type Error = ();
 
     fn try_from(value: NickelValue) -> Result<Self, Self::Error> {
         unsafe {
-            (self.tag() == ValueTag::Pointer)
-                .then_some(Rc::from_raw_parts())
+            (value.tag() == ValueTag::Pointer)
+                //.then_some(Rc::from_raw(value.0 as *const ContentData))
+                .then_some(Rc::from_raw(todo!()))
                 .ok_or(())
         }
     }
@@ -79,25 +81,25 @@ const VALUE_TAG_MASK: usize = 0b11;
 const fn encode_value(content: usize, tag: ValueTag) -> usize {
     match tag {
         ValueTag::Pointer => content,
-        _ => (content << 2) | tag,
+        _ => (content << 2) | (tag as usize),
     }
 }
 
 const fn decode_value(value: usize) -> usize {
-    match value & VALUE_TAG_MASK {
-        ValueTag::Pointer => tag,
+    match value & (VALUE_TAG_MASK as usize) {
+        ValueTag::Pointer => value,
         _ => value >> 2,
     }
 }
 
 const fn encode_inline(code: usize) -> usize {
-    encode_vaue(code, ValueTag::Inline)
+    encode_value(code, ValueTag::Inline)
 }
 
 /// Small values that can be inlined in the one-word representation of a Nickel value. Their numeric
 /// value is directly encoded (tagged), so that no bit shifting is needed
 /// at all for encoding and decoding them.
-#[repr(NonZero<usize>)]
+#[repr(usize)]
 pub enum InlineValue {
     Null = encode_inline(0),
     True = encode_inline(1),
@@ -106,6 +108,7 @@ pub enum InlineValue {
     EmptyRecord = encode_inline(4),
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
 pub enum ContentTag {
     Array,
@@ -120,20 +123,42 @@ pub enum ContentTag {
     Type,
 }
 
-#[align(8)]
-pub struct ContentHeader {
-    pub tag: ContentTag,
-    pub closurized: bool,
-    padding: [u8; 6],
+#[repr(align(8))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+/// A one-word header for a heap-allocated Nickel value. The layout is as follows (values are given
+/// in bits):
+///
+/// ```text
+/// +-----------------+-----------------+----------------------+
+/// | Closurized (1)  | Tag (7)         | Strong Ref Count (56) |
+/// +-----------------+-----------------+----------------------+
+/// ```
+pub struct ContentHeader(u64);
+
+impl ContentHeader {
+    pub fn tag(&self) -> ContentTag {
+        // The tag is stored in the 7 least significant bits of the header.
+        (((self.0 & 0x7F_FF_FF_FF_FF_FF_FF_FF) as u8) as ContentTag
+    }
+
+    pub fn closurized(&self) -> bool {
+        // The closurized bit is the most significant bit of the header.
+        (self.0.get & (1 << 63)) != 0
+    }
+
+    pub fn strong_ref_count(&self) -> u64 {
+        self.0 & 0x00_FF_FF_FF_FF_FF_FF_FF
+    }
 }
 
+//TODO:
 impl ContentHeader {
     pub fn closurized(mut self) -> Self {
         self.closurized = true;
         self
     }
 
-    pub fn with_tag(tag: ContentTag) -> Sef {
+    pub fn with_tag(tag: ContentTag) -> Self {
         Self {
             tag,
             closurized: false,
@@ -144,12 +169,7 @@ impl ContentHeader {
 
 /// Marker trait for representable values.
 pub trait ValueContent {
-    pub const TAG: ContentTag;
-}
-
-pub trait TaggedContent {
-    /// Get the tag of the value.
-    fn tag(&self) -> ContentTag;
+    const TAG: ContentTag;
 }
 
 pub type Array = Slice<NickelValue, 32>;
@@ -172,8 +192,8 @@ pub type ForeignId = ForeignIdPayload;
 
 pub type CustomContract = crate::term::CustomContract;
 
-impl ValueContent for Array {
-    const TAG: ContentTag = ContentTag::Array;
+pub trait TaggedContent {
+    fn tag(&self) -> ContentTag;
 }
 
 impl ValueContent for Array {
@@ -188,7 +208,7 @@ impl ValueContent for String {
     const TAG: ContentTag = ContentTag::String;
 }
 
-impl ContentTag for Thunk {
+impl ValueContent for Thunk {
     const TAG: ContentTag = ContentTag::Thunk;
 }
 
@@ -259,10 +279,21 @@ pub trait Encode<T: ValueContent>: TaggedContent {
     fn encode(value: T) -> Self;
 }
 
-#[align(8)]
-pub struct Bytes(pub [u8]);
 
-pub struct ValueContentPtr(Rc<ContentData>);
+/// A pointer to a heap-allocated, reference-counter (included in the pointee) Nickel value of
+/// variable size (although the size is a deterministic function of the tag) with a custom drop
+/// implementation that correctly calls the destructor of the corresponding value.
+///
+/// To maintain uniquness, [Self] can't be cloned and is always accessed through an `Rc`.
+pub struct ValueBlockPtr(NonNull<u8>);
+
+impl Drop for ValueBlockPtr {
+    fn drop(&mut self) {
+        todo!() 
+    }
+}
+
+pub struct ManagedContent(Rc<ValueBlockPtr>);
 
 /// The content of a heap-allocated Nickel value. The pointee of a `NickelValue` when the latter
 /// isn't an inline value.
@@ -280,6 +311,12 @@ impl ContentData {
     /// [Encode::encode].
     pub fn new<T: ValueContent>(body: T) -> Self {
         Self::encode(body)
+    }
+}
+
+impl TaggedContent for ContentData {
+    fn tag(&self) -> ContentTag {
+        self.header.tag
     }
 }
 


### PR DESCRIPTION
This is moving forward with RFC007. This PR aims implement the memory-packed representation of values described in the RFC. As we don't have a bytecode virtual machine yet, the _code_ part of the values will be using the old AST representation. But we'll trim a good part of the old AST representation, as all "values" (that is, weak head normal forms) will be represented using the new implementation, which should trim memory usage quite drastically, hopefully.

## Random thoughts (WIP)

- We can't use `[u8]` to represent the variable part of a value block, because then `Rc<ValueBlock>` is a fat pointer, and we can't cast it from and to a `usize` anymore. What's more, we don't actually need the size of `[u8]` - it's just the only way in Rust to represent a DST which is an arbitrary stream of bytes - because we encode it in the block header. While it would be relatively ok to waste one word in the header of a block, using a fat pointer for values would go from one word to two word for useless information, which is a no-go. My current inclination is to just implement reference counting ourselves (possible just coyping basic parts from the stdlib), and use a `NonNull<u8>` as our value block pointer. Doing so we also save some size, since Nickel doesn't expose the weak pointer abstraction, we can get rid of the weak ref count.