### PR TITLE
Better error message for undefined record field

### DIFF
--- a/cli/tests/snapshot/inputs/errors/accessing_unknown_field.ncl
+++ b/cli/tests/snapshot/inputs/errors/accessing_unknown_field.ncl
@@ -1,0 +1,3 @@
+# capture = 'stderr'
+# command = ['eval']
+(fun x => x.a) : {} -> _

--- a/cli/tests/snapshot/snapshots/snapshot__eval_stderr_accessing_unknown_field.ncl.snap
+++ b/cli/tests/snapshot/snapshots/snapshot__eval_stderr_accessing_unknown_field.ncl.snap
@@ -1,0 +1,13 @@
+---
+source: cli/tests/snapshot/main.rs
+expression: err
+---
+error: type error: missing field `a`
+  ┌─ [INPUTS_PATH]/errors/accessing_unknown_field.ncl:3:11
+  │
+3 │ (fun x => x.a) : {} -> _
+  │           ^ - `a` required here
+  │           │  
+  │           this record lacks `a`
+  │
+  = Attempted to access field `a` on an expression of type `{  }`

--- a/cli/tests/snapshot/snapshots/snapshot__eval_stderr_destructuring_nonexistent_idents.ncl.snap
+++ b/cli/tests/snapshot/snapshots/snapshot__eval_stderr_destructuring_nonexistent_idents.ncl.snap
@@ -2,11 +2,12 @@
 source: cli/tests/snapshot/main.rs
 expression: err
 ---
-error: type error: missing row `b`
+error: type error: missing field `b`
   ┌─ [INPUTS_PATH]/errors/destructuring_nonexistent_idents.ncl:4:18
   │
 4 │   let { a, b } = { a = 1, c = 2 } in
-  │                  ^^^^^^^^^^^^^^^^ this expression
+  │            -     ^^^^^^^^^^^^^^^^ this record lacks `b`
+  │            │      
+  │            `b` required here
   │
-  = Expected an expression of type `{ b : _a, a : _b }`, which contains the field `b`
-  = Found an expression of type `{ a : _c, c : _d }`, which does not contain the field `b`
+  = Attempted to access field `b` on an expression of type `{ a : _c, c : _d }`

--- a/core/src/typecheck/subtyping.rs
+++ b/core/src/typecheck/subtyping.rs
@@ -228,7 +228,7 @@ impl<'ast> SubsumedBy<'ast> for UnifRecordRows<'ast> {
                     let (ty_res, urrows_without_ty_res) = urrows1
                         .remove_row(&row2.id, &row2.typ, state, ctxt.var_level)
                         .map_err(|err| match err {
-                            RemoveRowError::Missing => RowUnifErrorKind::MissingRow(row2.id),
+                            RemoveRowError::Missing => RowUnifErrorKind::MissingRecordRow(row2.id),
                             RemoveRowError::Conflict => {
                                 RowUnifErrorKind::RecordRowConflict(row2.clone())
                             }
@@ -267,7 +267,7 @@ impl<'ast> SubsumedBy<'ast> for UnifRecordRows<'ast> {
                         row: UnifRecordRow { id, .. },
                         ..
                     },
-                ) => Err(Box::new(RowUnifErrorKind::MissingRow(id))),
+                ) => Err(Box::new(RowUnifErrorKind::MissingRecordRow(id))),
                 (
                     RecordRowsF::Extend {
                         row: UnifRecordRow { id, .. },

--- a/core/src/typecheck/unif.rs
+++ b/core/src/typecheck/unif.rs
@@ -1407,7 +1407,7 @@ impl<'ast> Unify<'ast> for UnifEnumRows<'ast> {
                         ..
                     },
                     EnumRowsF::Empty,
-                ) => Err(Box::new(RowUnifErrorKind::MissingRow(id))),
+                ) => Err(Box::new(RowUnifErrorKind::MissingEnumRow(id))),
                 (EnumRowsF::Extend { row, tail }, erows2 @ EnumRowsF::Extend { .. }) => {
                     let uerows2 = UnifEnumRows::Concrete {
                         erows: erows2,
@@ -1418,7 +1418,7 @@ impl<'ast> Unify<'ast> for UnifEnumRows<'ast> {
                         //TODO[adts]: it's ugly to create a temporary Option just to please the
                         //Box/Nobox types, we should find a better signature for remove_row
                         uerows2.remove_row(&row.id, &row.typ.clone().map(|typ| *typ), state, ctxt.var_level).map_err(|err| match err {
-                            RemoveRowError::Missing => RowUnifErrorKind::MissingRow(row.id),
+                            RemoveRowError::Missing => RowUnifErrorKind::MissingEnumRow(row.id),
                             RemoveRowError::Conflict => RowUnifErrorKind::EnumRowConflict(row.clone()),
                         })?;
 
@@ -1549,7 +1549,7 @@ impl<'ast> Unify<'ast> for UnifRecordRows<'ast> {
                         ..
                     },
                     RecordRowsF::Empty,
-                ) => Err(Box::new(RowUnifErrorKind::MissingRow(id))),
+                ) => Err(Box::new(RowUnifErrorKind::MissingRecordRow(id))),
                 (RecordRowsF::Extend { row, tail }, rrows2 @ RecordRowsF::Extend { .. }) => {
                     let urrows2 = UnifRecordRows::Concrete {
                         rrows: rrows2,
@@ -1559,7 +1559,7 @@ impl<'ast> Unify<'ast> for UnifRecordRows<'ast> {
                     let (ty2_result, urrows2_without_ty2) = urrows2
                         .remove_row(&row.id, &row.typ, state, ctxt.var_level)
                         .map_err(|err| match err {
-                            RemoveRowError::Missing => RowUnifErrorKind::MissingRow(row.id),
+                            RemoveRowError::Missing => RowUnifErrorKind::MissingRecordRow(row.id),
                             RemoveRowError::Conflict => {
                                 RowUnifErrorKind::RecordRowConflict(row.clone())
                             }

--- a/doc/manual/syntax.md
+++ b/doc/manual/syntax.md
@@ -1243,7 +1243,7 @@ qualify as a record type and is parsed as a record contract. This throws an
 
 ```nickel #repl
 > {foo = 1, bar = "foo" } : {foo : Number, bar : String, baz : Bool}
-error: type error: missing row `baz`
+error: type error: missing field `baz`
 [...]
 ```
 


### PR DESCRIPTION
Fixes #2354.

Compared to the suggested message in #2354, this has an extra pointer to the location of the record. I don't find it super useful in the example of #2354, but I think it's useful for the destructuring example in the snapshot tests.