### PR TITLE
Make the history file optional for the repl

### DIFF
--- a/cli/src/repl.rs
+++ b/cli/src/repl.rs
@@ -13,14 +13,9 @@ pub struct ReplCommand {
 
 impl ReplCommand {
     pub fn run(self, ctxt: &mut GlobalContext) {
-        let histfile = if let Some(h) = self.history_file {
-            h
-        } else {
-            BaseDirs::new()
-                .expect("Cannot retrieve home directory path")
-                .home_dir()
-                .join(".nickel_history")
-        };
+        let histfile = self
+            .history_file
+            .or_else(|| BaseDirs::new().map(|bd| bd.home_dir().join(".nickel_history")));
         ctxt.reporter.report_result(rustyline_frontend::repl(
             histfile,
             color_opt_from_clap(ctxt.opts.color),


### PR DESCRIPTION
While updating the website, I noticed that the docker instruction `docker run --rm -it ghcr.io/tweag/nickel:1.14.0 repl` fails because it doesn't have a home directory for the history file. This PR makes the history file optional, so the repl will still run without it.