### PR TITLE
Fix unintended line break in syntax documentation

### DIFF
--- a/doc/manual/syntax.md
+++ b/doc/manual/syntax.md
@@ -1128,7 +1128,7 @@ constructors we've just listed), and types can appear anywhere.
 Nickel features the following builtin types and type constructors:
 
 - Primitive types: `Number`, `String`, `Bool`, and `Dyn` (the dynamic type, which
-represents any value)
+  represents any value)
 - Arrays: `Array <type>` is an array whose elements are of type `<type>`.
 - Dictionaries: `{_ : <type>}` is a record whose fields are of type `<type>`.
 - Enums: `[| 'tag1 <type1?>, .., 'tagn <typen?>|]` is an enumeration comprised of


### PR DESCRIPTION
Fixes this unintended line break in one of the bullet lists in Syntax docs:

<img width="875" height="372" alt="image" src="https://github.com/user-attachments/assets/cb6ae4bb-880f-4a07-a6ba-c12b8835b6f6" />
