### PR TITLE
refactor: generate generic `ValueLens` impls with a macro

### DIFF
--- a/core/src/eval/value/lens.rs
+++ b/core/src/eval/value/lens.rs
@@ -300,8 +300,11 @@ macro_rules! impl_term_lens {
             //
             // # Safety
             //
-            // `value` must be a value block with tag `DataTag::Term`, and the inner term must
-            // match `Term::$term_cons`.
+            // `value` must be a value block with tag `DataTag::Term`.
+            //
+            // # Panics
+            //
+            // Panics if the inner term doesn't match `Term::$term_cons`.
             pub(super) unsafe fn $lens_cons(value: NickelValue) -> Self {
                 Self {
                     value,


### PR DESCRIPTION
Depends on #2423

Now that all term variants only have one argument, it's possible to factor out all the `ValueLens<_>` implementations in a macro, which shaves a off a few hundred lines of code.