### PR TITLE
Apply pending contracts in the public API

### DIFF
--- a/core/src/eval/value/mod.rs
+++ b/core/src/eval/value/mod.rs
@@ -1781,6 +1781,18 @@ pub struct ArrayData {
     pub pending_contracts: Vec<RuntimeContract>,
 }
 
+impl ArrayData {
+    /// Iterates over all values in the array, with pending contracts applied.
+    pub fn iter_with_pending_contracts(
+        &self,
+        pos: PosIdx,
+    ) -> impl Iterator<Item = NickelValue> + use<'_> {
+        self.array.iter().cloned().map(move |v| {
+            RuntimeContract::apply_all(v, self.pending_contracts.iter().cloned(), pos)
+        })
+    }
+}
+
 pub type ThunkData = RefCell<lazy::ThunkData>;
 pub type TermData = Term;
 pub type LabelData = Label;
@@ -2350,6 +2362,13 @@ impl Container<&ArrayData> {
         self.into_opt()
             .into_iter()
             .flat_map(|array_data| array_data.array.iter())
+    }
+
+    /// Iterates over the elements of the array, with pending contracts applied.
+    pub fn iter_with_pending_contracts(&self, pos: PosIdx) -> impl Iterator<Item = NickelValue> {
+        self.into_opt()
+            .into_iter()
+            .flat_map(move |array_data| array_data.iter_with_pending_contracts(pos))
     }
 
     /// Iterates over the pending contracts.

--- a/core/src/eval/value/mod.rs
+++ b/core/src/eval/value/mod.rs
@@ -1787,8 +1787,8 @@ impl ArrayData {
         &self,
         pos: PosIdx,
     ) -> impl Iterator<Item = NickelValue> + use<'_> {
-        self.array.iter().cloned().map(move |v| {
-            RuntimeContract::apply_all(v, self.pending_contracts.iter().cloned(), pos)
+        self.array.iter().map(move |v| {
+            RuntimeContract::apply_all(v.clone(), self.pending_contracts.iter().cloned(), pos)
         })
     }
 }

--- a/core/src/term/record.rs
+++ b/core/src/term/record.rs
@@ -358,6 +358,17 @@ impl Field {
             RecordExtKind::WithoutValue
         }
     }
+
+    /// Retrieves the field's value, applying any pending contracts.
+    pub fn value_with_pending_contracts(&self) -> Option<NickelValue> {
+        self.value.as_ref().map(|value| {
+            RuntimeContract::apply_all(
+                value.clone(),
+                self.pending_contracts.iter().cloned(),
+                value.pos_idx(),
+            )
+        })
+    }
 }
 
 impl Traverse<NickelValue> for Field {

--- a/nickel/src/lib.rs
+++ b/nickel/src/lib.rs
@@ -567,6 +567,15 @@ impl Record<'_> {
     }
 
     /// If this field name is present in the record, return the field value.
+    ///
+    /// If this record was obtained through shallow evaluation, the returned
+    /// expression might be unevaluated. Even if the array did not contain
+    /// complex nested sub-expressions, the returned expression might be
+    /// unevaluated because of deferred contracts. For example, if you start
+    /// with the expression `{ foo : 1 } | { foo | Number }`, evaluate it shallowly
+    /// and then call `value_by_name("foo")`, you'll get back an expression
+    /// representing `1 | Number` and you'll need to evaluate further to
+    /// extract the value `1`.
     pub fn value_by_name(&self, key: &str) -> Option<Expr> {
         self.data
             .get(Ident::new(key).into())
@@ -579,6 +588,15 @@ impl Record<'_> {
     /// If this record was deeply evaluated, every defined field will have a value
     /// (i.e. the `Option<Expr>` returned here will never be `None`). However,
     /// shallowly evaluated records may have fields with no value.
+    ///
+    /// If this record was obtained through shallow evaluation, the returned
+    /// expression might be unevaluated. Even if the array did not contain
+    /// complex nested sub-expressions, the returned expression might be
+    /// unevaluated because of deferred contracts. For example, if you start
+    /// with the expression `{ foo : 1 } | { foo | Number }`, evaluate it shallowly
+    /// and then call `key_value_by_index(0)`, you'll get back an expression
+    /// representing `1 | Number` and you'll need to evaluate further to
+    /// extract the value `1`.
     pub fn key_value_by_index(&self, idx: usize) -> Option<(&str, Option<Expr>)> {
         self.data.into_opt().and_then(|data| {
             data.fields.get_index(idx).map(|(key, fld)| {
@@ -639,6 +657,15 @@ impl<'a> Array<'a> {
     }
 
     /// Returns the element at the requested index, if the index is in-bounds.
+    ///
+    /// If this array was obtained through shallow evaluation, the returned
+    /// expression might be unevaluated. Even if the array did not contain
+    /// complex nested sub-expressions, the returned expression might be
+    /// unevaluated because of deferred contracts. For example, if you start
+    /// with the expression `[1, 2, 3] | Array Number`, evaluate it shallowly
+    /// and then `get` the element at index zero, you'll get back an expression
+    /// representing `1 | Number` and you'll need to evaluate further to
+    /// extract the value `1`.
     pub fn get(&self, idx: usize) -> Option<Expr> {
         let arr = self.array();
         arr.get(idx).map(|value| Expr {
@@ -663,7 +690,7 @@ impl<'a> IntoIterator for Array<'a> {
     fn into_iter(self) -> Self::IntoIter {
         let arr = self.array();
         let pending_contracts = match arr {
-            Container::Empty => &[][..],
+            Container::Empty => [].as_slice(),
             Container::Alloc(arr) => &arr.pending_contracts,
         };
         ArrayIter {


### PR DESCRIPTION
I'm not totally sure about the position handling for contract application in arrays: it seemed to mostly be the case that the contract application for array elements is assigned to the position of the array itself. But there was one place where it was given the position of the array element instead. This PR goes with the former option, since it was the most common.

Fixes #2514 