### PR TITLE
Keep the closure environment in eval_permissive

### DIFF
--- a/core/src/ast/compat.rs
+++ b/core/src/ast/compat.rs
@@ -1559,7 +1559,7 @@ fn merge_fields(
 
 /// Wrap a value in a [crate::term::Term::Closurize] operator with the same position index.
 #[inline]
-fn closurize(value: NickelValue) -> NickelValue {
+pub(crate) fn closurize(value: NickelValue) -> NickelValue {
     let pos_idx = value.pos_idx();
     NickelValue::term(term::Term::Closurize(value), pos_idx)
 }

--- a/core/src/eval/value/mod.rs
+++ b/core/src/eval/value/mod.rs
@@ -94,7 +94,9 @@ impl PartialEq for NickelValue {
             (ValueContentRef::String(string1), ValueContentRef::String(string2)) => {
                 string1 == string2
             }
-            (ValueContentRef::Thunk(thunk1), ValueContentRef::Thunk(thunk2)) => thunk1 == thunk2,
+            (ValueContentRef::Thunk(thunk1), ValueContentRef::Thunk(thunk2)) => {
+                *thunk1.borrow() == *thunk2.borrow()
+            }
             (ValueContentRef::Term(term1), ValueContentRef::Term(term2)) => term1 == term2,
             (ValueContentRef::Label(label1), ValueContentRef::Label(label2)) => label1 == label2,
             (
@@ -129,7 +131,7 @@ impl fmt::Debug for NickelValue {
             ValueContentRef::Array(container) => write!(f, "Array({container:?})"),
             ValueContentRef::Record(container) => write!(f, "Record({container:?})"),
             ValueContentRef::String(string) => write!(f, "String({string})"),
-            ValueContentRef::Thunk(thunk) => write!(f, "Thunk({thunk:?})"),
+            ValueContentRef::Thunk(thunk) => write!(f, "Thunk({:?})", thunk.borrow()),
             ValueContentRef::Term(term) => write!(f, "Term({term:?})"),
             ValueContentRef::Label(label) => write!(f, "Label({label:?})"),
             ValueContentRef::EnumVariant(enum_variant_data) => {

--- a/core/src/typ.rs
+++ b/core/src/typ.rs
@@ -41,6 +41,7 @@
 //! Conversely, any Nickel term seen as a contract corresponds to a type, which is opaque and can
 //! only be equated with itself.
 use crate::{
+    ast::compat::closurize,
     environment::Environment,
     error::{EvalErrorKind, ParseError, ParseErrors, TypecheckErrorData},
     eval::value::{Array, NickelValue},
@@ -587,12 +588,12 @@ impl Subcontract for EnumRows {
                             mk_term::var(variant_arg)
                         );
 
-                        mk_term::enum_variant(row.id, arg)
+                        closurize(mk_term::enum_variant(row.id, arg))
                     } else {
                         mk_term::var(value_arg)
                     };
 
-                    let body = mk_term::enum_variant("Ok", body);
+                    let body = closurize(mk_term::enum_variant("Ok", body));
 
                     let pattern = Pattern {
                         data: PatternData::Enum(alloc.alloc(EnumPattern {


### PR DESCRIPTION
When recursing into a record, array, or enum, `eval_permissive` was losing the closure's environment. I'm a little surprised this worked at all, but it especially broke enum contracts, which rely on generated variables in their environment.

Fixes #2483.

The reason this caused #2483 was because the enum contract was failing on an undefined generated variable instead of with a contract violation. This didn't generate any LSP diagnostics at all because we only report LSP diagnostics if they have a location.