### PR TITLE
[RFC007] Reduce `Term` size, chapter: errors

### DIFF
--- a/core/src/ast/compat.rs
+++ b/core/src/ast/compat.rs
@@ -582,7 +582,7 @@ impl<'ast> FromMainline<'ast, term::Term> for Node<'ast> {
             }
             Term::Import(term::Import::Package { id }) => alloc.import_package(*id),
             Term::ResolvedImport(_) => panic!("didn't expect a resolved import at parsing stage"),
-            Term::ParseError(error) => alloc.parse_error(error.clone()),
+            Term::ParseError(error) => alloc.parse_error((**error).clone()),
             Term::RuntimeError(_) => panic!("didn't expect a runtime error at parsing stage"),
             Term::Value(value) | Term::Closurize(value) => {
                 Ast::from_mainline(alloc, pos_table, value).node
@@ -1671,13 +1671,13 @@ impl<'ast> FromAst<Ast<'ast>> for NickelValue {
                     // causes an unbound variable error (which it shouldn't anyway if the term has
                     // been correctly typechecked), we pack this error as a parse error in the AST.
                     .unwrap_or_else(|err| {
-                        Term::ParseError(ParseError::UnboundTypeVariables(vec![err.0])).into()
+                        Term::parse_error(ParseError::UnboundTypeVariables(vec![err.0])).into()
                     });
 
                 NickelValue::typ(typ, contract, pos_table.push(ast.pos))
             }
             Node::ParseError(error) => {
-                NickelValue::term(Term::ParseError((*error).clone()), pos_table.push(ast.pos))
+                NickelValue::term(Term::parse_error((*error).clone()), pos_table.push(ast.pos))
             }
         };
 

--- a/core/src/eval/fixpoint.rs
+++ b/core/src/eval/fixpoint.rs
@@ -85,7 +85,8 @@ pub fn rec_env<'a, I: Iterator<Item = (&'a LocIdent, &'a Field)>, C: Cache>(
                     pos_access: PosIdx::NONE,
                 };
 
-                let closure: Closure = NickelValue::from(Term::RuntimeError(error)).into();
+                let closure: Closure =
+                    NickelValue::from(Term::RuntimeError(Box::new(error))).into();
 
                 (id.ident(), cache.add(closure, BindingType::Normal))
             }

--- a/core/src/eval/value/lens.rs
+++ b/core/src/eval/value/lens.rs
@@ -191,8 +191,8 @@ pub enum TermContent {
     Annotated(ValueLens<Box<AnnotatedData>>),
     Import(ValueLens<Import>),
     ResolvedImport(ValueLens<FileId>),
-    ParseError(ValueLens<ParseError>),
-    RuntimeError(ValueLens<EvalErrorKind>),
+    ParseError(ValueLens<Box<ParseError>>),
+    RuntimeError(ValueLens<Box<EvalErrorKind>>),
 }
 
 impl TermContent {
@@ -749,7 +749,7 @@ impl ValueLens<FileId> {
     }
 }
 
-impl ValueLens<ParseError> {
+impl ValueLens<Box<ParseError>> {
     /// Creates a new lens extracting [crate::term::Term::ParseError].
     ///
     /// # Safety
@@ -764,7 +764,7 @@ impl ValueLens<ParseError> {
     }
 
     /// Extractor for [crate::term::Term::ParseError].
-    fn term_parse_error_extractor(value: NickelValue) -> ParseError {
+    fn term_parse_error_extractor(value: NickelValue) -> Box<ParseError> {
         let term = ValueLens::<TermData>::content_extractor(value);
 
         if let Term::ParseError(err) = term {
@@ -775,7 +775,7 @@ impl ValueLens<ParseError> {
     }
 }
 
-impl ValueLens<EvalErrorKind> {
+impl ValueLens<Box<EvalErrorKind>> {
     /// Creates a new lens extracting [crate::term::Term::RuntimeError].
     ///
     /// # Safety
@@ -790,7 +790,7 @@ impl ValueLens<EvalErrorKind> {
     }
 
     /// Extractor for [crate::term::Term::RuntimeError].
-    fn term_runtime_error_extractor(value: NickelValue) -> EvalErrorKind {
+    fn term_runtime_error_extractor(value: NickelValue) -> Box<EvalErrorKind> {
         let term = ValueLens::<TermData>::content_extractor(value);
 
         if let Term::RuntimeError(err) = term {

--- a/core/src/term/mod.rs
+++ b/core/src/term/mod.rs
@@ -142,8 +142,6 @@ pub struct AnnotatedData {
 /// representation described in RFC007. The remaining constructors of [Term] are the equivalent of
 /// "code" in the future VM, that is, computations.
 #[derive(Debug, Clone, PartialEq)]
-// This attribute is temporary; we will box the remaining variants soon.
-#[allow(clippy::large_enum_variant)]
 pub enum Term {
     /// An evaluated expression.
     Value(NickelValue),
@@ -230,7 +228,7 @@ pub enum Term {
 
     /// A term that couldn't be parsed properly. Used by the LSP to handle partially valid
     /// programs.
-    ParseError(ParseError),
+    ParseError(Box<ParseError>),
 
     /// A delayed runtime error. Usually, errors are raised and abort the execution right away,
     /// without the need to store them in the AST. However, some cases require a term which aborts
@@ -255,7 +253,7 @@ pub enum Term {
     /// missing field definition error. Thus, we need to bind `bar` to a term wich, if ever
     /// evaluated, will raise a proper missing field definition error. This is precisely the
     /// behavior of `RuntimeError`.
-    RuntimeError(EvalErrorKind),
+    RuntimeError(Box<EvalErrorKind>),
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
@@ -937,6 +935,10 @@ impl Term {
 
     pub fn annotated(annot: TypeAnnotation, inner: NickelValue) -> Self {
         Term::Annotated(Box::new(AnnotatedData { annot, inner }))
+    }
+
+    pub fn parse_error(error: ParseError) -> Self {
+        Term::ParseError(Box::new(error))
     }
 }
 

--- a/core/src/term/pattern/compile.rs
+++ b/core/src/term/pattern/compile.rs
@@ -1026,10 +1026,10 @@ impl Compile for MatchData {
         }
 
         let error_case = NickelValue::term(
-            Term::RuntimeError(EvalErrorKind::NonExhaustiveMatch {
+            Term::RuntimeError(Box::new(EvalErrorKind::NonExhaustiveMatch {
                 value: value.clone(),
                 pos: pos_idx,
-            }),
+            })),
             pos_idx,
         );
 

--- a/core/src/transform/desugar_destructuring.rs
+++ b/core/src/transform/desugar_destructuring.rs
@@ -127,10 +127,10 @@ pub fn desugar_let(
         ));
 
         let error_case = NickelValue::term(
-            Term::RuntimeError(EvalErrorKind::FailedDestructuring {
+            Term::RuntimeError(Box::new(EvalErrorKind::FailedDestructuring {
                 value: rhs.clone(),
                 pattern: pat.clone(),
-            }),
+            })),
             pos_table.push(pos),
         );
 


### PR DESCRIPTION
Follow-up of previous `Term` size reduction PR (#2409 and subsequent). This PR boxes error data stored in a term. This PR finally brings `Term` back down to `40` bytes.