### PR TITLE
Refactor Program to use the builder pattern for construction

### DIFF
--- a/cli/src/input.rs
+++ b/cli/src/input.rs
@@ -1,6 +1,11 @@
 use std::path::PathBuf;
 
-use nickel_lang_core::{ast::InputFormat, eval::cache::lazy::CBNCache, program::Program};
+use nickel_lang_core::{
+    ast::InputFormat,
+    eval::cache::lazy::CBNCache,
+    files::Files,
+    program::{Program, ProgramBuilder},
+};
 
 #[cfg(feature = "package-experimental")]
 use nickel_lang_package::{ManifestFile, config::Config as PackageConfig};
@@ -81,32 +86,10 @@ pub trait Prepare {
 
 impl<C: clap::Args + Customize, F: clap::Args + InputFormatOptions> Prepare for InputOptions<C, F> {
     fn prepare(&self, ctx: &mut GlobalContext) -> PrepareResult<Program<CBNCache>> {
-        let mut program = match self.files.as_slice() {
-            [] => Program::new_from_stdin(
-                self.format_options.stdin_format(),
-                std::io::stderr(),
-                ctx.reporter.clone(),
-            ),
-            [p] => Program::new_from_file(p, std::io::stderr(), ctx.reporter.clone()),
-            files => Program::new_from_files(files, std::io::stderr(), ctx.reporter.clone()),
-        }?;
-
-        program
-            .add_contract_paths(self.apply_contract.iter())
-            .map_err(|error| {
-                PrepareError::Error(crate::error::Error::Program {
-                    error,
-                    files: program.files(),
-                })
-            })?;
-        program.add_import_paths(self.import_path.iter());
-
-        if let Ok(nickel_path) = std::env::var("NICKEL_IMPORT_PATH") {
-            program.add_import_paths(nickel_path.split(':'));
-        }
-
+        // Resolve the package map first — it's independent of program construction and may itself
+        // fail (manifest open / lock / package fetch).
         #[cfg(feature = "package-experimental")]
-        {
+        let package_map = {
             let manifest_path = self.manifest_path.clone().or_else(|| {
                 // If the manifest path isn't given, where should we start
                 // looking for it? If there's only one file, we start with the
@@ -137,9 +120,47 @@ impl<C: clap::Args + Customize, F: clap::Args + InputFormatOptions> Prepare for 
 
                 let (_lock, resolution) = manifest.lock(config.clone())?;
                 nickel_lang_package::index::ensure_index_packages_downloaded(&resolution)?;
-                program.set_package_map(resolution.package_map(&manifest)?);
+                Some(resolution.package_map(&manifest)?)
+            } else {
+                None
             }
+        };
+
+        let mut builder = ProgramBuilder::new()
+            .with_trace(std::io::stderr())
+            .with_reporter(ctx.reporter.clone());
+
+        builder = if self.files.is_empty() {
+            builder.add_stdin(self.format_options.stdin_format())
+        } else {
+            builder.add_paths(self.files.iter().cloned())
+        };
+
+        builder = builder
+            .add_contract_paths(self.apply_contract.iter().cloned())
+            .add_import_paths(self.import_path.iter().cloned());
+
+        if let Ok(nickel_path) = std::env::var("NICKEL_IMPORT_PATH") {
+            builder = builder.add_import_paths(nickel_path.split(':').map(PathBuf::from));
         }
+
+        #[cfg(feature = "package-experimental")]
+        if let Some(map) = package_map {
+            builder = builder.with_package_map(map);
+        }
+
+        // The builder defers all I/O to `build()`, so any failure here is from opening an input
+        // file, registering an in-memory source, or loading a contract path. All such errors are
+        // `IOError`, whose rendering doesn't need the source database — `Files::empty()` is
+        // sufficient.
+        // `mut` is only needed in debug builds (for `set_skip_stdlib` below).
+        #[cfg_attr(not(debug_assertions), allow(unused_mut))]
+        let mut program = builder.build().map_err(|e| {
+            PrepareError::Error(crate::error::Error::Program {
+                files: Files::empty(),
+                error: e.into(),
+            })
+        })?;
 
         #[cfg(debug_assertions)]
         if self.nostdlib {

--- a/core/src/deserialize.rs
+++ b/core/src/deserialize.rs
@@ -1,7 +1,6 @@
 //! Deserialization of an evaluated program to plain Rust types.
 
 use malachite::base::{num::conversion::traits::RoundingFrom, rounding_modes::RoundingMode};
-use nickel_lang_parser::ast::InputFormat;
 use std::{ffi::OsString, io::Cursor, iter::ExactSizeIterator};
 
 use serde::de::{
@@ -10,7 +9,7 @@ use serde::de::{
 };
 
 use crate::{
-    error::{self, NullReporter},
+    error,
     eval::{
         cache::CacheImpl,
         value::{
@@ -19,7 +18,7 @@ use crate::{
         },
     },
     identifier::LocIdent,
-    program::{Input, Program},
+    program::{Program, ProgramBuilder},
     term::{IndexMap, record::Field},
 };
 
@@ -116,15 +115,11 @@ impl From<RustDeserializationError> for EvalOrDeserError {
     }
 }
 
-fn from_input<'a, T, Content, Source>(input: Input<Content, Source>) -> Result<T, EvalOrDeserError>
+fn from_builder<'a, T>(builder: ProgramBuilder) -> Result<T, EvalOrDeserError>
 where
     T: serde::Deserialize<'a>,
-    Content: std::io::Read,
-    Source: Into<OsString>,
 {
-    let mut program =
-        Program::<CacheImpl>::new_from_input(input, std::io::stderr(), NullReporter {})
-            .map_err(error::IOError::from)?;
+    let mut program: Program<CacheImpl> = builder.with_trace(std::io::stderr()).build()?;
 
     Ok(T::deserialize(program.eval_full_for_export().map_err(
         |err| EvalOrDeserError::new(err, program.files()),
@@ -135,29 +130,29 @@ pub fn from_str<'a, T>(s: &'a str) -> Result<T, EvalOrDeserError>
 where
     T: serde::Deserialize<'a>,
 {
-    from_input(Input::Source(Cursor::new(s), "string", InputFormat::Nickel))
+    from_builder(ProgramBuilder::new().add_source_string(s.to_owned(), "string"))
 }
 
 pub fn from_slice<'a, T>(v: &'a [u8]) -> Result<T, EvalOrDeserError>
 where
     T: serde::Deserialize<'a>,
 {
-    from_input(Input::Source(Cursor::new(v), "slice", InputFormat::Nickel))
+    from_builder(ProgramBuilder::new().add_source(Cursor::new(v.to_owned()), "slice"))
 }
 
 pub fn from_path<T>(path: impl Into<OsString>) -> Result<T, EvalOrDeserError>
 where
     T: serde::de::DeserializeOwned,
 {
-    from_input(Input::<std::fs::File, _>::Path(path))
+    from_builder(ProgramBuilder::new().add_path(path))
 }
 
 pub fn from_reader<R, T>(rdr: R) -> Result<T, EvalOrDeserError>
 where
-    R: std::io::Read,
+    R: std::io::Read + 'static,
     T: serde::de::DeserializeOwned,
 {
-    from_input(Input::Source(rdr, "reader", InputFormat::Nickel))
+    from_builder(ProgramBuilder::new().add_source(rdr, "reader"))
 }
 
 /// An error occurred during deserialization to Rust.
@@ -752,22 +747,20 @@ mod tests {
 
     use nickel_lang_utils::{
         nickel_lang_core::{
-            deserialize::RustDeserializationError, error::NullReporter, eval::value::NickelValue,
+            deserialize::RustDeserializationError, eval::value::NickelValue,
+            program::ProgramBuilder,
         },
         test_program::TestProgram,
     };
     use serde::Deserialize;
 
     fn eval(source: &str) -> NickelValue {
-        TestProgram::new_from_source(
-            Cursor::new(source),
-            "source",
-            std::io::stderr(),
-            NullReporter {},
-        )
-        .expect("program shouldn't fail")
-        .eval_full()
-        .expect("evaluation shouldn't fail")
+        let mut program: TestProgram = ProgramBuilder::new()
+            .add_source_string(source.to_owned(), "source")
+            .with_trace(std::io::stderr())
+            .build()
+            .expect("program shouldn't fail");
+        program.eval_full().expect("evaluation shouldn't fail")
     }
 
     #[test]

--- a/core/src/error/mod.rs
+++ b/core/src/error/mod.rs
@@ -28,6 +28,7 @@ use crate::{
         ty_path::{self, PathSpan},
     },
     position::{PosIdx, PosTable, RawSpan, TermPos},
+    program::BuilderError,
     repl,
     serialize::{ExportFormat, NickelPointer, NickelPointerElem},
     term::{Number, record::FieldMetadata},
@@ -778,6 +779,21 @@ impl From<ImportErrorKind> for TypecheckError {
         Box::new(TypecheckErrorData::new(AstAlloc::new(), |_alloc| {
             TypecheckErrorKind::ImportError(error)
         }))
+    }
+}
+
+impl From<BuilderError> for Error {
+    fn from(error: BuilderError) -> Error {
+        match error {
+            BuilderError::NoInputs => Error::IOError(IOError(
+                "ProgramBuilder::build: no inputs were added".to_owned(),
+            )),
+            BuilderError::Io {
+                path: Some(p),
+                error,
+            } => Error::IOError(IOError(format!("source {}: {error}", p.display()))),
+            BuilderError::Io { path: None, error } => Error::IOError(IOError(error.to_string())),
+        }
     }
 }
 

--- a/core/src/package.rs
+++ b/core/src/package.rs
@@ -98,10 +98,12 @@ impl std::fmt::Display for PackageMap {
 
 #[cfg(test)]
 mod tests {
-    use std::io::Cursor;
-
     use super::*;
-    use crate::{error::NullReporter, eval::cache::CacheImpl, program::Program, term::Number};
+    use crate::{
+        eval::cache::CacheImpl,
+        program::{Program, ProgramBuilder},
+        term::Number,
+    };
     use nickel_lang_utils::project_root::project_root;
 
     // Test basic package map functionality by building one manually out of
@@ -117,14 +119,11 @@ mod tests {
             packages: std::iter::once(((pkg1, Ident::new("dep")), pkg2)).collect(),
         };
 
-        let mut p: Program<CacheImpl> = Program::new_from_source(
-            Cursor::new("import pkg"),
-            "<test>",
-            std::io::sink(),
-            NullReporter {},
-        )
-        .unwrap();
-        p.set_package_map(map);
+        let mut p: Program<CacheImpl> = ProgramBuilder::new()
+            .add_source_string("import pkg".to_owned(), "<test>")
+            .with_package_map(map)
+            .build()
+            .unwrap();
 
         assert_eq!(
             p.eval_full().unwrap().as_number().unwrap(),

--- a/core/src/program.rs
+++ b/core/src/program.rs
@@ -25,7 +25,7 @@ use crate::{
     cache::*,
     closurize::Closurize as _,
     error::{
-        Error, EvalError, EvalErrorKind, IOError, ParseError, ParseErrors, Reporter,
+        Error, EvalError, EvalErrorKind, IOError, NullReporter, ParseError, ParseErrors, Reporter,
         warning::Warning,
     },
     eval::{
@@ -260,216 +260,7 @@ pub struct Program<EC: EvalCache> {
     pub contracts: Vec<ProgramContract>,
 }
 
-/// The Possible Input Sources, anything that a Nickel program can be created from
-pub enum Input<T, S> {
-    /// A filepath
-    Path(S),
-    /// The source is anything that can be Read from, the second argument is the name the source should have in the cache.
-    Source(T, S, InputFormat),
-}
-
 impl<EC: EvalCache> Program<EC> {
-    /// Create a program by reading it from the standard input.
-    pub fn new_from_stdin(
-        stdin_format: InputFormat,
-        trace: impl Write + 'static,
-        reporter: impl Reporter<(Warning, Files)> + 'static,
-    ) -> std::io::Result<Self> {
-        Program::new_from_source_with_format(io::stdin(), "<stdin>", stdin_format, trace, reporter)
-    }
-
-    /// Constructor that abstracts over the Input type (file, string, etc.). Used by
-    /// the other constructors. Published for those that need abstraction over the kind of Input.
-    ///
-    /// The format of the input is Nickel by default. However, for [Input::Path]s, the format is
-    /// determined from the file extension. This is useful to merge Nickel and non-Nickel files, or
-    /// to apply extra contracts to non-Nickel configurations.
-    pub fn new_from_input<T, S>(
-        input: Input<T, S>,
-        trace: impl Write + 'static,
-        reporter: impl Reporter<(Warning, Files)> + 'static,
-    ) -> std::io::Result<Self>
-    where
-        T: Read,
-        S: Into<OsString>,
-    {
-        increment!("Program::new");
-        let mut cache = CacheHub::new();
-
-        let main_id = match input {
-            Input::Path(path) => {
-                let path = path.into();
-                let format = InputFormat::from_path(&path).unwrap_or_default();
-                cache.sources.add_file(path, format)?
-            }
-            Input::Source(source, name, format) => {
-                let path = PathBuf::from(name.into());
-                cache
-                    .sources
-                    .add_source(SourcePath::Path(path, format), source)?
-            }
-        };
-
-        Ok(Self {
-            main_id,
-            vm_ctxt: VmContext::new(cache, trace, reporter),
-            overrides: Vec::new(),
-            field: FieldPath::new(),
-            contracts: Vec::new(),
-        })
-    }
-
-    /// Constructor that abstracts over an iterator of Inputs (file, strings, etc). Published for
-    /// those that need abstraction over the kind of Input or want to mix multiple different kinds
-    /// of Input.
-    ///
-    /// The format of each input is Nickel by default. However, for [Input::Path]s, the format is
-    /// determined from the file extension. This is useful to merge Nickel and non-Nickel files, or
-    /// to apply extra contracts to non-Nickel configurations.
-    pub fn new_from_inputs<I, T, S>(
-        inputs: I,
-        trace: impl Write + 'static,
-        reporter: impl Reporter<(Warning, Files)> + 'static,
-    ) -> std::io::Result<Self>
-    where
-        I: IntoIterator<Item = Input<T, S>>,
-        T: Read,
-        S: Into<OsString>,
-    {
-        increment!("Program::new");
-        let mut cache = CacheHub::new();
-
-        let merge_term = inputs
-            .into_iter()
-            .map(|input| match input {
-                Input::Path(path) => {
-                    let path = path.into();
-                    let format = InputFormat::from_path(&path).unwrap_or_default();
-
-                    NickelValue::from(Term::Import(Import::Path { path, format }))
-                }
-                Input::Source(source, name, format) => {
-                    let name = name.into();
-                    let mut import_path = OsString::new();
-                    // See https://github.com/tweag/nickel/issues/2362 and the documentation of
-                    // IN_MEMORY_SOURCE_PATH_PREFIX
-                    import_path.push(IN_MEMORY_SOURCE_PATH_PREFIX);
-                    import_path.push(name.clone());
-
-                    cache
-                        .sources
-                        .add_source(SourcePath::Path(name.into(), format), source)
-                        .unwrap();
-                    NickelValue::from(Term::Import(Import::Path {
-                        path: import_path,
-                        format,
-                    }))
-                }
-            })
-            .reduce(|acc, f| mk_term::op2(BinaryOp::Merge(Label::default().into()), acc, f))
-            .unwrap();
-
-        let main_id = cache.sources.add_string(
-            SourcePath::Generated("main".into()),
-            format!("{merge_term}"),
-        );
-
-        Ok(Self {
-            main_id,
-            vm_ctxt: VmContext::new(cache, trace, reporter),
-            overrides: Vec::new(),
-            field: FieldPath::new(),
-            contracts: Vec::new(),
-        })
-    }
-
-    /// Create program from possibly multiple files. Each input `path` is
-    /// turned into a [`Term::Import`] and the main program will be the
-    /// [`BinaryOp::Merge`] of all the inputs.
-    pub fn new_from_files<I, P>(
-        paths: I,
-        trace: impl Write + 'static,
-        reporter: impl Reporter<(Warning, Files)> + 'static,
-    ) -> std::io::Result<Self>
-    where
-        I: IntoIterator<Item = P>,
-        P: Into<OsString>,
-    {
-        // The File type parameter is a dummy type and not used.
-        // It just needed to be something that implements Read, and File seemed fitting.
-        Self::new_from_inputs(
-            paths.into_iter().map(Input::<std::fs::File, _>::Path),
-            trace,
-            reporter,
-        )
-    }
-
-    pub fn new_from_file(
-        path: impl Into<OsString>,
-        trace: impl Write + 'static,
-        reporter: impl Reporter<(Warning, Files)> + 'static,
-    ) -> std::io::Result<Self> {
-        // The File type parameter is a dummy type and not used.
-        // It just needed to be something that implements Read, and File seemed fitting.
-        Self::new_from_input(Input::<std::fs::File, _>::Path(path), trace, reporter)
-    }
-
-    /// Create a program by reading it from a generic source.
-    pub fn new_from_source<T, S>(
-        source: T,
-        source_name: S,
-        trace: impl Write + 'static,
-        reporter: impl Reporter<(Warning, Files)> + 'static,
-    ) -> std::io::Result<Self>
-    where
-        T: Read,
-        S: Into<OsString>,
-    {
-        Self::new_from_input(
-            Input::Source(source, source_name, InputFormat::Nickel),
-            trace,
-            reporter,
-        )
-    }
-
-    /// Create a program by reading it from a generic source. The format of the source may be
-    /// specified to be something other than Nickel.
-    pub fn new_from_source_with_format<T, S>(
-        source: T,
-        source_name: S,
-        source_format: InputFormat,
-        trace: impl Write + 'static,
-        reporter: impl Reporter<(Warning, Files)> + 'static,
-    ) -> std::io::Result<Self>
-    where
-        T: Read,
-        S: Into<OsString>,
-    {
-        Self::new_from_input(
-            Input::Source(source, source_name, source_format),
-            trace,
-            reporter,
-        )
-    }
-
-    /// Create program from possibly multiple sources. The main program will be
-    /// the [`BinaryOp::Merge`] of all the inputs.
-    pub fn new_from_sources<I, T, S>(
-        sources: I,
-        trace: impl Write + 'static,
-        reporter: impl Reporter<(Warning, Files)> + 'static,
-    ) -> std::io::Result<Self>
-    where
-        I: IntoIterator<Item = (T, S)>,
-        T: Read,
-        S: Into<OsString>,
-    {
-        let inputs = sources
-            .into_iter()
-            .map(|(s, n)| Input::Source(s, n, InputFormat::Nickel));
-        Self::new_from_inputs(inputs, trace, reporter)
-    }
-
     /// Parse an assignment of the form `path.to_field=value` as an override, with the provided
     /// merge priority. Assignments are typically provided by the user on the command line, as part
     /// of the customize mode.
@@ -499,54 +290,6 @@ impl<EC: EvalCache> Program<EC> {
     /// Adds a contract to be applied to the final program.
     pub fn add_contract(&mut self, contract: ProgramContract) {
         self.contracts.push(contract);
-    }
-
-    /// Adds a list of contracts to be applied to the final program, specified as file paths. Those
-    /// contracts will be parsed, typechecked and further processed together with the rest of the
-    /// program.
-    pub fn add_contract_paths<P>(
-        &mut self,
-        contract_files: impl IntoIterator<Item = P>,
-    ) -> Result<(), Error>
-    where
-        OsString: From<P>,
-    {
-        let prog_contracts: Result<Vec<_>, _> = contract_files
-            .into_iter()
-            .map(|file| -> Result<_, Error> {
-                let file: OsString = file.into();
-                let file_str = file.to_string_lossy().into_owned();
-
-                let file_id = self
-                    .vm_ctxt
-                    .import_resolver
-                    .sources
-                    .add_file(file, InputFormat::Nickel)
-                    .map_err(|err| {
-                        Error::IOError(IOError(format!(
-                            "when opening contract file `{}`: {}",
-                            &file_str, err
-                        )))
-                    })?;
-
-                Ok(ProgramContract::Source(file_id))
-            })
-            .collect();
-
-        self.contracts.extend(prog_contracts?);
-        Ok(())
-    }
-
-    /// Adds import paths to the end of the list.
-    pub fn add_import_paths<P>(&mut self, paths: impl Iterator<Item = P>)
-    where
-        PathBuf: From<P>,
-    {
-        self.vm_ctxt.import_resolver.sources.add_import_paths(paths);
-    }
-
-    pub fn set_package_map(&mut self, map: PackageMap) {
-        self.vm_ctxt.import_resolver.sources.set_package_map(map)
     }
 
     /// Only parse the program (and any additional attached contracts), don't typecheck or
@@ -1154,6 +897,8 @@ impl<EC: EvalCache> Program<EC> {
         ))
     }
 
+    /// Skip loading the standard library on the next preparation step. Only available in debug
+    /// builds, since the underlying field on [`crate::cache::CacheHub`] is debug-gated.
     #[cfg(debug_assertions)]
     pub fn set_skip_stdlib(&mut self) {
         self.vm_ctxt.import_resolver.skip_stdlib = true;
@@ -1201,6 +946,410 @@ impl<EC: EvalCache> Program<EC> {
     /// Returns a reference to the position table.
     pub fn pos_table(&self) -> &PosTable {
         &self.vm_ctxt.pos_table
+    }
+}
+
+/// An error that occurred during a call to [`ProgramBuilder::build`].
+#[derive(Debug)]
+pub enum BuilderError {
+    /// No nickel code was provided to build the program.
+    NoInputs,
+    /// An I/O error occurred reading an input file.
+    Io {
+        path: Option<PathBuf>,
+        error: std::io::Error,
+    },
+}
+
+impl std::error::Error for BuilderError {}
+
+impl std::fmt::Display for BuilderError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Io { path, error } => {
+                if let Some(path) = path {
+                    write!(f, "{}: {error}", path.display())
+                } else {
+                    error.fmt(f)
+                }
+            }
+            Self::NoInputs => write!(f, "ProgramBuilder::build: no inputs were added"),
+        }
+    }
+}
+
+/// An input source held by a [`ProgramBuilder`].
+///
+/// The concrete `Read` implementation is erased to `Box<dyn Read>` so that builders can mix paths
+/// and heterogeneous in-memory sources without per-source generics.
+enum BuilderInput {
+    /// A filesystem path. The format is inferred from the path's extension.
+    Path(OsString),
+    /// An in-memory source. Parsed as `format` and identified by `name` in the source cache.
+    Source {
+        source: Box<dyn Read>,
+        name: OsString,
+        format: InputFormat,
+    },
+}
+
+/// Builder for [`Program`].
+///
+/// Accumulates inputs and configuration, then produces a [`Program`] via [`Self::build`]. All I/O
+/// is deferred to `build`, so the configuration methods themselves are infallible.
+///
+/// # Generic parameters
+///
+/// - `R` — the warning reporter type, defaulting to [`NullReporter`].
+/// - `W` — the trace writer type, defaulting to [`io::Sink`].
+///
+/// Defaults can be replaced with [`Self::with_reporter`] and [`Self::with_trace`]; both consume
+/// `self` and return a builder with the new generic parameter.
+///
+/// # Example
+///
+/// ```no_run
+/// use nickel_lang_core::{eval::cache::CacheImpl, program::{Program, ProgramBuilder}};
+///
+/// let program: Program<CacheImpl> = ProgramBuilder::new()
+///     .add_path("config.ncl")
+///     .add_import_paths(["./vendor"])
+///     .build()
+///     .unwrap();
+/// ```
+pub struct ProgramBuilder<R = NullReporter, W = io::Sink> {
+    inputs: Vec<BuilderInput>,
+    overrides: Vec<FieldOverride>,
+    field: FieldPath,
+    contracts: Vec<ProgramContract>,
+    contract_paths: Vec<OsString>,
+    import_paths: Vec<PathBuf>,
+    package_map: Option<PackageMap>,
+    trace: W,
+    reporter: R,
+}
+
+impl Default for ProgramBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ProgramBuilder {
+    /// Create an empty builder with the default reporter ([`NullReporter`]) and trace writer
+    /// ([`io::sink`]). Use [`Self::with_reporter`] and [`Self::with_trace`] to override them.
+    pub fn new() -> Self {
+        ProgramBuilder {
+            inputs: Vec::new(),
+            overrides: Vec::new(),
+            field: FieldPath::new(),
+            contracts: Vec::new(),
+            contract_paths: Vec::new(),
+            import_paths: Vec::new(),
+            package_map: None,
+            trace: io::sink(),
+            reporter: NullReporter {},
+        }
+    }
+}
+
+impl<R, W> ProgramBuilder<R, W> {
+    /// Add a single filesystem path as an input. The format is inferred from the path's extension.
+    pub fn add_path(mut self, path: impl Into<OsString>) -> Self {
+        self.inputs.push(BuilderInput::Path(path.into()));
+        self
+    }
+
+    /// Add multiple filesystem paths as inputs.
+    pub fn add_paths<I, P>(mut self, paths: I) -> Self
+    where
+        I: IntoIterator<Item = P>,
+        P: Into<OsString>,
+    {
+        self.inputs
+            .extend(paths.into_iter().map(|p| BuilderInput::Path(p.into())));
+        self
+    }
+
+    /// Add an in-memory source as an input, parsed as Nickel.
+    pub fn add_source(self, source: impl Read + 'static, name: impl Into<OsString>) -> Self {
+        self.add_source_with_format(source, name, InputFormat::Nickel)
+    }
+
+    /// Add the given string as an in-memory Nickel source.
+    pub fn add_source_string<S: ToOwned>(self, source: S, name: impl Into<OsString>) -> Self
+    where
+        S::Owned: Into<String>,
+    {
+        self.add_source_with_format(
+            std::io::Cursor::new(source.to_owned().into()),
+            name,
+            InputFormat::Nickel,
+        )
+    }
+
+    /// Add an in-memory source as an input, with an explicit format.
+    pub fn add_source_with_format(
+        mut self,
+        source: impl Read + 'static,
+        name: impl Into<OsString>,
+        format: InputFormat,
+    ) -> Self {
+        self.inputs.push(BuilderInput::Source {
+            source: Box::new(source),
+            name: name.into(),
+            format,
+        });
+        self
+    }
+
+    /// Add standard input as an input source, with the given format.
+    pub fn add_stdin(self, format: InputFormat) -> Self {
+        self.add_source_with_format(io::stdin(), "<stdin>", format)
+    }
+
+    /// Append overrides to be applied to the program at evaluation time.
+    pub fn add_overrides(mut self, overrides: impl IntoIterator<Item = FieldOverride>) -> Self {
+        self.overrides.extend(overrides);
+        self
+    }
+
+    /// Append a contract to be applied to the final program.
+    pub fn add_contract(mut self, contract: ProgramContract) -> Self {
+        self.contracts.push(contract);
+        self
+    }
+
+    /// Append contract files to be applied to the final program. The files are read at
+    /// [`Self::build`] time.
+    pub fn add_contract_paths<I, P>(mut self, paths: I) -> Self
+    where
+        I: IntoIterator<Item = P>,
+        P: Into<OsString>,
+    {
+        self.contract_paths
+            .extend(paths.into_iter().map(Into::into));
+        self
+    }
+
+    /// Append import paths, searched (in order) when resolving relative imports.
+    pub fn add_import_paths<I, P>(mut self, paths: I) -> Self
+    where
+        I: IntoIterator<Item = P>,
+        P: Into<PathBuf>,
+    {
+        self.import_paths.extend(paths.into_iter().map(Into::into));
+        self
+    }
+
+    /// Set the field path the program will operate on.
+    pub fn with_field_path(mut self, field: FieldPath) -> Self {
+        self.field = field;
+        self
+    }
+
+    /// Set the package map used to resolve package imports.
+    pub fn with_package_map(mut self, map: PackageMap) -> Self {
+        self.package_map = Some(map);
+        self
+    }
+
+    /// Replace the trace writer (where output from the `trace` builtin goes).
+    pub fn with_trace<W2>(self, trace: W2) -> ProgramBuilder<R, W2>
+    where
+        W2: Write + 'static,
+    {
+        ProgramBuilder {
+            inputs: self.inputs,
+            overrides: self.overrides,
+            field: self.field,
+            contracts: self.contracts,
+            contract_paths: self.contract_paths,
+            import_paths: self.import_paths,
+            package_map: self.package_map,
+            trace,
+            reporter: self.reporter,
+        }
+    }
+
+    /// Replace the warning reporter.
+    pub fn with_reporter<R2>(self, reporter: R2) -> ProgramBuilder<R2, W>
+    where
+        R2: Reporter<(Warning, Files)> + 'static,
+    {
+        ProgramBuilder {
+            inputs: self.inputs,
+            overrides: self.overrides,
+            field: self.field,
+            contracts: self.contracts,
+            contract_paths: self.contract_paths,
+            import_paths: self.import_paths,
+            package_map: self.package_map,
+            trace: self.trace,
+            reporter,
+        }
+    }
+}
+
+impl<R, W> ProgramBuilder<R, W>
+where
+    R: Reporter<(Warning, Files)> + 'static,
+    W: Write + 'static,
+{
+    /// Consume the builder and produce a [`Program`].
+    ///
+    /// Performs all deferred I/O: opens path inputs, registers in-memory sources, and loads
+    /// contract files. Returns an error if any of these fail, or if no input has been added.
+    pub fn build<EC: EvalCache>(self) -> Result<Program<EC>, BuilderError> {
+        increment!("Program::new");
+
+        let ProgramBuilder {
+            inputs,
+            overrides,
+            field,
+            mut contracts,
+            contract_paths,
+            import_paths,
+            package_map,
+            trace,
+            reporter,
+        } = self;
+
+        if inputs.is_empty() {
+            return Err(BuilderError::NoInputs);
+        }
+
+        let mut cache = CacheHub::new();
+
+        let main_id = if inputs.len() == 1 {
+            // Single-input fast path: register it directly and use its file id as the main id.
+            let input = inputs.into_iter().next().expect("len == 1");
+            register_single_input(&mut cache, input)?
+        } else {
+            // Multi-input: synthesize a `Merge` over imports of each input, then use that as the
+            // main id.
+            let mut iter = inputs.into_iter();
+            let first = iter.next().expect("len > 1");
+            let first_term = register_input_as_import(&mut cache, first)?;
+
+            let merge_term = iter.try_fold(
+                first_term,
+                |acc, input| -> Result<NickelValue, BuilderError> {
+                    let term = register_input_as_import(&mut cache, input)?;
+                    Ok(mk_term::op2(
+                        BinaryOp::Merge(Label::default().into()),
+                        acc,
+                        term,
+                    ))
+                },
+            )?;
+
+            cache.sources.add_string(
+                SourcePath::Generated("main".into()),
+                format!("{merge_term}"),
+            )
+        };
+
+        cache.sources.add_import_paths(import_paths.into_iter());
+        if let Some(map) = package_map {
+            cache.sources.set_package_map(map);
+        }
+
+        for file in contract_paths {
+            let file_id = cache
+                .sources
+                .add_file(file.clone(), InputFormat::Nickel)
+                .map_err(|err| BuilderError::Io {
+                    path: Some(file.into()),
+                    error: err,
+                })?;
+            contracts.push(ProgramContract::Source(file_id));
+        }
+
+        let vm_ctxt = VmContext::new(cache, trace, reporter);
+
+        Ok(Program {
+            main_id,
+            vm_ctxt,
+            overrides,
+            field,
+            contracts,
+        })
+    }
+}
+
+/// Register a single [`BuilderInput`] in the cache and return its [`FileId`]. Used for the
+/// single-input path of [`ProgramBuilder::build`], which doesn't need to synthesize a `Merge`
+/// term.
+fn register_single_input(
+    cache: &mut CacheHub,
+    input: BuilderInput,
+) -> Result<crate::files::FileId, BuilderError> {
+    match input {
+        BuilderInput::Path(path) => {
+            let format = InputFormat::from_path(&path).unwrap_or_default();
+            cache
+                .sources
+                .add_file(path.clone(), format)
+                .map_err(|err| BuilderError::Io {
+                    path: Some(path.into()),
+                    error: err,
+                })
+        }
+        BuilderInput::Source {
+            source,
+            name,
+            format,
+        } => {
+            let path = PathBuf::from(name);
+            cache
+                .sources
+                .add_source(SourcePath::Path(path.clone(), format), source)
+                .map_err(|err| BuilderError::Io {
+                    path: Some(path),
+                    error: err,
+                })
+        }
+    }
+}
+
+/// Register a [`BuilderInput`] in the cache and return a [`Term::Import`] referring to it. Used
+/// for the multi-input path of [`ProgramBuilder::build`].
+fn register_input_as_import(
+    cache: &mut CacheHub,
+    input: BuilderInput,
+) -> Result<NickelValue, BuilderError> {
+    match input {
+        BuilderInput::Path(path) => {
+            let format = InputFormat::from_path(&path).unwrap_or_default();
+            Ok(NickelValue::from(Term::Import(Import::Path {
+                path,
+                format,
+            })))
+        }
+        BuilderInput::Source {
+            source,
+            name,
+            format,
+        } => {
+            let mut import_path = OsString::new();
+            // See https://github.com/tweag/nickel/issues/2362 and the documentation of
+            // IN_MEMORY_SOURCE_PATH_PREFIX
+            import_path.push(IN_MEMORY_SOURCE_PATH_PREFIX);
+            import_path.push(&name);
+
+            cache
+                .sources
+                .add_source(SourcePath::Path(name.clone().into(), format), source)
+                .map_err(|err| BuilderError::Io {
+                    path: Some(name.into()),
+                    error: err,
+                })?;
+            Ok(NickelValue::from(Term::Import(Import::Path {
+                path: import_path,
+                format,
+            })))
+        }
     }
 }
 
@@ -1534,37 +1683,20 @@ mod doc {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{error::NullReporter, eval::cache::CacheImpl};
+    use crate::eval::cache::CacheImpl;
     use assert_matches::assert_matches;
-    use std::io::Cursor;
+
+    fn build_test_program(s: &str) -> Result<Program<CacheImpl>, BuilderError> {
+        ProgramBuilder::new().add_source_string(s, "<test>").build()
+    }
 
     fn eval_full(s: &str) -> Result<NickelValue, Error> {
-        let src = Cursor::new(s);
-
-        let mut p: Program<CacheImpl> =
-            Program::new_from_source(src, "<test>", std::io::sink(), NullReporter {}).map_err(
-                |io_err| {
-                    Error::eval_error(
-                        Default::default(),
-                        EvalErrorKind::Other(format!("IO error: {io_err}"), PosIdx::NONE),
-                    )
-                },
-            )?;
+        let mut p = build_test_program(s)?;
         p.eval_full()
     }
 
     fn typecheck(s: &str) -> Result<(), Error> {
-        let src = Cursor::new(s);
-
-        let mut p: Program<CacheImpl> =
-            Program::new_from_source(src, "<test>", std::io::sink(), NullReporter {}).map_err(
-                |io_err| {
-                    Error::eval_error(
-                        Default::default(),
-                        EvalErrorKind::Other(format!("IO error: {io_err}"), PosIdx::NONE),
-                    )
-                },
-            )?;
+        let mut p = build_test_program(s)?;
         p.typecheck(TypecheckMode::Walk)
     }
 
@@ -1606,5 +1738,40 @@ mod tests {
             typecheck("{foo = 1 + `, bar : Str = \"a\"}"),
             Err(Error::ParseErrors(_))
         );
+    }
+
+    #[test]
+    fn builder_evaluates_single_source() {
+        let mut prog: Program<CacheImpl> = ProgramBuilder::new()
+            .add_source_string("1 + 2", "<builder-test>")
+            .build()
+            .unwrap();
+        let v = prog.eval_full().unwrap();
+        assert_eq!(v.without_pos(), crate::term::make::integer(3).without_pos());
+    }
+
+    #[test]
+    fn builder_merges_multiple_sources() {
+        let mut prog: Program<CacheImpl> = ProgramBuilder::new()
+            .add_source_string("{ a = 1 }", "<a.ncl>")
+            .add_source_string("{ b = 2 }", "<b.ncl>")
+            .build()
+            .unwrap();
+        let v = prog.eval_full().unwrap();
+        let expected = crate::mk_record!(
+            ("a", crate::term::make::integer(1)),
+            ("b", crate::term::make::integer(2))
+        );
+        assert_eq!(v.without_pos(), expected);
+    }
+
+    #[test]
+    fn builder_rejects_no_inputs() {
+        let result: Result<Program<CacheImpl>, _> = ProgramBuilder::new().build();
+        match result {
+            Err(BuilderError::NoInputs) => {}
+            Err(e) => panic!("expected IOError, got {e:?}"),
+            Ok(_) => panic!("expected error for empty input set"),
+        }
     }
 }

--- a/core/src/serialize/mod.rs
+++ b/core/src/serialize/mod.rs
@@ -842,7 +842,7 @@ mod tests {
         cache::CacheHub,
         error::NullReporter,
         eval::{VirtualMachine, VmContext, cache::CacheImpl},
-        program::Program,
+        program::{Program, ProgramBuilder},
         term::{BinaryOp, make as mk_term},
     };
     use serde_json::json;
@@ -850,14 +850,11 @@ mod tests {
 
     #[track_caller]
     fn eval(s: &str) -> NickelValue {
-        let src = Cursor::new(s);
-        let mut prog = Program::<CacheImpl>::new_from_source(
-            src,
-            "<test>",
-            std::io::stderr(),
-            NullReporter {},
-        )
-        .unwrap();
+        let mut prog: Program<CacheImpl> = ProgramBuilder::new()
+            .add_source_string(s.to_owned(), "<test>")
+            .with_trace(std::io::stderr())
+            .build()
+            .unwrap();
         prog.eval_full().expect("program eval should succeed")
     }
 

--- a/core/tests/examples/main.rs
+++ b/core/tests/examples/main.rs
@@ -1,5 +1,8 @@
 use assert_matches::assert_matches;
-use nickel_lang_core::error::{Error, EvalErrorData, EvalErrorKind, NullReporter};
+use nickel_lang_core::{
+    error::{Error, EvalErrorData, EvalErrorKind},
+    program::ProgramBuilder,
+};
 use nickel_lang_utils::{
     annotated_test::{TestCase, read_annotated_test_case},
     project_root::project_root,
@@ -14,12 +17,11 @@ fn check_example_file(path: &str) {
         read_annotated_test_case(path).expect("Failed to parse annotated program");
 
     // `test_resources` uses paths relative to the workspace manifesty
-    let mut p = TestProgram::new_from_file(
-        project_root().join(path),
-        std::io::stderr(),
-        NullReporter {},
-    )
-    .expect("Failed to load program from file");
+    let mut p: TestProgram = ProgramBuilder::new()
+        .add_path(project_root().join(path))
+        .with_trace(std::io::stderr())
+        .build()
+        .expect("Failed to load program from file");
 
     match test.annotation {
         Expectation::Pass => {

--- a/core/tests/integration/main.rs
+++ b/core/tests/integration/main.rs
@@ -1,11 +1,12 @@
-use std::{io::Cursor, thread};
+use std::thread;
 
 use nickel_lang_core::{
     error::{
-        Error, EvalErrorKind, ExportErrorKind, ImportErrorKind, NullReporter, ParseError,
-        PointedExportErrorData, TypecheckErrorKind,
+        Error, EvalErrorKind, ExportErrorKind, ImportErrorKind, ParseError, PointedExportErrorData,
+        TypecheckErrorKind,
     },
     eval::value::NickelValue,
+    program::ProgramBuilder,
     typecheck::TypecheckMode,
 };
 
@@ -70,16 +71,13 @@ fn run_test(test_case: TestCase<Test>, path: String) {
     let test = test_case.annotation.test;
 
     for _ in 0..repeat {
-        let mut p = TestProgram::new_from_source(
-            Cursor::new(program.clone()),
-            path.as_str(),
-            std::io::stderr(),
-            NullReporter {},
-        )
-        .expect("");
+        let mut builder = ProgramBuilder::new()
+            .add_source_string(program.clone(), &path)
+            .with_trace(std::io::stderr());
         if let Some(imports) = &test_case.annotation.nickel_path {
-            p.add_import_paths(imports.iter());
+            builder = builder.add_import_paths(imports.iter().cloned());
         }
+        let p: TestProgram = builder.build().unwrap();
         match test.clone() {
             Expectation::Error(expected_err) => {
                 let err = eval_strategy.eval_program_to_err(p);
@@ -274,11 +272,11 @@ impl PartialEq<Error> for ErrorExpectation {
                 }
                 _ => false,
             },
-            Error::ImportError(data) => match (self, &**data) {
+            Error::ImportError(data) => matches!(
+                (self, &**data),
                 (ImportParseError, ImportErrorKind::ParseErrors(..))
-                | (ImportIoError, ImportErrorKind::IOError(..)) => true,
-                _ => false,
-            },
+                    | (ImportIoError, ImportErrorKind::IOError(..))
+            ),
             Error::ParseErrors(es) => {
                 let first_error = es
                     .errors

--- a/core/tests/integration/program_api.rs
+++ b/core/tests/integration/program_api.rs
@@ -1,31 +1,19 @@
 use nickel_lang_core::{
-    ast::InputFormat,
     error::Sink,
     eval::cache::lazy::CBNCache,
-    program::{Input, Program},
+    program::{Program, ProgramBuilder},
 };
 
 // Regression test for https://github.com/tweag/nickel/issues/2362
 #[test]
 fn multiple_inputs_non_paths() {
-    let sink = Sink::default();
-    let mut prog: Program<CBNCache> = Program::new_from_inputs(
-        [
-            Input::Source(
-                "{}".to_owned().as_bytes(),
-                &String::from("fst"),
-                InputFormat::Nickel,
-            ),
-            Input::Source(
-                "{} & {}".to_owned().as_bytes(),
-                &String::from("snd"),
-                InputFormat::Nickel,
-            ),
-        ],
-        std::io::stderr(),
-        sink,
-    )
-    .unwrap();
+    let mut prog: Program<CBNCache> = ProgramBuilder::new()
+        .add_source_string("{}", "fst")
+        .add_source_string("{} & {}", "snd")
+        .with_trace(std::io::stderr())
+        .with_reporter(Sink::default())
+        .build()
+        .unwrap();
 
     assert_eq!(&prog.eval_full_for_export().unwrap().to_string(), "{}");
 }

--- a/core/tests/integration/query.rs
+++ b/core/tests/integration/query.rs
@@ -1,7 +1,6 @@
 use nickel_lang_core::{
-    error::NullReporter,
     eval::cache::lazy::CBNCache,
-    program::Program,
+    program::{Program, ProgramBuilder},
     term::{TypeAnnotation, make as mk_term, record::FieldMetadata},
 };
 
@@ -18,18 +17,20 @@ impl ProgramExt for Program<CBNCache> {
     }
 }
 
+fn program_from(src: &'static str) -> TestProgram {
+    ProgramBuilder::new()
+        .add_source_string(src, "regr_tests")
+        .with_trace(std::io::stderr())
+        .build()
+        .unwrap()
+}
+
 #[test]
 pub fn test_query_metadata_basic() {
-    let result = TestProgram::new_from_source(
-        "{val | doc \"Test basic\" = (1 + 1)}".as_bytes(),
-        "regr_tests",
-        std::io::stderr(),
-        NullReporter {},
-    )
-    .unwrap()
-    .with_field_path("val")
-    .query()
-    .unwrap();
+    let result = program_from("{val | doc \"Test basic\" = (1 + 1)}")
+        .with_field_path("val")
+        .query()
+        .unwrap();
 
     assert_eq!(result.metadata.doc(), Some("Test basic"));
     assert_eq!(result.value.unwrap().without_pos(), mk_term::integer(2));
@@ -41,27 +42,9 @@ pub fn test_query_with_wildcard() {
 
     /// Checks whether `lhs` and `rhs` both evaluate to terms with the same static type
     #[track_caller]
-    fn assert_types_eq(lhs: &str, rhs: &str, path: &str) {
-        let term1 = TestProgram::new_from_source(
-            lhs.as_bytes(),
-            "regr_tests",
-            std::io::stderr(),
-            NullReporter {},
-        )
-        .unwrap()
-        .with_field_path(path)
-        .query()
-        .unwrap();
-        let term2 = TestProgram::new_from_source(
-            rhs.as_bytes(),
-            "regr_tests",
-            std::io::stderr(),
-            NullReporter {},
-        )
-        .unwrap()
-        .with_field_path(path)
-        .query()
-        .unwrap();
+    fn assert_types_eq(lhs: &'static str, rhs: &'static str, path: &str) {
+        let term1 = program_from(lhs).with_field_path(path).query().unwrap();
+        let term2 = program_from(rhs).with_field_path(path).query().unwrap();
         let (
             Some(FieldMetadata {
                 annotation:
@@ -95,16 +78,10 @@ pub fn test_query_with_wildcard() {
     }
 
     // Without wildcard, the result has no type annotation
-    let result = TestProgram::new_from_source(
-        "{value = 10}".as_bytes(),
-        "regr_tests",
-        std::io::stderr(),
-        NullReporter {},
-    )
-    .unwrap()
-    .with_field_path(path)
-    .query()
-    .unwrap();
+    let result = program_from("{value = 10}")
+        .with_field_path(path)
+        .query()
+        .unwrap();
 
     assert!(result.metadata.is_empty());
     // assert!(matches!(

--- a/package/src/error.rs
+++ b/package/src/error.rs
@@ -1,7 +1,9 @@
 use std::path::{Path, PathBuf};
 
 use gix::ObjectId;
-use nickel_lang_core::{error::INTERNAL_ERROR_MSG, files::Files, identifier::Ident};
+use nickel_lang_core::{
+    error::INTERNAL_ERROR_MSG, files::Files, identifier::Ident, program::BuilderError,
+};
 
 use crate::{
     UnversionedDependency,
@@ -303,5 +305,17 @@ impl From<gix::open::Error> for Error {
 impl From<gix::reference::head_tree_id::Error> for Error {
     fn from(e: gix::reference::head_tree_id::Error) -> Self {
         Self::OtherGit(e.into())
+    }
+}
+
+impl From<BuilderError> for Error {
+    fn from(error: BuilderError) -> Error {
+        match error {
+            BuilderError::NoInputs => Error::Io {
+                path: None,
+                error: std::io::Error::other("ProgramBuilder::build: no inputs were added"),
+            },
+            BuilderError::Io { path, error } => Error::Io { path, error },
+        }
     }
 }

--- a/package/src/manifest.rs
+++ b/package/src/manifest.rs
@@ -7,11 +7,10 @@ use std::{
 
 use nickel_lang_core::{
     cache::normalize_rel_path,
-    error::NullReporter,
     eval::{cache::CacheImpl, value::NickelValue},
     identifier::Ident,
     label::Label,
-    program::{Program, ProgramContract},
+    program::{Program, ProgramBuilder, ProgramContract},
     term::{RuntimeContract, Term, make},
 };
 use serde::Deserialize;
@@ -19,7 +18,7 @@ use serde::Deserialize;
 use crate::{
     Dependency, GitDependency, IndexDependency, UnversionedPrecisePkg,
     config::Config,
-    error::{Error, IoResultExt},
+    error::Error,
     index::{self, PackageIndex, path::RelativePathError},
     lock::{LockFile, LockFileEntry},
     resolve::{self, Resolution},
@@ -190,20 +189,26 @@ impl ManifestFile {
     /// Panics if the path has no parent.
     pub fn from_path(path: impl AsRef<Path>) -> Result<Self, Error> {
         let path = path.as_ref();
-        let prog =
-            Program::new_from_file(path, std::io::stderr(), NullReporter {}).with_path(path)?;
+        let prog = ProgramBuilder::new()
+            .add_path(path.as_os_str().to_owned())
+            .with_trace(std::io::stderr())
+            .build()?;
         ManifestFile::from_prog(path, prog)
     }
 
     /// Parse a file from UTF-8 data, evaluate it as a nickel file, and return the evaluated manifest.
     pub fn from_contents(data: &[u8]) -> Result<Self, Error> {
-        let prog = Program::new_from_source(
-            std::io::Cursor::new(data),
-            "<in-memory manifest>",
-            std::io::stderr(),
-            NullReporter {},
-        )
-        .without_path()?;
+        let prog = ProgramBuilder::new()
+            .add_source(
+                std::io::Cursor::new(data.to_owned()),
+                "<in-memory manifest>",
+            )
+            .with_trace(std::io::stderr())
+            .build()
+            .map_err(|e| crate::error::Error::Io {
+                path: None,
+                error: std::io::Error::other(format!("{e:?}")),
+            })?;
         ManifestFile::from_prog("<generated>".as_ref(), prog)
     }
 

--- a/package/tests/integration.rs
+++ b/package/tests/integration.rs
@@ -3,9 +3,9 @@ use std::{path::Path, process::ExitCode, sync::Arc};
 use util::{PackageBuilder, set_up_git_repo};
 
 use nickel_lang_core::{
-    error::{NullReporter, report::report_as_str},
+    error::report::report_as_str,
     eval::cache::lazy::CBNCache,
-    program::Program,
+    program::{Program, ProgramBuilder},
 };
 use nickel_lang_package::{
     ManifestFile, config::Config, index::PackageIndex, lock::LockFile, manifest::MANIFEST_NAME,
@@ -258,9 +258,11 @@ fn eval_all(manifest_path: &Path, config: &Config) {
         if name == MANIFEST_NAME || !name.ends_with(".ncl") {
             continue;
         }
-        let mut program =
-            Program::<CBNCache>::new_from_file(&path, std::io::sink(), NullReporter {}).unwrap();
-        program.set_package_map(map.clone());
+        let mut program: Program<CBNCache> = ProgramBuilder::new()
+            .add_path(path.as_os_str().to_owned())
+            .with_package_map(map.clone())
+            .build()
+            .unwrap();
         if let Err(e) = program.eval_full() {
             panic!(
                 "{}",

--- a/parser/src/ast/alloc.rs
+++ b/parser/src/ast/alloc.rs
@@ -69,6 +69,12 @@ pub struct AstAlloc {
     error_arena: typed_arena::Arena<ParseError>,
 }
 
+impl Default for AstAlloc {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl AstAlloc {
     /// Creates a new ast allocator.
     pub fn new() -> Self {

--- a/py-nickel/src/lib.rs
+++ b/py-nickel/src/lib.rs
@@ -1,13 +1,12 @@
 use std::ffi::OsString;
-use std::io::Cursor;
 
 use nickel_lang_core::{
     error::{
-        Error, NullReporter,
+        Error,
         report::{ColorOpt, report_as_str},
     },
     eval::cache::{Cache, CacheImpl},
-    program::Program,
+    program::{Program, ProgramBuilder},
     serialize,
 };
 
@@ -36,16 +35,13 @@ fn error_to_exception<E: Into<Error>, EC: Cache>(error: E, program: &mut Program
 #[pyfunction]
 #[pyo3(signature = (expr, import_paths=None))]
 pub fn run(expr: String, import_paths: Option<Vec<OsString>>) -> PyResult<String> {
-    let mut program: Program<CacheImpl> = Program::new_from_source(
-        Cursor::new(expr),
-        "python",
-        std::io::sink(),
-        NullReporter {},
-    )?;
-
+    let mut builder = ProgramBuilder::new().add_source_string(expr, "python");
     if let Some(import_paths) = import_paths {
-        program.add_import_paths(import_paths.into_iter());
+        builder = builder.add_import_paths(import_paths);
     }
+    let mut program: Program<CacheImpl> = builder
+        .build()
+        .expect("building from a single in-memory source cannot fail");
 
     let term = program
         .eval_full()

--- a/utils/src/test_program.rs
+++ b/utils/src/test_program.rs
@@ -1,27 +1,23 @@
 use nickel_lang_core::{
     ast::{Ast, AstAlloc},
-    error::{Error, NullReporter, ParseError},
+    error::{Error, ParseError},
     eval::{cache::CacheImpl, value::NickelValue},
     files::Files,
     parser::{ErrorTolerantParser as _, ErrorTolerantParserCompat, ExtendedTerm, grammar, lexer},
     position::PosTable,
-    program::Program,
+    program::{Program, ProgramBuilder},
     typecheck::TypecheckMode,
 };
-
-use std::io::Cursor;
 
 pub type TestProgram = Program<CacheImpl>;
 
 /// Create a program from a Nickel expression provided as a string.
 pub fn program_from_expr(s: impl std::string::ToString) -> TestProgram {
-    TestProgram::new_from_source(
-        Cursor::new(s.to_string()),
-        "test",
-        std::io::stderr(),
-        NullReporter {},
-    )
-    .unwrap()
+    ProgramBuilder::new()
+        .add_source_string(s.to_string(), "test")
+        .with_trace(std::io::stderr())
+        .build()
+        .unwrap()
 }
 
 pub fn eval(s: impl std::string::ToString) -> Result<NickelValue, Error> {
@@ -67,6 +63,9 @@ pub fn typecheck_fixture(f: &str) -> Result<(), Error> {
 
 fn program_from_test_fixture(f: &str) -> Program<CacheImpl> {
     let path = format!("{}/../tests/integration/{}", env!("CARGO_MANIFEST_DIR"), f);
-    Program::new_from_file(&path, std::io::stderr(), NullReporter {})
-        .unwrap_or_else(|e| panic!("Could not create program from `{path}`\n {e}"))
+    ProgramBuilder::new()
+        .add_path(&path)
+        .with_trace(std::io::stderr())
+        .build()
+        .unwrap_or_else(|e| panic!("Could not create program from `{path}`\n {e:?}"))
 }


### PR DESCRIPTION
Relates: #2600 

Creates a `ProgramBuilder` type to configure a `Program`, removing the ~11 different new_* methods that existed before.

Rough flow is:

```rust
let mut prog: Program<CacheImpl> = ProgramBuilder::new()
            .add_source(Cursor::new(s.to_owned()), "<test>")
            .with_trace(std::io::stderr())
            .build()
            .unwrap();
```

Spicy's:

 * I opted to erase the `T: Read` on the current `Input<T,S>` with `Box<dyn Read>`, so we didnt have to do the whole turbofish syntax to specify a type for an input that didnt need it.
 * Bikeshedding: should we name it `Builder` so its `program::Builder`? 

Future work:

 * new builder methods/fields to control the initial environmenrt as discussed in #2600