### PR TITLE
Fix `std.number.floor` and `std.array.range_step` functions

### DIFF
--- a/cli/tests/snapshot/snapshots/snapshot__eval_stderr_array_range_reversed_indices.ncl.snap
+++ b/cli/tests/snapshot/snapshots/snapshot__eval_stderr_array_range_reversed_indices.ncl.snap
@@ -4,9 +4,9 @@ expression: err
 ---
 error: contract broken by the caller of `range`
        invalid range
-    ┌─ <stdlib/std.ncl>:842:9
+    ┌─ <stdlib/std.ncl>:849:9
     │
-842 │       | std.contract.unstable.RangeFun Dyn
+849 │       | std.contract.unstable.RangeFun Dyn
     │         ---------------------------------- expected type
     │
     ┌─ [INPUTS_PATH]/errors/array_range_reversed_indices.ncl:3:19

--- a/cli/tests/snapshot/snapshots/snapshot__eval_stderr_base64_decode_invalid_encoding.ncl.snap
+++ b/cli/tests/snapshot/snapshots/snapshot__eval_stderr_base64_decode_invalid_encoding.ncl.snap
@@ -4,9 +4,9 @@ expression: err
 ---
 error: contract broken by a value
        Base64 decoding failed: Invalid symbol 33, offset 0.
-     ┌─ <stdlib/std.ncl>:4962:29
+     ┌─ <stdlib/std.ncl>:4960:29
      │
-4962 │         let decoded = str | Base64String
+4960 │         let decoded = str | Base64String
      │                             ------------ expected type
      │
      ┌─ [INPUTS_PATH]/errors/base64_decode_invalid_encoding.ncl:3:36

--- a/cli/tests/snapshot/snapshots/snapshot__eval_stderr_base64_decode_invalid_encoding.ncl.snap
+++ b/cli/tests/snapshot/snapshots/snapshot__eval_stderr_base64_decode_invalid_encoding.ncl.snap
@@ -4,9 +4,9 @@ expression: err
 ---
 error: contract broken by a value
        Base64 decoding failed: Invalid symbol 33, offset 0.
-     ┌─ <stdlib/std.ncl>:4924:29
+     ┌─ <stdlib/std.ncl>:4962:29
      │
-4924 │         let decoded = str | Base64String
+4962 │         let decoded = str | Base64String
      │                             ------------ expected type
      │
      ┌─ [INPUTS_PATH]/errors/base64_decode_invalid_encoding.ncl:3:36

--- a/cli/tests/snapshot/snapshots/snapshot__eval_stderr_base64_decode_non_string.ncl.snap
+++ b/cli/tests/snapshot/snapshots/snapshot__eval_stderr_base64_decode_non_string.ncl.snap
@@ -4,9 +4,9 @@ expression: err
 ---
 error: contract broken by a value
        Could not convert decoded value to string: invalid utf-8 sequence of 1 bytes from index 0
-     ┌─ <stdlib/std.ncl>:4924:29
+     ┌─ <stdlib/std.ncl>:4962:29
      │
-4924 │         let decoded = str | Base64String
+4962 │         let decoded = str | Base64String
      │                             ------------ expected type
      │
      ┌─ [INPUTS_PATH]/errors/base64_decode_non_string.ncl:3:36

--- a/cli/tests/snapshot/snapshots/snapshot__eval_stderr_base64_decode_non_string.ncl.snap
+++ b/cli/tests/snapshot/snapshots/snapshot__eval_stderr_base64_decode_non_string.ncl.snap
@@ -4,9 +4,9 @@ expression: err
 ---
 error: contract broken by a value
        Could not convert decoded value to string: invalid utf-8 sequence of 1 bytes from index 0
-     ┌─ <stdlib/std.ncl>:4962:29
+     ┌─ <stdlib/std.ncl>:4960:29
      │
-4962 │         let decoded = str | Base64String
+4960 │         let decoded = str | Base64String
      │                             ------------ expected type
      │
      ┌─ [INPUTS_PATH]/errors/base64_decode_non_string.ncl:3:36

--- a/cli/tests/snapshot/snapshots/snapshot__eval_stderr_fail_with.ncl.snap
+++ b/cli/tests/snapshot/snapshots/snapshot__eval_stderr_fail_with.ncl.snap
@@ -4,9 +4,9 @@ expression: err
 ---
 error: contract broken by a value
        div by zero
-     ┌─ <stdlib/std.ncl>:5504:24
+     ┌─ <stdlib/std.ncl>:5502:24
      │
-5504 │       fun msg => msg | Blame,
+5502 │       fun msg => msg | Blame,
      │                        ----- expected type
      │
      ┌─ [INPUTS_PATH]/errors/fail_with.ncl:5:19

--- a/cli/tests/snapshot/snapshots/snapshot__eval_stderr_fail_with.ncl.snap
+++ b/cli/tests/snapshot/snapshots/snapshot__eval_stderr_fail_with.ncl.snap
@@ -4,9 +4,9 @@ expression: err
 ---
 error: contract broken by a value
        div by zero
