### PR TITLE
Wrap App arguments in atoms

### DIFF
--- a/core/src/bytecode/pretty.rs
+++ b/core/src/bytecode/pretty.rs
@@ -543,16 +543,15 @@ impl Allocator {
     }
 
     /// Uniform handling of application-like syntax.
-    fn application<'a, 'b, I, T, U>(&'a self, head: T, args: I) -> DocBuilder<'a, Self>
+    fn application<'a, 'b, I, T>(&'a self, head: T, args: I) -> DocBuilder<'a, Self>
     where
-        I: Iterator<Item = U>,
+        I: Iterator<Item = &'b Ast<'b>>,
         T: for<'c> Pretty<'c, Self, ()> + Clone,
-        U: for<'c> Pretty<'c, Self, ()> + Clone,
     {
         docs![
             self,
             head,
-            self.concat(args.map(|arg| docs![self, self.line(), arg]))
+            self.concat(args.map(|arg| docs![self, self.line(), self.atom(arg)]))
                 .nest(2)
         ]
         .group()

--- a/utils/src/test_program.rs
+++ b/utils/src/test_program.rs
@@ -1,8 +1,9 @@
 use nickel_lang_core::{
+    bytecode::ast::{Ast, AstAlloc},
     error::{Error, NullReporter, ParseError},
     eval::cache::CacheImpl,
     files::Files,
-    parser::{grammar, lexer, ErrorTolerantParserCompat, ExtendedTerm},
+    parser::{grammar, lexer, ErrorTolerantParser as _, ErrorTolerantParserCompat, ExtendedTerm},
     program::Program,
     term::{RichTerm, Term},
     typecheck::TypecheckMode,
@@ -37,6 +38,14 @@ pub fn parse(s: &str) -> Result<RichTerm, ParseError> {
 
     grammar::TermParser::new()
         .parse_strict_compat(id, lexer::Lexer::new(s))
+        .map_err(|errs| errs.errors.first().unwrap().clone())
+}
+
+pub fn parse_bytecode_ast<'a>(alloc: &'a AstAlloc, s: &str) -> Result<Ast<'a>, ParseError> {
+    let id = Files::new().add("<test>", String::from(s));
+
+    grammar::TermParser::new()
+        .parse_strict(alloc, id, lexer::Lexer::new(s))
         .map_err(|errs| errs.errors.first().unwrap().clone())
 }
 


### PR DESCRIPTION
When pretty-printing the new ast, arguments to applications weren't being wrapped as atoms, leading to output like

```nickel
std.array.filter fun x => x == 1 [1]
```

This fixes the immediate issue, but it isn't tested because I didn't find tests for the new ast pretty-printing. Do we have them?