### PR TITLE
feat: lenses by reference and `take_unboxed`

### DIFF
--- a/core/src/eval/merge.rs
+++ b/core/src/eval/merge.rs
@@ -100,7 +100,7 @@ impl<'ctxt, R: ImportResolver, C: Cache> VirtualMachine<'ctxt, R, C> {
             (ValueContent::Bool(lens1), ValueContent::Bool(lens2))
                 // phys_eq allows comparison in the guard without consuming both lenses, which we
                 // need for the result
-                if lens1.peek().phys_eq(lens2.peek()) =>
+                if lens1.value().phys_eq(lens2.value()) =>
             {
                 Ok(NickelValue::bool_value(
                     lens1.take(),
@@ -272,7 +272,7 @@ impl<'ctxt, R: ImportResolver, C: Cache> VirtualMachine<'ctxt, R, C> {
             // for performance reasons: to avoid allocation, recomputation of fixpoint, etc.
             (ValueContent::Record(lens), ValueContent::Record(empty))
             | (ValueContent::Record(empty), ValueContent::Record(lens))
-                if empty.peek().is_inline_empty_record() =>
+                if empty.value().is_inline_empty_record() =>
             {
                 // In merge contract mode, we need to maintain the position of the first argument,
                 // which is the scrutinized value, to maintain good contract error messages.
@@ -281,7 +281,7 @@ impl<'ctxt, R: ImportResolver, C: Cache> VirtualMachine<'ctxt, R, C> {
                 // better to keep the position of the other argument (instead of the position of
                 // the merge), since the result will inherit everything from it.
                 let final_pos = if let MergeMode::Standard(_) = mode {
-                    lens.peek().pos_idx()
+                    lens.value().pos_idx()
                 } else {
                     pos1.to_inherited(&mut self.context.pos_table)
                 };

--- a/core/src/eval/mod.rs
+++ b/core/src/eval/mod.rs
@@ -905,7 +905,7 @@ impl<'ctxt, R: ImportResolver, C: Cache> VirtualMachine<'ctxt, R, C> {
                     // TODO[RFC007]: we clone the value, so taking the content is meaningless. We
                     // should probably do a `content()` call at the top of the eval function.
                     let result = match value.clone().content() {
-                        ValueContent::Array(lens) if lens.peek().is_inline_empty_array() => {
+                        ValueContent::Array(lens) if lens.value().is_inline_empty_array() => {
                             lens.restore()
                         }
                         ValueContent::Array(lens) => {
@@ -934,7 +934,7 @@ impl<'ctxt, R: ImportResolver, C: Cache> VirtualMachine<'ctxt, R, C> {
 
                             NickelValue::array(array, pending_contracts, pos_idx)
                         }
-                        ValueContent::Record(lens) if lens.peek().is_inline_empty_record() => {
+                        ValueContent::Record(lens) if lens.value().is_inline_empty_record() => {
                             lens.restore()
                         }
                         ValueContent::Record(lens) => NickelValue::record(

--- a/core/src/eval/operation.rs
+++ b/core/src/eval/operation.rs
@@ -691,7 +691,7 @@ impl<'ctxt, R: ImportResolver, C: Cache> VirtualMachine<'ctxt, R, C> {
                 })?;
 
                 match value.content() {
-                    ValueContent::Record(lens) if lens.peek().is_inline_empty_record() => {
+                    ValueContent::Record(lens) if lens.value().is_inline_empty_record() => {
                         Ok(lens.restore().with_pos_idx(pos_op).into())
                     }
                     ValueContent::Record(lens) => {
@@ -1110,7 +1110,7 @@ impl<'ctxt, R: ImportResolver, C: Cache> VirtualMachine<'ctxt, R, C> {
                 }
 
                 match value.content() {
-                    ValueContent::Record(lens) if !lens.peek().is_inline_empty_record() => {
+                    ValueContent::Record(lens) if !lens.value().is_inline_empty_record() => {
                         //unwrap(): the guard of the pattern exclude empty records
                         let record = lens.take().unwrap_alloc();
                         let fields = record
@@ -1145,7 +1145,7 @@ impl<'ctxt, R: ImportResolver, C: Cache> VirtualMachine<'ctxt, R, C> {
 
                         Ok(seq_terms(terms.into_iter(), pos_op, cont).into())
                     }
-                    ValueContent::Array(lens) if !lens.peek().is_inline_empty_array() => {
+                    ValueContent::Array(lens) if !lens.value().is_inline_empty_array() => {
                         //unwrap(): the guard of the pattern exclude empty arrays
                         let ArrayData {
                             array: ts,

--- a/core/src/eval/value/lens.rs
+++ b/core/src/eval/value/lens.rs
@@ -44,7 +44,7 @@ impl<T> ValueLens<T> {
     }
 
     /// Peeks at the underlying value, without consuming the lens.
-    pub fn peek(&self) -> &NickelValue {
+    pub fn value(&self) -> &NickelValue {
         &self.value
     }
 
@@ -73,7 +73,7 @@ impl<T: ValueBlockData + Clone> ValueLens<Container<T>> {
                 if v.is_inline() {
                     Container::Empty
                 } else {
-                    Container::Alloc(ValueLens::<T>::content_extractor(v))
+                    Container::Alloc(ValueLens::<T>::extract_or_clone(v))
                 }
             },
         }
@@ -89,17 +89,25 @@ impl<T: ValueBlockData + Clone> ValueLens<T> {
     pub(super) unsafe fn content_lens(value: NickelValue) -> Self {
         ValueLens {
             value,
-            lens: Self::content_extractor,
+            lens: Self::extract_or_clone,
         }
     }
 
-    /// Extractor for a value block.
-    fn content_extractor(value: NickelValue) -> T {
-        // Safety: the fields of LazyValueLens are private, so it can only be constructed from
-        // within this module. We maintain the invariant that if `content_extractor` is used as a
-        // lens for a `LazyValueLens` object, then `T : ValueBlockData` and `self.value` is a value
-        // block whose tag matches `T::TAG`, so `self.value.data` is a valid pointer to a
-        // `ValueBlockHeader` followed by a `U` at the right offset.
+    /// Custom extractor for a value block. If the reference is 1-counted, the content is extracted
+    /// and the first closure is called with an owned value. Otherwise, the second closure is
+    /// called with a reference to the content. This makes it possible to finer things than the
+    /// blunt clone of [Self::extract_or_clone], such as avoiding cloning the outer `Box` wrapper
+    /// of some `Term` variants when the data is shared.
+    fn with_content<F, G, R>(value: NickelValue, on_owned: F, on_ref: G) -> R
+    where
+        F: FnOnce(T) -> R,
+        G: FnOnce(&T) -> R,
+    {
+        // Safety: the fields of `ValueLens` are private, so it can only be constructed from within
+        // this module. We maintain the invariant that if `with_content` is used as a lens for
+        // a `ValueLens` object, then `T : ValueBlockData` and `self.value` is a value block whose
+        // tag matches `T::TAG`, so `self.value.data` is a valid pointer to a `ValueBlockHeader`
+        // followed by a `U` at the right offset.
         unsafe {
             let ptr = NonNull::new_unchecked(value.data as *mut u8);
             let ref_count = ptr.cast::<ValueBlockHeader>().as_ref().ref_count;
@@ -118,11 +126,16 @@ impl<T: ValueBlockData + Clone> ValueLens<T> {
                 // While we don't want the destructor to run, we do want to clean up the original
                 // allocation.
                 dealloc(ptr.as_ptr(), T::TAG.block_layout());
-                content
+                on_owned(content)
             } else {
-                ptr_content.as_ref().clone()
+                on_ref(ptr_content.as_ref())
             }
         }
+    }
+
+    /// Standard extractor for a value block.
+    fn extract_or_clone(value: NickelValue) -> T {
+        Self::with_content(value, |v| v, |data| data.clone())
     }
 }
 
@@ -314,9 +327,16 @@ macro_rules! impl_term_lens {
 
             // Extractor for `Term::$term_cons`.
             fn $lens_extrct(value: NickelValue) -> $type {
-                let term = ValueLens::<TermData>::content_extractor(value);
+                if let Term::$term_cons(data) = ValueLens::<TermData>::extract_or_clone(value) {
+                    data
+                } else {
+                    unreachable!()
+                }
+            }
 
-                if let Term::$term_cons(data) = term {
+            /// Peeks at the underlying term data without taking ownership.
+            pub fn peek(&self) -> &$type {
+                if let Some(Term::$term_cons(data)) = self.value.as_term() {
                     data
                 } else {
                     unreachable!()
@@ -326,34 +346,76 @@ macro_rules! impl_term_lens {
     };
 }
 
-impl ValueLens<NickelValue> {
-    /// Creates a new lens extracting [Term::Closurize].
-    ///
-    /// # Safety
-    ///
-    /// `value` must be a value block with tag [super::DataTag::Term].
-    ///
-    /// # Panic
-    ///
-    /// Panics if the inner term doesn't match [Term::Closurize].
-    pub(super) unsafe fn term_closurize_lens(value: NickelValue) -> Self {
-        Self {
-            value,
-            lens: Self::term_closurize_extractor,
-        }
-    }
+/// Same as `impl_term_lens!`, but specialized for terms with boxed payload, where the reference
+/// and the extraction code are different. In particular, we try to avoid allocating a new [Box]
+/// when copying non-1RC content (in practice, we always want to move the result on the stack).
+macro_rules! impl_term_boxed_lens {
+    ( $lens_cons:ident, $lens_extrct:ident, $term_cons:ident, $type:ty ) => {
+        impl ValueLens<Box<$type>> {
+            // Creates a new lens extracting `Term::$term_cons`.
+            //
+            // # Safety
+            //
+            // `value` must be a value block with tag `DataTag::Term`, and the inner term must
+            // match `Term::$term_cons`.
+            pub(super) unsafe fn $lens_cons(value: NickelValue) -> Self {
+                Self {
+                    value,
+                    lens: Self::$lens_extrct,
+                }
+            }
 
-    /// Extractor for [Term::Closurize].
-    fn term_closurize_extractor(value: NickelValue) -> NickelValue {
-        let term = ValueLens::<TermData>::content_extractor(value);
+            // Extractor for `Term::$term_cons`.
+            fn $lens_extrct(value: NickelValue) -> Box<$type> {
+                if let Term::$term_cons(data) = ValueLens::<TermData>::extract_or_clone(value) {
+                    data
+                } else {
+                    unreachable!()
+                }
+            }
 
-        if let Term::Closurize(inner) = term {
-            inner
-        } else {
-            unreachable!()
+            /// Variant of `take()` for boxed term data that returns the data unboxed. When the
+            /// value is shared, [Self::take_unboxed] avoids cloning the outer box and directly
+            /// clones the inner data instead. If you're going to move out of the box anyway,
+            /// prefer this variant, which should avoid an ephemeral heap-allocation.
+            pub fn take_unboxed(self) -> $type {
+                ValueLens::<TermData>::with_content(
+                    self.value,
+                    |owned| {
+                        if let Term::$term_cons(data) = owned {
+                            *data
+                        } else {
+                            unreachable!()
+                        }
+                    },
+                    |as_ref| {
+                        if let Term::$term_cons(data) = as_ref {
+                            (**data).clone()
+                        } else {
+                            unreachable!()
+                        }
+                    },
+                )
+            }
+
+            /// Returns a reference to the inner term data without taking ownership.
+            pub fn peek(&self) -> &$type {
+                if let Some(Term::$term_cons(data)) = self.value.as_term() {
+                    &**data
+                } else {
+                    unreachable!()
+                }
+            }
         }
-    }
+    };
 }
+
+impl_term_lens!(
+    term_closurize_lens,
+    term_closurize_extractor,
+    Closurize,
+    NickelValue
+);
 
 impl_term_lens!(
     term_str_chunks_lens,
@@ -364,53 +426,48 @@ impl_term_lens!(
 
 impl_term_lens!(term_fun_lens, term_fun_extractor, Fun, FunData);
 
-impl_term_lens!(
+impl_term_boxed_lens!(
     term_fun_pat_lens,
     term_fun_pat_extractor,
     FunPattern,
-    Box<FunPatternData>
+    FunPatternData
 );
 
-impl_term_lens!(term_let_lens, term_let_extractor, Let, Box<LetData>);
+impl_term_boxed_lens!(term_let_lens, term_let_extractor, Let, LetData);
 
-impl_term_lens!(
+impl_term_boxed_lens!(
     term_let_pat_lens,
     term_let_pat_extractor,
     LetPattern,
-    Box<LetPatternData>
+    LetPatternData
 );
 
 impl_term_lens!(term_app_lens, term_app_extractor, App, AppData);
 
 impl_term_lens!(term_var_lens, term_var_extractor, Var, LocIdent);
 
-impl_term_lens!(
+impl_term_boxed_lens!(
     term_rec_record_lens,
     term_rec_record_extractor,
     RecRecord,
-    Box<RecRecordData>
+    RecRecordData
 );
 
 impl_term_lens!(term_match_lens, term_match_extractor, Match, MatchData);
 
-impl_term_lens!(term_op1_lens, term_op1_extractor, Op1, Box<Op1Data>);
+impl_term_boxed_lens!(term_op1_lens, term_op1_extractor, Op1, Op1Data);
 
-impl_term_lens!(term_op2_lens, term_op2_extractor, Op2, Box<Op2Data>);
+impl_term_boxed_lens!(term_op2_lens, term_op2_extractor, Op2, Op2Data);
 
 impl_term_lens!(term_opn_lens, term_opn_extractor, OpN, OpNData);
 
-impl_term_lens!(
-    term_sealed_lens,
-    term_sealed_extractor,
-    Sealed,
-    Box<SealedData>
-);
+impl_term_boxed_lens!(term_sealed_lens, term_sealed_extractor, Sealed, SealedData);
 
-impl_term_lens!(
+impl_term_boxed_lens!(
     term_annotated_lens,
     term_annotated_extractor,
     Annotated,
-    Box<AnnotatedData>
+    AnnotatedData
 );
 
 impl_term_lens!(term_import_lens, term_import_extractor, Import, Import);

--- a/core/src/eval/value/mod.rs
+++ b/core/src/eval/value/mod.rs
@@ -2365,8 +2365,8 @@ impl Traverse<NickelValue> for NickelValue {
             | ValueContent::Thunk(_)
             | ValueContent::SealingKey(_)
             | ValueContent::ForeignId(_)) => lens.restore(),
-            ValueContent::Array(lens) if lens.peek().is_inline_empty_array() => lens.restore(),
-            ValueContent::Record(lens) if lens.peek().is_inline_empty_record() => lens.restore(),
+            ValueContent::Array(lens) if lens.value().is_inline_empty_array() => lens.restore(),
+            ValueContent::Record(lens) if lens.value().is_inline_empty_record() => lens.restore(),
             ValueContent::Term(lens) => {
                 let term = lens.take();
                 let term = term.traverse(f, order)?;

--- a/core/src/transform/desugar_destructuring.rs
+++ b/core/src/transform/desugar_destructuring.rs
@@ -26,10 +26,12 @@ pub fn transform_one(pos_table: &mut PosTable, value: NickelValue) -> NickelValu
     match value.content() {
         ValueContent::Term(term) => match term {
             TermContent::LetPattern(lens) => {
-                let data = lens.take();
-                NickelValue::term(desugar_let(pos_table, *data), pos_idx)
+                let data = lens.take_unboxed();
+                NickelValue::term(desugar_let(pos_table, data), pos_idx)
             }
-            TermContent::FunPattern(lens) => NickelValue::term(desugar_fun(*lens.take()), pos_idx),
+            TermContent::FunPattern(lens) => {
+                NickelValue::term(desugar_fun(lens.take_unboxed()), pos_idx)
+            }
             lens => lens.restore(),
         },
         lens => lens.restore(),

--- a/core/src/transform/gen_pending_contracts.rs
+++ b/core/src/transform/gen_pending_contracts.rs
@@ -77,7 +77,7 @@ pub fn transform_one(
     let pos_idx = value.pos_idx();
 
     Ok(match value.content() {
-        ValueContent::Record(lens) if lens.peek().is_inline_empty_record() => lens.restore(),
+        ValueContent::Record(lens) if lens.value().is_inline_empty_record() => lens.restore(),
         ValueContent::Record(lens) => {
             // unwrap(): we treated the inline empty record case above.
             let RecordData {

--- a/core/src/transform/substitute_wildcards.rs
+++ b/core/src/transform/substitute_wildcards.rs
@@ -52,7 +52,7 @@ pub fn transform_one(value: NickelValue, wildcards: &Wildcards) -> NickelValue {
                 term_lens.restore()
             }
         }
-        ValueContent::Record(lens) if lens.peek().is_inline_empty_record() => lens.restore(),
+        ValueContent::Record(lens) if lens.value().is_inline_empty_record() => lens.restore(),
         ValueContent::Record(record_lens) => {
             // unwrap(): we treated the inline empty record case above
             let record_data = record_lens.take().into_opt().unwrap();


### PR DESCRIPTION
This PR makes some improvements to lenses, before making use of them in the main eval loop (and in primop evaluation).

This PR adds a `data()` helper on term lenses, making it possible to look into the underlying data by reference without taking ownership, making lenses more flexible (one can match on a lens but still decide later on not to take ownership).

We also add a `take_unboxed` helper on boxed term variants, which avoids a `Box` clone - and thus an allocation - when the content is shared. The target is evaluation patterns where it's common to move out of the content anyway, so that the box layer is useless.