### PR TITLE
Make faster implementation of `std.array.sort` using merge sort

### DIFF
--- a/cli/tests/snapshot/snapshots/snapshot__eval_stderr_array_range_reversed_indices.ncl.snap
+++ b/cli/tests/snapshot/snapshots/snapshot__eval_stderr_array_range_reversed_indices.ncl.snap
@@ -4,9 +4,9 @@ expression: err
 ---
 error: contract broken by the caller of `range`
        invalid range
-    ┌─ <stdlib/std.ncl>:825:9
+    ┌─ <stdlib/std.ncl>:827:9
     │
-825 │       | std.contract.unstable.RangeFun Dyn
+827 │       | std.contract.unstable.RangeFun Dyn
     │         ---------------------------------- expected type
     │
     ┌─ [INPUTS_PATH]/errors/array_range_reversed_indices.ncl:3:19

--- a/cli/tests/snapshot/snapshots/snapshot__eval_stderr_array_range_reversed_indices.ncl.snap
+++ b/cli/tests/snapshot/snapshots/snapshot__eval_stderr_array_range_reversed_indices.ncl.snap
@@ -4,9 +4,9 @@ expression: err
 ---
 error: contract broken by the caller of `range`
        invalid range
-    ┌─ <stdlib/std.ncl>:810:9
+    ┌─ <stdlib/std.ncl>:825:9
     │
-810 │       | std.contract.unstable.RangeFun Dyn
+825 │       | std.contract.unstable.RangeFun Dyn
     │         ---------------------------------- expected type
     │
     ┌─ [INPUTS_PATH]/errors/array_range_reversed_indices.ncl:3:19

--- a/cli/tests/snapshot/snapshots/snapshot__eval_stderr_array_range_reversed_indices.ncl.snap
+++ b/cli/tests/snapshot/snapshots/snapshot__eval_stderr_array_range_reversed_indices.ncl.snap
@@ -4,9 +4,9 @@ expression: err
 ---
 error: contract broken by the caller of `range`
        invalid range
-    ┌─ <stdlib/std.ncl>:827:9
+    ┌─ <stdlib/std.ncl>:842:9
     │
-827 │       | std.contract.unstable.RangeFun Dyn
+842 │       | std.contract.unstable.RangeFun Dyn
     │         ---------------------------------- expected type
     │
     ┌─ [INPUTS_PATH]/errors/array_range_reversed_indices.ncl:3:19

--- a/cli/tests/snapshot/snapshots/snapshot__eval_stderr_array_range_step_negative_step.ncl.snap
+++ b/cli/tests/snapshot/snapshots/snapshot__eval_stderr_array_range_step_negative_step.ncl.snap
@@ -4,9 +4,9 @@ expression: err
 ---
 error: contract broken by the caller of `range_step`
        invalid range step
-    ┌─ <stdlib/std.ncl>:785:9
+    ┌─ <stdlib/std.ncl>:800:9
     │
-785 │       | std.contract.unstable.RangeFun (std.contract.unstable.RangeStep -> Dyn)
+800 │       | std.contract.unstable.RangeFun (std.contract.unstable.RangeStep -> Dyn)
     │         ----------------------------------------------------------------------- expected type
     │
     ┌─ [INPUTS_PATH]/errors/array_range_step_negative_step.ncl:3:27

--- a/cli/tests/snapshot/snapshots/snapshot__eval_stderr_array_range_step_negative_step.ncl.snap
+++ b/cli/tests/snapshot/snapshots/snapshot__eval_stderr_array_range_step_negative_step.ncl.snap
@@ -4,9 +4,9 @@ expression: err
 ---
 error: contract broken by the caller of `range_step`
        invalid range step
-    ┌─ <stdlib/std.ncl>:800:9
+    ┌─ <stdlib/std.ncl>:802:9
     │
-800 │       | std.contract.unstable.RangeFun (std.contract.unstable.RangeStep -> Dyn)
+802 │       | std.contract.unstable.RangeFun (std.contract.unstable.RangeStep -> Dyn)
     │         ----------------------------------------------------------------------- expected type
     │
     ┌─ [INPUTS_PATH]/errors/array_range_step_negative_step.ncl:3:27

