### PR TITLE
Publish to PyPI if the action was triggered by a release

### DIFF
--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -148,7 +148,7 @@ jobs:
   publish-to-pypi:
     name: Publish distribution to PyPI
     runs-on: ubuntu-latest
-    if: ${{ github.event.inputs.dry_run == 'false' }}
+    if: ${{ github.event_name == 'release' || github.event.inputs.dry_run == 'false' }}
     needs: [linux, musllinux, windows, macos, sdist]
     environment:
       name: pypi


### PR DESCRIPTION
This might fix #2374. We'll have to check after the next release.