### PR TITLE
refactor: remove unused `Term::Value` variant

### DIFF
--- a/core/src/ast/compat.rs
+++ b/core/src/ast/compat.rs
@@ -584,9 +584,7 @@ impl<'ast> FromMainline<'ast, term::Term> for Node<'ast> {
             Term::ResolvedImport(_) => panic!("didn't expect a resolved import at parsing stage"),
             Term::ParseError(error) => alloc.parse_error((**error).clone()),
             Term::RuntimeError(_) => panic!("didn't expect a runtime error at parsing stage"),
-            Term::Value(value) | Term::Closurize(value) => {
-                Ast::from_mainline(alloc, pos_table, value).node
-            }
+            Term::Closurize(value) => Ast::from_mainline(alloc, pos_table, value).node,
         }
     }
 }

--- a/core/src/eval/contract_eq.rs
+++ b/core/src/eval/contract_eq.rs
@@ -326,10 +326,7 @@ fn contract_eq_bounded(
                     data1.key == data2.key
                         && contract_eq_bounded(state, &data1.inner, env1, &data2.inner, env2)
                 }
-                (Term::Value(v1), Term::Value(v2))
-                | (Term::Closurize(v1), Term::Value(v2))
-                | (Term::Value(v1), Term::Closurize(v2))
-                | (Term::Closurize(v1), Term::Closurize(v2)) => {
+                (Term::Closurize(v1), Term::Closurize(v2)) => {
                     contract_eq_bounded(state, v1, env1, v2, env2)
                 }
                 // We don't treat imports, parse errors, functions, let-bindings nor pairs of terms

--- a/core/src/eval/mod.rs
+++ b/core/src/eval/mod.rs
@@ -704,10 +704,6 @@ impl<'ctxt, R: ImportResolver, C: Cache> VirtualMachine<'ctxt, R, C> {
                 ValueContentRef::Thunk(thunk) => {
                     self.enter_cache_index(None, thunk.clone(), pos_idx, env)?
                 }
-                ValueContentRef::Term(Term::Value(value)) => Closure {
-                    value: value.clone(),
-                    env,
-                },
                 ValueContentRef::Term(Term::Sealed(data)) => {
                     let stack_item = self.stack.peek_op_cont();
                     let closure = Closure {
@@ -1670,11 +1666,6 @@ pub fn subst<C: Cache>(
                     // Currently, there is no interest in replacing variables inside contracts, thus we
                     // limit the work of `subst`.
                     NickelValue::term(Term::Annotated(data), pos_idx)
-                }
-                // We erase `Value` nodes during substitution. When performing substitution, the
-                // goal is to remove indirections.
-                TermContent::Value(lens) => {
-                    subst(pos_table, cache, lens.take(), initial_env, env)
                 }
                 TermContent::Closurize(lens) => {
                     NickelValue::term(Term::Closurize(subst(pos_table, cache, lens.take(), initial_env, env)), pos_idx)

--- a/core/src/eval/value/lens.rs
+++ b/core/src/eval/value/lens.rs
@@ -173,7 +173,6 @@ impl ValueLens<bool> {
 /// This is the same type as [crate::term::Term] but where all the enum variant arguments have been
 /// wrapped in a lens.
 pub enum TermContent {
-    Value(ValueLens<NickelValue>),
     StrChunks(ValueLens<Vec<StrChunk<NickelValue>>>),
     Fun(ValueLens<FunData>),
     FunPattern(ValueLens<Box<FunPatternData>>),
@@ -199,7 +198,6 @@ impl TermContent {
     /// Do not access the content and restore the original value unchanged.
     pub fn restore(self) -> NickelValue {
         match self {
-            TermContent::Value(lens) => lens.restore(),
             TermContent::StrChunks(lens) => lens.restore(),
             TermContent::Fun(lens) => lens.restore(),
             TermContent::FunPattern(lens) => lens.restore(),
@@ -226,7 +224,6 @@ impl TermContent {
     /// matching before deciding to take data out.
     pub fn term(&self) -> &Term {
         let value = match self {
-            TermContent::Value(lens) => &lens.value,
             TermContent::StrChunks(lens) => &lens.value,
             TermContent::Fun(lens) => &lens.value,
             TermContent::FunPattern(lens) => &lens.value,
@@ -255,7 +252,6 @@ impl TermContent {
     /// Unconditionally take the inner `Term` out, ignoring the actual shape of the content.
     pub fn take(self) -> Term {
         let value = match self {
-            TermContent::Value(lens) => lens.value,
             TermContent::StrChunks(lens) => lens.value,
             TermContent::Fun(lens) => lens.value,
             TermContent::FunPattern(lens) => lens.value,
@@ -289,35 +285,11 @@ impl ValueLens<NickelValue> {
     /// # Safety
     ///
     /// `value` must be a value block with tag [super::DataTag::Term], and the inner term must
-    /// match [crate::term::Term::Value].
-    pub(super) unsafe fn term_value_lens(value: NickelValue) -> Self {
-        Self {
-            value,
-            lens: Self::term_value_extractor,
-        }
-    }
-
-    /// Creates a new lens extracting [crate::term::Term::Value].
-    ///
-    /// # Safety
-    ///
-    /// `value` must be a value block with tag [super::DataTag::Term], and the inner term must
     /// match [crate::term::Term::Closurize].
     pub(super) unsafe fn term_closurize_lens(value: NickelValue) -> Self {
         Self {
             value,
             lens: Self::term_closurize_extractor,
-        }
-    }
-
-    /// Extractor for [crate::term::Term::Value].
-    fn term_value_extractor(value: NickelValue) -> NickelValue {
-        let term = ValueLens::<TermData>::content_extractor(value);
-
-        if let Term::Value(inner) = term {
-            inner
-        } else {
-            unreachable!()
         }
     }
 

--- a/core/src/eval/value/mod.rs
+++ b/core/src/eval/value/mod.rs
@@ -803,9 +803,6 @@ impl NickelValue {
                             let term: &TermData = ValueBlockRc::decode_from_raw_unchecked(as_ptr);
 
                             ValueContent::Term(match term {
-                                Term::Value(_) => {
-                                    TermContent::Value(ValueLens::term_value_lens(self))
-                                }
                                 Term::StrChunks(_) => {
                                     TermContent::StrChunks(ValueLens::term_str_chunks_lens(self))
                                 }
@@ -1024,7 +1021,7 @@ impl NickelValue {
             ValueContentRef::Record(_) => Some("Record"),
             ValueContentRef::String(_) => Some("String"),
             ValueContentRef::Term(term) => match term {
-                Term::Value(v) | Term::Closurize(v) => v.type_of(),
+                Term::Closurize(v) => v.type_of(),
                 Term::RecRecord(..) => Some("Record"),
                 Term::Fun(..) | Term::FunPattern(..) => Some("Function"),
                 Term::Match { .. } => Some("MatchExpression"),

--- a/core/src/pretty.rs
+++ b/core/src/pretty.rs
@@ -1202,7 +1202,7 @@ impl<'a> Pretty<'a, Allocator> for &Term {
             Term::ResolvedImport(id) => allocator.text(format!("import <file_id: {id:?}>")),
             Term::ParseError(_) => allocator.text("%<parse error>"),
             Term::RuntimeError(_) => allocator.text("%<runtime error>"),
-            Term::Value(val) | Term::Closurize(val) => val.pretty(allocator),
+            Term::Closurize(val) => val.pretty(allocator),
         }
     }
 }

--- a/core/src/serialize/mod.rs
+++ b/core/src/serialize/mod.rs
@@ -4,7 +4,7 @@ use crate::{
     eval::value::{ArrayData, Container, EnumVariantData, NickelValue, ValueContentRef},
     identifier::{Ident, LocIdent},
     metrics,
-    term::{IndexMap, Number, Term, TypeAnnotation, record::RecordData},
+    term::{IndexMap, Number, TypeAnnotation, record::RecordData},
 };
 
 use serde::{
@@ -501,15 +501,6 @@ pub fn validate(format: ExportFormat, value: &NickelValue) -> Result<(), Pointed
                             .map_err(|err| err.with_elem(NickelPointerElem::Index(index)))
                     })?;
                 Ok(())
-            }
-            // Not sure if we should allow this. But supporting wrapped values might alleviate the
-            // pre-processing substitution work to be done upfront.
-            ValueContentRef::Term(term) => {
-                if let Term::Value(nickel_val) = term {
-                    do_validate(format, nickel_val)
-                } else {
-                    Err(ExportErrorKind::NonSerializable(value.clone()).into())
-                }
             }
             _ => Err(ExportErrorKind::NonSerializable(value.clone()).into()),
         }

--- a/core/src/transform/free_vars.rs
+++ b/core/src/transform/free_vars.rs
@@ -120,7 +120,7 @@ impl CollectFreeVars for Term {
                 }
             }
             Term::Annotated(data) => data.collect_free_vars(free_vars),
-            Term::Value(v) | Term::Closurize(v) => v.collect_free_vars(free_vars),
+            Term::Closurize(v) => v.collect_free_vars(free_vars),
         }
     }
 }


### PR DESCRIPTION
Depends on #2421

This PR removes the unused `Term::Value` variant. It was introduced with the compact value representation, vaguely following the idea that `Term` would be bytecode and compact values would be data/values, and thus that code needed to return values (the `return` of call-by-push-value). However, although this is a useful guideline and comparison, our setting is still a bit different from a proper bytecode virtual machine, and it's not currently needed to embed a value as `Term`. This PR thus gets rid of the unused variant.