--- a/cli/tests/snapshot/snapshots/snapshot__eval_stderr_array_range_step_negative_step.ncl.snap
+++ b/cli/tests/snapshot/snapshots/snapshot__eval_stderr_array_range_step_negative_step.ncl.snap
@@ -4,9 +4,9 @@ expression: err
 ---
 error: contract broken by the caller of `range_step`
        invalid range step
-    ┌─ <stdlib/std.ncl>:802:9
+    ┌─ <stdlib/std.ncl>:817:9
     │
-802 │       | std.contract.unstable.RangeFun (std.contract.unstable.RangeStep -> Dyn)
+817 │       | std.contract.unstable.RangeFun (std.contract.unstable.RangeStep -> Dyn)
     │         ----------------------------------------------------------------------- expected type
     │
     ┌─ [INPUTS_PATH]/errors/array_range_step_negative_step.ncl:3:27

--- a/cli/tests/snapshot/snapshots/snapshot__eval_stderr_base64_decode_invalid_encoding.ncl.snap
+++ b/cli/tests/snapshot/snapshots/snapshot__eval_stderr_base64_decode_invalid_encoding.ncl.snap
@@ -4,9 +4,9 @@ expression: err
 ---
 error: contract broken by a value
        Base64 decoding failed: Invalid symbol 33, offset 0.
-     ┌─ <stdlib/std.ncl>:4894:29
+     ┌─ <stdlib/std.ncl>:4909:29
      │
-4894 │         let decoded = str | Base64String
+4909 │         let decoded = str | Base64String
      │                             ------------ expected type
      │
      ┌─ [INPUTS_PATH]/errors/base64_decode_invalid_encoding.ncl:3:36

--- a/cli/tests/snapshot/snapshots/snapshot__eval_stderr_base64_decode_invalid_encoding.ncl.snap
+++ b/cli/tests/snapshot/snapshots/snapshot__eval_stderr_base64_decode_invalid_encoding.ncl.snap
@@ -4,9 +4,9 @@ expression: err
 ---
 error: contract broken by a value
        Base64 decoding failed: Invalid symbol 33, offset 0.
-     ┌─ <stdlib/std.ncl>:4909:29
+     ┌─ <stdlib/std.ncl>:4911:29
      │
-4909 │         let decoded = str | Base64String
+4911 │         let decoded = str | Base64String
      │                             ------------ expected type
      │
      ┌─ [INPUTS_PATH]/errors/base64_decode_invalid_encoding.ncl:3:36

--- a/cli/tests/snapshot/snapshots/snapshot__eval_stderr_base64_decode_invalid_encoding.ncl.snap
+++ b/cli/tests/snapshot/snapshots/snapshot__eval_stderr_base64_decode_invalid_encoding.ncl.snap
@@ -4,9 +4,9 @@ expression: err
 ---
 error: contract broken by a value
        Base64 decoding failed: Invalid symbol 33, offset 0.
-     ┌─ <stdlib/std.ncl>:4911:29
+     ┌─ <stdlib/std.ncl>:4926:29
      │
-4911 │         let decoded = str | Base64String
+4926 │         let decoded = str | Base64String
      │                             ------------ expected type
      │
      ┌─ [INPUTS_PATH]/errors/base64_decode_invalid_encoding.ncl:3:36

--- a/cli/tests/snapshot/snapshots/snapshot__eval_stderr_base64_decode_non_string.ncl.snap
+++ b/cli/tests/snapshot/snapshots/snapshot__eval_stderr_base64_decode_non_string.ncl.snap
@@ -4,9 +4,9 @@ expression: err
 ---
 error: contract broken by a value
        Could not convert decoded value to string: invalid utf-8 sequence of 1 bytes from index 0
-     ┌─ <stdlib/std.ncl>:4894:29
+     ┌─ <stdlib/std.ncl>:4909:29
      │
-4894 │         let decoded = str | Base64String
+4909 │         let decoded = str | Base64String
      │                             ------------ expected type
      │
      ┌─ [INPUTS_PATH]/errors/base64_decode_non_string.ncl:3:36

--- a/cli/tests/snapshot/snapshots/snapshot__eval_stderr_base64_decode_non_string.ncl.snap
+++ b/cli/tests/snapshot/snapshots/snapshot__eval_stderr_base64_decode_non_string.ncl.snap
@@ -4,9 +4,9 @@ expression: err
 ---
 error: contract broken by a value
        Could not convert decoded value to string: invalid utf-8 sequence of 1 bytes from index 0
