### PR TITLE
Clear out diagnostics for deleted files in nls

### DIFF
--- a/lsp/nls/src/files.rs
+++ b/lsp/nls/src/files.rs
@@ -62,6 +62,14 @@ pub fn handle_close(
     let (new_file_id, invalid) = server.world.close_file(uri.clone())?;
     info!("Closed file {uri}");
 
+    // If there's no new file ID, the file was deleted. If that's the case then
+    // we want to clear out any existing diagnostics on that file, since clients may
+    // still consider the deleted file to have an error for some purposes, like for
+    // showing directories where an error exists.
+    if new_file_id.is_none() {
+        server.publish_diagnostics(uri, Vec::new());
+    }
+
     Trace::reply(id);
     Ok((new_file_id, server.world.uris(invalid).cloned().collect()))
 }


### PR DESCRIPTION
This is a fix to an issue when `nls` is being used with VSCode, where if a file contains an error, and then that file is deleted, VSCode will still consider the directory containing that file to have an error, even though the file itself is gone. I haven't tested other editors so I'm not sure if similar issues exist with them or not.

Before deletion:
<img width="523" height="163" alt="image" src="https://github.com/user-attachments/assets/4094eade-a82c-406e-8d26-5c5bf209782c" />

After deletion:
<img width="338" height="138" alt="image" src="https://github.com/user-attachments/assets/2d728d6a-bfa3-4e07-9490-aded2706b7ed" />

This fixes this by publishing empty diagnostics for that file on deletion.