### PR TITLE
Change record typechecking to ignore fields with unparseable names.

### DIFF
--- a/lsp/nls/tests/inputs/diagnostics-unparseable-record-field-name.ncl
+++ b/lsp/nls/tests/inputs/diagnostics-unparseable-record-field-name.ncl
@@ -1,0 +1,9 @@
+### /diagnostics.ncl
+{
+  # The parser inserts an extra field into this record due to the duplicate comma,
+  # but it should be ignored for typechecking purposes. Diagnostics should only include the
+  # parser error.
+  x = 1,,
+  y = 2
+} : { x : Number, y : Number }
+### diagnostic = ["file:///diagnostics.ncl"]

--- a/lsp/nls/tests/inputs/diagnostics-unparseable-record-field-value.ncl
+++ b/lsp/nls/tests/inputs/diagnostics-unparseable-record-field-value.ncl
@@ -1,0 +1,9 @@
+### /diagnostics.ncl
+{
+  x = 1,
+  # A parser error exists here, but the typechecking error is useful in this case, so we want
+  # to make sure the typechecking diagnostic is still published.
+  z = ,
+  y = 2
+} : { x : Number, y : Number }
+### diagnostic = ["file:///diagnostics.ncl"]

--- a/lsp/nls/tests/snapshots/main__lsp__nls__tests__inputs__diagnostics-unparseable-record-field-name.ncl.snap
+++ b/lsp/nls/tests/snapshots/main__lsp__nls__tests__inputs__diagnostics-unparseable-record-field-name.ncl.snap
@@ -1,0 +1,5 @@
+---
+source: lsp/nls/tests/main.rs
+expression: output
+---
+[4:8-4:9: "unexpected token"]

--- a/lsp/nls/tests/snapshots/main__lsp__nls__tests__inputs__diagnostics-unparseable-record-field-value.ncl.snap
+++ b/lsp/nls/tests/snapshots/main__lsp__nls__tests__inputs__diagnostics-unparseable-record-field-value.ncl.snap
@@ -1,0 +1,5 @@
+---
+source: lsp/nls/tests/main.rs
+expression: output
+---
+[0:0-6:1: "type error: extra row `z`\nExpected an expression of type `{ x : Number, y : Number }`, which does not contain the field `z`\nFound an expression of type `{ x : Number, z : _a, y : Number }`, which contains the extra field `z`", 0:0-6:1: "this expression", 4:6-4:7: "unexpected token"]


### PR DESCRIPTION
This relates to #2418. It solves the specific instance of the issue by changing how typechecking works for records with parsing errors rather than solving the general problem of overlapping diagnostics, so I don't know if you'd want to consider the issue closed or not.

This changes record typechecking so that if the field name is unparseable, that field is ignored. So in the particular instance described in the issue, the record is inferred to have type { x : Number, y : Number }, so type checking succeeds and only the parse error diagnostic is published.
<img width="423" height="157" alt="image" src="https://github.com/user-attachments/assets/5f2d98fb-3c0d-41c1-8437-ad4fbb838125" />

I have not done the same when the value of a field is unparseable. So for example, this input will still issue a typechecking diagnostic:
```nickel
{
  x = 1,
  y = 2,
  z = 
} : { x : Number, y : Number}
```
<img width="886" height="302" alt="image" src="https://github.com/user-attachments/assets/67fc51f7-55f4-4500-839d-9362b7acafa1" />

I figured I'd leave this in because this would be a common situation when in the middle of editing a record. In that case, the feedback that there's a field being defined that's not allowed by the type is probably at least as important as knowing that there's a parsing error there, which might be just because the input isn't complete.