### PR TITLE
Make spans in Labels optional, to avoid the cost of constructing them

### DIFF
--- a/cli/src/doctest.rs
+++ b/cli/src/doctest.rs
@@ -447,7 +447,7 @@ fn doctest_transform(
                                     typ: eq_ty.clone(),
                                     label: Label {
                                         typ: Rc::new(eq_ty),
-                                        span: expected_span,
+                                        span: Some(expected_span),
                                         ..Default::default()
                                     },
                                 }],

--- a/core/src/bytecode/ast/compat.rs
+++ b/core/src/bytecode/ast/compat.rs
@@ -1085,7 +1085,7 @@ impl<'ast> FromAst<Type<'ast>> for term::LabeledType {
             typ: typ.clone(),
             label: label::Label {
                 typ: std::rc::Rc::new(typ),
-                span,
+                span: Some(span),
                 ..Default::default()
             },
         }
@@ -1483,7 +1483,7 @@ impl<'ast> FromAst<Ast<'ast>> for term::RichTerm {
         {
             // unwrap(): we expect all position to be set in the new AST (should be using span
             // directly in the future)
-            label.span = ast.pos.unwrap();
+            label.span = Some(ast.pos.unwrap());
         }
 
         result
@@ -1626,7 +1626,7 @@ fn merge_fields(
             }
             (t1, t2) => mk_term::op2(
                 BinaryOp::Merge(label::MergeLabel {
-                    span: id_span,
+                    span: Some(id_span),
                     kind: label::MergeKind::PiecewiseDef,
                 }),
                 RichTerm::new(t1, pos1),

--- a/core/src/error/mod.rs
+++ b/core/src/error/mod.rs
@@ -1356,7 +1356,9 @@ impl IntoDiagnostics for EvalError {
                     MergeKind::PiecewiseDef => "when combining the definitions of this field",
                 };
 
-                labels.push(secondary(&merge_label.span).with_message(span_label));
+                if let Some(merge_label_span) = &merge_label.span {
+                    labels.push(secondary(merge_label_span).with_message(span_label));
+                }
 
                 fn push_merge_note(notes: &mut Vec<String>, typ: &str) {
                     notes.push(format!(

--- a/core/src/label.rs
+++ b/core/src/label.rs
@@ -6,7 +6,6 @@ use std::{collections::HashMap, rc::Rc};
 
 use crate::{
     eval::cache::{Cache as EvalCache, CacheIndex},
-    files::Files,
     identifier::LocIdent,
     position::{RawSpan, TermPos},
     term::{
@@ -281,7 +280,7 @@ pub struct Label {
     pub diagnostics: Vec<ContractDiagnostic>,
 
     /// The position of the original contract.
-    pub span: RawSpan,
+    pub span: Option<RawSpan>,
 
     /// The index corresponding to the value being checked. Set at run-time by the interpreter.
     pub arg_idx: Option<CacheIndex>,
@@ -411,11 +410,6 @@ impl Label {
         Label {
             typ: Rc::new(Type::from(TypeF::Number)),
             diagnostics: vec![ContractDiagnostic::new().with_message(String::from("testing"))],
-            span: RawSpan {
-                src_id: Files::new().add("<test>", String::from("empty")),
-                start: 0.into(),
-                end: 1.into(),
-            },
             polarity: Polarity::Positive,
             ..Default::default()
         }
@@ -508,11 +502,7 @@ impl Default for Label {
     fn default() -> Label {
         Label {
             typ: Rc::new(Type::from(TypeF::Dyn)),
-            span: RawSpan {
-                src_id: Files::new().add("<null>", String::from("")),
-                start: 0.into(),
-                end: 1.into(),
-            },
+            span: None,
             polarity: Polarity::Positive,
             diagnostics: Default::default(),
             arg_idx: Default::default(),
@@ -554,7 +544,7 @@ pub enum MergeKind {
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub struct MergeLabel {
     /// The span of the original merge (which might then decompose into many others).
-    pub span: RawSpan,
+    pub span: Option<RawSpan>,
     pub kind: MergeKind,
 }
 

--- a/core/src/program.rs
+++ b/core/src/program.rs
@@ -706,7 +706,7 @@ impl<EC: EvalCache> Program<EC> {
                             term,
                             Label {
                                 typ: std::rc::Rc::new(typ),
-                                span,
+                                span: Some(span),
                                 ..Default::default()
                             },
                         ))

--- a/core/src/term/mod.rs
+++ b/core/src/term/mod.rs
@@ -772,7 +772,7 @@ impl LabeledType {
             typ: typ.clone(),
             label: Label {
                 typ: Rc::new(typ),
-                span,
+                span: Some(span),
                 ..Default::default()
             },
         }

--- a/core/src/term/pattern/compile.rs
+++ b/core/src/term/pattern/compile.rs
@@ -178,13 +178,11 @@ fn update_with_merge(record_id: LocIdent, id: LocIdent, field: Field) -> RichTer
 
     let span = annot
         .iter()
-        .map(|labeled_ty| labeled_ty.label.span)
+        .filter_map(|labeled_ty| labeled_ty.label.span)
         .chain(pos_value)
         // We fuse all the definite spans together.
         // unwrap(): all span should come from the same file
-        // unwrap(): we hope that at least one position is defined
-        .reduce(|span1, span2| span1.fuse(span2).unwrap())
-        .unwrap();
+        .reduce(|span1, span2| span1.fuse(span2).unwrap());
 
     let merge_label = MergeLabel {
         span,


### PR DESCRIPTION
I think it's nicer for them not to be optional, but we often have them as `None` during construction. Given that, I think having them explicitly optional is better than instantiating dummy `Files` all the time.

Fixes #2318 