### PR TITLE
Add std.array.chunk

### DIFF
--- a/cli/tests/snapshot/snapshots/snapshot__eval_stderr_base64_decode_invalid_encoding.ncl.snap
+++ b/cli/tests/snapshot/snapshots/snapshot__eval_stderr_base64_decode_invalid_encoding.ncl.snap
@@ -4,9 +4,9 @@ expression: err
 ---
 error: contract broken by a value
        Base64 decoding failed: Invalid symbol 33, offset 0.
-     ┌─ <stdlib/std.ncl>:4837:29
+     ┌─ <stdlib/std.ncl>:4896:29
      │
-4837 │         let decoded = str | Base64String
+4896 │         let decoded = str | Base64String
      │                             ------------ expected type
      │
      ┌─ [INPUTS_PATH]/errors/base64_decode_invalid_encoding.ncl:3:36

--- a/cli/tests/snapshot/snapshots/snapshot__eval_stderr_base64_decode_invalid_encoding.ncl.snap
+++ b/cli/tests/snapshot/snapshots/snapshot__eval_stderr_base64_decode_invalid_encoding.ncl.snap
@@ -4,9 +4,9 @@ expression: err
 ---
 error: contract broken by a value
        Base64 decoding failed: Invalid symbol 33, offset 0.
-     ┌─ <stdlib/std.ncl>:4896:29
+     ┌─ <stdlib/std.ncl>:4894:29
      │
-4896 │         let decoded = str | Base64String
+4894 │         let decoded = str | Base64String
      │                             ------------ expected type
      │
      ┌─ [INPUTS_PATH]/errors/base64_decode_invalid_encoding.ncl:3:36

--- a/cli/tests/snapshot/snapshots/snapshot__eval_stderr_base64_decode_non_string.ncl.snap
+++ b/cli/tests/snapshot/snapshots/snapshot__eval_stderr_base64_decode_non_string.ncl.snap
@@ -4,9 +4,9 @@ expression: err
 ---
 error: contract broken by a value
        Could not convert decoded value to string: invalid utf-8 sequence of 1 bytes from index 0
-     ┌─ <stdlib/std.ncl>:4837:29
+     ┌─ <stdlib/std.ncl>:4896:29
      │
-4837 │         let decoded = str | Base64String
+4896 │         let decoded = str | Base64String
      │                             ------------ expected type
      │
      ┌─ [INPUTS_PATH]/errors/base64_decode_non_string.ncl:3:36

--- a/cli/tests/snapshot/snapshots/snapshot__eval_stderr_base64_decode_non_string.ncl.snap
+++ b/cli/tests/snapshot/snapshots/snapshot__eval_stderr_base64_decode_non_string.ncl.snap
@@ -4,9 +4,9 @@ expression: err
 ---
 error: contract broken by a value
        Could not convert decoded value to string: invalid utf-8 sequence of 1 bytes from index 0
-     ┌─ <stdlib/std.ncl>:4896:29
+     ┌─ <stdlib/std.ncl>:4894:29
      │
-4896 │         let decoded = str | Base64String
+4894 │         let decoded = str | Base64String
      │                             ------------ expected type
      │
      ┌─ [INPUTS_PATH]/errors/base64_decode_non_string.ncl:3:36

--- a/cli/tests/snapshot/snapshots/snapshot__eval_stderr_fail_with.ncl.snap
+++ b/cli/tests/snapshot/snapshots/snapshot__eval_stderr_fail_with.ncl.snap
@@ -4,9 +4,9 @@ expression: err
 ---
 error: contract broken by a value
        div by zero
-     ┌─ <stdlib/std.ncl>:5379:24
+     ┌─ <stdlib/std.ncl>:5438:24
      │
-5379 │       fun msg => msg | Blame,
+5438 │       fun msg => msg | Blame,
      │                        ----- expected type
      │
      ┌─ [INPUTS_PATH]/errors/fail_with.ncl:5:19

