### PR TITLE
refactor: introduce AppData

### DIFF
--- a/core/src/eval/cache/lazy.rs
+++ b/core/src/eval/cache/lazy.rs
@@ -601,7 +601,7 @@ impl Thunk {
             .map(|id| NickelValue::from(Term::Var(id.into())));
 
         args.fold(as_function_closurized, |partial_app, arg| {
-            NickelValue::from(Term::App(partial_app, arg))
+            NickelValue::from(Term::app(partial_app, arg))
         })
     }
 

--- a/core/src/eval/contract_eq.rs
+++ b/core/src/eval/contract_eq.rs
@@ -207,9 +207,9 @@ fn contract_eq_bounded(
                             }
                         })
                 }
-                (Term::App(head1, arg1), Term::App(head2, arg2)) => {
-                    contract_eq_bounded(state, head1, env1, head2, env2)
-                        && contract_eq_bounded(state, arg1, env1, arg2, env2)
+                (Term::App(data1), Term::App(data2)) => {
+                    contract_eq_bounded(state, &data1.head, env1, &data2.head, env2)
+                        && contract_eq_bounded(state, &data1.arg, env1, &data2.arg, env2)
                 }
                 // All variables must be bound at this stage. This is checked by the typechecker when
                 // walking annotations. However, we may assume that `env` is a local environment (that it

--- a/core/src/eval/mod.rs
+++ b/core/src/eval/mod.rs
@@ -762,18 +762,18 @@ impl<'ctxt, R: ImportResolver, C: Cache> VirtualMachine<'ctxt, R, C> {
                     let idx = self.get_var(*id, &env, pos_idx)?;
                     self.enter_cache_index(Some(*id), idx, pos_idx, env)?
                 }
-                ValueContentRef::Term(Term::App(head, arg)) => {
+                ValueContentRef::Term(Term::App(data)) => {
                     self.call_stack.enter_app(&self.context.pos_table, pos_idx);
 
                     self.stack.push_arg(
                         Closure {
-                            value: arg.clone(),
+                            value: data.arg.clone(),
                             env: env.clone(),
                         },
                         pos_idx,
                     );
                     Closure {
-                        value: head.clone(),
+                        value: data.head.clone(),
                         env,
                     }
                 }
@@ -1077,7 +1077,7 @@ impl<'ctxt, R: ImportResolver, C: Cache> VirtualMachine<'ctxt, R, C> {
 
                             match value {
                                 Some(value) => NickelValue::term(
-                                    Term::App(extend, value),
+                                    Term::app(extend, value),
                                     pos_dyn_field.to_inherited(&mut self.context.pos_table),
                                 ),
                                 None => extend,
@@ -1582,11 +1582,11 @@ pub fn subst<C: Cache>(
                     "Pattern {:?} has not been transformed before evaluation", lens.restore()
                 ),
                 TermContent::App(lens) => {
-                    let (head, arg) = lens.take();
-                    let head = subst(pos_table, cache, head, initial_env, env);
-                    let arg = subst(pos_table, cache, arg, initial_env, env);
+                    let mut data = lens.take();
+                    data.head = subst(pos_table, cache, data.head, initial_env, env);
+                    data.arg = subst(pos_table, cache, data.arg, initial_env, env);
 
-                    NickelValue::term(Term::App(head, arg), pos_idx)
+                    NickelValue::term(Term::App(data), pos_idx)
                 }
                 TermContent::Match(lens) => {
                     let data = lens.take();

--- a/core/src/eval/operation.rs
+++ b/core/src/eval/operation.rs
@@ -621,7 +621,7 @@ impl<'ctxt, R: ImportResolver, C: Cache> VirtualMachine<'ctxt, R, C> {
                                 );
 
                                 NickelValue::term(
-                                    Term::App(f_as_var.clone(), t_with_ctrs),
+                                    Term::app(f_as_var.clone(), t_with_ctrs),
                                     pos_op_inh,
                                 )
                                 .closurize(&mut self.context.cache, env.clone())

--- a/core/src/eval/value/lens.rs
+++ b/core/src/eval/value/lens.rs
@@ -9,8 +9,8 @@ use crate::{
     files::FileId,
     identifier::LocIdent,
     term::{
-        AnnotatedData, FunData, FunPatternData, Import, LetData, LetPatternData, MatchData,
-        Op1Data, Op2Data, OpNData, RecRecordData, SealedData, StrChunk, Term,
+        AnnotatedData, AppData, FunData, FunPatternData, Import, LetData, LetPatternData,
+        MatchData, Op1Data, Op2Data, OpNData, RecRecordData, SealedData, StrChunk, Term,
     },
 };
 
@@ -179,7 +179,7 @@ pub enum TermContent {
     FunPattern(ValueLens<Box<FunPatternData>>),
     Let(ValueLens<Box<LetData>>),
     LetPattern(ValueLens<Box<LetPatternData>>),
-    App(ValueLens<(NickelValue, NickelValue)>),
+    App(ValueLens<AppData>),
     Var(ValueLens<LocIdent>),
     RecRecord(ValueLens<Box<RecRecordData>>),
     Closurize(ValueLens<NickelValue>),
@@ -463,7 +463,7 @@ impl ValueLens<Box<LetPatternData>> {
     }
 }
 
-impl ValueLens<(NickelValue, NickelValue)> {
+impl ValueLens<AppData> {
     /// Creates a new lens extracting [crate::term::Term::App].
     ///
     /// # Safety
@@ -478,11 +478,11 @@ impl ValueLens<(NickelValue, NickelValue)> {
     }
 
     /// Extractor for [crate::term::Term::App].
-    fn term_app_extractor(value: NickelValue) -> (NickelValue, NickelValue) {
+    fn term_app_extractor(value: NickelValue) -> AppData {
         let term = ValueLens::<TermData>::content_extractor(value);
 
-        if let Term::App(fun, arg) = term {
-            (fun, arg)
+        if let Term::App(data) = term {
+            data
         } else {
             unreachable!()
         }

--- a/core/src/eval/value/mod.rs
+++ b/core/src/eval/value/mod.rs
@@ -1032,7 +1032,7 @@ impl NickelValue {
                 Term::Annotated(..) => Some("Annotated"),
                 Term::Let(..)
                 | Term::LetPattern(..)
-                | Term::App(_, _)
+                | Term::App(_)
                 | Term::Var(_)
                 | Term::Op1(_)
                 | Term::Op2(_)

--- a/core/src/term/mod.rs
+++ b/core/src/term/mod.rs
@@ -127,6 +127,12 @@ pub struct AnnotatedData {
     pub inner: NickelValue,
 }
 
+#[derive(Clone, Debug, PartialEq)]
+pub struct AppData {
+    pub head: NickelValue,
+    pub arg: NickelValue,
+}
+
 /// The runtime representation of a Nickel computation.
 ///
 /// # History
@@ -170,7 +176,7 @@ pub enum Term {
     LetPattern(Box<LetPatternData>),
 
     /// An application. Push the argument on the stack and proceed with the evaluation of the head.
-    App(NickelValue, NickelValue),
+    App(AppData),
 
     /// A variable. Fetch the corresponding value from the environment.
     Var(LocIdent),
@@ -755,7 +761,7 @@ impl Term {
             Term::Annotated(..) => Some("Annotated"),
             Term::Let(..)
             | Term::LetPattern(..)
-            | Term::App(_, _)
+            | Term::App(_)
             | Term::Var(_)
             | Term::Op1(_)
             | Term::Op2(_)
@@ -935,6 +941,10 @@ impl Term {
 
     pub fn annotated(annot: TypeAnnotation, inner: NickelValue) -> Self {
         Term::Annotated(Box::new(AnnotatedData { annot, inner }))
+    }
+
+    pub fn app(head: NickelValue, arg: NickelValue) -> Self {
+        Term::App(AppData { head, arg })
     }
 
     pub fn parse_error(error: ParseError) -> Self {
@@ -1800,10 +1810,10 @@ impl Traverse<NickelValue> for Term {
 
                 Term::LetPattern(data)
             }
-            Term::App(head, arg) => {
-                let head = head.traverse(f, order)?;
-                let arg = arg.traverse(f, order)?;
-                Term::App(head, arg)
+            Term::App(mut data) => {
+                data.head = data.head.traverse(f, order)?;
+                data.arg = data.arg.traverse(f, order)?;
+                Term::App(data)
             }
             Term::Match(data) => {
                 // The annotation on `map_res` use Result's corresponding trait to convert from
@@ -1958,9 +1968,10 @@ impl Traverse<NickelValue> for Term {
                 .arg1
                 .traverse_ref(f, state)
                 .or_else(|| data.arg2.traverse_ref(f, state)),
-            Term::App(t1, t2) => t1
+            Term::App(data) => data
+                .head
                 .traverse_ref(f, state)
-                .or_else(|| t2.traverse_ref(f, state)),
+                .or_else(|| data.arg.traverse_ref(f, state)),
             Term::RecRecord(data) => data
                 .record
                 .fields
@@ -2009,7 +2020,7 @@ pub mod make {
     macro_rules! mk_app {
         ( $f:expr, $arg:expr) => {
             $crate::eval::value::NickelValue::from(
-                $crate::term::Term::App(
+                $crate::term::Term::app(
                     $crate::eval::value::NickelValue::from($f),
                     $crate::eval::value::NickelValue::from($arg)
                 )


### PR DESCRIPTION
While not needed for reducing the size of term, this PR continues the work of the previous `Term` size reduction PR (started in #2409) by introducing a bespoke structure for `Term::App`. This makes `Term` uniform, as `App` was the last variant constructor with unnamed parameters, and opens the door for a better `TermContent` lens API, where we could decide to look at the content by reference instead of taking it out by value (not implemented in this PR).