### PR TITLE
Move the inherited bit to PosIdx

### DIFF
--- a/core/src/eval/merge.rs
+++ b/core/src/eval/merge.rs
@@ -86,7 +86,7 @@ impl<'ctxt, R: ImportResolver, C: Cache> VirtualMachine<'ctxt, R, C> {
     ) -> Result<Closure, ErrorKind> {
         let pos1 = v1.pos_idx();
         let pos2 = v2.pos_idx();
-        let pos_op_inh = pos_op.to_inherited(&mut self.context.pos_table);
+        let pos_op_inh = pos_op.to_inherited();
 
         // Determines if we need to wrap the result in `'Ok` upon successful merging, which is the case
         // when in contract merge mode. We're going to move out of `mode` at some point, so we need to
@@ -252,7 +252,7 @@ impl<'ctxt, R: ImportResolver, C: Cache> VirtualMachine<'ctxt, R, C> {
                 let final_pos = if let MergeMode::Standard(_) = mode {
                     non_empty.pos_idx()
                 } else {
-                    pos1.to_inherited(&mut self.context.pos_table)
+                    pos1.to_inherited()
                 };
 
                 Ok(non_empty
@@ -334,7 +334,7 @@ impl<'ctxt, R: ImportResolver, C: Cache> VirtualMachine<'ctxt, R, C> {
                 let final_pos = if let MergeMode::Standard(_) = mode {
                     pos_op_inh
                 } else {
-                    pos1.to_inherited(&mut self.context.pos_table)
+                    pos1.to_inherited()
                 };
 
                 let merge_label = MergeLabel::from(mode);

--- a/core/src/eval/mod.rs
+++ b/core/src/eval/mod.rs
@@ -1053,7 +1053,7 @@ impl<'ctxt, R: ImportResolver, C: Cache> VirtualMachine<'ctxt, R, C> {
                             match value {
                                 Some(value) => NickelValue::term(
                                     Term::app(extend, value),
-                                    pos_dyn_field.to_inherited(&mut self.context.pos_table),
+                                    pos_dyn_field.to_inherited(),
                                 ),
                                 None => extend,
                             }
@@ -1282,22 +1282,6 @@ impl<'ctxt, R: ImportResolver, C: Cache> VirtualMachine<'ctxt, R, C> {
         let mut ret = Vec::new();
         inner(self, &mut ret, value, recursion_limit);
         ret
-    }
-
-    /// This is a temporary, ugly work-around for the fact that the VM owns both the position table
-    /// and the cache, but [crate::program::Program] sometimes need to access both at the same
-    /// time, mutably. Ideally, either the VM would borrow them, or the position table would be
-    /// owned by something else and just passed for evaluation, or any other design - but it sounds
-    /// abusive that the VM owns the two, which should be able to survive it or be initialized
-    /// before it.
-    pub(crate) fn _with_resolver_and_table<F, T>(&mut self, f: F) -> T
-    where
-        F: for<'a> FnOnce(&'a mut PosTable, &'a mut R) -> T,
-    {
-        f(
-            &mut self.context.pos_table,
-            &mut self.context.import_resolver,
-        )
     }
 }
 

--- a/core/src/eval/value/mod.rs
+++ b/core/src/eval/value/mod.rs
@@ -1526,7 +1526,7 @@ impl TryFrom<u64> for RefCount {
 /// The header for a heap-allocated Nickel value which is laid out at the beginning of a value
 /// block directly followed by the value data.
 // We set a minimal alignment of `4` bytes, so that pointers to the content of a value block
-// (which are aligned to the max of the alignement of `ValueBlockHeader` and the content) is
+// (which are aligned to the max of the alignment of `ValueBlockHeader` and the content) is
 // guaranteed to have at least the last 2 bits free for tagging (although we currently only use one
 // bits).
 #[repr(Rust, align(4))]

--- a/utils/src/bench.rs
+++ b/utils/src/bench.rs
@@ -172,7 +172,7 @@ macro_rules! ncl_bench_group {
                             let id = cache.sources.add_file(bench.path(), InputFormat::Nickel).unwrap();
 
                             if matches!(bench.eval_mode, $crate::bench::EvalMode::TypeCheck) {
-                                cache.parse_to_term(&mut pos_table, id, nickel_lang_core::cache::InputFormat::Nickel).unwrap();
+                                cache.parse_to_ast(id).unwrap();
                             } else{
                                 cache.prepare_eval_only(&mut pos_table, id).unwrap();
                                 runner = resolve_imports(&mut pos_table, runner, &mut cache).unwrap().transformed_term;


### PR DESCRIPTION
This PR moves the "inherited" bit from the position table to the position index, so that the evaluator doesn't need to be constantly adding to the position table. As a consequence, the number of allowed positions has gone down to about 2 billion. (But we aren't using more indices for inherited positions, which cancels things out a little)

This doesn't completely remove the need for mutating the pos table during eval: as noted in [this TODO](https://github.com/tweag/nickel/blob/cd67dc5b100f6f8e896c12470f05296319eba20e/core/src/eval/mod.rs#L495) records have `TermPos` inside their fields and so require pos table modifications at runtime. I think that's the only remaining reason (in a few places) that the pos table gets modified during eval.

I measured a 1-2% improvement on most benchmarks.