--- a/cli/tests/snapshot/snapshots/snapshot__eval_stderr_fail_with.ncl.snap
+++ b/cli/tests/snapshot/snapshots/snapshot__eval_stderr_fail_with.ncl.snap
@@ -4,9 +4,9 @@ expression: err
 ---
 error: contract broken by a value
        div by zero
-     ┌─ <stdlib/std.ncl>:5438:24
+     ┌─ <stdlib/std.ncl>:5436:24
      │
-5438 │       fun msg => msg | Blame,
+5436 │       fun msg => msg | Blame,
      │                        ----- expected type
      │
      ┌─ [INPUTS_PATH]/errors/fail_with.ncl:5:19

--- a/cli/tests/snapshot/snapshots/snapshot__eval_stderr_subcontract_nested_custom_diagnostics.ncl.snap
+++ b/cli/tests/snapshot/snapshots/snapshot__eval_stderr_subcontract_nested_custom_diagnostics.ncl.snap
@@ -21,9 +21,9 @@ warning: plain functions as contracts are deprecated
    = wrap this function using one of the constructors in `std.contract` instead, like `std.contract.from_validator` or `std.contract.custom`
 
 warning: plain functions as contracts are deprecated
-     ┌─ <stdlib/std.ncl>:1757:9
+     ┌─ <stdlib/std.ncl>:1816:9
      │
-1757 │         %contract/apply% contract (%label/push_diag% label) value,
+1816 │         %contract/apply% contract (%label/push_diag% label) value,
      │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ applied to this term
      │
      ┌─ [INPUTS_PATH]/errors/subcontract_nested_custom_diagnostics.ncl:3:21

--- a/cli/tests/snapshot/snapshots/snapshot__eval_stderr_subcontract_nested_custom_diagnostics.ncl.snap
+++ b/cli/tests/snapshot/snapshots/snapshot__eval_stderr_subcontract_nested_custom_diagnostics.ncl.snap
@@ -21,9 +21,9 @@ warning: plain functions as contracts are deprecated
    = wrap this function using one of the constructors in `std.contract` instead, like `std.contract.from_validator` or `std.contract.custom`
 
 warning: plain functions as contracts are deprecated
-     ┌─ <stdlib/std.ncl>:1816:9
+     ┌─ <stdlib/std.ncl>:1814:9
      │
-1816 │         %contract/apply% contract (%label/push_diag% label) value,
+1814 │         %contract/apply% contract (%label/push_diag% label) value,
      │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ applied to this term
      │
      ┌─ [INPUTS_PATH]/errors/subcontract_nested_custom_diagnostics.ncl:3:21

--- a/cli/tests/snapshot/snapshots/snapshot__package_stderr_invalid-git-dep.ncl.snap
+++ b/cli/tests/snapshot/snapshots/snapshot__package_stderr_invalid-git-dep.ncl.snap
@@ -6,9 +6,9 @@ error: failed to evaluate package manifest
 
 error: contract broken by the value of `ref`
        expected 40 characters, got 18
-     ┌─ <stdlib/std.ncl>:3408:17
+     ┌─ <stdlib/std.ncl>:3467:17
      │
-3408 │               | [| 'Head, 'Branch String, 'Tag String, 'Commit std.package.GitId |]
+3467 │               | [| 'Head, 'Branch String, 'Tag String, 'Commit std.package.GitId |]
      │                 ------------------------------------------------------------------- expected type
      │
      ┌─ [INPUTS_PATH]/package/invalid-git-dep.ncl:10:60

--- a/cli/tests/snapshot/snapshots/snapshot__package_stderr_invalid-git-dep.ncl.snap
+++ b/cli/tests/snapshot/snapshots/snapshot__package_stderr_invalid-git-dep.ncl.snap
@@ -6,9 +6,9 @@ error: failed to evaluate package manifest
 
 error: contract broken by the value of `ref`
        expected 40 characters, got 18
-     ┌─ <stdlib/std.ncl>:3467:17
+     ┌─ <stdlib/std.ncl>:3465:17
      │
