### PR TITLE
[RFC007] Reduce `Term` size, chapter: `RecRecord`

### DIFF
--- a/cli/src/query.rs
+++ b/cli/src/query.rs
@@ -83,14 +83,15 @@ impl From<Field> for QueryResult {
                     fields.sort();
                     Some(fields.into_iter().map(LocIdent::ident).collect())
                 }
-                ValueContentRef::Term(Term::RecRecord(record, includes, dyn_fields, ..))
-                    if !record.fields.is_empty() =>
-                {
-                    let mut fields: Vec<_> = record.fields.keys().map(LocIdent::ident).collect();
-                    fields.extend(includes.iter().map(|incl| incl.ident.ident()));
+                ValueContentRef::Term(Term::RecRecord(data)) if !data.record.fields.is_empty() => {
+                    let mut fields: Vec<_> =
+                        data.record.fields.keys().map(LocIdent::ident).collect();
+                    fields.extend(data.includes.iter().map(|incl| incl.ident.ident()));
                     fields.sort();
+
                     let dynamic = Ident::from("<dynamic>");
-                    fields.extend(dyn_fields.iter().map(|_| dynamic));
+                    fields.extend(data.dyn_fields.iter().map(|_| dynamic));
+
                     Some(fields)
                 }
                 // Empty record has empty sub_fields

--- a/core/src/eval/fixpoint.rs
+++ b/core/src/eval/fixpoint.rs
@@ -159,5 +159,5 @@ pub fn revert<C: Cache>(cache: &mut C, record_data: RecordData) -> Term {
     // aren't reconstructed, so the result of a merge never has any include expressions.
     //
     // The fields are already closurized.
-    Term::RecRecord(record_data, Vec::new(), Vec::new(), None, true)
+    Term::rec_record(record_data, Vec::new(), Vec::new(), None, true)
 }

--- a/core/src/eval/merge.rs
+++ b/core/src/eval/merge.rs
@@ -414,7 +414,7 @@ impl<'ctxt, R: ImportResolver, C: Cache> VirtualMachine<'ctxt, R, C> {
                     // they are seen, and there's no way back. We always set them to empty here.
                     //
                     // The result is already closurized, so we set `closurized` to true.
-                    Term::RecRecord(
+                    Term::rec_record(
                         RecordData::new(m, attrs, None),
                         Vec::new(),
                         Vec::new(),

--- a/core/src/parser/tests.rs
+++ b/core/src/parser/tests.rs
@@ -8,8 +8,9 @@ use crate::{
     position::PosTable,
     term::Number,
     term::{
-        Term::*,
-        {BinaryOp, StrChunk, UnaryOp, record}, {Term, make as mk_term},
+        BinaryOp, StrChunk,
+        Term::{self, *},
+        UnaryOp, make as mk_term, record,
     },
 };
 
@@ -73,7 +74,7 @@ fn mk_symbolic_single_chunk(prefix: &str, s: &str) -> NickelValue {
     // record.
     if let ValueContent::Term(TermContent::Closurize(lens)) = result.content() {
         if let ValueContent::Record(r_lens) = lens.take().content() {
-            NickelValue::term_posless(RecRecord(
+            NickelValue::term_posless(Term::rec_record(
                 r_lens.take().unwrap_or_alloc(),
                 Vec::new(),
                 Vec::new(),
@@ -285,7 +286,7 @@ fn record_terms() {
 
     assert_eq!(
         parse_without_pos("{ a = 1, b = 2, c = 3}"),
-        RecRecord(
+        Term::rec_record(
             record::RecordData::with_field_values(
                 vec![
                     (LocIdent::from("a"), mk_term::integer(1)),
@@ -304,7 +305,7 @@ fn record_terms() {
 
     assert_eq!(
         parse_without_pos("{ a = 1, \"%{123}\" = (if 4 then 5 else 6), d = 42}"),
-        RecRecord(
+        Term::rec_record(
             record::RecordData::with_field_values(
                 vec![
                     (LocIdent::from("a"), mk_term::integer(1)),
@@ -329,7 +330,7 @@ fn record_terms() {
 
     assert_eq!(
         parse_without_pos("{ a = 1, \"\\\"%}%\" = 2}"),
-        RecRecord(
+        Term::rec_record(
             record::RecordData::with_field_values(
                 vec![
                     (LocIdent::from("a"), mk_term::integer(1)),

--- a/core/src/pretty.rs
+++ b/core/src/pretty.rs
@@ -1084,8 +1084,8 @@ impl<'a> Pretty<'a, Allocator> for &Term {
             }
             .group(),
             Term::Var(id) => allocator.as_string(id),
-            Term::RecRecord(record_data, includes, dyn_fields, _, _) => {
-                allocator.record(record_data, includes, dyn_fields)
+            Term::RecRecord(data) => {
+                allocator.record(&data.record, &data.includes, &data.dyn_fields)
             }
             Term::Match(data) => docs![
                 allocator,

--- a/core/src/repl/query_print.rs
+++ b/core/src/repl/query_print.rs
@@ -219,14 +219,14 @@ fn render_query_result<R: QueryPrinter>(
                 fields.sort();
                 renderer.write_fields(out, fields.into_iter().map(LocIdent::ident))
             }
-            ValueContentRef::Term(Term::RecRecord(record, includes, dyn_fields, ..))
-                if !record.fields.is_empty() =>
-            {
-                let mut fields: Vec<_> = record.fields.keys().map(LocIdent::ident).collect();
-                fields.extend(includes.iter().map(|incl| incl.ident.ident()));
+            ValueContentRef::Term(Term::RecRecord(data)) if !data.record.fields.is_empty() => {
+                let mut fields: Vec<_> = data.record.fields.keys().map(LocIdent::ident).collect();
+                fields.extend(data.includes.iter().map(|incl| incl.ident.ident()));
                 fields.sort();
+
                 let dynamic = Ident::from("<dynamic>");
-                fields.extend(dyn_fields.iter().map(|_| dynamic));
+                fields.extend(data.dyn_fields.iter().map(|_| dynamic));
+
                 renderer.write_fields(out, fields.into_iter())
             }
             ValueContentRef::Record(..) | ValueContentRef::Term(Term::RecRecord(..)) => {

--- a/core/src/repl/rustyline_frontend.rs
+++ b/core/src/repl/rustyline_frontend.rs
@@ -71,26 +71,26 @@ pub fn repl(histfile: Option<PathBuf>, color_opt: ColorOpt) -> Result<(), InitEr
                                 container.len()
                             )
                         }
-                        ValueContentRef::Term(Term::RecRecord(record, includes, dyn_fields, ..)) => {
-                            if !dyn_fields.is_empty() {
+                        ValueContentRef::Term(Term::RecRecord(data)) => {
+                            if !data.dyn_fields.is_empty() {
                                 println!(
                                     "Warning: loading dynamic fields is currently not supported. \
                                     {} symbols ignored",
-                                    dyn_fields.len()
+                                    data.dyn_fields.len()
                                 );
                             }
 
-                            if !includes.is_empty() {
+                            if !data.includes.is_empty() {
                                 println!(
                                     "Warning: loading record with `include` expressions is currently not supported. \
                                     {} symbols ignored",
-                                    includes.len()
+                                    data.includes.len()
                                 );
                             }
 
                             println!(
                                 "Loaded {} symbol(s) in the environment.",
-                                record.fields.len()
+                                data.record.fields.len()
                             )
                         }
                         _ => (),

--- a/core/src/serialize/yaml.rs
+++ b/core/src/serialize/yaml.rs
@@ -643,8 +643,7 @@ fn ast_to_term(pos_table: &mut PosTable, ast: Ast<'_>) -> NickelValue {
 
                 Ok(match value.content() {
                     ValueContent::Term(TermContent::RecRecord(lens)) => {
-                        let (record, _, _, _, _) = lens.take();
-                        NickelValue::record(record, pos_idx)
+                        NickelValue::record(lens.take().record, pos_idx)
                     }
                     lens => lens.restore(),
                 })

--- a/core/src/term/mod.rs
+++ b/core/src/term/mod.rs
@@ -82,6 +82,21 @@ pub struct LetPatternData {
     pub attrs: LetAttrs,
 }
 
+#[derive(Clone, Debug, PartialEq)]
+pub struct RecRecordData {
+    pub record: RecordData,
+    /// Fields defined through `include` expressions.
+    pub includes: Vec<Include>,
+    /// Dynamic fields, whose name is defined by interpolation.
+    pub dyn_fields: Vec<(NickelValue, Field)>,
+    /// Dependency tracking between fields. It is filled by the free var transformation, and is
+    /// `None` before.
+    pub deps: Option<RecordDeps>,
+    /// If the recursive record has been closurized already (currently this is mostly the case for
+    /// records coming out from merging.
+    pub closurized: bool,
+}
+
 /// The runtime representation of a Nickel computation.
 ///
 /// # History
@@ -132,13 +147,7 @@ pub enum Term {
 
     /// A recursive record, where the fields can reference each others. Computes the fixpoint and
     /// produces a record value with the proper recursive environment.
-    RecRecord(
-        RecordData,
-        Vec<Include>,              /* fields defined through `include` expressions */
-        Vec<(NickelValue, Field)>, /* field whose name is defined by interpolation */
-        Option<RecordDeps>, /* dependency tracking between fields. None before the free var pass */
-        bool,               /* is it closurized */
-    ),
+    RecRecord(Box<RecRecordData>),
 
     /// A container value (array or record) that has yet to be closurized. This will closurize each
     /// elements of the container in the current environment.
@@ -1006,6 +1015,22 @@ impl Term {
             bindings,
             body,
             attrs,
+        }))
+    }
+
+    pub fn rec_record(
+        record: RecordData,
+        includes: Vec<Include>,
+        dyn_fields: Vec<(NickelValue, Field)>,
+        deps: Option<RecordDeps>,
+        closurized: bool,
+    ) -> Self {
+        Term::RecRecord(Box::new(RecRecordData {
+            record,
+            includes,
+            dyn_fields,
+            deps,
+            closurized,
         }))
     }
 }
@@ -1933,16 +1958,19 @@ impl Traverse<NickelValue> for Term {
                 let inner = inner.traverse(f, order)?;
                 Term::Sealed(key, inner, label)
             }
-            Term::RecRecord(record, includes, dyn_fields, deps, closurized) => {
+            Term::RecRecord(mut data) => {
                 // The annotation on `map_res` uses Result's corresponding trait to convert from
                 // Iterator<Result> to a Result<Iterator>
-                let static_fields_res: Result<IndexMap<LocIdent, Field>, E> = record
+                let static_fields_res: Result<IndexMap<LocIdent, Field>, E> = data
+                    .record
                     .fields
                     .into_iter()
                     // For the conversion to work, note that we need a Result<(Ident,Field), E>
                     .map(|(id, field)| Ok((id, field.traverse(f, order)?)))
                     .collect();
-                let dyn_fields_res: Result<Vec<(NickelValue, Field)>, E> = dyn_fields
+
+                data.dyn_fields = data
+                    .dyn_fields
                     .into_iter()
                     .map(|(id_t, field)| {
                         let id_t = id_t.traverse(f, order)?;
@@ -1950,14 +1978,15 @@ impl Traverse<NickelValue> for Term {
 
                         Ok((id_t, field))
                     })
-                    .collect();
-                Term::RecRecord(
-                    RecordData::new(static_fields_res?, record.attrs, record.sealed_tail),
-                    includes,
-                    dyn_fields_res?,
-                    deps,
-                    closurized,
-                )
+                    .collect::<Result<Vec<_>, _>>()?;
+
+                data.record = RecordData::new(
+                    static_fields_res?,
+                    data.record.attrs,
+                    data.record.sealed_tail,
+                );
+
+                Term::RecRecord(data)
             }
             Term::StrChunks(chunks) => {
                 let chunks_res: Result<Vec<StrChunk<NickelValue>>, E> = chunks
@@ -2030,12 +2059,13 @@ impl Traverse<NickelValue> for Term {
             Term::App(t1, t2) | Term::Op2(_, t1, t2) => t1
                 .traverse_ref(f, state)
                 .or_else(|| t2.traverse_ref(f, state)),
-            Term::RecRecord(data, _, dyn_data, _, _) => data
+            Term::RecRecord(data) => data
+                .record
                 .fields
                 .values()
                 .find_map(|field| field.traverse_ref(f, state))
                 .or_else(|| {
-                    dyn_data.iter().find_map(|(id, field)| {
+                    data.dyn_fields.iter().find_map(|(id, field)| {
                         id.traverse_ref(f, state)
                             .or_else(|| field.traverse_ref(f, state))
                     })

--- a/core/src/transform/gen_pending_contracts.rs
+++ b/core/src/transform/gen_pending_contracts.rs
@@ -99,36 +99,18 @@ pub fn transform_one(
         }
         ValueContent::Term(lens) => match lens {
             TermContent::RecRecord(lens) => {
-                let (record_data, includes, dyn_fields, deps, closurized) = lens.take();
+                let mut data = lens.take();
 
-                let RecordData {
-                    fields,
-                    attrs,
-                    sealed_tail,
-                } = record_data;
-
-                let fields = attach_to_fields(pos_table, fields)?;
-                let dyn_fields = dyn_fields
+                data.record.fields = attach_to_fields(pos_table, data.record.fields)?;
+                data.dyn_fields = data
+                    .dyn_fields
                     .into_iter()
                     .map(|(id_term, field)| {
                         Ok((id_term, with_pending_contracts(pos_table, field)?))
                     })
                     .collect::<Result<_, _>>()?;
 
-                NickelValue::term(
-                    Term::RecRecord(
-                        RecordData {
-                            fields,
-                            attrs,
-                            sealed_tail,
-                        },
-                        includes,
-                        dyn_fields,
-                        deps,
-                        closurized,
-                    ),
-                    pos_idx,
-                )
+                NickelValue::term(Term::RecRecord(data), pos_idx)
             }
             lens => lens.restore(),
         },

--- a/core/src/transform/substitute_wildcards.rs
+++ b/core/src/transform/substitute_wildcards.rs
@@ -38,18 +38,16 @@ pub fn transform_one(value: NickelValue, wildcards: &Wildcards) -> NickelValue {
                     pos_idx,
                 )
             } else if let TermContent::RecRecord(record_lens) = term_lens {
-                let (record_data, includes, dyn_fields, deps, closurized) = record_lens.take();
+                let mut data = record_lens.take();
 
-                let record_data = record_data.subst_wildcards(wildcards);
-                let dyn_fields = dyn_fields
+                data.record = data.record.subst_wildcards(wildcards);
+                data.dyn_fields = data
+                    .dyn_fields
                     .into_iter()
                     .map(|(id_t, field)| (id_t, field.subst_wildcards(wildcards)))
                     .collect();
 
-                NickelValue::term(
-                    Term::RecRecord(record_data, includes, dyn_fields, deps, closurized),
-                    pos_idx,
-                )
+                NickelValue::term(Term::RecRecord(data), pos_idx)
             } else {
                 term_lens.restore()
             }

--- a/core/tests/integration/free_vars.rs
+++ b/core/tests/integration/free_vars.rs
@@ -43,9 +43,10 @@ fn check_dyn_vars(expr: &str, expected: Vec<Vec<&str>>) -> bool {
 
     match value.content() {
         ValueContent::Term(TermContent::RecRecord(lens)) => {
-            let (_data, _includes, dyns, deps, _closurized) = lens.take();
-            let deps = deps.unwrap();
-            dyns.len() == deps.dyn_fields.len() && dyn_free_vars_subset(&deps.dyn_fields, expected)
+            let data = lens.take();
+            let deps = data.deps.unwrap();
+            data.dyn_fields.len() == deps.dyn_fields.len()
+                && dyn_free_vars_subset(&deps.dyn_fields, expected)
         }
         _ => panic!("{expr} hasn't been parsed as a record"),
     }
@@ -59,11 +60,11 @@ fn check_stat_and_includes(expr: &str, mut expected: IndexMap<&str, Vec<&str>>) 
 
     match value.content() {
         ValueContent::Term(TermContent::RecRecord(lens)) => {
-            let (record, includes, _dyns, deps, _closurized) = lens.take();
-            let deps = deps.unwrap();
+            let data = lens.take();
+            let deps = data.deps.unwrap();
 
             stat_free_vars_subset(&deps.stat_fields, &mut expected)
-            && record.fields.len() + includes.len() == deps.stat_fields.len()
+            && data.record.fields.len() + data.includes.len() == deps.stat_fields.len()
             // the inclusion test functions `xxx_free_vars_incl` above take the free variables out
             // of expected as they are matched, so we expect that at the end of the test,
             // `expected` is empty (there was no extra field specified in `expected`)


### PR DESCRIPTION
Depends #2410

Follow-up of #2410 and #2409. Add a bespoke structure for recursive record data, and box it in `Term`.