### PR TITLE
Recursively closurize the overrides

### DIFF
--- a/cli/tests/snapshot/inputs/customize-mode/closurization.ncl
+++ b/cli/tests/snapshot/inputs/customize-mode/closurization.ncl
@@ -1,0 +1,12 @@
+# capture = 'stderr'
+# command = ['export']
+# extra_args = [
+#  '--',
+#  'inputs.user="me"',
+# ]
+{
+  inputs = {
+    user | String | default = "defaultuser",
+  },
+  result = inputs.user,
+}

--- a/cli/tests/snapshot/snapshots/snapshot__export_stderr_closurization.ncl.snap
+++ b/cli/tests/snapshot/snapshots/snapshot__export_stderr_closurization.ncl.snap
@@ -1,0 +1,5 @@
+---
+source: cli/tests/snapshot/main.rs
+expression: err
+---
+

--- a/core/src/term/make/builder.rs
+++ b/core/src/term/make/builder.rs
@@ -230,10 +230,12 @@ where
     let fst = it.next().unwrap();
 
     let content = it.rev().fold(content, |acc, id| {
-        record::Field::from(NickelValue::record_posless(RecordData {
-            fields: [(LocIdent::from(id), acc)].into(),
-            ..Default::default()
-        }))
+        record::Field::from(NickelValue::term_posless(Term::Closurize(
+            NickelValue::record_posless(RecordData {
+                fields: [(LocIdent::from(id), acc)].into(),
+                ..Default::default()
+            }),
+        )))
     });
 
     (fst.into(), content)
@@ -349,9 +351,8 @@ impl Record {
     /// # Closurization
     ///
     /// [Self::build] is intended to provide a ready-to-use value, so the built record is wrapped
-    /// into a [crate::term::Term::Closurize] operation. Otherwise, since records are assumed to be
-    /// closurized during evaluation, using a bare record at runtime would either panic or
-    /// introduce subtle bugs.
+    /// into a [crate::term::Term::Closurize] operation, as are any sub-records implicitly created
+    /// by field paths. However, field values are not automatically closurized.
     pub fn build(self) -> NickelValue {
         let elaborated = self
             .fields


### PR DESCRIPTION
Although we were closurizing the records created by the cli customize mode, we weren't doing so recursively, so nested records weren't handled correctly.

This PR removes the automatic closurization from `Record::build`, because it's the only part of that module that does closurization. Instead, I made it a separate utility function.

Fixes #2491 