### PR TITLE
Missing field from contract

### DIFF
--- a/cli/tests/snapshot/inputs/errors/field_access_under_contract.ncl
+++ b/cli/tests/snapshot/inputs/errors/field_access_under_contract.ncl
@@ -1,0 +1,3 @@
+# capture = 'stderr'
+# command = ['eval']
+({} | { name | String }).name

--- a/cli/tests/snapshot/inputs/errors/field_access_under_domain_contract.ncl
+++ b/cli/tests/snapshot/inputs/errors/field_access_under_domain_contract.ncl
@@ -1,0 +1,3 @@
+# capture = 'stderr'
+# command = ['eval']
+let f | { name | String } -> String = fun x => x.name in f {}

--- a/cli/tests/snapshot/snapshots/snapshot__eval_stderr_fail_additional_contract.ncl.snap
+++ b/cli/tests/snapshot/snapshots/snapshot__eval_stderr_fail_additional_contract.ncl.snap
@@ -15,9 +15,3 @@ error: missing definition for `baz`
 5 │ │   bar = "hello, world!",
 6 │ │ }
   │ ╰─' in this record
-
-note: 
-  ┌─ [IMPORTS_PATH]/additional_contract1.ncl:3:9
-  │
-3 │   baz | Bool,
-  │         ^^^^ bound here

--- a/cli/tests/snapshot/snapshots/snapshot__eval_stderr_fail_additional_two_contracts1.ncl.snap
+++ b/cli/tests/snapshot/snapshots/snapshot__eval_stderr_fail_additional_two_contracts1.ncl.snap
@@ -15,9 +15,3 @@ error: missing definition for `baz`
 5 │ │   bar = "hello, world!",
 6 │ │ }
   │ ╰─' in this record
-
-note: 
-  ┌─ [IMPORTS_PATH]/additional_contract1.ncl:3:9
-  │
-3 │   baz | Bool,
-  │         ^^^^ bound here

--- a/cli/tests/snapshot/snapshots/snapshot__eval_stderr_fail_additional_two_contracts2.ncl.snap
+++ b/cli/tests/snapshot/snapshots/snapshot__eval_stderr_fail_additional_two_contracts2.ncl.snap
@@ -15,9 +15,3 @@ error: missing definition for `bar`
 5 │ │   baz = false,
 6 │ │ }
   │ ╰─' in this record
-
-note: 
-  ┌─ [IMPORTS_PATH]/additional_contract2.ncl:3:9
-  │
-3 │   bar | String,
-  │         ^^^^^^ bound here

--- a/cli/tests/snapshot/snapshots/snapshot__eval_stderr_field_access_under_contract.ncl.snap
+++ b/cli/tests/snapshot/snapshots/snapshot__eval_stderr_field_access_under_contract.ncl.snap
@@ -1,0 +1,11 @@
+---
+source: cli/tests/snapshot/main.rs
+expression: err
+---
+error: missing definition for `name`
+  ┌─ [INPUTS_PATH]/errors/field_access_under_contract.ncl:3:9
+  │
+3 │ ({} | { name | String }).name
+  │  --     ^^^^ required here
+  │  │       
+  │  in this record

--- a/cli/tests/snapshot/snapshots/snapshot__eval_stderr_field_access_under_domain_contract.ncl.snap
+++ b/cli/tests/snapshot/snapshots/snapshot__eval_stderr_field_access_under_domain_contract.ncl.snap
@@ -1,0 +1,11 @@
+---
+source: cli/tests/snapshot/main.rs
+expression: err
+---
+error: missing definition for `name`
+  ┌─ [INPUTS_PATH]/errors/field_access_under_domain_contract.ncl:3:11
+  │
+3 │ let f | { name | String } -> String = fun x => x.name in f {}
+  │           ^^^^                                             -- in this record
+  │           │                                                 
+  │           required here


### PR DESCRIPTION
This is an attempt to improve error messages caused by missing fields in records with contracts applied. The motivation here is that if I have a value like `x | { fld }` and I try to evaluate `x.fld`, then if `fld` is missing it should be a contract error and not the fault of the field access.

This PR doesn't make it a contract error, because at the time the field access is evaluated we don't seem to have the record contract around anymore to blame. The best I could manage was to change the missing field error to point at the location of the contract.

As an example of why we would prefer a proper contract error, consider

```nickel
let f | { name | String } -> String = fun x => x.name in f {}
```

If we could blame the contract `{ name | String }` here, the existing blame machinery would turn that into "contract violated by caller", which would be the ideal message I think. Anyway, the previous state of nickel would point to the `x.name` in the body of the function. After this PR, it will point to the `name` in the function's contract. I think that's a little better.