### PR TITLE
[RFC007] Reduce `Term` size, chapter: `let`

### DIFF
--- a/core/src/bytecode/ast/compat.rs
+++ b/core/src/bytecode/ast/compat.rs
@@ -418,23 +418,23 @@ impl<'ast> FromMainline<'ast, term::Term> for Node<'ast> {
 
                 alloc.fun(args, final_body.to_ast(alloc, pos_table))
             }
-            Term::Let(bindings, body, attrs) => alloc.let_block(
-                bindings.iter().map(|(id, value)| LetBinding {
+            Term::Let(data) => alloc.let_block(
+                data.bindings.iter().map(|(id, value)| LetBinding {
                     pattern: Pattern::any(*id),
                     value: value.to_ast(alloc, pos_table),
                     metadata: Default::default(),
                 }),
-                body.to_ast(alloc, pos_table),
-                attrs.rec,
+                data.body.to_ast(alloc, pos_table),
+                data.attrs.rec,
             ),
-            Term::LetPattern(bindings, body, attrs) => alloc.let_block(
-                bindings.iter().map(|(pat, value)| LetBinding {
+            Term::LetPattern(data) => alloc.let_block(
+                data.bindings.iter().map(|(pat, value)| LetBinding {
                     pattern: pat.to_ast(alloc, pos_table),
                     value: value.to_ast(alloc, pos_table),
                     metadata: Default::default(),
                 }),
-                body.to_ast(alloc, pos_table),
-                attrs.rec,
+                data.body.to_ast(alloc, pos_table),
+                data.attrs.rec,
             ),
             Term::App(fun, arg) => {
                 match fun.as_term() {
@@ -1527,7 +1527,7 @@ impl<'ast> FromAst<Ast<'ast>> for NickelValue {
                 };
 
                 let term = if let Some(bindings) = try_bindings {
-                    Term::Let(bindings, body, attrs)
+                    Term::let_in(bindings, body, attrs)
                 } else {
                     let bindings = bindings
                         .iter()
@@ -1545,7 +1545,7 @@ impl<'ast> FromAst<Ast<'ast>> for NickelValue {
                         )
                         .collect();
 
-                    Term::LetPattern(bindings, body, attrs)
+                    Term::let_pattern(bindings, body, attrs)
                 };
 
                 NickelValue::term(term, pos_table.push(ast.pos))

--- a/core/src/eval/value/mod.rs
+++ b/core/src/eval/value/mod.rs
@@ -1219,6 +1219,12 @@ impl NickelValue {
     }
 }
 
+impl Default for NickelValue {
+    fn default() -> Self {
+        Self::null()
+    }
+}
+
 // Since a `NickelValue` can be a reference-counted pointer in disguise, we can't just copy it
 // blindly. We need to make sure the reference count is incremented accordingly.
 impl Clone for NickelValue {

--- a/core/src/pretty.rs
+++ b/core/src/pretty.rs
@@ -996,17 +996,17 @@ impl<'a> Pretty<'a, Allocator> for &Term {
             Term::FunPattern(data) => {
                 allocator.function(allocator.pat_with_parens(&data.pattern), &data.body)
             }
-            Term::Let(bindings, body, attrs) => docs![
+            Term::Let(data) => docs![
                 allocator,
                 "let",
                 allocator.space(),
-                if attrs.rec {
+                if data.attrs.rec {
                     docs![allocator, "rec", allocator.space()]
                 } else {
                     allocator.nil()
                 },
                 allocator.intersperse(
-                    bindings
+                    data.bindings
                         .iter()
                         .map(|(k, v)| allocator.binding(*k, v.clone())),
                     docs![allocator, ",", allocator.line()]
@@ -1017,19 +1017,19 @@ impl<'a> Pretty<'a, Allocator> for &Term {
             .nest(2)
             .group()
             .append(allocator.line())
-            .append(body.pretty(allocator).nest(2))
+            .append(data.body.pretty(allocator).nest(2))
             .group(),
-            Term::LetPattern(bindings, body, attrs) => docs![
+            Term::LetPattern(data) => docs![
                 allocator,
                 "let",
                 allocator.space(),
-                if attrs.rec {
+                if data.attrs.rec {
                     docs![allocator, "rec", allocator.space()]
                 } else {
                     allocator.nil()
                 },
                 allocator.intersperse(
-                    bindings
+                    data.bindings
                         .iter()
                         .map(|(k, v)| allocator.binding(k, v.clone())),
                     docs![allocator, ",", allocator.line()]
@@ -1040,7 +1040,7 @@ impl<'a> Pretty<'a, Allocator> for &Term {
             .nest(2)
             .group()
             .append(allocator.line())
-            .append(body.pretty(allocator).nest(2))
+            .append(data.body.pretty(allocator).nest(2))
             .group(),
             Term::App(head, arg) => match head.as_term() {
                 Some(Term::App(iop, t))

--- a/core/src/term/mod.rs
+++ b/core/src/term/mod.rs
@@ -66,6 +66,20 @@ pub struct FunData {
     pub body: NickelValue,
 }
 
+#[derive(Clone, Debug, PartialEq)]
+pub struct LetData {
+    pub bindings: SmallVec<[(LocIdent, NickelValue); 4]>,
+    pub body: NickelValue,
+    pub attrs: LetAttrs,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct LetPatternData {
+    pub bindings: SmallVec<[(Pattern, NickelValue); 1]>,
+    pub body: NickelValue,
+    pub attrs: LetAttrs,
+}
+
 /// The runtime representation of a Nickel computation.
 ///
 /// # History
@@ -104,14 +118,9 @@ pub enum Term {
 
     /// A let binding. Adds the binding to the environment and proceeds with the evaluation of the
     /// body.
-    Let(
-        SmallVec<[(LocIdent, NickelValue); 4]>,
-        NickelValue,
-        LetAttrs,
-    ),
-
+    Let(Box<LetData>),
     /// A destructuring let-binding.
-    LetPattern(SmallVec<[(Pattern, NickelValue); 1]>, NickelValue, LetAttrs),
+    LetPattern(Box<LetPatternData>),
 
     /// An application. Push the argument on the stack and proceed with the evaluation of the head.
     App(NickelValue, NickelValue),
@@ -828,6 +837,30 @@ impl Term {
     /// Builds a term representing a function that patterns match on its argument.
     pub fn fun_pattern(pattern: Pattern, body: NickelValue) -> Self {
         Term::FunPattern(Box::new(FunPatternData { pattern, body }))
+    }
+
+    pub fn let_in(
+        bindings: SmallVec<[(LocIdent, NickelValue); 4]>,
+        body: NickelValue,
+        attrs: LetAttrs,
+    ) -> Self {
+        Term::Let(Box::new(LetData {
+            bindings,
+            body,
+            attrs,
+        }))
+    }
+
+    pub fn let_pattern(
+        bindings: SmallVec<[(Pattern, NickelValue); 1]>,
+        body: NickelValue,
+        attrs: LetAttrs,
+    ) -> Self {
+        Term::LetPattern(Box::new(LetPatternData {
+            bindings,
+            body,
+            attrs,
+        }))
     }
 }
 
@@ -1669,21 +1702,25 @@ impl Traverse<NickelValue> for Term {
                 data.body = data.body.traverse(f, order)?;
                 Term::FunPattern(data)
             }
-            Term::Let(bindings, body, attrs) => {
-                let bindings = bindings
+            Term::Let(mut data) => {
+                data.bindings = data
+                    .bindings
                     .into_iter()
                     .map(|(key, val)| Ok((key, val.traverse(f, order)?)))
                     .collect::<Result<_, E>>()?;
-                let body = body.traverse(f, order)?;
-                Term::Let(bindings, body, attrs)
+                data.body = data.body.traverse(f, order)?;
+
+                Term::Let(data)
             }
-            Term::LetPattern(bindings, body, attrs) => {
-                let bindings = bindings
+            Term::LetPattern(mut data) => {
+                data.bindings = data
+                    .bindings
                     .into_iter()
                     .map(|(key, val)| Ok((key, val.traverse(f, order)?)))
                     .collect::<Result<_, E>>()?;
-                let body = body.traverse(f, order)?;
-                Term::LetPattern(bindings, body, attrs)
+                data.body = data.body.traverse(f, order)?;
+
+                Term::LetPattern(data)
             }
             Term::App(head, arg) => {
                 let head = head.traverse(f, order)?;
@@ -1821,14 +1858,16 @@ impl Traverse<NickelValue> for Term {
             | Term::Value(t)
             | Term::Closurize(t) => t.traverse_ref(f, state),
             Term::FunPattern(data) => data.body.traverse_ref(f, state),
-            Term::Let(bindings, body, _) => bindings
+            Term::Let(data) => data
+                .bindings
                 .iter()
                 .find_map(|(_id, t)| t.traverse_ref(f, state))
-                .or_else(|| body.traverse_ref(f, state)),
-            Term::LetPattern(bindings, body, _) => bindings
+                .or_else(|| data.body.traverse_ref(f, state)),
+            Term::LetPattern(data) => data
+                .bindings
                 .iter()
                 .find_map(|(_pat, t)| t.traverse_ref(f, state))
-                .or_else(|| body.traverse_ref(f, state)),
+                .or_else(|| data.body.traverse_ref(f, state)),
             Term::App(t1, t2) | Term::Op2(_, t1, t2) => t1
                 .traverse_ref(f, state)
                 .or_else(|| t2.traverse_ref(f, state)),
@@ -1968,17 +2007,16 @@ pub mod make {
         I: Into<LocIdent>,
         Iter: IntoIterator<Item = (I, T1)>,
     {
-        let attrs = LetAttrs {
-            binding_type: BindingType::Normal,
-            rec,
-        };
-        Term::Let(
+        Term::let_in(
             bindings
                 .into_iter()
                 .map(|(id, t)| (id.into(), t.into()))
                 .collect(),
             t2.into(),
-            attrs,
+            LetAttrs {
+                binding_type: BindingType::Normal,
+                rec,
+            },
         )
         .into()
     }
@@ -2007,7 +2045,7 @@ pub mod make {
         T2: Into<NickelValue>,
         D: Into<Pattern>,
     {
-        Term::LetPattern(
+        Term::let_pattern(
             std::iter::once((pat.into(), t1.into())).collect(),
             t2.into(),
             LetAttrs::default(),
@@ -2022,17 +2060,16 @@ pub mod make {
         D: Into<Pattern>,
         Iter: IntoIterator<Item = (D, T1)>,
     {
-        let attrs = LetAttrs {
-            binding_type: BindingType::Normal,
-            rec,
-        };
-        Term::LetPattern(
+        Term::let_pattern(
             bindings
                 .into_iter()
                 .map(|(pat, t)| (pat.into(), t.into()))
                 .collect(),
             body.into(),
-            attrs,
+            LetAttrs {
+                binding_type: BindingType::Normal,
+                rec,
+            },
         )
         .into()
     }


### PR DESCRIPTION
Following the introduction of `Fun(Pattern)Data` (#2409), we continue the effort toward making `Term` better structured and smaller by introducing bespoke structures for let-related data, and boxing them in `Term`.