### PR TITLE
Implement ProgramBuilder::extend_initial_env and plumbing

### DIFF
--- a/core/src/cache.rs
+++ b/core/src/cache.rs
@@ -1377,6 +1377,16 @@ impl CacheHub {
         asts.add_type_bindings(pos_table, slice, term)
     }
 
+    /// Registers each given identifier in the typing environment as `Dyn`. Used to expose
+    /// host-provided top-level names to the typechecker. See
+    /// [AstCache::add_dyn_type_bindings] for details.
+    pub fn add_dyn_type_bindings<I>(&mut self, idents: I)
+    where
+        I: IntoIterator<Item = crate::identifier::Ident>,
+    {
+        self.asts.add_dyn_type_bindings(&self.sources, idents);
+    }
+
     /// Converts an AST and all of its transitive dependencies to the runtime representation,
     /// populating the term cache. `file_id` and any of its Nickel dependencies must be present in
     /// the AST cache, or [CacheError::IncompatibleState] is returned. However, for non-Nickel
@@ -2851,6 +2861,26 @@ mod ast_cache {
                     .collect();
 
                 *slf.type_ctxt = typecheck::mk_initial_ctxt(slf.alloc, stdlib_terms_vec).unwrap();
+            });
+        }
+
+        /// Adds bindings to the typing environment with type [`ast::typ::TypeF::Dyn`], one per
+        /// identifier in `idents`. Used to expose host-provided extras to the typechecker without
+        /// committing to a more precise type.
+        ///
+        /// Ensures that the initial typing context is populated first, so the registrations are
+        /// layered on top of stdlib and win on collision.
+        pub fn add_dyn_type_bindings<I>(&mut self, sources: &SourceCache, idents: I)
+        where
+            I: IntoIterator<Item = crate::identifier::Ident>,
+        {
+            self.populate_type_ctxt(sources);
+            self.with_mut(|slf| {
+                for ident in idents {
+                    slf.type_ctxt
+                        .type_env
+                        .insert(ident, typecheck::UnifType::concrete(ast::typ::TypeF::Dyn));
+                }
             });
         }
 

--- a/core/src/eval/mod.rs
+++ b/core/src/eval/mod.rs
@@ -140,6 +140,11 @@ pub struct VmContext<R: ImportResolver, C: Cache> {
     pub cache: C,
     /// The position table, mapping position indices to spans.
     pub pos_table: PosTable,
+    /// Bindings to layer on top of the stdlib in the initial environment when a [VirtualMachine]
+    /// is created via [VirtualMachine::new]. On collision, the extension wins; on duplicate
+    /// identifiers within the vector, the later entry wins. Configured via
+    /// [Self::with_extend_env]; defaults to empty.
+    extend_env: Vec<(Ident, NickelValue)>,
 }
 
 impl<R: ImportResolver, C: Cache> VmContext<R, C> {
@@ -167,7 +172,17 @@ impl<R: ImportResolver, C: Cache> VmContext<R, C> {
             reporter: Box::new(reporter),
             cache: C::new(),
             pos_table,
+            extend_env: Vec::new(),
         }
+    }
+
+    /// Layer additional bindings on top of the stdlib in the initial environment of any
+    /// [VirtualMachine] subsequently constructed from this context. Calling this
+    /// multiple times replaces the previously configured bindings. On collision
+    /// with the initial evaluation environment, the extension wins.
+    pub fn with_extend_env(mut self, env: Vec<(Ident, NickelValue)>) -> Self {
+        self.extend_env = env;
+        self
     }
 }
 
@@ -200,6 +215,15 @@ impl<C: Cache> VmContext<ImportCaches, C> {
         self.prepare_eval_impl(main_id, false)
     }
 
