### PR TITLE
perf: remove useless reserve

### DIFF
--- a/core/src/term/mod.rs
+++ b/core/src/term/mod.rs
@@ -406,7 +406,6 @@ impl RuntimeContract {
     ) -> Vec<RuntimeContract> {
         let len1 = contracts1.len();
         let mut result = contracts1;
-        result.reserve(contracts2.len());
 
         for ctr2 in contracts2 {
             let is_duplicate = result[..len1].iter().any(|ctr1| {
@@ -672,7 +671,6 @@ impl TypeAnnotation {
     pub fn combine_dedup(left: Self, right: Self) -> Self {
         let len1 = left.contracts.len();
         let mut contracts = left.contracts;
-        contracts.reserve(right.contracts.len() + 1);
 
         let typ = match (left.typ, right.typ) {
             (left_ty @ Some(_), Some(right_ty)) => {


### PR DESCRIPTION
After looking at flamegraphs for other reasons, some `reserve`s  took a surprisingly visible portion of the graph (on the order  of the %). Those `reserve` don't make sense (they unconditionally reserve more space for cases where it's not clear what will happen, which is a waste if we don't need it, and in the event where we actually extend the vector, the default behavior should only resize once in the vast majority of cases).

The  most surprising effect is on memory though. This seems to have a large impact, with overall 22% less peak memory consumption on the OPL benchmark, and 27% less leaked memory in total.