### PR TITLE
[nix-experimental] Provide the proper base path to Nix with `%eval_nix%`

### DIFF
--- a/core/src/cache.rs
+++ b/core/src/cache.rs
@@ -1580,9 +1580,8 @@ pub trait ImportResolver {
     /// This method need to be here because the evaluator makes use of it (when evaluating the
     /// `eval_nix` primop), but at this stage it only has access to the `ImportResolver` interface.
     /// We could give a default implementation here just using [Self::get_path], but we also need
-    /// `get_base_dir_for_nix` in [SourceCache]. We reuse the latter
-    /// [SourceCache::get_base_dir_for_nix`] implementation instead of duplicating a more generic
-    /// variant here.
+    /// `get_base_dir_for_nix` in [SourceCache]. We reuse the latter `implementation instead of
+    /// duplicating a more generic variant here.
     #[cfg(feature = "nix-experimental")]
     fn get_base_dir_for_nix(&self, file_id: FileId) -> PathBuf;
 }

--- a/core/src/nix_ffi/cpp/nix.cc
+++ b/core/src/nix_ffi/cpp/nix.cc
@@ -28,7 +28,7 @@ struct DummyEvalCommand : virtual EvalCommand {
 };
 
 // FIXME: error messages have an extra `error:` on them
-rust::String eval_to_json(rust::Str nixCode)
+rust::String eval_to_json(rust::Str nixCode, const std::string & baseDir)
 {
   auto dummy = DummyEvalCommand({});
   initNix();
@@ -36,7 +36,7 @@ rust::String eval_to_json(rust::Str nixCode)
   auto & state = *dummy.getEvalState();
 
   auto vRes = state.allocValue();
-  state.eval(state.parseExprFromString(std::string(nixCode), state.rootPath(CanonPath::root)), *vRes);
+  state.eval(state.parseExprFromString(std::string(nixCode), state.rootPath(CanonPath(baseDir))), *vRes);
 
   std::stringstream out;
   NixStringContext context;

--- a/core/src/nix_ffi/cpp/nix.hh
+++ b/core/src/nix_ffi/cpp/nix.hh
@@ -7,4 +7,4 @@
 
 using namespace nix;
 
-rust::String eval_to_json(const rust::Str nix_code);
+rust::String eval_to_json(const rust::Str nix_code, const std::string & base_dir);

--- a/core/src/nix_ffi/mod.rs
+++ b/core/src/nix_ffi/mod.rs
@@ -1,9 +1,26 @@
+use cxx::let_cxx_string;
+
 #[cxx::bridge]
 mod internal {
     unsafe extern "C++" {
         include!("nickel-lang-core/src/nix_ffi/cpp/nix.hh");
-        fn eval_to_json(nix_code: &str) -> Result<String>;
+        fn eval_to_json(nix_code: &str, base_dir: &CxxString) -> Result<String>;
     }
 }
 
-pub use internal::*;
+/// Calls to the Nix FFI to evaluate the given Nix code and returns the result as a JSON string.
+///
+/// # Arguments
+///
+/// - `nix_code`: the Nix code to evaluate, as a string.
+/// - `base_dir`: the base directory passed to the Nix evaluator, which is used to resolve imports
+///   on the Nix side.
+pub fn eval_to_json(nix_code: &str, base_dir: &std::path::Path) -> Result<String, cxx::Exception> {
+    // There is no builtin binding type for passing `OsStr` across FFI boundaries in cxx currently
+    // (https://github.com/dtolnay/cxx/issues/1291), so we build a raw [u8] slice, then a
+    // `std::string` from it (or rather the corresponding version `CxxString` in the Rust world)
+    // and pass this to the C++ side.
+    let path_bytes = base_dir.as_os_str().as_encoded_bytes();
+    let_cxx_string!(path_string = path_bytes);
+    internal::eval_to_json(nix_code, &path_string)
+}

--- a/flake.nix
+++ b/flake.nix
@@ -315,7 +315,7 @@
 
           buildWorkspace = { pnameSuffix ? "", extraNickelFeatures ? [ ], extraBuildArgs ? "", extraArgs ? { } }:
             let
-              featureArgs = pkgs.lib.optionalString
+              featuresArg = pkgs.lib.optionalString
                 (extraNickelFeatures != [ ])
                 ("--features " + pkgs.lib.strings.concatStringsSep " " extraNickelFeatures);
             in
@@ -339,7 +339,7 @@
                   (builtins.elem "nix-experimental" extraNickelFeatures)
                   ([ boost nix ]);
 
-              cargoExtraArgs = "${cargoBuildExtraArgs} ${featureArgs} ${extraBuildArgs} --workspace";
+              cargoExtraArgs = "${cargoBuildExtraArgs} ${featuresArg} ${extraBuildArgs} --workspace";
               CARGO_PROFILE = profile;
             } // extraArgs);
 


### PR DESCRIPTION
For the nix-experimental feature, we didn't provide the correct base path when instantiating the Nix evaluator, making it impossible to fetch files from Nix code. This commit fixes the issue, and doing so, adds an output to the flake to make it easy to build Nickel with the nix-experimental feature enabled.