### PR TITLE
Plumb custom_transform into EntryState to minimize traversal

### DIFF
--- a/cli/src/doctest.rs
+++ b/cli/src/doctest.rs
@@ -296,7 +296,7 @@ impl TestCommand {
         let mut registry = TestRegistry::default();
         program.typecheck(TypecheckMode::Walk)?;
         program
-            .custom_transform(|cache, rt| doctest_transform(cache, &mut registry, rt))
+            .custom_transform(0, |cache, rt| doctest_transform(cache, &mut registry, rt))
             .map_err(|e| e.unwrap_error("transforming doctest"))?;
         Ok((program.eval_closurized_record_spine()?, registry))
     }

--- a/core/src/program.rs
+++ b/core/src/program.rs
@@ -541,18 +541,19 @@ impl<EC: EvalCache> Program<EC> {
     /// Applies a custom transformation to the main term, assuming that it has been parsed but not
     /// yet transformed.
     ///
-    /// The term is left in whatever state it started in.
-    ///
-    /// This state-management isn't great, as it breaks the usual linear order of state changes.
-    /// In particular, there's no protection against double-applying the same transformation, and no
-    /// protection against applying it to a term that's in an unexpected state.
-    pub fn custom_transform<E, F>(&mut self, mut transform: F) -> Result<(), CacheError<E>>
+    /// If multiple invocations of `custom_transform` are needed, each subsequent invocation must supply
+    /// `transform_id` with with a number higher than that of all previous invocations.
+    pub fn custom_transform<E, F>(
+        &mut self,
+        transform_id: usize,
+        mut transform: F,
+    ) -> Result<(), CacheError<E>>
     where
         F: FnMut(&mut CacheHub, RichTerm) -> Result<RichTerm, E>,
     {
         self.vm
             .import_resolver_mut()
-            .custom_transform(self.main_id, &mut transform)
+            .custom_transform(self.main_id, transform_id, &mut transform)
     }
 
     /// Retrieve the parsed term, typecheck it, and generate a fresh initial environment. If


### PR DESCRIPTION
Fixes #2344

This change addresses the underlying cause of performance issues in https://github.com/tweag/nickel/issues/2344, which was that a dense web of imports will result in lots of duplicated invocations when using `custom_transform`.

This change introduces custom transformations to the `EntryState` state machine, which allows iteration over terms to avoid terms which have already been applied to the custom transformation.

I can also confirm this addresses the issue upstream!

Thanks @jneem for coaching!!