-3467 │               | [| 'Head, 'Branch String, 'Tag String, 'Commit std.package.GitId |]
+3465 │               | [| 'Head, 'Branch String, 'Tag String, 'Commit std.package.GitId |]
      │                 ------------------------------------------------------------------- expected type
      │
      ┌─ [INPUTS_PATH]/package/invalid-git-dep.ncl:10:60

--- a/cli/tests/snapshot/snapshots/snapshot__package_stderr_invalid-version.ncl.snap
+++ b/cli/tests/snapshot/snapshots/snapshot__package_stderr_invalid-version.ncl.snap
@@ -6,9 +6,9 @@ error: failed to evaluate package manifest
 
 error: contract broken by the value of `version`
        invalid semver
-     ┌─ <stdlib/std.ncl>:3487:17
+     ┌─ <stdlib/std.ncl>:3546:17
      │
-3487 │               | Semver
+3546 │               | Semver
      │                 ------ expected type
      │
      ┌─ [INPUTS_PATH]/package/invalid-version.ncl:6:13

--- a/cli/tests/snapshot/snapshots/snapshot__package_stderr_invalid-version.ncl.snap
+++ b/cli/tests/snapshot/snapshots/snapshot__package_stderr_invalid-version.ncl.snap
@@ -6,9 +6,9 @@ error: failed to evaluate package manifest
 
 error: contract broken by the value of `version`
        invalid semver
-     ┌─ <stdlib/std.ncl>:3546:17
+     ┌─ <stdlib/std.ncl>:3544:17
      │
-3546 │               | Semver
+3544 │               | Semver
      │                 ------ expected type
      │
      ┌─ [INPUTS_PATH]/package/invalid-version.ncl:6:13

--- a/cli/tests/snapshot/snapshots/snapshot__package_stderr_missing-field.ncl.snap
+++ b/cli/tests/snapshot/snapshots/snapshot__package_stderr_missing-field.ncl.snap
@@ -5,9 +5,9 @@ expression: err
 error: failed to evaluate package manifest
 
 error: missing definition for `authors`
-     ┌─ <stdlib/std.ncl>:3560:13
+     ┌─ <stdlib/std.ncl>:3558:13
      │
-3560 │             authors
+3558 │             authors
      │             ^^^^^^^ required here
      │
      ┌─ [INPUTS_PATH]/package/missing-field.ncl:4:1

--- a/cli/tests/snapshot/snapshots/snapshot__package_stderr_missing-field.ncl.snap
+++ b/cli/tests/snapshot/snapshots/snapshot__package_stderr_missing-field.ncl.snap
@@ -5,9 +5,9 @@ expression: err
 error: failed to evaluate package manifest
 
 error: missing definition for `authors`
-     ┌─ <stdlib/std.ncl>:3501:13
+     ┌─ <stdlib/std.ncl>:3560:13
      │
-3501 │             authors
+3560 │             authors
      │             ^^^^^^^ required here
      │
      ┌─ [INPUTS_PATH]/package/missing-field.ncl:4:1

--- a/core/stdlib/std.ncl
+++ b/core/stdlib/std.ncl
@@ -1111,6 +1111,65 @@
         array
         |> sort cmp
         |> dedup_sorted cmp,
