### PR TITLE
Fix crash in NLS when creating typechecking diagnostics

### DIFF
--- a/core/src/error/mod.rs
+++ b/core/src/error/mod.rs
@@ -1877,8 +1877,8 @@ mod blame_error {
                 let type_pprinted = format!("{ty}");
                 let file_id = files.add(super::UNKNOWN_SOURCE_NAME, type_pprinted.clone());
 
-                let ty_with_pos = FixedTypeParser::new()
-                    .parse_strict_compat(file_id, Lexer::new(&type_pprinted))
+                let (ty_with_pos, _) = FixedTypeParser::new()
+                    .parse_tolerant_compat(file_id, Lexer::new(&type_pprinted))
                     .unwrap();
 
                 ty_path::span(path.iter().peekable(), &ty_with_pos)

--- a/lsp/nls/tests/inputs/diagnostics-unparseable-type.ncl
+++ b/lsp/nls/tests/inputs/diagnostics-unparseable-type.ncl
@@ -1,0 +1,3 @@
+### /diagnostics.ncl
+(fun a => a) : { _ : _ } -> { _ }
+### diagnostic = ["file:///diagnostics.ncl"]

--- a/lsp/nls/tests/snapshots/main__lsp__nls__tests__inputs__diagnostics-unparseable-type.ncl.snap
+++ b/lsp/nls/tests/snapshots/main__lsp__nls__tests__inputs__diagnostics-unparseable-type.ncl.snap
@@ -1,0 +1,5 @@
+---
+source: lsp/nls/tests/main.rs
+expression: output
+---
+[0:10-0:11: "incompatible types\nExpected an expression of type `{  <parse error>, }` (a contract)\nFound an expression of type `{ _ : _ }`\nStatic types and contracts are not compatible", 0:10-0:11: "this expression", 0:32-0:33: "unexpected token"]


### PR DESCRIPTION
The following input crashes the LSP:

```
(fun a => a) : { _ : _ } -> { _ }
```

The reason is that the LSP uses error tolerant parsing, but then while creating the diagnostics the type gets parsed again strictly, and crashes on an unwrap(). I've changed this to use error tolerant parsing as well, which prevents the crash.

I'll probably follow up on this because the generated diagnostics end up being pretty weird, an example is below. In this case it probably makes the most sense to just suppress the typechecking error and only issue the parsing one.

<img width="678" height="195" alt="image" src="https://github.com/user-attachments/assets/741f6ac6-84e7-4bb7-91d6-aa0d5f1ced2b" />
