### PR TITLE
Print more information for git errors

### DIFF
--- a/git/src/lib.rs
+++ b/git/src/lib.rs
@@ -23,7 +23,7 @@ pub enum Error {
     #[error("target `{target}` not found in `{url}`")]
     TargetNotFound { url: Box<gix::Url>, target: Target },
 
-    #[error(transparent)]
+    #[error("{0:?}")]
     Internal(#[from] anyhow::Error),
 }
 


### PR DESCRIPTION
This information would have helped with the filenames issue. And in general, if there's some error in the git fetch then I think it makes sense to display the root cause since there's nothing else we can do.