+    /// Register every binding configured via [Self::with_extend_env] in the typing context as
+    /// `Dyn`. No-op if the extend env is empty. Idempotent: callable multiple times.
+    pub fn register_extend_env_for_typecheck(&mut self) {
+        if !self.extend_env.is_empty() {
+            let idents: Vec<_> = self.extend_env.iter().map(|(id, _)| *id).collect();
+            self.import_resolver.add_dyn_type_bindings(idents);
+        }
+    }
+
     fn prepare_eval_impl(
         &mut self,
         main_id: FileId,
@@ -209,6 +233,8 @@ impl<C: Cache> VmContext<ImportCaches, C> {
             "runtime:prepare_stdlib",
             self.import_resolver.prepare_stdlib(&mut self.pos_table)?
         );
+
+        self.register_extend_env_for_typecheck();
 
         measure_runtime!(
             "runtime:prepare_main",
@@ -1227,8 +1253,19 @@ impl<'ctxt, R: ImportResolver, C: Cache> VirtualMachine<'ctxt, R, C> {
 impl<'ctxt, C: Cache> VirtualMachine<'ctxt, ImportCaches, C> {
     /// Creates a new VM, and automatically fills the initial environment with
     /// `context.import_resolver.mk_initial_env()`.
+    ///
+    /// Use [VmContext::with_extend_env] to expose additional names
+    /// at the top level.
     pub fn new(context: &'ctxt mut VmContext<ImportCaches, C>) -> Self {
-        let initial_env = context.import_resolver.mk_eval_env(&mut context.cache);
+        let mut initial_env = context.import_resolver.mk_eval_env(&mut context.cache);
+        // Allocate a fresh thunk for each extras binding. The values were supplied by the
+        // caller in raw form, so we wrap them in closures with an empty local env before
+        // inserting into the initial env. Later entries shadow earlier ones on duplicate
+        // identifiers, and any binding here shadows the stdlib on collision.
+        for (id, value) in &context.extend_env {
+            let idx = context.cache.add(value.clone().into(), BindingType::Normal);
+            initial_env.insert(*id, idx);
+        }
 
         VirtualMachine {
             context,

--- a/core/src/eval/tests.rs
+++ b/core/src/eval/tests.rs
@@ -428,3 +428,75 @@ fn foreign_id() {
     let fid = LocIdent::from(Ident::new("ForeignId"));
     assert_matches!(ty.as_enum_tag(), Some(f) if f == fid);
 }
+
+// Tests for the `extend_env` plumbing on `VmContext`: bindings layered on top of the stdlib at
+// `VirtualMachine::new` time, with extras winning on collision.
+mod extras {
+    use super::*;
+    use crate::{
+        cache::{CacheHub, SourcePath},
+        error::Error,
+    };
+
+    /// Build a program with the given source and extras, prepare and evaluate it.
+    fn run(source: &str, extras: Vec<(Ident, NickelValue)>) -> Result<NickelValue, Error> {
+        let mut cache = CacheHub::new();
+        let file_id = cache
+            .sources
+            .add_string(SourcePath::Generated("test".into()), source.to_string());
+
+        let mut vm_ctxt: VmContext<_, CacheImpl> =
+            VmContext::new(cache, std::io::sink(), NullReporter {}).with_extend_env(extras);
+
+        let prepared = vm_ctxt.prepare_eval(file_id)?;
+        Ok(VirtualMachine::new(&mut vm_ctxt).eval(prepared)?)
+    }
+
+    #[test]
+    fn extras_resolved() {
+        let v = run("a + 1", vec![("a".into(), mk_term::integer(1))]).unwrap();
+        assert_eq!(v.without_pos(), mk_term::integer(2));
+    }
+
+    #[test]
+    fn extras_alongside_stdlib() {
+        // Reference both the extra `a` and an stdlib symbol; std.array.length [a] == 1.
+        let v = run(
+            "std.array.length [a]",
+            vec![("a".into(), mk_term::integer(1))],
+        )
+        .unwrap();
+        assert_eq!(v.without_pos(), mk_term::integer(1));
+    }
+
+    #[test]
+    fn extras_win_collision() {
+        // Override the top-level `std` binding with an integer to prove extras shadow stdlib.
+        let v = run("std", vec![("std".into(), mk_term::integer(42))]).unwrap();
+        assert_eq!(v.without_pos(), mk_term::integer(42));
+    }
+
+    #[test]
+    fn empty_extras_is_noop() {
+        let with_empty = run("std.array.length [1, 2, 3]", Vec::new())
+            .unwrap()
+            .without_pos();
+
+        // Same source evaluated with no extras configured at all.
+        let mut cache = CacheHub::new();
+        let file_id = cache.sources.add_string(
+            SourcePath::Generated("test".into()),
+            String::from("std.array.length [1, 2, 3]"),
+        );
+        let mut vm_ctxt: VmContext<_, CacheImpl> =
+            VmContext::new(cache, std::io::sink(), NullReporter {});
+        let prepared = vm_ctxt.prepare_eval(file_id).unwrap();
+        let baseline = VirtualMachine::new(&mut vm_ctxt)
+            .eval(prepared)
+            .unwrap()
+            .without_pos();
+
+        assert_eq!(with_empty, baseline);
+        assert_eq!(with_empty, mk_term::integer(3));
+    }
+}

--- a/core/src/program.rs
+++ b/core/src/program.rs
@@ -34,7 +34,7 @@ use crate::{
         value::{Container, NickelValue, ValueContent},
     },
     files::{FileId, Files},
-    identifier::LocIdent,
+    identifier::{Ident, LocIdent},
     label::Label,
     metrics::{increment, measure_runtime},
     package::PackageMap,
@@ -610,6 +610,8 @@ impl<EC: EvalCache> Program<EC> {
         }
 
         self.vm_ctxt.import_resolver.load_stdlib()?;
+        self.vm_ctxt.register_extend_env_for_typecheck();
+
         self.vm_ctxt
             .import_resolver
             .typecheck(self.main_id, initial_mode)
@@ -1025,6 +1027,7 @@ pub struct ProgramBuilder<R = NullReporter, W = io::Sink> {
     contract_paths: Vec<OsString>,
     import_paths: Vec<PathBuf>,
     package_map: Option<PackageMap>,
+    extra_env: Vec<(Ident, NickelValue)>,
     trace: W,
     reporter: R,
 }
@@ -1047,6 +1050,7 @@ impl ProgramBuilder {
             contract_paths: Vec::new(),
             import_paths: Vec::new(),
             package_map: None,
+            extra_env: Vec::new(),
             trace: io::sink(),
             reporter: NullReporter {},
         }
@@ -1167,6 +1171,7 @@ impl<R, W> ProgramBuilder<R, W> {
             contract_paths: self.contract_paths,
             import_paths: self.import_paths,
             package_map: self.package_map,
+            extra_env: self.extra_env,
             trace,
             reporter: self.reporter,
         }
@@ -1185,9 +1190,32 @@ impl<R, W> ProgramBuilder<R, W> {
             contract_paths: self.contract_paths,
             import_paths: self.import_paths,
             package_map: self.package_map,
+            extra_env: self.extra_env,
             trace: self.trace,
             reporter,
         }
+    }
+
+    /// Layer additional bindings in addition to the standard library in the program's initial
+    /// environment.
+    ///
+    /// Calling this method multiple times is additive: bindings accumulate, with later
+    /// calls overriding earlier ones on collision.
+    ///
+    /// ```
+    /// use nickel_lang_core::{
+    ///     eval::value::NickelValue,
+    ///     identifier::Ident,
+    /// };
+    ///
+    /// let extras: Vec<(Ident, NickelValue)> = vec![
+    ///     (Ident::from("hostname"), NickelValue::string_posless("example.com")),
+    /// ];
+    /// // `extras` can now be passed to ProgramBuilder::extend_initial_env
+    /// ```
+    pub fn extend_initial_env(mut self, env: Vec<(Ident, NickelValue)>) -> Self {
+        self.extra_env.extend(env);
+        self
     }
 }
 
@@ -1211,6 +1239,7 @@ where
             contract_paths,
             import_paths,
             package_map,
+            extra_env,
             trace,
             reporter,
         } = self;
@@ -1266,7 +1295,7 @@ where
             contracts.push(ProgramContract::Source(file_id));
         }
 
-        let vm_ctxt = VmContext::new(cache, trace, reporter);
+        let vm_ctxt = VmContext::new(cache, trace, reporter).with_extend_env(extra_env);
 
         Ok(Program {
             main_id,
@@ -1773,5 +1802,73 @@ mod tests {
             Err(e) => panic!("expected IOError, got {e:?}"),
             Ok(_) => panic!("expected error for empty input set"),
         }
+    }
+
+    #[test]
+    fn builder_extend_initial_env_basic() {
+        let mut prog: Program<CacheImpl> = ProgramBuilder::new()
+            .add_source_string("a + 1", "<extras-basic>")
+            .extend_initial_env(vec![("a".into(), mk_term::integer(1))])
+            .build()
+            .unwrap();
+
+        let v = prog.eval().unwrap();
+        assert_eq!(v.without_pos(), mk_term::integer(2));
+    }
+
+    #[test]
+    fn builder_no_extend_unchanged() {
+        let mut prog: Program<CacheImpl> = ProgramBuilder::new()
+            .add_source_string("a + 1", "<extras-absent>")
+            .build()
+            .unwrap();
+
+        let err = prog.eval().expect_err("extras path should not leak");
+        let msg = format!("{err:?}");
+        assert!(
+            msg.contains("UnboundIdentifier"),
+            "expected an unbound-identifier error, got: {msg}",
+        );
+    }
+
+    #[test]
+    fn builder_extras_with_stdlib() {
+        let mut prog: Program<CacheImpl> = ProgramBuilder::new()
+            .add_source_string("std.array.length [a, a, a]", "<extras-stdlib>")
+            .extend_initial_env(vec![("a".into(), mk_term::integer(7))])
+            .build()
+            .unwrap();
+
+        let v = prog.eval().unwrap();
+        assert_eq!(v.without_pos(), mk_term::integer(3));
+    }
+
+    #[test]
+    fn builder_typecheck_accepts_extras() {
+        // In walk mode, untyped code that references `a` typechecks as long as `a` is bound.
+        // Registering `a` as `Dyn` via extras lets the typechecker resolve the identifier.
+        let source = "a + 1";
+        let mut prog: Program<CacheImpl> = ProgramBuilder::new()
+            .add_source_string(source, "<extras-typecheck>")
+            .extend_initial_env(vec![("a".into(), mk_term::integer(1))])
+            .build()
+            .unwrap();
+
+        prog.typecheck(TypecheckMode::Walk)
+            .expect("typecheck should resolve `a` from extras as Dyn");
+    }
+
+    #[test]
+    fn typecheck_unbound_when_extras_absent() {
+        let source = "a + 1";
+        let mut prog: Program<CacheImpl> = ProgramBuilder::new()
+            .add_source_string(source, "<extras-typecheck-absent>")
+            .build()
+            .unwrap();
+
+        let err = prog
+            .typecheck(TypecheckMode::Walk)
+            .expect_err("typecheck must fail without extras");
+        assert_matches!(err, Error::TypecheckError(_));
     }
 }

--- a/utils/src/bench.rs
+++ b/utils/src/bench.rs
@@ -178,13 +178,12 @@ macro_rules! ncl_bench_group {
                                 runner = resolve_imports(&mut pos_table, runner, &mut cache).unwrap().transformed_term;
                             }
 
-                            let vm_ctxt = VmContext {
-                                    import_resolver: cache,
-                                    trace: Box::new(std::io::sink()),
-                                    reporter: Box::new(nickel_lang_core::error::NullReporter {}),
-                                    cache: eval_cache.clone(),
-                                    pos_table,
-                            };
+                            let vm_ctxt: VmContext<_, CacheImpl> = VmContext::new_with_pos_table(
+                                cache,
+                                pos_table,
+                                std::io::sink(),
+                                nickel_lang_core::error::NullReporter {},
+                            );
 
                             // We need to make a new eval environment for each instance. First,
                             // envs contain thunks, which are shared state and will have different


### PR DESCRIPTION
Fixes #2600 

This PR implements the ability for a user of `Program` to define additional values in the initial environment.

The wiggly-est bit was trying to make this work with the typecheck logic + the cache types. I kinda short-circuited on just registering everything as a `Dyn` - let me know if this is inappropriate or you have suggestions of how we should integrate with the type check path.

I also made `Environment` be the type where additional bindings are communicated, but given you have to mint it with a `CacheImpl` im not sure that was the right choice.