### PR TITLE
Fix evaluation order of record pattern matches, and related ident leakage

### DIFF
--- a/core/tests/integration/inputs/pattern-matching/pattern_evaluation_order.ncl
+++ b/core/tests/integration/inputs/pattern-matching/pattern_evaluation_order.ncl
@@ -1,0 +1,17 @@
+# test.type = 'pass'
+[
+  let x = { has_number = false } in
+  { has_number = x.has_number, test = x.number == 1 }
+  |> match {
+    { has_number = true, test = true } => "number == 1",
+    { has_number = true, test = false } => "number != 1",
+    { has_number = false, .. } => true,
+  },
+  let x = {} in
+  [ true, { test = x.number == 1 }]
+  |> match {
+    [ false, { test = true }] => false,
+    [ true, _] => true,
+  },
+]
+|> std.test.assert_all


### PR DESCRIPTION
The issue was essentially that we were checking patterns in record fields in the wrong order. But fixing the order exposed another bug with bindings leaking into the wrong match arm (which fortunately I was already testing for).

Basically, I had thought that binding leakage could be avoided if we make sure never to shadow anything in the failure continuation. But while folding record (and array) pattern matching, the failure continuation becomes part of the success continuation. So in fact you need to avoid shadowing anything ever. This PR avoids shadowing by only using fresh vars during `CompilePart::compile_part`, and doing the real binding just before the match arm (or the guard, if there is one).

Fixes #2450.