### PR TITLE
[RFC007] Add some helpers to the compact value representation and `Term` value block

### DIFF
--- a/core/src/bytecode/value/mod.rs
+++ b/core/src/bytecode/value/mod.rs
@@ -437,7 +437,7 @@ impl NickelValue {
 
     /// Returns the body tag of the underlying value block, or `None` if `self` is an inline value.
     pub fn body_tag(&self) -> Option<BodyTag> {
-        (matches!(self.tag(), ValueTag::Pointer)).then(|| {
+        (self.tag() == ValueTag::Pointer).then(|| {
             // Safety: if `self.tag()` is `Pointer`, then `self.data` must be valid pointer to a
             // value  block.
             unsafe {
@@ -450,7 +450,7 @@ impl NickelValue {
     /// Determines if a value is in evaluated form, called weak head normal form (WHNF). See
     /// [crate::term::Term::is_whnf] for more detais.
     pub fn is_whnf(&self) -> bool {
-        matches!(self.body_tag(), Some(BodyTag::Thunk | BodyTag::Term))
+        !matches!(self.body_tag(), Some(BodyTag::Thunk | BodyTag::Term))
     }
 
     /// Returns the class of an expression in WHNF.


### PR DESCRIPTION
As I'm in the process of migrating `Term` to use the new `NickelValue`, I need to implement various `Term` helpers for `NickelValue`. This PR is a reasonably-sized and independent chunk of that work. It also include a new value block type for terms, that will prove useful when interleaving terms and values.