### PR TITLE
chore(cargo,packaging): add `cargo-binstall` support for nickel-lang-cli and nls

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -51,3 +51,13 @@ regex.workspace = true
 nickel-lang-utils.workspace = true
 test-generator.workspace = true
 insta = { workspace = true, features = ["filters"] }
+
+[package.metadata.binstall]
+pkg-url = "{repo}/releases/download/{version}/nickel-{target-arch}-{target-family}{binary-ext}"
+pkg-fmt = "bin"
+# https://github.com/cargo-bins/cargo-binstall/issues/2328 macos
+# https://github.com/cargo-bins/cargo-binstall/issues/2126 arm64 vs aarch64
+[package.metadata.binstall.overrides.aarch64-apple-darwin]
+pkg-url = "{repo}/releases/download/{version}/nickel-arm64-macos"
+[package.metadata.binstall.overrides.aarch64-unknown-linux-musl]
+pkg-url = "{repo}/releases/download/{version}/nickel-arm64-linux"

--- a/lsp/nls/Cargo.toml
+++ b/lsp/nls/Cargo.toml
@@ -60,3 +60,13 @@ test-generator.workspace = true
 
 [features]
 nix-experimental = ["nickel-lang-core/nix-experimental"]
+
+[package.metadata.binstall]
+pkg-url = "{repo}/releases/download/{version}/nls-{target-arch}-{target-family}{binary-ext}"
+pkg-fmt = "bin"
+# https://github.com/cargo-bins/cargo-binstall/issues/2328 macos
+# https://github.com/cargo-bins/cargo-binstall/issues/2126 arm64 vs aarch64
+[package.metadata.binstall.overrides.aarch64-apple-darwin]
+pkg-url = "{repo}/releases/download/{version}/nls-arm64-macos"
+[package.metadata.binstall.overrides.aarch64-unknown-linux-musl]
+pkg-url = "{repo}/releases/download/{version}/nls-arm64-linux"


### PR DESCRIPTION
Using [wasmtime manifest](https://github.com/bytecodealliance/wasmtime/blob/3e3fafe8c61d2506c50a8dc2b179a4c3feb08695/Cargo.toml#L16-L32) as reference, added `cargo-binstall` ability to download from the github releases:

https://github.com/bytecodealliance/wit-deps/blob/074a6fafc9510623d9e45a2d91aed42d98452a85/Cargo.toml#L12-L21

`cargo-binstall` reference doc for URLs: https://github.com/cargo-bins/cargo-binstall/blob/main/SUPPORT.md#support-for-cargo-binstall