### PR TITLE
Pass sources from World into background eval

### DIFF
--- a/core/src/cache.rs
+++ b/core/src/cache.rs
@@ -684,6 +684,22 @@ impl ImportData {
         ret
     }
 
+    /// Returns the set of files that this file transitively depends on.
+    pub fn transitive_imports(&self, file: FileId) -> HashSet<FileId> {
+        let mut ret = HashSet::new();
+        let mut stack = vec![file];
+
+        while let Some(file) = stack.pop() {
+            for f in self.imports(file) {
+                if ret.insert(f) {
+                    stack.push(f);
+                }
+            }
+        }
+
+        ret
+    }
+
     /// Returns `true` if those import data are empty.
     pub fn is_empty(&self) -> bool {
         self.imports.is_empty() && self.rev_imports.is_empty()

--- a/lsp/nls/src/analysis.rs
+++ b/lsp/nls/src/analysis.rs
@@ -7,6 +7,7 @@
 use std::{collections::HashMap, convert::Infallible};
 
 use lsp_server::{ErrorCode, ResponseError};
+use lsp_types::Url;
 use ouroboros::self_referencing;
 
 use nickel_lang_core::{
@@ -665,6 +666,7 @@ impl<'std> PackedAnalysis<'std> {
         sources: &'a mut SourceCache,
         import_data: &'a mut ImportData,
         import_targets: &'a mut ImportTargets,
+        file_uris: &'a mut HashMap<FileId, Url>,
         reg: AnalysisRegistryRef<'a, 'std>,
     ) -> (Vec<AnalysisTarget<'std>>, Result<(), Vec<TypecheckError>>) {
         self.with_mut(move |slf| {
@@ -685,6 +687,7 @@ impl<'std> PackedAnalysis<'std> {
                 sources,
                 import_data,
                 import_targets,
+                file_uris,
             };
 
             let typecheck_result = typecheck_visit(


### PR DESCRIPTION
fixes #2322.

This is the most straightforward way I could find to share the state of world with the background eval task and prevent synchronization issues. The downside is that the contents of the file to evaluate and its dependencies have to get copied into the background thread on every evaluation. I figured I'd check if this was ok despite that since the alternatives I can think of would be significantly more complicated. I did try just using a mutex to share SourceCache but it's not thread safe due to Rc being used pretty frequently throughout core.