### PR TITLE
Remove extraneous binding in std.array.dedup

### DIFF
--- a/cli/tests/snapshot/snapshots/snapshot__eval_stderr_base64_decode_invalid_encoding.ncl.snap
+++ b/cli/tests/snapshot/snapshots/snapshot__eval_stderr_base64_decode_invalid_encoding.ncl.snap
@@ -4,9 +4,9 @@ expression: err
 ---
 error: contract broken by a value
        Base64 decoding failed: Invalid symbol 33, offset 0.
-     ┌─ <stdlib/std.ncl>:4926:29
+     ┌─ <stdlib/std.ncl>:4924:29
      │
-4926 │         let decoded = str | Base64String
+4924 │         let decoded = str | Base64String
      │                             ------------ expected type
      │
      ┌─ [INPUTS_PATH]/errors/base64_decode_invalid_encoding.ncl:3:36

--- a/cli/tests/snapshot/snapshots/snapshot__eval_stderr_base64_decode_non_string.ncl.snap
+++ b/cli/tests/snapshot/snapshots/snapshot__eval_stderr_base64_decode_non_string.ncl.snap
@@ -4,9 +4,9 @@ expression: err
 ---
 error: contract broken by a value
        Could not convert decoded value to string: invalid utf-8 sequence of 1 bytes from index 0
-     ┌─ <stdlib/std.ncl>:4926:29
+     ┌─ <stdlib/std.ncl>:4924:29
      │
-4926 │         let decoded = str | Base64String
+4924 │         let decoded = str | Base64String
      │                             ------------ expected type
      │
      ┌─ [INPUTS_PATH]/errors/base64_decode_non_string.ncl:3:36

--- a/cli/tests/snapshot/snapshots/snapshot__eval_stderr_fail_with.ncl.snap
+++ b/cli/tests/snapshot/snapshots/snapshot__eval_stderr_fail_with.ncl.snap
@@ -4,9 +4,9 @@ expression: err
 ---
 error: contract broken by a value
        div by zero
-     ┌─ <stdlib/std.ncl>:5468:24
+     ┌─ <stdlib/std.ncl>:5466:24
      │
-5468 │       fun msg => msg | Blame,
+5466 │       fun msg => msg | Blame,
      │                        ----- expected type
      │
      ┌─ [INPUTS_PATH]/errors/fail_with.ncl:5:19

--- a/cli/tests/snapshot/snapshots/snapshot__eval_stderr_subcontract_nested_custom_diagnostics.ncl.snap
+++ b/cli/tests/snapshot/snapshots/snapshot__eval_stderr_subcontract_nested_custom_diagnostics.ncl.snap
@@ -21,9 +21,9 @@ warning: plain functions as contracts are deprecated
    = wrap this function using one of the constructors in `std.contract` instead, like `std.contract.from_validator` or `std.contract.custom`
 
 warning: plain functions as contracts are deprecated
-     ┌─ <stdlib/std.ncl>:1846:9
+     ┌─ <stdlib/std.ncl>:1844:9
      │
-1846 │         %contract/apply% contract (%label/push_diag% label) value,
+1844 │         %contract/apply% contract (%label/push_diag% label) value,
      │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ applied to this term
      │
      ┌─ [INPUTS_PATH]/errors/subcontract_nested_custom_diagnostics.ncl:3:21

--- a/cli/tests/snapshot/snapshots/snapshot__package_stderr_invalid-git-dep.ncl.snap
+++ b/cli/tests/snapshot/snapshots/snapshot__package_stderr_invalid-git-dep.ncl.snap
@@ -6,9 +6,9 @@ error: failed to evaluate package manifest
 
 error: contract broken by the value of `ref`
        expected 40 characters, got 18
-     ┌─ <stdlib/std.ncl>:3497:17
+     ┌─ <stdlib/std.ncl>:3495:17
      │
-3497 │               | [| 'Head, 'Branch String, 'Tag String, 'Commit std.package.GitId |]
+3495 │               | [| 'Head, 'Branch String, 'Tag String, 'Commit std.package.GitId |]
      │                 ------------------------------------------------------------------- expected type
      │
      ┌─ [INPUTS_PATH]/package/invalid-git-dep.ncl:10:60

--- a/cli/tests/snapshot/snapshots/snapshot__package_stderr_invalid-version.ncl.snap
+++ b/cli/tests/snapshot/snapshots/snapshot__package_stderr_invalid-version.ncl.snap
@@ -6,9 +6,9 @@ error: failed to evaluate package manifest
 
 error: contract broken by the value of `version`
        invalid semver
-     ┌─ <stdlib/std.ncl>:3576:17
+     ┌─ <stdlib/std.ncl>:3574:17
      │
-3576 │               | Semver
+3574 │               | Semver
      │                 ------ expected type
      │
      ┌─ [INPUTS_PATH]/package/invalid-version.ncl:6:13

--- a/cli/tests/snapshot/snapshots/snapshot__package_stderr_missing-field.ncl.snap
+++ b/cli/tests/snapshot/snapshots/snapshot__package_stderr_missing-field.ncl.snap
@@ -5,9 +5,9 @@ expression: err
 error: failed to evaluate package manifest
 
 error: missing definition for `authors`
-     ┌─ <stdlib/std.ncl>:3590:13
+     ┌─ <stdlib/std.ncl>:3588:13
      │
-3590 │             authors
+3588 │             authors
      │             ^^^^^^^ required here
      │
      ┌─ [INPUTS_PATH]/package/missing-field.ncl:4:1

--- a/core/stdlib/std.ncl
+++ b/core/stdlib/std.ncl
@@ -1044,8 +1044,6 @@
         ```
       "%
       = fun array =>
-        let length = %array/length% array in
-
         fold_left
           (fun acc x =>
             if elem x acc then


### PR DESCRIPTION
- **Update vscode package metadata**
- **chore(deps): bump serde_with from 3.14.0 to 3.21.0**
- **Add std.array.group**
- **Accept snapshot changes**
- **std.array.group: Add tests**
- **Add std.array.chunk**
- **std.array.chunk: Add tests**
- **Address review comments**
- **Make faster implementation of `std.array.sort` using merge sort**
- **Fix snapshot tests**
- **Apply code review suggestions**
- **Add additional doc example for `std.array.sort` in order to test stability**
- **chore(deps): bump quinn-proto from 0.11.14 to 0.11.16**
- **Remove extraneous binding in std.array.dedup**
