### PR TITLE
Avoid copying file contents in LSP eval

### DIFF
--- a/core/src/cache.rs
+++ b/core/src/cache.rs
@@ -42,6 +42,7 @@ use std::{
     io::{self, Read},
     path::{Path, PathBuf},
     result::Result,
+    sync::Arc,
     time::SystemTime,
 };
 
@@ -404,6 +405,13 @@ impl SourceCache {
     /// Panics if the file id is invalid.
     pub fn source(&self, id: FileId) -> &str {
         self.files.source(id)
+    }
+
+    /// Returns a cloned Arc to the content of the file
+    ///
+    /// Panics if the file id is invalid.
+    pub fn clone_source(&self, id: FileId) -> Arc<str> {
+        self.files.clone_source(id)
     }
 
     /// Loads a new source as a string and add it to the name-id table.

--- a/lsp/nls/Cargo.toml
+++ b/lsp/nls/Cargo.toml
@@ -42,7 +42,7 @@ ouroboros.workspace = true
 pretty.workspace = true
 regex.workspace = true
 scopeguard.workspace = true
-serde = { workspace = true, features = ["derive"] }
+serde = { workspace = true, features = ["derive", "rc"] }
 serde_json.workspace = true
 thiserror.workspace = true
 git-version.workspace = true


### PR DESCRIPTION
Shares file contents with an Arc when sending it to the BackgroundJobs thread rather than copying the string. It's not exactly the approach we discussed but this has a more minimal impact to core.