-     ┌─ <stdlib/std.ncl>:4911:29
+     ┌─ <stdlib/std.ncl>:4926:29
      │
-4911 │         let decoded = str | Base64String
+4926 │         let decoded = str | Base64String
      │                             ------------ expected type
      │
      ┌─ [INPUTS_PATH]/errors/base64_decode_non_string.ncl:3:36

--- a/cli/tests/snapshot/snapshots/snapshot__eval_stderr_base64_decode_non_string.ncl.snap
+++ b/cli/tests/snapshot/snapshots/snapshot__eval_stderr_base64_decode_non_string.ncl.snap
@@ -4,9 +4,9 @@ expression: err
 ---
 error: contract broken by a value
        Could not convert decoded value to string: invalid utf-8 sequence of 1 bytes from index 0
-     ┌─ <stdlib/std.ncl>:4909:29
+     ┌─ <stdlib/std.ncl>:4911:29
      │
-4909 │         let decoded = str | Base64String
+4911 │         let decoded = str | Base64String
      │                             ------------ expected type
      │
      ┌─ [INPUTS_PATH]/errors/base64_decode_non_string.ncl:3:36

--- a/cli/tests/snapshot/snapshots/snapshot__eval_stderr_fail_with.ncl.snap
+++ b/cli/tests/snapshot/snapshots/snapshot__eval_stderr_fail_with.ncl.snap
@@ -4,9 +4,9 @@ expression: err
 ---
 error: contract broken by a value
        div by zero
-     ┌─ <stdlib/std.ncl>:5451:24
+     ┌─ <stdlib/std.ncl>:5453:24
      │
-5451 │       fun msg => msg | Blame,
+5453 │       fun msg => msg | Blame,
      │                        ----- expected type
      │
      ┌─ [INPUTS_PATH]/errors/fail_with.ncl:5:19

--- a/cli/tests/snapshot/snapshots/snapshot__eval_stderr_fail_with.ncl.snap
+++ b/cli/tests/snapshot/snapshots/snapshot__eval_stderr_fail_with.ncl.snap
@@ -4,9 +4,9 @@ expression: err
 ---
 error: contract broken by a value
        div by zero
-     ┌─ <stdlib/std.ncl>:5453:24
+     ┌─ <stdlib/std.ncl>:5468:24
      │
-5453 │       fun msg => msg | Blame,
+5468 │       fun msg => msg | Blame,
      │                        ----- expected type
      │
      ┌─ [INPUTS_PATH]/errors/fail_with.ncl:5:19

--- a/cli/tests/snapshot/snapshots/snapshot__eval_stderr_fail_with.ncl.snap
+++ b/cli/tests/snapshot/snapshots/snapshot__eval_stderr_fail_with.ncl.snap
@@ -4,9 +4,9 @@ expression: err
 ---
 error: contract broken by a value
        div by zero
-     ┌─ <stdlib/std.ncl>:5436:24
+     ┌─ <stdlib/std.ncl>:5451:24
      │
-5436 │       fun msg => msg | Blame,
+5451 │       fun msg => msg | Blame,
      │                        ----- expected type
      │
      ┌─ [INPUTS_PATH]/errors/fail_with.ncl:5:19

--- a/cli/tests/snapshot/snapshots/snapshot__eval_stderr_subcontract_nested_custom_diagnostics.ncl.snap
+++ b/cli/tests/snapshot/snapshots/snapshot__eval_stderr_subcontract_nested_custom_diagnostics.ncl.snap
@@ -21,9 +21,9 @@ warning: plain functions as contracts are deprecated
    = wrap this function using one of the constructors in `std.contract` instead, like `std.contract.from_validator` or `std.contract.custom`
 
 warning: plain functions as contracts are deprecated
-     ┌─ <stdlib/std.ncl>:1831:9
+     ┌─ <stdlib/std.ncl>:1846:9
      │
-1831 │         %contract/apply% contract (%label/push_diag% label) value,
+1846 │         %contract/apply% contract (%label/push_diag% label) value,
      │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ applied to this term
      │
      ┌─ [INPUTS_PATH]/errors/subcontract_nested_custom_diagnostics.ncl:3:21

