### PR TITLE
Format nickel converted from other formats

### DIFF
--- a/cli/src/convert.rs
+++ b/cli/src/convert.rs
@@ -113,7 +113,18 @@ impl ConvertCommand {
 
         let ast = ast.map_err(|error| Error::Program { files, error })?;
 
-        self.write(&ast.to_string())?;
+        let nickel_string = {
+            let mut output = Vec::new();
+            let unformatted = ast.to_string();
+            // In principle formatting should be infallible here, but if it fails somehow the
+            // unformatted string will be returned.
+            if nickel_lang_core::format::format(unformatted.as_bytes(), &mut output).is_ok() {
+                String::from_utf8(output).unwrap_or(unformatted)
+            } else {
+                unformatted
+            }
+        };
+        self.write(&nickel_string)?;
 
         Ok(())
     }

--- a/cli/tests/integration/stdin_format.rs
+++ b/cli/tests/integration/stdin_format.rs
@@ -124,8 +124,9 @@ fn converts_json_from_stdin() {
         vec!["convert", "--stdin-format", "json"],
         "{ \"foo\": \"hello\", \"bar\": 123 }",
     );
+
     assert_eq!(output.stderr, "");
-    assert_eq!(output.stdout, "{ foo = \"hello\", bar = 123 }");
+    assert_eq!(output.stdout.trim(), "{ foo = \"hello\", bar = 123 }");
 }
 
 #[test]

--- a/cli/tests/snapshot/snapshots/snapshot__convert_stdout_json.json.snap
+++ b/cli/tests/snapshot/snapshots/snapshot__convert_stdout_json.json.snap
@@ -2,4 +2,4 @@
 source: cli/tests/snapshot/main.rs
 expression: out
 ---
-{ foo = [ 1, 2 ], bar = {} }
+{ foo = [1, 2], bar = {} }

--- a/cli/tests/snapshot/snapshots/snapshot__convert_stdout_json.yaml.snap
+++ b/cli/tests/snapshot/snapshots/snapshot__convert_stdout_json.yaml.snap
@@ -2,4 +2,4 @@
 source: cli/tests/snapshot/main.rs
 expression: out
 ---
-{ foo = [ 1, 2 ], bar = {} }
+{ foo = [1, 2], bar = {} }

--- a/cli/tests/snapshot/snapshots/snapshot__convert_stdout_toml.toml.snap
+++ b/cli/tests/snapshot/snapshots/snapshot__convert_stdout_toml.toml.snap
@@ -2,4 +2,4 @@
 source: cli/tests/snapshot/main.rs
 expression: out
 ---
-{ foo = { bar = [ 1, 2 ] }, baz = [ { hi = "bye" } ] }
+{ foo = { bar = [1, 2] }, baz = [{ hi = "bye" }] }

--- a/cli/tests/snapshot/snapshots/snapshot__convert_stdout_yaml.yaml.snap
+++ b/cli/tests/snapshot/snapshots/snapshot__convert_stdout_yaml.yaml.snap
@@ -2,4 +2,4 @@
 source: cli/tests/snapshot/main.rs
 expression: out
 ---
-{ foo = [ 1, 2 ], bar = null }
+{ foo = [1, 2], bar = null }


### PR DESCRIPTION
Pretty much any time I've used `nickel convert` it has been to store the result to a file, so I think it would make sense to have the output formatted already. This PR implements that.