### PR TITLE
Add --no-format flag to nickel convert

### DIFF
--- a/cli/src/convert.rs
+++ b/cli/src/convert.rs
@@ -30,6 +30,11 @@ pub struct ConvertCommand {
     /// Output file. Standard output by default
     #[arg(short, long)]
     pub output: Option<PathBuf>,
+
+    /// Skip formatting the output. Useful for batch conversions or when
+    /// formatted output isn't needed.
+    #[arg(long = "no-formatting")]
+    pub no_formatting: bool,
 }
 
 impl ConvertCommand {
@@ -114,14 +119,18 @@ impl ConvertCommand {
         let ast = ast.map_err(|error| Error::Program { files, error })?;
 
         let nickel_string = {
-            let mut output = Vec::new();
             let unformatted = ast.to_string();
-            // In principle formatting should be infallible here, but if it fails somehow the
-            // unformatted string will be returned.
-            if nickel_lang_core::format::format(unformatted.as_bytes(), &mut output).is_ok() {
-                String::from_utf8(output).unwrap_or(unformatted)
-            } else {
+            if self.no_formatting {
                 unformatted
+            } else {
+                let mut output = Vec::new();
+                // In principle formatting should be infallible here, but if it fails somehow the
+                // unformatted string will be returned.
+                if nickel_lang_core::format::format(unformatted.as_bytes(), &mut output).is_ok() {
+                    String::from_utf8(output).unwrap_or(unformatted)
+                } else {
+                    unformatted
+                }
             }
         };
         self.write(&nickel_string)?;

--- a/cli/tests/snapshot/main.rs
+++ b/cli/tests/snapshot/main.rs
@@ -104,6 +104,18 @@ fn check_conversion_snapshots(path: &str) {
     assert_snapshot_filtered!(file.prefixed_test_name("convert_stderr"), err);
 }
 
+#[test_resources("cli/tests/snapshot/inputs/**/convert/*")]
+fn check_conversion_no_format_snapshots(path: &str) {
+    let file = TestFile::from_project_path(path);
+    let invocation = NickelInvocation::new()
+        .file(&file)
+        .args(["convert", "--no-formatting"]);
+
+    let (out, err) = invocation.snapshot();
+    assert_snapshot_filtered!(file.prefixed_test_name("convert_no_format_stdout"), out);
+    assert_snapshot_filtered!(file.prefixed_test_name("convert_no_format_stderr"), err);
+}
+
 struct TestFile {
     path_buf: PathBuf,
 }

--- a/cli/tests/snapshot/snapshots/snapshot__convert_no_format_stderr_json.foo.snap
+++ b/cli/tests/snapshot/snapshots/snapshot__convert_no_format_stderr_json.foo.snap
@@ -1,0 +1,5 @@
+---
+source: cli/tests/snapshot/main.rs
+expression: err
+---
+error: could not determine format of input file `[INPUTS_PATH]/convert/json.foo`

--- a/cli/tests/snapshot/snapshots/snapshot__convert_no_format_stderr_json.json.snap
+++ b/cli/tests/snapshot/snapshots/snapshot__convert_no_format_stderr_json.json.snap
@@ -1,0 +1,5 @@
+---
+source: cli/tests/snapshot/main.rs
+expression: err
+---
+

--- a/cli/tests/snapshot/snapshots/snapshot__convert_no_format_stderr_json.txt.snap
+++ b/cli/tests/snapshot/snapshots/snapshot__convert_no_format_stderr_json.txt.snap
@@ -1,0 +1,5 @@
+---
+source: cli/tests/snapshot/main.rs
+expression: err
+---
+

--- a/cli/tests/snapshot/snapshots/snapshot__convert_no_format_stderr_json.yaml.snap
+++ b/cli/tests/snapshot/snapshots/snapshot__convert_no_format_stderr_json.yaml.snap
@@ -1,0 +1,5 @@
+---
+source: cli/tests/snapshot/main.rs
+expression: err
+---
+

--- a/cli/tests/snapshot/snapshots/snapshot__convert_no_format_stderr_toml.toml.snap
+++ b/cli/tests/snapshot/snapshots/snapshot__convert_no_format_stderr_toml.toml.snap
@@ -1,0 +1,5 @@
+---
+source: cli/tests/snapshot/main.rs
+expression: err
+---
+

--- a/cli/tests/snapshot/snapshots/snapshot__convert_no_format_stderr_yaml.yaml.snap
+++ b/cli/tests/snapshot/snapshots/snapshot__convert_no_format_stderr_yaml.yaml.snap
@@ -1,0 +1,5 @@
+---
+source: cli/tests/snapshot/main.rs
+expression: err
+---
+

--- a/cli/tests/snapshot/snapshots/snapshot__convert_no_format_stdout_json.foo.snap
+++ b/cli/tests/snapshot/snapshots/snapshot__convert_no_format_stdout_json.foo.snap
@@ -1,0 +1,5 @@
+---
+source: cli/tests/snapshot/main.rs
+expression: out
+---
+

--- a/cli/tests/snapshot/snapshots/snapshot__convert_no_format_stdout_json.json.snap
+++ b/cli/tests/snapshot/snapshots/snapshot__convert_no_format_stdout_json.json.snap
@@ -1,0 +1,5 @@
+---
+source: cli/tests/snapshot/main.rs
+expression: out
+---
+{ foo = [ 1, 2 ], bar = {} }

--- a/cli/tests/snapshot/snapshots/snapshot__convert_no_format_stdout_json.txt.snap
+++ b/cli/tests/snapshot/snapshots/snapshot__convert_no_format_stdout_json.txt.snap
@@ -1,0 +1,5 @@
+---
+source: cli/tests/snapshot/main.rs
+expression: out
+---
+"{\n  \"foo\": [1, 2],\n  \"bar\": {}\n}\n"

--- a/cli/tests/snapshot/snapshots/snapshot__convert_no_format_stdout_json.yaml.snap
+++ b/cli/tests/snapshot/snapshots/snapshot__convert_no_format_stdout_json.yaml.snap
@@ -1,0 +1,5 @@
+---
+source: cli/tests/snapshot/main.rs
+expression: out
+---
+{ foo = [ 1, 2 ], bar = {} }

--- a/cli/tests/snapshot/snapshots/snapshot__convert_no_format_stdout_toml.toml.snap
+++ b/cli/tests/snapshot/snapshots/snapshot__convert_no_format_stdout_toml.toml.snap
@@ -1,0 +1,5 @@
+---
+source: cli/tests/snapshot/main.rs
+expression: out
+---
+{ foo = { bar = [ 1, 2 ] }, baz = [ { hi = "bye" } ] }

--- a/cli/tests/snapshot/snapshots/snapshot__convert_no_format_stdout_yaml.yaml.snap
+++ b/cli/tests/snapshot/snapshots/snapshot__convert_no_format_stdout_yaml.yaml.snap
@@ -1,0 +1,5 @@
+---
+source: cli/tests/snapshot/main.rs
+expression: out
+---
+{ foo = [ 1, 2 ], bar = null }

--- a/doc/manual/cli.md
+++ b/doc/manual/cli.md
@@ -399,6 +399,10 @@ Text files will be converted to Nickel strings: if `data.txt` contains the
 string `Hello, "world"` then `nickel convert data.txt` will output
 `"Hello, \"world\""`.
 
+By default, the converted output is auto-formatted. Pass `--no-formatting` to
+skip the formatting step, which can be useful for batch conversions or when
+formatted output isn't needed.
+
 The input type will be auto-detected based on the file extension. If you want to
 force the input type, supply the input on stdin and use the `--stdin-format` flag,
 like `cat data | nickel convert --stdin-format json`.


### PR DESCRIPTION
Closes #2504

Adds a `--no-format` flag to `nickel convert` that skips the auto-formatting step. This is useful for batch conversions or cases where formatted output isn't needed.

## Changes

- Added `--no-format` boolean flag to `ConvertCommand` (clap `#[arg(long)]`)
- When set, the converted AST output is returned as-is without running through the formatter
- Added snapshot tests for `--no-format` covering all input formats (JSON, YAML, TOML, text, Nickel, unknown extension)

## Test plan

- [x] `cargo test -p nickel-cli` passes (all existing + new snapshot tests)
- [x] Manual verification: `nickel convert --no-format` produces unformatted output
- [x] Verified snapshot diffs show the expected difference (e.g. `[1, 2]` formatted vs `[ 1, 2 ]` unformatted)