### PR TITLE
[RFC007] Reduce `Term` size, chapter: functions

### DIFF
--- a/core/src/closurize.rs
+++ b/core/src/closurize.rs
@@ -257,7 +257,7 @@ impl Closurize for RecordData {
 pub fn should_share(value: &NickelValue) -> bool {
     match value.content_ref() {
         ValueContentRef::Term(Term::Var(_)
-            | Term::Fun(_, _)
+            | Term::Fun(_)
             // match acts like a function, and is a WHNF
             | Term::Match(_)) => false,
         ValueContentRef::Term(_)

--- a/core/src/eval/cache/lazy.rs
+++ b/core/src/eval/cache/lazy.rs
@@ -220,7 +220,7 @@ impl ThunkData {
                 // that order, we want to build `fun a => (fun b => (fun c => body))`. We thus need
                 // a reverse fold.
                 let as_function = args.rfold(body, |built, id| {
-                    NickelValue::from(Term::Fun(id.into(), built))
+                    NickelValue::from(Term::fun(id.into(), built))
                 });
 
                 ThunkData::new(Closure {

--- a/core/src/eval/mod.rs
+++ b/core/src/eval/mod.rs
@@ -84,7 +84,7 @@ use crate::{
     position::{PosIdx, PosTable},
     program::FieldPath,
     term::{
-        BinaryOp, BindingType, Import, LetAttrs, MatchBranch, MatchData, RecordOpKind,
+        BinaryOp, BindingType, FunData, Import, LetAttrs, MatchBranch, MatchData, RecordOpKind,
         RuntimeContract, StrChunk, Term, UnaryOp, make as mk_term,
         pattern::compile::Compile,
         record::{Field, RecordData},
@@ -1130,7 +1130,7 @@ impl<'ctxt, R: ImportResolver, C: Cache> VirtualMachine<'ctxt, R, C> {
                 }
                 // Function call if there's no continuation on the stack (otherwise, the function
                 // is just an argument to a primop or to put in the eval cache)
-                ValueContentRef::Term(Term::Fun(arg, body)) if !has_cont_on_stack => {
+                ValueContentRef::Term(Term::Fun(FunData { arg, body })) if !has_cont_on_stack => {
                     if let Some((idx, pos_app)) = self.stack.pop_arg_as_idx(&mut self.context.cache)
                     {
                         self.call_stack.enter_fun(&self.context.pos_table, pos_app);

--- a/core/src/eval/operation.rs
+++ b/core/src/eval/operation.rs
@@ -4023,7 +4023,7 @@ fn eq<C: Cache>(
 fn eta_expand(op: UnaryOp, pos_op: PosIdx) -> Term {
     let param = LocIdent::fresh();
 
-    Term::Fun(
+    Term::fun(
         param,
         NickelValue::term(
             Term::Op1(op, NickelValue::term(Term::Var(param), pos_op)),

--- a/core/src/eval/value/lens.rs
+++ b/core/src/eval/value/lens.rs
@@ -10,8 +10,8 @@ use crate::{
     identifier::LocIdent,
     label::Label,
     term::{
-        BinaryOp, Import, LetAttrs, MatchData, NAryOp, SealingKey, StrChunk, Term, TypeAnnotation,
-        UnaryOp,
+        BinaryOp, FunData, FunPatternData, Import, LetAttrs, MatchData, NAryOp, SealingKey,
+        StrChunk, Term, TypeAnnotation, UnaryOp,
         pattern::Pattern,
         record::{Field, Include, RecordData, RecordDeps},
     },
@@ -197,8 +197,8 @@ pub type RecRecordData = (
 pub enum TermContent {
     Value(ValueLens<NickelValue>),
     StrChunks(ValueLens<Vec<StrChunk<NickelValue>>>),
-    Fun(ValueLens<(LocIdent, NickelValue)>),
-    FunPattern(ValueLens<(Pattern, NickelValue)>),
+    Fun(ValueLens<FunData>),
+    FunPattern(ValueLens<Box<FunPatternData>>),
     Let(ValueLens<LetData>),
     LetPattern(ValueLens<LetPatternData>),
     App(ValueLens<(NickelValue, NickelValue)>),
@@ -381,7 +381,7 @@ impl ValueLens<Vec<StrChunk<NickelValue>>> {
     }
 }
 
-impl ValueLens<(LocIdent, NickelValue)> {
+impl ValueLens<FunData> {
     /// Creates a new lens extracting [crate::term::Term::Fun].
     ///
     /// # Safety
@@ -396,18 +396,18 @@ impl ValueLens<(LocIdent, NickelValue)> {
     }
 
     /// Extractor for [crate::term::Term::Fun].
-    fn term_fun_extractor(value: NickelValue) -> (LocIdent, NickelValue) {
+    fn term_fun_extractor(value: NickelValue) -> FunData {
         let term = ValueLens::<TermData>::content_extractor(value);
 
-        if let Term::Fun(arg, body) = term {
-            (arg, body)
+        if let Term::Fun(data) = term {
+            data
         } else {
             unreachable!()
         }
     }
 }
 
-impl ValueLens<(Pattern, NickelValue)> {
+impl ValueLens<Box<FunPatternData>> {
     /// Creates a new lens extracting [crate::term::Term::FunPattern].
     ///
     /// # Safety
@@ -422,11 +422,11 @@ impl ValueLens<(Pattern, NickelValue)> {
     }
 
     /// Extractor for [crate::term::Term::FunPattern].
-    fn term_fun_pat_extractor(value: NickelValue) -> (Pattern, NickelValue) {
+    fn term_fun_pat_extractor(value: NickelValue) -> Box<FunPatternData> {
         let term = ValueLens::<TermData>::content_extractor(value);
 
-        if let Term::FunPattern(pat, body) = term {
-            (pat, body)
+        if let Term::FunPattern(data) = term {
+            data
         } else {
             unreachable!()
         }

--- a/core/src/pretty.rs
+++ b/core/src/pretty.rs
@@ -491,13 +491,18 @@ impl Allocator {
 
         loop {
             match body.as_term() {
-                Some(Term::Fun(id, val)) => {
-                    builder = docs![self, builder, self.line(), self.as_string(id)];
-                    body = val;
+                Some(Term::Fun(data)) => {
+                    builder = docs![self, builder, self.line(), self.as_string(data.arg)];
+                    body = &data.body;
                 }
-                Some(Term::FunPattern(pat, val)) => {
-                    builder = docs![self, builder, self.line(), self.pat_with_parens(pat)];
-                    body = val;
+                Some(Term::FunPattern(data)) => {
+                    builder = docs![
+                        self,
+                        builder,
+                        self.line(),
+                        self.pat_with_parens(&data.pattern)
+                    ];
+                    body = &data.body;
                 }
                 _ => break,
             }
@@ -985,8 +990,10 @@ impl<'a> Pretty<'a, Allocator> for &Term {
     fn pretty(self, allocator: &'a Allocator) -> DocBuilder<'a, Allocator> {
         match self {
             Term::StrChunks(chunks) => allocator.chunks(chunks, StringRenderStyle::Multiline),
-            Term::Fun(id, body) => allocator.function(allocator.as_string(id), body),
-            Term::FunPattern(pat, body) => allocator.function(allocator.pat_with_parens(pat), body),
+            Term::Fun(data) => allocator.function(allocator.as_string(data.arg), &data.body),
+            Term::FunPattern(data) => {
+                allocator.function(allocator.pat_with_parens(&data.pattern), &data.body)
+            }
             Term::Let(bindings, body, attrs) => docs![
                 allocator,
                 "let",


### PR DESCRIPTION
# Reduce `Term` size: functions

## Context

This PR is a continuation of the compact value representation work, toward the same goal of optimizing the size of the core representations of the interpreter. Now that we have split WHNFs as compact values, we attack the `Term` struct, with the goal of boxing many enum variant data to bring it back to a reasonable size.

## Content

This PR starts the work with functions (`Term::Fun` and `Term::FunPattern`), creating bespoke structures to store all data. For now the function data aren't boxed, as I initially fix the limit to 40 bytes for a
variant (quite arbitrarily, but that allows to unbox a bunch of basic cases like `App`, `Fun`, and so on). This limit is of course subject to change. `Term::Fun` fits within those 40 bytes.

We still introduce a separate `FunData`, which give explicit names to the components, make function data first-class, and make it easy to box it in the future, should we want to make `Term` even smaller.
