### PR TITLE
Fix parse error when using negative number literals in match patterns

### DIFF
--- a/core/tests/integration/inputs/pattern-matching/basics.ncl
+++ b/core/tests/integration/inputs/pattern-matching/basics.ncl
@@ -58,5 +58,10 @@
   }
   |> eval {}
   |> (==) 11,
+
+  match {
+    -1 => true,
+    _ => false,
+  } (-1)
 ]
 |> std.test.assert_all

--- a/parser/src/ast/mod.rs
+++ b/parser/src/ast/mod.rs
@@ -487,6 +487,23 @@ impl<'ast> Ast<'ast> {
                         })),
                         ..r.clone()
                     })),
+                    Node::Match(m) => {
+                        let branches = alloc.alloc_many(m.branches.iter().cloned().map(|branch| {
+                            MatchBranch {
+                                pattern: branch.pattern.without_pos(alloc),
+                                ..branch
+                            }
+                        }));
+                        Node::Match(Match { branches })
+                    }
+                    Node::Fun { args, body } => {
+                        let new_args =
+                            alloc.alloc_many(args.iter().map(|it| it.clone().without_pos(alloc)));
+                        Node::Fun {
+                            args: new_args,
+                            body,
+                        }
+                    }
                     n => n,
                 };
                 Ok(Ast {

--- a/parser/src/ast/pattern/mod.rs
+++ b/parser/src/ast/pattern/mod.rs
@@ -3,6 +3,8 @@ use std::collections::{HashMap, hash_map::Entry};
 
 use super::{Annotation, Ast, Number};
 
+#[cfg(test)]
+use crate::ast::AstAlloc;
 use crate::{
     error::ParseError, identifier::LocIdent, impl_display_from_bytecode_pretty, position::TermPos,
     traverse::*,
@@ -151,6 +153,112 @@ impl Pattern<'_> {
             Some(*id)
         } else {
             None
+        }
+    }
+}
+
+impl<'ast> Pattern<'ast> {
+    #[cfg(test)]
+    /// Recursively remove all positions from a pattern. This is used in testing to check equality
+    /// between expressions while ignoring location.
+    pub fn without_pos(self, alloc: &'ast AstAlloc) -> Pattern<'ast> {
+        let pattern_data = match &self.data {
+            PatternData::Constant(pattern) => {
+                let new_pattern = alloc.alloc(ConstantPattern {
+                    data: pattern.data.clone(),
+                    pos: TermPos::None,
+                });
+                PatternData::Constant(new_pattern)
+            }
+            PatternData::Or(pattern) => {
+                let patterns = alloc.alloc_many(
+                    pattern
+                        .patterns
+                        .into_iter()
+                        .map(|it| it.clone().without_pos(alloc)),
+                );
+                let new_pattern = alloc.alloc(OrPattern {
+                    patterns,
+                    pos: TermPos::None,
+                });
+                PatternData::Or(new_pattern)
+            }
+            PatternData::Any(ident) => PatternData::Any(ident.with_pos(TermPos::None)),
+            PatternData::Array(pattern) => {
+                let patterns = alloc.alloc_many(
+                    pattern
+                        .patterns
+                        .iter()
+                        .map(|it| it.clone().without_pos(alloc)),
+                );
+                let tail = match &pattern.tail {
+                    TailPattern::Capture(ident) => {
+                        TailPattern::Capture(ident.with_pos(TermPos::None))
+                    }
+                    other => other.clone(),
+                };
+                let new_pattern = alloc.alloc(ArrayPattern {
+                    patterns,
+                    tail,
+                    pos: TermPos::None,
+                });
+                PatternData::Array(new_pattern)
+            }
+            PatternData::Enum(pattern) => {
+                let new_pattern = alloc.alloc(EnumPattern {
+                    tag: pattern.tag.with_pos(TermPos::None),
+                    pattern: pattern
+                        .pattern
+                        .as_ref()
+                        .map(|it| it.clone().without_pos(alloc)),
+                    pos: TermPos::None,
+                });
+                PatternData::Enum(new_pattern)
+            }
+            PatternData::Record(pattern) => {
+                let patterns = alloc.alloc_many(pattern.patterns.iter().map(|it| {
+                    let an_typ = it
+                        .annotation
+                        .typ
+                        .clone()
+                        .map(|typ| typ.with_pos(TermPos::None));
+                    let an_contracts = alloc.alloc_many(
+                        it.annotation
+                            .contracts
+                            .iter()
+                            .map(|it| it.clone().with_pos(TermPos::None)),
+                    );
+                    let default = it.default.as_ref().map(|it| it.clone().without_pos(alloc));
+                    FieldPattern {
+                        matched_id: it.matched_id.with_pos(TermPos::None),
+                        annotation: Annotation {
+                            typ: an_typ,
+                            contracts: an_contracts,
+                        },
+                        default,
+                        pattern: it.pattern.clone().without_pos(alloc),
+                        pos: TermPos::None,
+                    }
+                }));
+                let tail = match &pattern.tail {
+                    TailPattern::Capture(ident) => {
+                        TailPattern::Capture(ident.with_pos(TermPos::None))
+                    }
+                    other => other.clone(),
+                };
+                let new_pattern = alloc.alloc(RecordPattern {
+                    patterns,
+                    tail,
+                    pos: TermPos::None,
+                });
+                PatternData::Record(new_pattern)
+            }
+            PatternData::Wildcard => PatternData::Wildcard,
+        };
+        Pattern {
+            data: pattern_data,
+            pos: TermPos::None,
+            alias: self.alias.map(|it| it.with_pos(TermPos::None)),
         }
     }
 }

--- a/parser/src/ast/pattern/mod.rs
+++ b/parser/src/ast/pattern/mod.rs
@@ -3,8 +3,6 @@ use std::collections::{HashMap, hash_map::Entry};
 
 use super::{Annotation, Ast, Number};
 
-#[cfg(test)]
-use crate::ast::AstAlloc;
 use crate::{
     error::ParseError, identifier::LocIdent, impl_display_from_bytecode_pretty, position::TermPos,
     traverse::*,
@@ -161,7 +159,7 @@ impl<'ast> Pattern<'ast> {
     #[cfg(test)]
     /// Recursively remove all positions from a pattern. This is used in testing to check equality
     /// between expressions while ignoring location.
-    pub fn without_pos(self, alloc: &'ast AstAlloc) -> Pattern<'ast> {
+    pub fn without_pos(self, alloc: &'ast crate::ast::AstAlloc) -> Pattern<'ast> {
         let pattern_data = match &self.data {
             PatternData::Constant(pattern) => {
                 let new_pattern = alloc.alloc(ConstantPattern {
@@ -174,7 +172,7 @@ impl<'ast> Pattern<'ast> {
                 let patterns = alloc.alloc_many(
                     pattern
                         .patterns
-                        .into_iter()
+                        .iter()
                         .map(|it| it.clone().without_pos(alloc)),
                 );
                 let new_pattern = alloc.alloc(OrPattern {

--- a/parser/src/grammar.lalrpop
+++ b/parser/src/grammar.lalrpop
@@ -806,7 +806,7 @@ ConstantPattern: ConstantPattern<'ast> = {
 
 ConstantPatternData: ConstantPatternData<'ast> = {
     Bool => ConstantPatternData::Bool(<>),
-    NumberLiteral => ConstantPatternData::Number(alloc.alloc_number(<>)),
+    SignedNumLiteral => ConstantPatternData::Number(alloc.alloc_number(<>)),
     // We could accept multiline strings here, but it's unlikely that this will
     // result in very readable match expressions. For now we restrict ourselves
     // to standard string; we can always extend to multiline later if needed

--- a/parser/src/tests.rs
+++ b/parser/src/tests.rs
@@ -1,7 +1,8 @@
 use crate::{
     ErrorTolerantParser,
     ast::{
-        Ast, AstAlloc, InputFormat, Node, Number, StringChunk, builder,
+        Ast, AstAlloc, InputFormat, MatchBranch, Node, Number, StringChunk, builder,
+        pattern::{ConstantPattern, ConstantPatternData},
         primop::PrimOp,
         record::{FieldDef, FieldMetadata, FieldPathElem, Record},
     },
@@ -706,6 +707,33 @@ fn ty_var_kind_mismatch() {
             name
         )
     }
+}
+
+#[test]
+// Regression test for [#2629](https://github.com/nickel-lang/nickel/issues/2629)
+fn negative_num_in_match_pattern() {
+    use crate::ast::pattern;
+    let alloc = AstAlloc::new();
+
+    let pattern_val = Number::from(-1);
+    let pattern = ConstantPattern {
+        data: ConstantPatternData::Number(&pattern_val),
+        pos: TermPos::None,
+    };
+    assert_eq!(
+        parse_without_pos(&alloc, "match { -1 => 1 }"),
+        alloc
+            .match_expr(vec![MatchBranch {
+                pattern: pattern::Pattern {
+                    data: pattern::PatternData::Constant(&pattern),
+                    alias: None,
+                    pos: TermPos::None
+                },
+                guard: None,
+                body: alloc.number(Number::from(1)).into()
+            }])
+            .into()
+    );
 }
 
 #[test]


### PR DESCRIPTION
Fixes #2629

The main change here is to match a `SignedNumLiteral` instead of a `NumberLiteral` in constant patterns so negative values can be matched. The rest is just to get `without_pos` to work for patterns so I can write a test for it. The `without_pos` implementation isn't fully tested and is likely to have some issues but it's only used in `#[cfg(test)]` so I hope that's all right.