### PR TITLE
Add std.array.group

### DIFF
--- a/cli/tests/snapshot/snapshots/snapshot__eval_stderr_array_range_reversed_indices.ncl.snap
+++ b/cli/tests/snapshot/snapshots/snapshot__eval_stderr_array_range_reversed_indices.ncl.snap
@@ -4,9 +4,9 @@ expression: err
 ---
 error: contract broken by the caller of `range`
        invalid range
-    ┌─ <stdlib/std.ncl>:771:9
+    ┌─ <stdlib/std.ncl>:810:9
     │
-771 │       | std.contract.unstable.RangeFun Dyn
+810 │       | std.contract.unstable.RangeFun Dyn
     │         ---------------------------------- expected type
     │
     ┌─ [INPUTS_PATH]/errors/array_range_reversed_indices.ncl:3:19

--- a/cli/tests/snapshot/snapshots/snapshot__eval_stderr_array_range_step_negative_step.ncl.snap
+++ b/cli/tests/snapshot/snapshots/snapshot__eval_stderr_array_range_step_negative_step.ncl.snap
@@ -4,9 +4,9 @@ expression: err
 ---
 error: contract broken by the caller of `range_step`
        invalid range step
-    ┌─ <stdlib/std.ncl>:746:9
+    ┌─ <stdlib/std.ncl>:785:9
     │
-746 │       | std.contract.unstable.RangeFun (std.contract.unstable.RangeStep -> Dyn)
+785 │       | std.contract.unstable.RangeFun (std.contract.unstable.RangeStep -> Dyn)
     │         ----------------------------------------------------------------------- expected type
     │
     ┌─ [INPUTS_PATH]/errors/array_range_step_negative_step.ncl:3:27

--- a/cli/tests/snapshot/snapshots/snapshot__eval_stderr_base64_decode_invalid_encoding.ncl.snap
+++ b/cli/tests/snapshot/snapshots/snapshot__eval_stderr_base64_decode_invalid_encoding.ncl.snap
@@ -4,9 +4,9 @@ expression: err
 ---
 error: contract broken by a value
        Base64 decoding failed: Invalid symbol 33, offset 0.
-     ┌─ <stdlib/std.ncl>:4798:29
+     ┌─ <stdlib/std.ncl>:4837:29
      │
-4798 │         let decoded = str | Base64String
+4837 │         let decoded = str | Base64String
      │                             ------------ expected type
      │
      ┌─ [INPUTS_PATH]/errors/base64_decode_invalid_encoding.ncl:3:36

--- a/cli/tests/snapshot/snapshots/snapshot__eval_stderr_base64_decode_non_string.ncl.snap
+++ b/cli/tests/snapshot/snapshots/snapshot__eval_stderr_base64_decode_non_string.ncl.snap
@@ -4,9 +4,9 @@ expression: err
 ---
 error: contract broken by a value
        Could not convert decoded value to string: invalid utf-8 sequence of 1 bytes from index 0
-     ┌─ <stdlib/std.ncl>:4798:29
+     ┌─ <stdlib/std.ncl>:4837:29
      │
-4798 │         let decoded = str | Base64String
+4837 │         let decoded = str | Base64String
      │                             ------------ expected type
      │
      ┌─ [INPUTS_PATH]/errors/base64_decode_non_string.ncl:3:36

--- a/cli/tests/snapshot/snapshots/snapshot__eval_stderr_fail_with.ncl.snap
+++ b/cli/tests/snapshot/snapshots/snapshot__eval_stderr_fail_with.ncl.snap
@@ -4,9 +4,9 @@ expression: err
 ---
 error: contract broken by a value
        div by zero
-     ┌─ <stdlib/std.ncl>:5340:24
+     ┌─ <stdlib/std.ncl>:5379:24
      │
-5340 │       fun msg => msg | Blame,
+5379 │       fun msg => msg | Blame,
      │                        ----- expected type
      │
      ┌─ [INPUTS_PATH]/errors/fail_with.ncl:5:19

--- a/cli/tests/snapshot/snapshots/snapshot__eval_stderr_subcontract_nested_custom_diagnostics.ncl.snap
+++ b/cli/tests/snapshot/snapshots/snapshot__eval_stderr_subcontract_nested_custom_diagnostics.ncl.snap
@@ -21,9 +21,9 @@ warning: plain functions as contracts are deprecated
    = wrap this function using one of the constructors in `std.contract` instead, like `std.contract.from_validator` or `std.contract.custom`
 
 warning: plain functions as contracts are deprecated
-     ┌─ <stdlib/std.ncl>:1718:9
+     ┌─ <stdlib/std.ncl>:1757:9
      │
-1718 │         %contract/apply% contract (%label/push_diag% label) value,
+1757 │         %contract/apply% contract (%label/push_diag% label) value,
      │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ applied to this term
      │
      ┌─ [INPUTS_PATH]/errors/subcontract_nested_custom_diagnostics.ncl:3:21

--- a/cli/tests/snapshot/snapshots/snapshot__package_stderr_invalid-git-dep.ncl.snap
+++ b/cli/tests/snapshot/snapshots/snapshot__package_stderr_invalid-git-dep.ncl.snap
@@ -6,9 +6,9 @@ error: failed to evaluate package manifest
 
 error: contract broken by the value of `ref`
        expected 40 characters, got 18
-     ┌─ <stdlib/std.ncl>:3369:17
+     ┌─ <stdlib/std.ncl>:3408:17
      │
