### PR TITLE
feat(export): add YAML document start marker to export output

### DIFF
--- a/cli/tests/snapshot/inputs/export/yaml.ncl
+++ b/cli/tests/snapshot/inputs/export/yaml.ncl
@@ -1,0 +1,12 @@
+# capture = 'stdout'
+# command = ['export']
+# extra_args = ['--format', 'yaml']
+{
+  a_record = {
+    even = {
+      more = {
+        nested = "record"
+      }
+    }
+  }
+}

--- a/cli/tests/snapshot/inputs/query/query_yaml.ncl
+++ b/cli/tests/snapshot/inputs/query/query_yaml.ncl
@@ -1,0 +1,3 @@
+# capture = 'stdout'
+# command = [ 'query', '--field', 'greeting', '--format', 'yaml' ]
+{ greeting | doc "A friendly greeting" = "hello" }

--- a/cli/tests/snapshot/snapshots/snapshot__export_stdout_yaml.ncl.snap
+++ b/cli/tests/snapshot/snapshots/snapshot__export_stdout_yaml.ncl.snap
@@ -1,0 +1,10 @@
+---
+source: cli/tests/snapshot/main.rs
+assertion_line: 78
+expression: out
+---
+---
+a_record:
+  even:
+    more:
+      nested: record

--- a/cli/tests/snapshot/snapshots/snapshot__query_stdout_query_yaml.ncl.snap
+++ b/cli/tests/snapshot/snapshots/snapshot__query_stdout_query_yaml.ncl.snap
@@ -1,0 +1,11 @@
+---
+source: cli/tests/snapshot/main.rs
+assertion_line: 78
+expression: out
+---
+---
+doc: A friendly greeting
+optional: false
+not_exported: false
+priority: '0'
+value: '"hello"'

--- a/core/src/serialize/mod.rs
+++ b/core/src/serialize/mod.rs
@@ -542,8 +542,12 @@ where
         MetadataExportFormat::Markdown => unimplemented!(),
         MetadataExportFormat::Json => serde_json::to_writer_pretty(writer, &item)
             .map_err(|err| ExportErrorKind::Other(err.to_string())),
-        MetadataExportFormat::Yaml => serde_yaml::to_writer(writer, &item)
-            .map_err(|err| ExportErrorKind::Other(err.to_string())),
+        MetadataExportFormat::Yaml => {
+            writeln!(writer, "---")
+                .map_err(|err| ExportErrorKind::Other(err.to_string()))?;
+            serde_yaml::to_writer(writer, &item)
+                .map_err(|err| ExportErrorKind::Other(err.to_string()))
+        }
         MetadataExportFormat::Toml => toml::to_string_pretty(item)
             .map_err(|err| ExportErrorKind::Other(err.to_string()))
             .and_then(|s| {
@@ -570,8 +574,12 @@ where
     match format {
         ExportFormat::Json => serde_json::to_writer_pretty(writer, &value)
             .map_err(|err| ExportErrorKind::Other(err.to_string())),
-        ExportFormat::Yaml => serde_yaml::to_writer(writer, &value)
-            .map_err(|err| ExportErrorKind::Other(err.to_string())),
+        ExportFormat::Yaml => {
+            writeln!(writer, "---")
+                .map_err(|err| ExportErrorKind::Other(err.to_string()))?;
+            serde_yaml::to_writer(writer, &value)
+                .map_err(|err| ExportErrorKind::Other(err.to_string()))
+        }
         ExportFormat::YamlDocuments => {
             if let Some(arr) = value.as_array() {
                 for value in arr.iter() {

--- a/core/src/serialize/mod.rs
+++ b/core/src/serialize/mod.rs
@@ -543,8 +543,7 @@ where
         MetadataExportFormat::Json => serde_json::to_writer_pretty(writer, &item)
             .map_err(|err| ExportErrorKind::Other(err.to_string())),
         MetadataExportFormat::Yaml => {
-            writeln!(writer, "---")
-                .map_err(|err| ExportErrorKind::Other(err.to_string()))?;
+            writeln!(writer, "---").map_err(|err| ExportErrorKind::Other(err.to_string()))?;
             serde_yaml::to_writer(writer, &item)
                 .map_err(|err| ExportErrorKind::Other(err.to_string()))
         }
@@ -575,8 +574,7 @@ where
         ExportFormat::Json => serde_json::to_writer_pretty(writer, &value)
             .map_err(|err| ExportErrorKind::Other(err.to_string())),
         ExportFormat::Yaml => {
-            writeln!(writer, "---")
-                .map_err(|err| ExportErrorKind::Other(err.to_string()))?;
+            writeln!(writer, "---").map_err(|err| ExportErrorKind::Other(err.to_string()))?;
             serde_yaml::to_writer(writer, &value)
                 .map_err(|err| ExportErrorKind::Other(err.to_string()))
         }


### PR DESCRIPTION
## Summary

- Prepend `---` document start marker when exporting to YAML format, matching the behavior already present in the `yaml-documents` format
- Applied to both `ExportFormat::Yaml` and `MetadataExportFormat::Yaml` to keep the two "near-verbatim copy" functions in sync
- Added snapshot tests for both `nickel export --format yaml` and `nickel query --format yaml`

<img width="1209" height="560" alt="Screenshot 2026-03-22 at 8 51 15 PM" src="https://github.com/user-attachments/assets/02595fed-b1e3-48af-b143-1feab79987d3" />

Closes #1979

## Test plan

- [x] `cargo test -p nickel-lang-cli check_snapshots` — 132/132 passing
- [x] `cargo check` — clean
- [x] Manual verification: `echo '{ name = "world" }' | cargo run -p nickel-lang-cli -- export --format yaml` outputs `---` header
- [x] Manual verification: `query --format yaml` also outputs `---` header
- [x] `export --format yaml-documents` behavior unchanged
- [x] `export --format json` unaffected