--- a/cli/tests/snapshot/snapshots/snapshot__eval_stderr_subcontract_nested_custom_diagnostics.ncl.snap
+++ b/cli/tests/snapshot/snapshots/snapshot__eval_stderr_subcontract_nested_custom_diagnostics.ncl.snap
@@ -21,9 +21,9 @@ warning: plain functions as contracts are deprecated
    = wrap this function using one of the constructors in `std.contract` instead, like `std.contract.from_validator` or `std.contract.custom`
 
 warning: plain functions as contracts are deprecated
-     ┌─ <stdlib/std.ncl>:1814:9
+     ┌─ <stdlib/std.ncl>:1829:9
      │
-1814 │         %contract/apply% contract (%label/push_diag% label) value,
+1829 │         %contract/apply% contract (%label/push_diag% label) value,
      │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ applied to this term
      │
      ┌─ [INPUTS_PATH]/errors/subcontract_nested_custom_diagnostics.ncl:3:21

--- a/cli/tests/snapshot/snapshots/snapshot__eval_stderr_subcontract_nested_custom_diagnostics.ncl.snap
+++ b/cli/tests/snapshot/snapshots/snapshot__eval_stderr_subcontract_nested_custom_diagnostics.ncl.snap
@@ -21,9 +21,9 @@ warning: plain functions as contracts are deprecated
    = wrap this function using one of the constructors in `std.contract` instead, like `std.contract.from_validator` or `std.contract.custom`
 
 warning: plain functions as contracts are deprecated
-     ┌─ <stdlib/std.ncl>:1829:9
+     ┌─ <stdlib/std.ncl>:1831:9
      │
-1829 │         %contract/apply% contract (%label/push_diag% label) value,
+1831 │         %contract/apply% contract (%label/push_diag% label) value,
      │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ applied to this term
      │
      ┌─ [INPUTS_PATH]/errors/subcontract_nested_custom_diagnostics.ncl:3:21

--- a/cli/tests/snapshot/snapshots/snapshot__package_stderr_invalid-git-dep.ncl.snap
+++ b/cli/tests/snapshot/snapshots/snapshot__package_stderr_invalid-git-dep.ncl.snap
@@ -6,9 +6,9 @@ error: failed to evaluate package manifest
 
 error: contract broken by the value of `ref`
        expected 40 characters, got 18
-     ┌─ <stdlib/std.ncl>:3465:17
+     ┌─ <stdlib/std.ncl>:3480:17
      │
-3465 │               | [| 'Head, 'Branch String, 'Tag String, 'Commit std.package.GitId |]
+3480 │               | [| 'Head, 'Branch String, 'Tag String, 'Commit std.package.GitId |]
      │                 ------------------------------------------------------------------- expected type
      │
      ┌─ [INPUTS_PATH]/package/invalid-git-dep.ncl:10:60

--- a/cli/tests/snapshot/snapshots/snapshot__package_stderr_invalid-git-dep.ncl.snap
+++ b/cli/tests/snapshot/snapshots/snapshot__package_stderr_invalid-git-dep.ncl.snap
@@ -6,9 +6,9 @@ error: failed to evaluate package manifest
 
 error: contract broken by the value of `ref`
        expected 40 characters, got 18
-     ┌─ <stdlib/std.ncl>:3482:17
+     ┌─ <stdlib/std.ncl>:3497:17
      │
-3482 │               | [| 'Head, 'Branch String, 'Tag String, 'Commit std.package.GitId |]
+3497 │               | [| 'Head, 'Branch String, 'Tag String, 'Commit std.package.GitId |]
      │                 ------------------------------------------------------------------- expected type
      │
      ┌─ [INPUTS_PATH]/package/invalid-git-dep.ncl:10:60

--- a/cli/tests/snapshot/snapshots/snapshot__package_stderr_invalid-git-dep.ncl.snap
+++ b/cli/tests/snapshot/snapshots/snapshot__package_stderr_invalid-git-dep.ncl.snap
@@ -6,9 +6,9 @@ error: failed to evaluate package manifest
 
 error: contract broken by the value of `ref`
        expected 40 characters, got 18
-     ┌─ <stdlib/std.ncl>:3480:17
+     ┌─ <stdlib/std.ncl>:3482:17
      │
