### PR TITLE
[RFC007] Reduce `Term` size, chapter: `Sealed`

### DIFF
--- a/core/src/eval/contract_eq.rs
+++ b/core/src/eval/contract_eq.rs
@@ -321,8 +321,9 @@ fn contract_eq_bounded(
                         false
                     }
                 }
-                (Term::Sealed(key1, inner1, _), Term::Sealed(key2, inner2, _)) => {
-                    key1 == key2 && contract_eq_bounded(state, inner1, env1, inner2, env2)
+                (Term::Sealed(data1), Term::Sealed(data2)) => {
+                    data1.key == data2.key
+                        && contract_eq_bounded(state, &data1.inner, env1, &data2.inner, env2)
                 }
                 (Term::Value(v1), Term::Value(v2))
                 | (Term::Closurize(v1), Term::Value(v2))

--- a/core/src/eval/operation.rs
+++ b/core/src/eval/operation.rs
@@ -1685,7 +1685,7 @@ impl<'ctxt, R: ImportResolver, C: Cache> VirtualMachine<'ctxt, R, C> {
                 Ok(mk_fun!(
                     "x",
                     NickelValue::term(
-                        Term::Sealed(*key, mk_term::var("x"), label.clone()),
+                        Term::sealed(*key, mk_term::var("x"), label.clone()),
                         pos_op_inh
                     )
                 )
@@ -2161,7 +2161,7 @@ impl<'ctxt, R: ImportResolver, C: Cache> VirtualMachine<'ctxt, R, C> {
                 }
             }
             BinaryOp::Unseal => {
-                if let Some(s1) = value1.as_sealing_key() {
+                if let Some(key) = value1.as_sealing_key() {
                     // The last argument (lazy, on the stack) of unseal is an expression raising
                     // blame. If the keys match, we ignore the blame and thus return a function
                     // `const unsealed_term_content`. Otherwise, we return `id`.
@@ -2169,10 +2169,10 @@ impl<'ctxt, R: ImportResolver, C: Cache> VirtualMachine<'ctxt, R, C> {
                     // Since the stack is set up as `[.] blame_expr`, this does ignore the error
                     // and proceed with the unsealed term in the happy path, or on the opposite
                     // drop the sealed term and proceed with the error on the stack otherwise.
-                    Ok(if let Some(Term::Sealed(s2, inner, _)) = value2.as_term() {
-                        if s1 == s2 {
+                    Ok(if let Some(Term::Sealed(data)) = value2.as_term() {
+                        if key == &data.key {
                             Closure {
-                                value: mk_fun!(LocIdent::fresh(), inner.clone()),
+                                value: mk_fun!(LocIdent::fresh(), data.inner.clone()),
                                 env: env2,
                             }
                         } else {

--- a/core/src/eval/value/lens.rs
+++ b/core/src/eval/value/lens.rs
@@ -8,10 +8,9 @@ use crate::{
     error::{EvalErrorData, ParseError},
     files::FileId,
     identifier::LocIdent,
-    label::Label,
     term::{
         FunData, FunPatternData, Import, LetData, LetPatternData, MatchData, Op1Data, Op2Data,
-        OpNData, RecRecordData, SealingKey, StrChunk, Term, TypeAnnotation,
+        OpNData, RecRecordData, SealedData, StrChunk, Term, TypeAnnotation,
     },
 };
 
@@ -188,7 +187,7 @@ pub enum TermContent {
     Op1(ValueLens<Box<Op1Data>>),
     Op2(ValueLens<Box<Op2Data>>),
     OpN(ValueLens<OpNData>),
-    Sealed(ValueLens<(SealingKey, NickelValue, Label)>),
+    Sealed(ValueLens<Box<SealedData>>),
     Annotated(ValueLens<(TypeAnnotation, NickelValue)>),
     Import(ValueLens<Import>),
     ResolvedImport(ValueLens<FileId>),
@@ -646,7 +645,7 @@ impl ValueLens<OpNData> {
     }
 }
 
-impl ValueLens<(SealingKey, NickelValue, Label)> {
+impl ValueLens<Box<SealedData>> {
     /// Creates a new lens extracting [crate::term::Term::Sealed].
     ///
     /// # Safety
@@ -661,11 +660,11 @@ impl ValueLens<(SealingKey, NickelValue, Label)> {
     }
 
     /// Extractor for [crate::term::Term::Sealed].
-    fn term_sealed_extractor(value: NickelValue) -> (SealingKey, NickelValue, Label) {
+    fn term_sealed_extractor(value: NickelValue) -> Box<SealedData> {
         let term = ValueLens::<TermData>::content_extractor(value);
 
-        if let Term::Sealed(key, body, label) = term {
-            (key, body, label)
+        if let Term::Sealed(data) = term {
+            data
         } else {
             unreachable!()
         }

--- a/core/src/pretty.rs
+++ b/core/src/pretty.rs
@@ -1172,7 +1172,7 @@ impl<'a> Pretty<'a, Allocator> for &Term {
                 .nest(2)
             ]
             .group(),
-            Term::Sealed(_i, _inner, _lbl) => allocator.text("%<sealed>"),
+            Term::Sealed(_) => allocator.text("%<sealed>"),
             Term::Annotated(annot, val) => allocator.atom(val).append(annot.pretty(allocator)),
             Term::Import(term::Import::Path { path, format }) => {
                 docs![

--- a/core/src/transform/free_vars.rs
+++ b/core/src/transform/free_vars.rs
@@ -110,7 +110,7 @@ impl CollectFreeVars for Term {
             Term::Op1(data) => data.collect_free_vars(free_vars),
             Term::Op2(data) => data.collect_free_vars(free_vars),
             Term::OpN(data) => data.collect_free_vars(free_vars),
-            Term::Sealed(_, t, _) => t.collect_free_vars(free_vars),
+            Term::Sealed(data) => data.inner.collect_free_vars(free_vars),
             Term::RecRecord(data) => data.collect_free_vars(free_vars),
             Term::StrChunks(chunks) => {
                 for chunk in chunks {


### PR DESCRIPTION
Depends on #2414

Continues the refactoring of `Term`. Separate the data of `Term::Sealed` into a bespoke structure, and box it.