-     ┌─ <stdlib/std.ncl>:5466:24
+     ┌─ <stdlib/std.ncl>:5504:24
      │
-5466 │       fun msg => msg | Blame,
+5504 │       fun msg => msg | Blame,
      │                        ----- expected type
      │
      ┌─ [INPUTS_PATH]/errors/fail_with.ncl:5:19

--- a/cli/tests/snapshot/snapshots/snapshot__eval_stderr_subcontract_nested_custom_diagnostics.ncl.snap
+++ b/cli/tests/snapshot/snapshots/snapshot__eval_stderr_subcontract_nested_custom_diagnostics.ncl.snap
@@ -21,9 +21,9 @@ warning: plain functions as contracts are deprecated
    = wrap this function using one of the constructors in `std.contract` instead, like `std.contract.from_validator` or `std.contract.custom`
 
 warning: plain functions as contracts are deprecated
-     ┌─ <stdlib/std.ncl>:1844:9
+     ┌─ <stdlib/std.ncl>:1851:9
      │
-1844 │         %contract/apply% contract (%label/push_diag% label) value,
+1851 │         %contract/apply% contract (%label/push_diag% label) value,
      │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ applied to this term
      │
      ┌─ [INPUTS_PATH]/errors/subcontract_nested_custom_diagnostics.ncl:3:21

--- a/cli/tests/snapshot/snapshots/snapshot__package_stderr_invalid-git-dep.ncl.snap
+++ b/cli/tests/snapshot/snapshots/snapshot__package_stderr_invalid-git-dep.ncl.snap
@@ -6,15 +6,9 @@ error: failed to evaluate package manifest
 
 error: contract broken by the value of `ref`
        expected 40 characters, got 18
-<<<<<<< HEAD
-     ┌─ <stdlib/std.ncl>:3495:17
+     ┌─ <stdlib/std.ncl>:3531:17
      │
-3495 │               | [| 'Head, 'Branch String, 'Tag String, 'Commit std.package.GitId |]
-=======
-     ┌─ <stdlib/std.ncl>:3535:17
-     │
-3535 │               | [| 'Head, 'Branch String, 'Tag String, 'Commit std.package.GitId |]
->>>>>>> 85f946c8 (Fix `std.number.floor` and `std.array.range_step` functions)
+3531 │               | [| 'Head, 'Branch String, 'Tag String, 'Commit std.package.GitId |]
      │                 ------------------------------------------------------------------- expected type
      │
      ┌─ [INPUTS_PATH]/package/invalid-git-dep.ncl:10:60

--- a/cli/tests/snapshot/snapshots/snapshot__package_stderr_invalid-git-dep.ncl.snap
+++ b/cli/tests/snapshot/snapshots/snapshot__package_stderr_invalid-git-dep.ncl.snap
@@ -6,9 +6,15 @@ error: failed to evaluate package manifest
 
 error: contract broken by the value of `ref`
        expected 40 characters, got 18
+<<<<<<< HEAD
      ┌─ <stdlib/std.ncl>:3495:17
      │
 3495 │               | [| 'Head, 'Branch String, 'Tag String, 'Commit std.package.GitId |]
+=======
+     ┌─ <stdlib/std.ncl>:3535:17
+     │
+3535 │               | [| 'Head, 'Branch String, 'Tag String, 'Commit std.package.GitId |]
+>>>>>>> 85f946c8 (Fix `std.number.floor` and `std.array.range_step` functions)
      │                 ------------------------------------------------------------------- expected type
      │
      ┌─ [INPUTS_PATH]/package/invalid-git-dep.ncl:10:60

--- a/cli/tests/snapshot/snapshots/snapshot__package_stderr_invalid-version.ncl.snap
+++ b/cli/tests/snapshot/snapshots/snapshot__package_stderr_invalid-version.ncl.snap
@@ -6,15 +6,9 @@ error: failed to evaluate package manifest
 
 error: contract broken by the value of `version`
        invalid semver
-<<<<<<< HEAD
-     ┌─ <stdlib/std.ncl>:3574:17
+     ┌─ <stdlib/std.ncl>:3610:17
      │
-3574 │               | Semver
-=======
-     ┌─ <stdlib/std.ncl>:3614:17
-     │
-3614 │               | Semver
->>>>>>> 85f946c8 (Fix `std.number.floor` and `std.array.range_step` functions)
+3610 │               | Semver
      │                 ------ expected type
      │
      ┌─ [INPUTS_PATH]/package/invalid-version.ncl:6:13

--- a/cli/tests/snapshot/snapshots/snapshot__package_stderr_invalid-version.ncl.snap
+++ b/cli/tests/snapshot/snapshots/snapshot__package_stderr_invalid-version.ncl.snap
@@ -6,9 +6,15 @@ error: failed to evaluate package manifest
 
 error: contract broken by the value of `version`
        invalid semver
+<<<<<<< HEAD
      ┌─ <stdlib/std.ncl>:3574:17
      │
 3574 │               | Semver
