### PR TITLE
Fix performance of UsageLookup

### DIFF
--- a/lsp/nls/src/usage.rs
+++ b/lsp/nls/src/usage.rs
@@ -171,7 +171,7 @@ impl<'ast> UsageLookup<'ast> {
             &mut |ast: &'ast Ast<'ast>, env: &Environment<'ast>| {
                 self.fill(alloc, ast, env);
 
-                TraverseControl::Continue
+                TraverseControl::SkipBranch
             },
             env,
         );


### PR DESCRIPTION
When visiting a contract inside a type, we should `fill` it but not continue the traversal (because `fill` already recurses).