-3480 │               | [| 'Head, 'Branch String, 'Tag String, 'Commit std.package.GitId |]
+3482 │               | [| 'Head, 'Branch String, 'Tag String, 'Commit std.package.GitId |]
      │                 ------------------------------------------------------------------- expected type
      │
      ┌─ [INPUTS_PATH]/package/invalid-git-dep.ncl:10:60

--- a/cli/tests/snapshot/snapshots/snapshot__package_stderr_invalid-version.ncl.snap
+++ b/cli/tests/snapshot/snapshots/snapshot__package_stderr_invalid-version.ncl.snap
@@ -6,9 +6,9 @@ error: failed to evaluate package manifest
 
 error: contract broken by the value of `version`
        invalid semver
-     ┌─ <stdlib/std.ncl>:3561:17
+     ┌─ <stdlib/std.ncl>:3576:17
      │
-3561 │               | Semver
+3576 │               | Semver
      │                 ------ expected type
      │
      ┌─ [INPUTS_PATH]/package/invalid-version.ncl:6:13

--- a/cli/tests/snapshot/snapshots/snapshot__package_stderr_invalid-version.ncl.snap
+++ b/cli/tests/snapshot/snapshots/snapshot__package_stderr_invalid-version.ncl.snap
@@ -6,9 +6,9 @@ error: failed to evaluate package manifest
 
 error: contract broken by the value of `version`
        invalid semver
-     ┌─ <stdlib/std.ncl>:3544:17
+     ┌─ <stdlib/std.ncl>:3559:17
      │
-3544 │               | Semver
+3559 │               | Semver
      │                 ------ expected type
      │
      ┌─ [INPUTS_PATH]/package/invalid-version.ncl:6:13

--- a/cli/tests/snapshot/snapshots/snapshot__package_stderr_invalid-version.ncl.snap
+++ b/cli/tests/snapshot/snapshots/snapshot__package_stderr_invalid-version.ncl.snap
@@ -6,9 +6,9 @@ error: failed to evaluate package manifest
 
 error: contract broken by the value of `version`
        invalid semver
-     ┌─ <stdlib/std.ncl>:3559:17
+     ┌─ <stdlib/std.ncl>:3561:17
      │
-3559 │               | Semver
+3561 │               | Semver
      │                 ------ expected type
      │
      ┌─ [INPUTS_PATH]/package/invalid-version.ncl:6:13

--- a/cli/tests/snapshot/snapshots/snapshot__package_stderr_missing-field.ncl.snap
+++ b/cli/tests/snapshot/snapshots/snapshot__package_stderr_missing-field.ncl.snap
@@ -5,9 +5,9 @@ expression: err
 error: failed to evaluate package manifest
 
 error: missing definition for `authors`
-     ┌─ <stdlib/std.ncl>:3573:13
+     ┌─ <stdlib/std.ncl>:3575:13
      │
-3573 │             authors
+3575 │             authors
      │             ^^^^^^^ required here
      │
      ┌─ [INPUTS_PATH]/package/missing-field.ncl:4:1

--- a/cli/tests/snapshot/snapshots/snapshot__package_stderr_missing-field.ncl.snap
+++ b/cli/tests/snapshot/snapshots/snapshot__package_stderr_missing-field.ncl.snap
@@ -5,9 +5,9 @@ expression: err
 error: failed to evaluate package manifest
 
 error: missing definition for `authors`
-     ┌─ <stdlib/std.ncl>:3558:13
+     ┌─ <stdlib/std.ncl>:3573:13
      │
-3558 │             authors
+3573 │             authors
      │             ^^^^^^^ required here
      │
      ┌─ [INPUTS_PATH]/package/missing-field.ncl:4:1

--- a/cli/tests/snapshot/snapshots/snapshot__package_stderr_missing-field.ncl.snap
+++ b/cli/tests/snapshot/snapshots/snapshot__package_stderr_missing-field.ncl.snap
@@ -5,9 +5,9 @@ expression: err
 error: failed to evaluate package manifest
 
 error: missing definition for `authors`
-     ┌─ <stdlib/std.ncl>:3575:13
+     ┌─ <stdlib/std.ncl>:3590:13
      │
-3575 │             authors
+3590 │             authors
      │             ^^^^^^^ required here
      │
      ┌─ [INPUTS_PATH]/package/missing-field.ncl:4:1

