### PR TITLE
Create `Analysis` even when typechecking fails in nls

### DIFF
--- a/lsp/nls/src/analysis.rs
+++ b/lsp/nls/src/analysis.rs
@@ -745,10 +745,20 @@ impl<'std> PackedAnalysis<'std> {
 
             (
                 new_imports,
-                typecheck_result.map(|type_tables| {
-                    let type_lookups = collector.complete(alloc, type_tables);
-                    *slf.analysis = Analysis::new(alloc, slf.ast, type_lookups, slf.init_term_env);
-                }),
+                typecheck_result
+                    .map(|type_tables| {
+                        let type_lookups = collector.complete(alloc, type_tables);
+                        *slf.analysis =
+                            Analysis::new(alloc, slf.ast, type_lookups, slf.init_term_env);
+                    })
+                    .inspect_err(|_| {
+                        *slf.analysis = Analysis::new(
+                            alloc,
+                            slf.ast,
+                            CollectedTypes::default(),
+                            slf.init_term_env,
+                        );
+                    }),
             )
         })
     }

--- a/lsp/nls/tests/inputs/completion-typecheck-error.ncl
+++ b/lsp/nls/tests/inputs/completion-typecheck-error.ncl
@@ -1,0 +1,6 @@
+### /completion.ncl
+{ foo = 1, b } : { foo : Number, bar : Number }
+### [[request]]
+### type = "Completion"
+### textDocument.uri = "file:///completion.ncl"
+### position = { line = 0, character = 12 }

--- a/lsp/nls/tests/snapshots/main__lsp__nls__tests__inputs__completion-typecheck-error.ncl.snap
+++ b/lsp/nls/tests/snapshots/main__lsp__nls__tests__inputs__completion-typecheck-error.ncl.snap
@@ -1,0 +1,5 @@
+---
+source: lsp/nls/tests/main.rs
+expression: output
+---
+[bar (Number), foo (Number)]


### PR DESCRIPTION
This fixes an issue where an `Analysis` was not getting created for a file in the case that typechecking failed. This meant that certain features would break in the presence of typechecking errors even if they don't depend on the typechecking result, like completions and usage lookups.