### PR TITLE
chore: add `profiling` profile with release optimizations and debug information

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -149,3 +149,7 @@ opt-level = 3
 [profile.release]
 lto = "fat"
 codegen-units = 1
+
+[profile.profiling]
+inherits = "release"
+debug = true


### PR DESCRIPTION
Useful for flamegraphs and profiling in general.