--- a/core/stdlib/std.ncl
+++ b/core/stdlib/std.ncl
@@ -646,7 +646,8 @@
         "%
       = fun cmp array =>
         let rec merge = fun first second =>
-          match {
+          [first, second]
+          |> match {
             [[], ys] => ys,
             [xs, []] => xs,
             [[x, ..rest_xs],  [y, ..rest_ys]] =>
@@ -654,19 +655,20 @@
                 [y] @ merge first rest_ys
               else
                 [x] @ merge rest_xs second,
-          } [first, second]
+          }
         in
         let rec merge_sort = fun array =>
-          match {
+          array
+          |> match {
             [] => [],
             [x] => [x],
             xs =>
               let length = %array/length% array in
-              let half = (length / 2) |> std.number.floor in
+              let half = std.number.floor (length / 2) in
               let left = %array/slice% 0 half array in
               let right = %array/slice% half length array in
               merge (merge_sort left) (merge_sort right)
-          } array
+          }
         in
         merge_sort array,
 

--- a/core/stdlib/std.ncl
+++ b/core/stdlib/std.ncl
@@ -644,16 +644,31 @@
           # => [ 1, 2, 4, 5 ]
           ```
         "%
-      #TODO: maybe inline partition to avoid contract checks?
       = fun cmp array =>
-        let length = %array/length% array in
-        let first = %array/at% array 0 in
-        let rest = %array/slice% 1 length array in
-        let parts = partition (fun x => (cmp x first == 'Lesser)) rest in
-        if length <= 1 then
-          array
-        else
-          (sort cmp (parts.right)) @ [first] @ (sort cmp (parts.wrong)),
+        let rec merge = fun first second =>
+          match {
+            [[], ys] => ys,
+            [xs, []] => xs,
+            [[x, ..rest_xs],  [y, ..rest_ys]] =>
+              if cmp x y == 'Greater then
+                [y] @ merge first rest_ys
+              else
+                [x] @ merge rest_xs second,
+          } [first, second]
+        in
+        let rec merge_sort = fun array =>
+          match {
+            [] => [],
+            [x] => [x],
+            xs =>
+              let length = %array/length% array in
+              let half = (length / 2) |> std.number.floor in
+              let left = %array/slice% 0 half array in
+              let right = %array/slice% half length array in
+              merge (merge_sort left) (merge_sort right)
+          } array
+        in
+        merge_sort array,
 
     flat_map
       : forall a b. (a -> Array b) -> Array a -> Array b

--- a/core/stdlib/std.ncl
+++ b/core/stdlib/std.ncl
@@ -632,18 +632,33 @@
 
           # Examples
 
-          ```nickel
+          ```nickel multiline
+          std.array.sort std.number.compare [ 4, 5, 1, 2 ]
+          # => [ 1, 2, 4, 5 ]
+
+          std.array.sort std.string.compare [ "c", "b", "baz", "foo", "a", "bar" ]
+          # => [ "a", "b", "bar", "baz", "c", "foo" ]
+
+          # Sort strings by length
           std.array.sort (fun x y =>
-            if x < y then
+            let len_x = std.string.length x in
+            let len_y = std.string.length y in
+            if len_x < len_y then
               'Lesser
-            else if (x == y) then
+            else if (len_x == len_y) then
               'Equal
             else
               'Greater)
-            [ 4, 5, 1, 2 ]
-          # => [ 1, 2, 4, 5 ]
+            [ "c", "foo", "hello", "baz", "a", "b", "world", "bar" ]
+          # => [ "c", "a", "b", "foo", "baz", "bar", "hello", "world" ]
           ```
         "%
+      # The "Sort strings by length" example was added primarily to test how different elements
+      # with equality under the comparison operator are sorted. This is an implementation of
+      # merge sort, which is a stable sorting algorithm, so equal elements will appear in the
+      # same order in the input and output arrays. The test is likely to break if that behavior
+      # changes. While stability isn't a strict requirement, it's preferable not to change this
+      # behavior unnecessarily.
       = fun cmp array =>
         let rec merge = fun first second =>
           [first, second]


### PR DESCRIPTION
Fixes #2637

This fixes the cubic complexity of the `std.array.sort` implementation by reimplementing it with merge sort, which should run in O(n log n) in the worst case.