### PR TITLE
fix(stdlib): avoid panic in string.find on a match at the end of the string

### DIFF
--- a/core/src/term/string.rs
+++ b/core/src/term/string.rs
@@ -329,10 +329,18 @@ impl NickelString {
             // The indices returned by the `regex` crate are byte offsets into
             // the string, but we need to return the index into the Nickel string,
             // i.e., the grapheme cluster index which starts at this byte offset.
+            //
+            // A match can start at the very end of the string (for example an
+            // empty match like `^$` on the empty string), in which case no
+            // grapheme cluster starts at that byte offset. We append the
+            // byte length paired with the total cluster count so that such a
+            // match maps to the index past the last cluster.
             let adjusted_index = self
                 .grapheme_indices(true)
                 .enumerate()
-                .find_map(|(grapheme_idx, (byte_offset, _))| {
+                .map(|(grapheme_idx, (byte_offset, _))| (byte_offset, grapheme_idx))
+                .chain(std::iter::once((self.len(), self.length())))
+                .find_map(|(byte_offset, grapheme_idx)| {
                     if byte_offset == first_match.start() {
                         Some(grapheme_idx.into())
                     } else {

--- a/core/tests/integration/inputs/stdlib/string_find.ncl
+++ b/core/tests/integration/inputs/stdlib/string_find.ncl
@@ -8,5 +8,6 @@ let { string, .. } = std in
   std.string.find "(\\d+)\\.(\\d+)\\.(\\d+)" "1.2.3" == { groups = ["1", "2", "3"], index = 0, matched = "1.2.3" },
   std.string.find "(\\p{Emoji})=(\\w+)" "😀=smiling" == { groups = ["😀", "smiling"], index = 0, matched = "😀=smiling" },
   std.string.find "a(b)?" "ac" == { groups = [""], index = 0, matched = "a" },
+  std.string.find "^$" "" == { groups = [], index = 0, matched = "" },
 ]
 |> std.test.assert_all


### PR DESCRIPTION
Fixes #2627.

`std.string.find` panics when the match ends at the end of the string, such as `std.string.find "^$" ""`. The code translates the regex byte offset to a grapheme cluster index by scanning `grapheme_indices`, but no cluster starts at the very end of the string (and the empty string has no clusters at all), so the `expect` on the lookup fires.

The byte offset for a match at the end of the string equals the string's byte length, which maps to the total cluster count. I append that pair to the scan so the lookup resolves instead of panicking, and added the empty-match case from the issue to the existing `string_find` fixture.