### PR TITLE
Clean up Ident conversions to reduce accidental allocations

### DIFF
--- a/core/src/term/string.rs
+++ b/core/src/term/string.rs
@@ -41,6 +41,12 @@ impl From<NickelString> for LocIdent {
     }
 }
 
+impl<'a> From<&'a NickelString> for LocIdent {
+    fn from(s: &'a NickelString) -> Self {
+        LocIdent::from(s.0.as_str())
+    }
+}
+
 // The below impls broadly allow `NclString`s to be treated just like
 // Rust `String`s.
 


### PR DESCRIPTION
The original goal of this PR was to delete our custom interner, but that didn't work out.

I found three widely-used crates for string interning:
- `lasso`, which appears unmaintained and apparently doesn't build on recent versions of rust. There's a fork (lasso2), but it isn't widely used
- `string-interner`, which seems pretty similar to our existing approach. For our usage, the main downside is that it doesn't build in the notion of a process-wide interner. That means we need to put the `StringInterner` object in a global `Mutex`, and then we can't support our current usage of `Ident::label`, because the returned `&str` can only live as long as the temporary mutex lock. `string-interner` does have a variant with stable address, so in principle we could transmute the references. But then we haven't succeeded in delegating our unsafe code...
- `internment`, which builds in an easy-to-use global intern table. Unfortunately, it caused some substantial slowdowns in our benchmarks (about 10% across the board -- I ran it a few times to confirm). I'm not totally sure, but this might be because it increases `Ident`'s size from 4 to 8 bytes (because it basically becomes `&'static str`).

So after all that, our interning code is mostly untouched. I tweaked the conversions a bit to avoid allocations (for example, previously our conversion from `&str` to `Ident` was passing through a temporary `String`). Benchmarks improved by about 2-6%.

I also noticed that our generated identifiers aren't guaranteed unique, because there are ways besides `Ident::fresh` to create identifiers like `"%1"`. I left this as a FIXME, because I wasn't sure how to address it. One possibility is to reserve a bit in `Ident` to mark generated identifiers. This would guarantee that they always compare not-equal to non-generated identifiers, but it does cut the identifier space in half, supporting only 2B generated ids and 2B non-generated ids.