### PR TITLE
Allow unicode escape sequences in string literals

### DIFF
--- a/core/src/error/mod.rs
+++ b/core/src/error/mod.rs
@@ -1943,6 +1943,9 @@ impl IntoDiagnostics for ParseError {
             ParseError::InvalidAsciiEscapeCode(span) => Diagnostic::error()
                 .with_message("invalid ascii escape code")
                 .with_labels(vec![primary(&span)]),
+            ParseError::InvalidUnicodeEscapeCode(span) => Diagnostic::error()
+                .with_message("invalid unicode escape code")
+                .with_labels(vec![primary(&span)]),
             ParseError::StringDelimiterMismatch {
                 opening_delimiter,
                 closing_delimiter,

--- a/doc/manual/syntax.md
+++ b/doc/manual/syntax.md
@@ -248,15 +248,16 @@ ending.
 A backslash `` \ `` followed by one or more characters is interpreted as an
 escape sequence. The following escape sequences are supported:
 
-|    Escape sequence | Description                                    |
-|:------------------:|:-----------------------------------------------|
-| `\\`               | Backslash `` \ ``                              |
-| `\"`               | Double quote `"`                               |
-| `\n`               | New line                                       |
-| `\t`               | Tab                                            |
-| `\r`               | Carriage return                                |
-| `\%`               | Percent sign `%`                               |
-| `\x[a-zA-Z0-9]{2}` | Ascii code sequence (e.g. `\x20` is a space)   |
+|    Escape sequence     | Description                                                                                                                  |
+|:----------------------:|:-----------------------------------------------------------------------------------------------------------------------------|
+| `\\`                   | Backslash `` \ ``                                                                                                            |
+| `\"`                   | Double quote `"`                                                                                                             |
+| `\n`                   | New line                                                                                                                     |
+| `\t`                   | Tab                                                                                                                          |
+| `\r`                   | Carriage return                                                                                                              |
+| `\%`                   | Percent sign `%`                                                                                                             |
+| `\x[a-fA-F0-9]{2}`     | Ascii code sequence (e.g. `\x20` is a space)                                                                                 |
+| `\u{[a-fA-F0-9]{1,6}}` | Unicode code sequence. These are variable length, so for example `\u{61}` is the letter 'a' and `\u{1f62d}` is the 😭 emoji. |
 
 #### Symbolic Strings
 

--- a/parser/src/error.rs
+++ b/parser/src/error.rs
@@ -19,6 +19,8 @@ pub enum LexicalError {
     InvalidEscapeSequence(usize),
     /// Invalid escape ASCII code in a string literal.
     InvalidAsciiEscapeCode(usize),
+    /// Invalid unicode escape code in a string literal.
+    InvalidUnicodeEscapeCode(Range<usize>),
     /// A multiline string was closed with a delimiter which has a `%` count higher than the
     /// opening delimiter.
     StringDelimiterMismatch {
@@ -112,6 +114,8 @@ pub enum ParseError {
     InvalidEscapeSequence(RawSpan),
     /// Invalid ASCII escape code in a string literal.
     InvalidAsciiEscapeCode(RawSpan),
+    /// Invalid unicode escape code in a string literal.
+    InvalidUnicodeEscapeCode(RawSpan),
     /// A multiline string was closed with a delimiter which has a `%` count higher than the
     /// opening delimiter.
     StringDelimiterMismatch {
@@ -265,6 +269,9 @@ impl ParseError {
             }
             LexicalError::InvalidAsciiEscapeCode(location) => {
                 ParseError::InvalidAsciiEscapeCode(mk_span(file_id, location, location + 2))
+            }
+            LexicalError::InvalidUnicodeEscapeCode(location) => {
+                ParseError::InvalidUnicodeEscapeCode(mk_span(file_id, location.start, location.end))
             }
             LexicalError::StringDelimiterMismatch {
                 opening_delimiter,


### PR DESCRIPTION
Closes #2516

This adds support for unicode escape sequences in string literals using a braced syntax like `\u{e7a8}`. It allows for variable length sequences up to 6 characters (anything longer is above the unicode character range).

I also made a quick fix to the documentation where it says that ascii code sequences can match the pattern `\x[a-zA-Z0-9]{2}`, when only hex characters are allowed, so it should be `\x[a-fA-F0-9]{2}`.

One thing I was wondering is if I should make the lexer less strict in what it matches as an escape code so that it can display a more specific error. Right now most errors would just show a generic `invalid escape sequence` message. Or maybe it'd be better for the invalid escape sequence message to show usage information whenever an escape code is known but isn't matched because it's being used incorrectly.