### PR TITLE
Publish C libraries during release

### DIFF
--- a/.github/workflows/release-artifacts.yaml
+++ b/.github/workflows/release-artifacts.yaml
@@ -171,6 +171,5 @@ jobs:
           gh release upload --clobber $Env:RELEASE_TAG nickel-x86_64-windows.exe
           gh release upload --clobber $Env:RELEASE_TAG nickel-pkg-x86_64-windows.exe
           gh release upload --clobber $Env:RELEASE_TAG nls-x86_64-windows.exe
-          gh release upload --clobber $Env:RELEASE_TAG nls-x86_64-windows.exe
           gh release upload --clobber $Env:RELEASE_TAG libnickel_lang-x86_64-windows-mingw.a
           gh release upload --clobber $Env:RELEASE_TAG libnickel_lang-x86_64-windows-mingw.dll


### PR DESCRIPTION
This adds precompiled C libraries to the release artifacts. I've tested [here](https://github.com/nickel-lang/go-nickel/pull/2) that the resulting static libraries pass the go bindings' tests.