-3369 │               | [| 'Head, 'Branch String, 'Tag String, 'Commit std.package.GitId |]
+3408 │               | [| 'Head, 'Branch String, 'Tag String, 'Commit std.package.GitId |]
      │                 ------------------------------------------------------------------- expected type
      │
      ┌─ [INPUTS_PATH]/package/invalid-git-dep.ncl:10:60

--- a/cli/tests/snapshot/snapshots/snapshot__package_stderr_invalid-version.ncl.snap
+++ b/cli/tests/snapshot/snapshots/snapshot__package_stderr_invalid-version.ncl.snap
@@ -6,9 +6,9 @@ error: failed to evaluate package manifest
 
 error: contract broken by the value of `version`
        invalid semver
-     ┌─ <stdlib/std.ncl>:3448:17
+     ┌─ <stdlib/std.ncl>:3487:17
      │
-3448 │               | Semver
+3487 │               | Semver
      │                 ------ expected type
      │
      ┌─ [INPUTS_PATH]/package/invalid-version.ncl:6:13

--- a/cli/tests/snapshot/snapshots/snapshot__package_stderr_missing-field.ncl.snap
+++ b/cli/tests/snapshot/snapshots/snapshot__package_stderr_missing-field.ncl.snap
@@ -5,9 +5,9 @@ expression: err
 error: failed to evaluate package manifest
 
 error: missing definition for `authors`
-     ┌─ <stdlib/std.ncl>:3462:13
+     ┌─ <stdlib/std.ncl>:3501:13
      │
-3462 │             authors
+3501 │             authors
      │             ^^^^^^^ required here
      │
      ┌─ [INPUTS_PATH]/package/missing-field.ncl:4:1

--- a/core/stdlib/std.ncl
+++ b/core/stdlib/std.ncl
@@ -524,6 +524,8 @@
           elements that satisfy the predicate, while `wrong` will contain those
           that do not.
 
+          `partition` is a special case of `group`.
+
           # Examples
 
           ```nickel
@@ -531,14 +533,51 @@
           # => { right = [ 2, 4, 3 ], wrong = [ 5, 7, 8, 6 ] }
           ```
         "%
-      = fun pred l =>
-        let aux = fun acc x =>
-          if pred x then
-            { right = acc.right @ [x], wrong = acc.wrong }
-          else
-            { right = acc.right, wrong = acc.wrong @ [x] }
-        in
-        fold_left aux { right = [], wrong = [] } l,
+      = fun pred xs =>
+        let result = group (fun x => if pred x then "right" else "wrong") xs in
+        {
+          right = std.record.get_or "right" [] result,
+          wrong = std.record.get_or "wrong" [] result,
+        },
+
+    group
+      : forall a. (a -> String) -> Array a -> { _ : Array a }
+      | Dyn -> Dyn -> { _ | std.array.NonEmpty }
+      | doc m%"
+        Groups the elements of an array by key. Keys are computed
+        by the given key selection function.
+
+        The result is a dictionary mapping each distinct key to
+        a (non-empty) array of all elements that share this key. The
+        order of the elements is preserved.
+
+        `partition` is a special case of `group`.
+
+        # Examples
+
+        ```nickel multiline
+        group (fun x => x.type) [
+          { type = "fruit", name = "apple" },
+          { type = "vegetable", name = "leek" },
+          { type = "fruit", name = "pear" },
+        ]
+        # => {
+        #      fruit =
+        #        [ { name = "apple", type = "fruit", }, { name = "pear", type = "fruit", } ],
+        #      vegetable = [ { name = "leek", type = "vegetable", } ],
+        #    }
+
+        group (fun x => if x < 5 then "right" else "wrong") [ 2, 4, 5, 3, 7, 8, 6 ]
+        # => { right = [ 2, 4, 3 ], wrong = [ 5, 7, 8, 6 ] }
+        ```
+      "%
+      = fun f =>
+        std.array.fold_left
+          (fun acc x =>
+            let key = f x in
+            std.record.update key (append x (std.record.get_or key [] acc)) acc
+          )
+          {},
 
     generate
       : forall a. (Number -> a) -> Number -> Array a

--- a/core/tests/integration/inputs/core/arrays.ncl
+++ b/core/tests/integration/inputs/core/arrays.ncl
@@ -11,6 +11,10 @@
   std.array.length [1,2,3] == 3,
   std.array.length ([] @ [1,2] @ [3,4] @ []) == 4,
 
+  # group
+  std.array.group std.to_string [] == {},
+  std.array.group std.to_string [1,2,2,3,3,1] == { "1" = [1,1], "2" = [2,2], "3" = [3,3], },
+
   # sort
   let cmp = fun x y =>
     if x < y then 'Lesser


### PR DESCRIPTION
`std.array.group` is a generalization of `std.array.partition` to an
arbitrary number of keys instead of just `right` and `wrong`. Data
munging in Nickel is often structured as chains of calls to
`std.array.flat_map`, `std.array.filter` and the like. This is as in
C#'s [LINQ][ms-query-ops] that calls out 5 basic data operations,
which we only partially support today:

- ✅ filter data with `std.array.filter`
- ✅ order data with `std.array.sort`
- ❌ group data
- ❌ join data (except in a limited form with `std.array.zip`)
- ✅ project data with `std.array.map` and `std.array.flat_map`

Here we implement the "group data" operation.

[ms-query-ops]: https://learn.microsoft.com/en-us/dotnet/csharp/linq/standard-query-operators/
