### PR TITLE
Initial experiments with applying nls to yaml

### DIFF
--- a/lsp/nls/src/codespan_lsp.rs
+++ b/lsp/nls/src/codespan_lsp.rs
@@ -13,15 +13,13 @@ use std::ops::Range;
 fn location_to_position(
     line_str: &str,
     line: usize,
-    column: usize,
+    mut column: usize,
     byte_index: usize,
 ) -> Result<LspPosition, Error> {
     if column > line_str.len() {
-        let max = line_str.len();
-        let given = column;
-
-        Err(Error::ColumnTooLarge { given, max })
-    } else if !line_str.is_char_boundary(column) {
+        column = line_str.len();
+    }
+    if !line_str.is_char_boundary(column) {
         let given = byte_index;
 
         Err(Error::InvalidCharBoundary { given })


### PR DESCRIPTION
In this hacky experiment, whenever we load a data file (like `test.yaml`) nls will try to find a Nickel file nearby (at `test.ncl`) and apply it as a contract.

It works, but I think it will be cleaner (and allow, for example, completions) if we parse the yaml to `Ast` and store it in the analysis cache. Currently we're re-parsing the yaml on every change, which actually isn't too slow because the Nickel contract isn't reloaded.

I think I'll wait for the value representation to land before trying to push this further, since it's related to `SourceCache::parse_other`

<img width="1896" height="1010" alt="20250916_17h10m43s_grim" src="https://github.com/user-attachments/assets/440f50a4-4579-48b3-8884-30a2d6d1dd9c" />
