### PR TITLE
Cargo.toml: update wasm-bindgen to 0.2.108, still need to update `flake.nix`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ lsp-harness = { version = "0.1.0", path = "./lsp/lsp-harness" }
 # if this version changes without the nix output hashes being updated. It's okay
 # to bump the version (for example if not doing so prevents some dependency from
 # building) but flake.nix needs to be kept in sync.
-wasm-bindgen = "=0.2.100"
+wasm-bindgen = "=0.2.108"
 
 anstyle = "1.0.13"
 anyhow = "1.0.97"


### PR DESCRIPTION
Context: `wasm-bindgen` version is incompatible with selection of major crates like `reqwest`. See: 

 * https://github.com/topiary/topiary/pull/1214
 * https://github.com/topiary/topiary/issues/1128

Could someone who has a working `nix` + flakes setup run the flake to get the values for `pkgs.fetchCrate { pname = "wasm-bindgen-cli" }.hash` and `pkgs.rustPlatform.fetchCargoVendor { ... }.hash` ? I can update the PR with these.