### PR TITLE
chore: improve and update README (wording and roadmap)

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,10 +37,7 @@ Nickel's salient traits are:
 - **Design by contract**: *contracts* are a principled approach to validation.
     In a Nickel configuration, contracts act like *schemas*. You can write your
     own, mix them with existing contracts, and enforce that your configuration
-    is correct by sprinkling simple type-like annotations. The Nickel
-    interpreter also uses contracts under the hood to provide meaningful error
-    messages when statically typed functions are misused from within dynamically
-    typed code.
+    is correct by sprinkling simple type-like annotations.
 
 The motto guiding Nickel's design is:
 > Great defaults, design for extensibility


### PR DESCRIPTION
This is a pass on the README, mixing both cosmetic changes and information update.

## Content

- There's been a wordplay around a nickel and "the cheap configuration language" for a long time. I've always found that bothering because "cheap" has a clear negative connotation as well. This PR changes the catchphrase to something else (partly taken from the website).
- The very first description of Nickel's important traits is a bit heavy and convoluted, IMHO. I've tried to reword those parts to make them simpler, clearer and more efficient.
- Added a bunch of missing links to satellite projects (vim and emacs plugins, e.g.).
- Make using the `nixpkgs` version of Nickel the default (using stable instead of latest `master`, plus the fact that the build from `nixpkgs` should be much faster, if not cached)
- Updated the roadmap. For now there's no Nix interop work in the pipe, and 1.15.1 has done quite a bit of general performance work. Personally I'd like to tackle incremental evaluation next, so I put that top of the list.