### PR TITLE
Allow priority to be set for background evaluation in the LSP

### DIFF
--- a/lsp/nls/src/server.rs
+++ b/lsp/nls/src/server.rs
@@ -209,7 +209,7 @@ impl Server {
                     serde_json::from_value::<DidOpenTextDocumentParams>(notification.params)?;
                 let uri = params.text_document.uri.clone();
                 let invalid = crate::files::handle_open(self, params)?;
-                self.background_jobs.eval_file(uri, &self.world);
+                self.background_jobs.priority_eval_file(uri, &self.world);
                 for uri in invalid {
                     self.background_jobs.eval_file(uri, &self.world);
                 }
@@ -236,7 +236,7 @@ impl Server {
                     serde_json::from_value::<DidChangeTextDocumentParams>(notification.params)?;
                 let uri = params.text_document.uri.clone();
                 let invalid = crate::files::handle_save(self, params)?;
-                self.background_jobs.eval_file(uri, &self.world);
+                self.background_jobs.priority_eval_file(uri, &self.world);
                 for uri in invalid {
                     self.background_jobs.eval_file(uri, &self.world);
                 }


### PR DESCRIPTION
This improves the LSP background evaluation by making sure that the most relevant evaluations are done first. In particular, whatever file has just been edited or opened will be the first to have its evaluation diagnostics published. It does this by creating two separate stacks for the background evaluator, the normal stack and a new high priority stack. Whenever it selects a file to evaluate it will select from the high priority stack first and only select from the normal stack if no high priority items are available. I have a project where in the worst case, it can take over 90 seconds from when I edit a file to when I see the eval diagnostics for that file. With this change I see the diagnostics for the current file in a few seconds in the same case.