### PR TITLE
[RFC007] Reduce `Term` size, chapter: `Annotated`

### DIFF
--- a/cli/src/doctest.rs
+++ b/cli/src/doctest.rs
@@ -451,7 +451,7 @@ fn doctest_transform(
                         );
                         let eq = mk_app!(eq, expected_term);
                         let eq_ty = Type::from(TypeF::Contract(eq));
-                        test_term = Term::Annotated(
+                        test_term = Term::annotated(
                             TypeAnnotation {
                                 typ: None,
                                 contracts: vec![LabeledType {

--- a/core/src/bytecode/ast/compat.rs
+++ b/core/src/bytecode/ast/compat.rs
@@ -572,9 +572,9 @@ impl<'ast> FromMainline<'ast, term::Term> for Node<'ast> {
                 alloc.prim_op(op, args)
             }
             Term::Sealed(..) => panic!("didn't expect a sealed term at the first stage"),
-            Term::Annotated(annot, term) => alloc.annotated(
-                annot.to_ast(alloc, pos_table),
-                term.to_ast(alloc, pos_table),
+            Term::Annotated(data) => alloc.annotated(
+                data.annot.to_ast(alloc, pos_table),
+                data.inner.to_ast(alloc, pos_table),
             ),
             Term::Import(term::Import::Path { path, format }) => {
                 alloc.import_path(path.clone(), *format)
@@ -1496,7 +1496,7 @@ impl<'ast> FromAst<Ast<'ast>> for NickelValue {
                     }
 
                     NickelValue::term(
-                        term::Term::Annotated(metadata.annotation.to_mainline(pos_table), value),
+                        term::Term::annotated(metadata.annotation.to_mainline(pos_table), value),
                         pos_table.push(pos),
                     )
                 }
@@ -1643,7 +1643,7 @@ impl<'ast> FromAst<Ast<'ast>> for NickelValue {
                 NickelValue::term(term, pos_table.push(ast.pos))
             }
             Node::Annotated { annot, inner } => NickelValue::term(
-                Term::Annotated(
+                Term::annotated(
                     (*annot).to_mainline(pos_table),
                     inner.to_mainline(pos_table),
                 ),

--- a/core/src/eval/contract_eq.rs
+++ b/core/src/eval/contract_eq.rs
@@ -280,8 +280,9 @@ fn contract_eq_bounded(
                 }
                 // We must compare the inner values as well as the corresponding contracts or type
                 // annotations.
-                (Term::Annotated(annot1, t1), Term::Annotated(annot2, t2)) => {
-                    let value_eq = contract_eq_bounded(state, t1, env1, t2, env2);
+                (Term::Annotated(data1), Term::Annotated(data2)) => {
+                    let value_eq =
+                        contract_eq_bounded(state, &data1.inner, env1, &data2.inner, env2);
 
                     // TODO:
                     // - does it really make sense to compare the annotations?
@@ -293,8 +294,8 @@ fn contract_eq_bounded(
 
                     // We use the same logic as in the typechecker: the type associated to an annotated
                     // value is either the type annotation, or the first contract annotation.
-                    let ty1 = annot1.first();
-                    let ty2 = annot2.first();
+                    let ty1 = data1.annot.first();
+                    let ty2 = data2.annot.first();
 
                     let ty_eq = match (ty1, ty2) {
                         (None, None) => true,

--- a/core/src/eval/value/lens.rs
+++ b/core/src/eval/value/lens.rs
@@ -9,8 +9,8 @@ use crate::{
     files::FileId,
     identifier::LocIdent,
     term::{
-        FunData, FunPatternData, Import, LetData, LetPatternData, MatchData, Op1Data, Op2Data,
-        OpNData, RecRecordData, SealedData, StrChunk, Term, TypeAnnotation,
+        AnnotatedData, FunData, FunPatternData, Import, LetData, LetPatternData, MatchData,
+        Op1Data, Op2Data, OpNData, RecRecordData, SealedData, StrChunk, Term,
     },
 };
 
@@ -188,7 +188,7 @@ pub enum TermContent {
     Op2(ValueLens<Box<Op2Data>>),
     OpN(ValueLens<OpNData>),
     Sealed(ValueLens<Box<SealedData>>),
-    Annotated(ValueLens<(TypeAnnotation, NickelValue)>),
+    Annotated(ValueLens<Box<AnnotatedData>>),
     Import(ValueLens<Import>),
     ResolvedImport(ValueLens<FileId>),
     ParseError(ValueLens<ParseError>),
@@ -671,7 +671,7 @@ impl ValueLens<Box<SealedData>> {
     }
 }
 
-impl ValueLens<(TypeAnnotation, NickelValue)> {
+impl ValueLens<Box<AnnotatedData>> {
     /// Creates a new lens extracting [crate::term::Term::Annotated].
     ///
     /// # Safety
@@ -686,11 +686,11 @@ impl ValueLens<(TypeAnnotation, NickelValue)> {
     }
 
     /// Extractor for [crate::term::Term::Annotated].
-    fn term_annotated_extractor(value: NickelValue) -> (TypeAnnotation, NickelValue) {
+    fn term_annotated_extractor(value: NickelValue) -> Box<AnnotatedData> {
         let term = ValueLens::<TermData>::content_extractor(value);
 
-        if let Term::Annotated(annot, body) = term {
-            (annot, body)
+        if let Term::Annotated(data) = term {
+            data
         } else {
             unreachable!()
         }

--- a/core/src/pretty.rs
+++ b/core/src/pretty.rs
@@ -464,15 +464,15 @@ impl Allocator {
         docs![
             self,
             lhs,
-            if let Some(Term::Annotated(annot, _)) = val.as_term() {
-                annot.pretty(self)
+            if let Some(Term::Annotated(data)) = val.as_term() {
+                data.annot.pretty(self)
             } else {
                 self.nil()
             },
             self.line(),
             "= ",
-            if let Some(Term::Annotated(_, inner)) = val.as_term() {
-                inner.pretty(self)
+            if let Some(Term::Annotated(data)) = val.as_term() {
+                data.inner.pretty(self)
             } else {
                 val.pretty(self)
             },
@@ -1173,7 +1173,7 @@ impl<'a> Pretty<'a, Allocator> for &Term {
             ]
             .group(),
             Term::Sealed(_) => allocator.text("%<sealed>"),
-            Term::Annotated(annot, val) => allocator.atom(val).append(annot.pretty(allocator)),
+            Term::Annotated(data) => allocator.atom(&data.inner).append(data.annot.pretty(allocator)),
             Term::Import(term::Import::Path { path, format }) => {
                 docs![
                     allocator,

--- a/core/src/transform/free_vars.rs
+++ b/core/src/transform/free_vars.rs
@@ -8,8 +8,8 @@ use crate::{
     identifier::Ident,
     term::pattern::*,
     term::{
-        FunData, FunPatternData, IndexMap, LetData, LetPatternData, MatchBranch, Op1Data, Op2Data,
-        OpNData, RecRecordData, StrChunk, Term, TypeAnnotation,
+        AnnotatedData, FunData, FunPatternData, IndexMap, LetData, LetPatternData, MatchBranch,
+        Op1Data, Op2Data, OpNData, RecRecordData, StrChunk, Term, TypeAnnotation,
         record::{Field, FieldDeps, Include, RecordDeps},
     },
     typ::{RecordRowF, RecordRows, RecordRowsF, Type, TypeF},
@@ -119,13 +119,7 @@ impl CollectFreeVars for Term {
                     }
                 }
             }
-            Term::Annotated(annot, t) => {
-                for ctr in annot.iter_mut() {
-                    ctr.typ.collect_free_vars(free_vars)
-                }
-
-                t.collect_free_vars(free_vars);
-            }
+            Term::Annotated(data) => data.collect_free_vars(free_vars),
             Term::Value(v) | Term::Closurize(v) => v.collect_free_vars(free_vars),
         }
     }
@@ -345,6 +339,16 @@ impl CollectFreeVars for OpNData {
         for t in &mut self.args {
             t.collect_free_vars(set);
         }
+    }
+}
+
+impl CollectFreeVars for AnnotatedData {
+    fn collect_free_vars(&mut self, set: &mut HashSet<Ident>) {
+        for ctr in self.annot.iter_mut() {
+            ctr.typ.collect_free_vars(set)
+        }
+
+        self.inner.collect_free_vars(set);
     }
 }
 

--- a/core/src/transform/substitute_wildcards.rs
+++ b/core/src/transform/substitute_wildcards.rs
@@ -26,17 +26,17 @@ pub fn transform_one(value: NickelValue, wildcards: &Wildcards) -> NickelValue {
 
     match value.content() {
         ValueContent::Term(term_lens) => {
-            if let Term::Annotated(TypeAnnotation { typ: Some(_), .. }, _) = term_lens.term() {
+            if let Term::Annotated(data) = term_lens.term()
+                && data.annot.typ.is_some()
+            {
                 let TermContent::Annotated(value_lens) = term_lens else {
                     unreachable!("TermContent::Annotated expected")
                 };
 
-                let (annot, inner) = value_lens.take();
+                let mut data = value_lens.take();
+                data.annot = data.annot.subst_wildcards(wildcards);
 
-                NickelValue::term(
-                    Term::Annotated(annot.subst_wildcards(wildcards), inner),
-                    pos_idx,
-                )
+                NickelValue::term(Term::Annotated(data), pos_idx)
             } else if let TermContent::RecRecord(record_lens) = term_lens {
                 let mut data = record_lens.take();
 

--- a/lsp/nls/src/world.rs
+++ b/lsp/nls/src/world.rs
@@ -431,7 +431,7 @@ impl World {
         // unwrap: we don't expect an error here, since we already typechecked above.
         let contract_value = vm_ctxt.prepare_eval_only(contract_id).unwrap();
 
-        let value = NickelValue::term_posless(Term::Annotated(
+        let value = NickelValue::term_posless(Term::annotated(
             TypeAnnotation {
                 typ: None,
                 contracts: vec![LabeledType {


### PR DESCRIPTION
Depends on #2415

Folow-up of similar previous PRs. Introduce `AnnotatedData` structure for `Term::Annotated` and box it.