+
+    chunk
+      : forall a k. (a -> k) -> Array a -> Array (Array a)
+      | Dyn -> Dyn -> Array std.array.NonEmpty
+      | doc m%"
+
+        Splits an array into maximal consecutive runs of elements that
+        share the same key, where the key of an element is computed by
+        the given function.
+
+        The order of elements is preserved, so flattening the result
+        yields the original array. For any key selection function `f`
+        and any array `xs`, we have:
+
+        `std.array.flatten (std.array.chunk f xs) == xs`
+
+        # Examples
+
+        ```nickel multiline
+        chunk (fun x => x) [1, 1, 2, 3]
+        # => [ [1, 1], [2], [3] ]
+
+        chunk (fun x => x % 2) [1, 3, 2, 4, 5]
+        # => [ [1, 3], [2, 4], [5] ]
+
+        chunk (fun x => x) []
+        # => []
+        ```
+      "%
+      = fun f xs =>
+        xs
+        |> match {
+          [] => [],
+          _ =>
+            let op = fun { chunks, current_key, start, end } x =>
+              let x_key = f x in
+              if x_key != current_key then
+                let chunks = chunks |> append (%array/slice% start end xs) in
+                let start = end in
+                let end = end + 1 in
+                let current_key = x_key in
+                { include [chunks, current_key, start, end] }
+              else
+                let end = end + 1 in
+                { include [chunks, current_key, start, end] }
+            in
+            let init = {
+              chunks = [],
+              current_key = f (first xs),
+              start = 0,
+              end = 1,
+            }
+            in
+            fold_left op init (drop_first xs)
+            |> match {
+              { chunks, start, end, .. } =>
+                chunks |> append (%array/slice% start end xs)
+            }
+        },
   },
 
   contract = {

--- a/core/stdlib/std.ncl
+++ b/core/stdlib/std.ncl
@@ -1140,11 +1140,9 @@
         # => []
         ```
       "%
-      = fun f xs =>
-        xs
-        |> match {
+      = fun f => match {
           [] => [],
-          _ =>
+          xs @ [x1, ..xs'] =>
             let op = fun { chunks, current_key, start, end } x =>
               let x_key = f x in
               if x_key != current_key then
@@ -1159,12 +1157,12 @@
             in
             let init = {
               chunks = [],
-              current_key = f (first xs),
+              current_key = f x1,
               start = 0,
               end = 1,
             }
             in
-            fold_left op init (drop_first xs)
+            fold_left op init xs'
             |> match {
               { chunks, start, end, .. } =>
                 chunks |> append (%array/slice% start end xs)

--- a/core/tests/integration/inputs/core/arrays.ncl
+++ b/core/tests/integration/inputs/core/arrays.ncl
@@ -22,6 +22,10 @@
     else 'Greater
   in std.array.sort cmp [3, 42, -1, -5] == [-5, -1, 3, 42],
 
+  # chunk
+  std.array.chunk (fun x => x) [] == [],
+  std.array.chunk (fun x => x) [1,2,2,3,3,1] == [[1], [2, 2], [3, 3], [1]],
+
   # Test case added after https://github.com/tweag/nickel/issues/154
   let x = 1 in let l = [x] @ [2] in (%array/at% l 0) == 1,
 


### PR DESCRIPTION
This function is the analog to Haskell's `groupBy`. The latter is a misnomer, in that grouping in relational terms is more accurately captured by nickel-lang/nickel#2638. However, `groupBy` is still useful. It computes a sequence of maximal *runs*, where runs are sequences of elements that share a same key. Where `std.array.group` mashes together all sequences of all elements identified by key, `std.array.chunk` does not: chunking `[0, 0, 1, 0]` yields `[[0, 0], [1], [0]]`.

Example use cases:
- cleaning up a list by removing duplicates or merging adjacent (e.g. firewall) rules while preserving the semantically significant input order
- grouping by key while preserving the order of keys, e.g. grouping devices for a dashboard by floor in a building without reordering floors

Thoughts on naming follows. We don't use `group` because that is already taken. Using `chunk` follows precedent from,

- [Ruby](https://ruby-doc.org/3.4.1/Enumerable.html#method-i-chunk)
- [Rust](https://doc.rust-lang.org/std/primitive.slice.html#method.chunk_by)

Alternatively, we could use `runs` as a name, but that would be breaking with the style of the rest of the library, where function names are verbs instead of nouns. And `run` would suggest something else entirely.

It should be noted that in some languages (Kotlin, C#), chunking means creating sequences of fixed size. We could consider passing the index into the user-supplied key selection function, in order to support computing chunks of fixed size as a special case. Or add `chunk_with_index`, like we have `map_with_index`. I haven't had a use so far for chunking based on element position.

Note on implementation: `std.array.group` could be implemented by composing `sort` and `chunk`. However, `partition` is implemented in terms of `group` and `sort` in terms of `partition`, so we'd have a circular dependency. Therefore, we keep separate the implementations of `group` and `chunk`.
