### PR TITLE
Update vscode package metadata

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -684,14 +684,14 @@
 
       # Build the Nickel VSCode extension
       vscodeExtension = pkgs.mkYarnPackage {
-        pname = "vscode-nickel";
+        pname = "vscode-nickel-lang";
         src = pkgs.lib.cleanSource ./lsp/vscode-extension;
 
         buildPhase = ''
           # yarn tries to create a .yarn file in $HOME. There's probably a
           # better way to fix this but setting HOME to TMPDIR works for now.
           export HOME="$TMPDIR"
-          cd deps/vscode-nickel
+          cd deps/vscode-nickel-lang
           yarn --offline compile
           yarn --offline vsce package --yarn -o $pname.vsix
         '';

--- a/lsp/README.md
+++ b/lsp/README.md
@@ -86,25 +86,25 @@ your editor.
 
 #### Build the extension
 
-NLS is currently not available through the vscode marketplace, but this
-repository includes an extension that can be built locally via Nix (see the
-section about the Nix setup).
+NLS is currently available through the vscode and openvsx.org marketplaces (just
+search for `nickel-lang`), but this repository also includes an extension that
+can be built locally via Nix (see the section about the Nix setup).
 
 - One-liner:
 
   ```console
-  code --install-extension $(nix build ./\#vscodeExtension --no-link --print-out-paths)/vscode-nickel.vsix
+  code --install-extension $(nix build ./\#vscodeExtension --no-link --print-out-paths)/vscode-nickel-lang.vsix
   ```
 
 - In two steps, going via VSCode:
   - Build with Nix:
 
       ```console
-      nix build github:tweag/nickel#vscodeExtension
+      nix build github:nickel-lang/nickel#vscodeExtension
       ```
 
   - Then, in VSCode, use "Extension: Install from VSIX" in the vscode command
-    palette and choose `./result/vscode-nickel.vsix`.
+    palette and choose `./result/vscode-nickel-lang.vsix`.
 
 #### Configuration
 

--- a/lsp/vscode-extension/README.md
+++ b/lsp/vscode-extension/README.md
@@ -56,7 +56,7 @@ From the root of the Nickel project:
 nix build .\#vscodeExtension
 ```
 
-The VSIX extension will be at `./result/vscode-nickel.vsix`.
+The VSIX extension will be at `./result/vscode-nickel-lang.vsix`.
 
 ### With Yarn
 
@@ -66,7 +66,7 @@ From this directory:
 yarn install && yarn compile && yarn vsce package --yarn
 ```
 
-The VSIX extension will be at `./vscode-nickel-[version].vsix`.
+The VSIX extension will be at `./vscode-nickel-lang-[version].vsix`.
 
 ## Updating `package.json`
 

--- a/lsp/vscode-extension/package.json
+++ b/lsp/vscode-extension/package.json
@@ -1,15 +1,15 @@
 {
-  "name": "vscode-nickel",
-  "displayName": "Nickel Language Support",
+  "name": "vscode-nickel-lang",
+  "displayName": "Nickel Configuration Language",
   "description": "Syntax highlighting, formatting and LSP integration for the Nickel programming language in VSCode",
   "author": "Nickel contributors",
   "license": "MIT",
   "version": "0.5.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/tweag/nickel"
+    "url": "https://github.com/nickel-lang/nickel"
   },
-  "publisher": "tweag",
+  "publisher": "nickel-lang",
   "categories": [
     "Programming Languages",
     "Language Packs",


### PR DESCRIPTION
For a start, this updates the repo url in the vscode package metadata, which I think should be uncontroversial.

It also updates the publisher, which is a little more annoying and will cause some churn, but I think this is more accurate? And because vscode marketplace insists on having unique `name` and `displayName` (even across different publishers) it tweaks those fields a little.