+=======
+     ┌─ <stdlib/std.ncl>:3614:17
+     │
+3614 │               | Semver
+>>>>>>> 85f946c8 (Fix `std.number.floor` and `std.array.range_step` functions)
      │                 ------ expected type
      │
      ┌─ [INPUTS_PATH]/package/invalid-version.ncl:6:13

--- a/cli/tests/snapshot/snapshots/snapshot__package_stderr_missing-field.ncl.snap
+++ b/cli/tests/snapshot/snapshots/snapshot__package_stderr_missing-field.ncl.snap
@@ -5,9 +5,15 @@ expression: err
 error: failed to evaluate package manifest
 
 error: missing definition for `authors`
+<<<<<<< HEAD
      ┌─ <stdlib/std.ncl>:3588:13
      │
 3588 │             authors
+=======
+     ┌─ <stdlib/std.ncl>:3628:13
+     │
+3628 │             authors
+>>>>>>> 85f946c8 (Fix `std.number.floor` and `std.array.range_step` functions)
      │             ^^^^^^^ required here
      │
      ┌─ [INPUTS_PATH]/package/missing-field.ncl:4:1

--- a/cli/tests/snapshot/snapshots/snapshot__package_stderr_missing-field.ncl.snap
+++ b/cli/tests/snapshot/snapshots/snapshot__package_stderr_missing-field.ncl.snap
@@ -5,15 +5,9 @@ expression: err
 error: failed to evaluate package manifest
 
 error: missing definition for `authors`
-<<<<<<< HEAD
-     ┌─ <stdlib/std.ncl>:3588:13
+     ┌─ <stdlib/std.ncl>:3624:13
      │
-3588 │             authors
-=======
-     ┌─ <stdlib/std.ncl>:3628:13
-     │
-3628 │             authors
->>>>>>> 85f946c8 (Fix `std.number.floor` and `std.array.range_step` functions)
+3624 │             authors
      │             ^^^^^^^ required here
      │
      ┌─ [INPUTS_PATH]/package/missing-field.ncl:4:1

--- a/core/stdlib/std.ncl
+++ b/core/stdlib/std.ncl
@@ -2860,12 +2860,11 @@
         ```
       "%
       = fun x =>
-        if x % 1 == 0 then
-          x
-        else if x >= 0 then
-          x - (x % 1)
+        let r = x % 1 in
+        if r >= 0 then
+          x - r
         else
-          x - 1 - (x % 1),
+          x - 1 - r,
 
     ceil
       : Number -> Number
@@ -2886,12 +2885,11 @@
         ```
       "%
       = fun x =>
-        if x % 1 == 0 then
-          x
-        else if x >= 0 then
-          x + (1 - (x % 1))
+        let r = x % 1 in
+        if r <= 0 then
+          x - r
         else
-          x - (x % 1),
+          x - r + 1,
 
     abs
       : Number -> Number

--- a/core/stdlib/std.ncl
+++ b/core/stdlib/std.ncl
@@ -827,14 +827,21 @@
 
           # Examples
 
-          ```nickel
+          ```nickel multiline
           std.array.range_step (-1.5) 2 0.5
            # => [ -1.5, -1, -0.5, 0, 0.5, 1, 1.5 ]
+
+          std.array.range_step 0 17 8
+          # => [ 0, 8, 16 ]
+
+          # If a step generates a value equal to `end`, it is excluded.
+          std.array.range_step 0 16 8
+          # => [ 0, 8 ]
           ```
         "%
       = fun start end step =>
         %array/generate%
-          ((end - start) / step |> std.number.floor)
+          ((end - start) / step |> std.number.ceil)
           (fun i => start + i * step),
 
     range
@@ -2073,7 +2080,7 @@
             "%
           =
             %contract/custom% (fun _label value =>
-              if %typeof% value == 'Number && value < 0 then
+              if %typeof% value == 'Number && value <= 0 then
                 'Error {
                   message = "invalid range step",
                   notes = ["Expected a positive number, got %{value}"],
@@ -2847,13 +2854,44 @@
 
         std.number.floor (-42.5)
         # => -43
+
+        std.number.floor (-3)
+        # => -3
         ```
       "%
       = fun x =>
-        if x >= 0 then
+        if x % 1 == 0 then
+          x
+        else if x >= 0 then
           x - (x % 1)
         else
           x - 1 - (x % 1),
+
+    ceil
+      : Number -> Number
+      | doc m%"
+        Rounds a number up to the next integer.
+
+        # Examples
+
+        ```nickel multiline
+        std.number.ceil 22.3
+        # => 23
+
+        std.number.ceil (-12.7)
+        # => -12
+
+        std.number.ceil (-4)
+        # => -4
+        ```
+      "%
+      = fun x =>
+        if x % 1 == 0 then
+          x
+        else if x >= 0 then
+          x + (1 - (x % 1))
+        else
+          x - (x % 1),
 
     abs
       : Number -> Number


### PR DESCRIPTION
Fixes #2646
Fixes #2645

This fixes a couple of bugs in the standard library:
- `std.number.floor` works incorrectly for negative integers
- `std.number.range_step` sometimes drops the last generated number

This also adds `std.number.ceil` to the standard library since it's needed to fix the issue with `range_step`